### PR TITLE
Fix extra759 to find secrets on Lambda variables with their name @jfagoagas

### DIFF
--- a/checks/check_extra759
+++ b/checks/check_extra759
@@ -35,7 +35,7 @@ extra759(){
     if [[ $LIST_OF_FUNCTIONS ]]; then
       for lambdafunction in $LIST_OF_FUNCTIONS;do
         LAMBDA_FUNCTION_VARIABLES_FILE="$SECRETS_TEMP_FOLDER/extra759-$lambdafunction-$regx-variables.txt"
-        LAMBDA_FUNCTION_VARIABLES=$($AWSCLI lambda $PROFILE_OPT --region $regx get-function-configuration --function-name $lambdafunction --query 'Environment.Variables' --output text > $LAMBDA_FUNCTION_VARIABLES_FILE)
+        LAMBDA_FUNCTION_VARIABLES=$($AWSCLI lambda $PROFILE_OPT --region $regx get-function-configuration --function-name $lambdafunction --query 'Environment.Variables' --output json > $LAMBDA_FUNCTION_VARIABLES_FILE)
         if [ -s $LAMBDA_FUNCTION_VARIABLES_FILE ];then
         # Implementation using https://github.com/Yelp/detect-secrets
         FINDINGS=$(secretsDetector file $LAMBDA_FUNCTION_VARIABLES_FILE)

--- a/prowler
+++ b/prowler
@@ -99,7 +99,7 @@ USAGE:
       -I                  External ID to be used when assuming roles (not mandatory), requires -A and -R
       -w                  whitelist file. See whitelist_sample.txt for reference and format
                             (i.e.: whitelist_sample.txt)
-      -N <shodan_api_key> Shoadan API key used by check extra7102.
+      -N <shodan_api_key> Shodan API key used by check extra7102.
       -o                  Custom output directory, if not specified will use default prowler/output, requires -M <mode>
                             (i.e.: -M csv -o /tmp/reports/)
       -B                  Custom output bucket, requires -M <mode> and it can work also with -o flag.


### PR DESCRIPTION
Fix AWS cli output format to extract Lambda environment variables with their name. Extracting it using `text` format was causing that `detect-secrets` can not identify them.

## Previous
- `secrets.txt` extracted with `text` format:
`rs.z5v9fI<alU(xUCG5oG%qL test-user 2390 =hq3v-z7h38V=29fiRx=U7p4 admin-user 9999 https://fake-domain.org`
- Prowler output
`PASS! eu-west-1: No secrets found in Lambda function test-lambda variables`
## Fixed
- `secrets.txt` extracted with `json` format:
```
{
 "PASSWORD1": "rs.z5v9fI<alU(xUCG5oG%qL",
 "USER1": "test-user",
 "PORT1": "2390",
 "PASSWORD2": "=hq3v-z7h38V=29fiRx=U7p4",
 "USER2": "admin-user",
 "PORT2": "9999",
 "DOMAIN1": "https://fake-domain.org"
}
```
- Prowler output
`FAIL! eu-west-1: Potential secret found in Lambda function test-lambda variables`

This PR fix https://github.com/toniblyx/prowler/issues/900
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
