### PR TITLE
Support for fargate's container metadata endpoint

### DIFF
--- a/include/aws_profile_loader
+++ b/include/aws_profile_loader
@@ -26,6 +26,11 @@ if [[ $PROFILE ]]; then
 elif [[ $AWS_ACCESS_KEY_ID && $AWS_SECRET_ACCESS_KEY || $AWS_SESSION_TOKEN ]];then
     PROFILE="ENV"
     PROFILE_OPT=""
+elif [[ -n $AWS_CONTAINER_CREDENTIALS_RELATIVE_URI ]] && [[ -z $INSTANCE_PROFILE ]]; then
+    PROFILE="INSTANCE-PROFILE"
+    AWS_ACCESS_KEY_ID=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI | grep AccessKeyId | cut -d':' -f2 | sed 's/[^0-9A-Z]*//g')
+    AWS_SECRET_ACCESS_KEY_ID=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI | grep SecretAccessKey | cut -d':' -f2 | sed 's/[^0-9A-Za-z/+=]*//g')
+    AWS_SESSION_TOKEN=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI  grep Token| cut -d':' -f2 | sed 's/[^0-9A-Za-z/+=]*//g')
 elif [[ $INSTANCE_PROFILE ]];then
     PROFILE="INSTANCE-PROFILE"
     AWS_ACCESS_KEY_ID=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/${INSTANCE_PROFILE} | grep AccessKeyId | cut -d':' -f2 | sed 's/[^0-9A-Z]*//g')


### PR DESCRIPTION
If you're running prowler in a fargate container in AWS you don't get an instance profile back from `http://169.254.169.254/latest/meta-data/iam/security-credentials/` instead you get an empty string. In this case if you have an empty instance profile and the `$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environmental variable is set you can get the same access keys and token from a slightly different URI. This change will detect this and set the required ENV vars for a clean prowler run.