### PR TITLE
New group and checks for Codebuild

### DIFF
--- a/check261
+++ b/check261
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+CHECK_ID_check261="26.1"
+CHECK_TITLE_check261="[check261] CodeBuild Project last invoked greater then 90 days"
+CHECK_SCORED_check261="NOT_SCORED"
+CHECK_CIS_LEVEL_check261="LEVEL1"
+CHECK_SEVERITY_check261="High"
+CHECK_ASFF_TYPE_check261="Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark"
+CHECK_ALTERNATE_check101="check261"
+CHECK_SERVICENAME_check261="codebuild"
+CHECK_RISK_check261='The CodeBuild projects are very old and can be checked if they are being used currently'
+CHECK_REMEDIATION_check261=''
+CHECK_DOC_check261=''
+CHECK_CAF_EPIC_check261='CODEBUILD'
+
+check261(){
+    textInfo "Looking for all build projects with last build invocation greater then 30 days in all regions"
+    for regx in ${REGIONS}; do
+        LIST_OF_PROJECTS=$("${AWSCLI}" codebuild list-projects --region "${regx}" --query 'projects[*]' --output text 2>&1)
+        if [[ $(echo "${LIST_OF_PROJECTS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "${regx}: Access Denied trying to list Codebuild projects" "${regx}"
+            continue
+        fi
+        for project in ${LIST_OF_PROJECTS}; do
+            project_id=$("${AWSCLI}" codebuild list-builds-for-project --project-name "${project}" --query 'ids[0]' --region "${regx}" --output text | head -n 1 2>&1)
+            if [[ $(echo "${project_id}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+                textInfo "${regx}: Access Denied trying to Id for Codebuild project ${project} in" "${regx}"
+                continue
+            fi
+            last_invoked_time=$("${AWSCLI}" codebuild batch-get-builds --ids ${project_id} --region "${regx}" --query 'builds[0].endTime' --output text 2>&1)
+            if [[ $(echo "${last_invoked_time}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+                textInfo "${regx}: Access Denied trying to get build details for Codebuild project ID ${project_id} in" "${regx}"
+            else
+                integer_time=${last_invoked_time%.*}
+                current_time=$(date +%s)
+                if [[ $(($current_time - $integer_time)) -ge $((90*60*60)) ]]; then
+                    textFail "${regx}: CodeBuild project: ${project} was last invoked greater then 30 days"
+                fi
+            fi
+        done
+    done
+}

--- a/checks/check262
+++ b/checks/check262
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2019) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+CHECK_ID_check262="26.1"
+CHECK_TITLE_check262="[check262] CodeBuild Project with user controlled buildspec"
+CHECK_SCORED_check262="NOT_SCORED"
+CHECK_CIS_LEVEL_check262="LEVEL1"
+CHECK_SEVERITY_check262="High"
+CHECK_ASFF_TYPE_check262="Software and Configuration Checks/Industry and Regulatory Standards/CIS AWS Foundations Benchmark"
+CHECK_ALTERNATE_check101="check262"
+CHECK_SERVICENAME_check262="codebuild"
+CHECK_RISK_check262='The CodeBuild projects with user controlled buildspec'
+CHECK_REMEDIATION_check262=''
+CHECK_DOC_check262=''
+CHECK_CAF_EPIC_check262='CODEBUILD'
+
+check262(){
+    textInfo "Looking for all build projects with user controlled buildspec files"
+    for regx in ${REGIONS}; do
+        LIST_OF_PROJECTS=$("${AWSCLI}" codebuild list-projects --region "${regx}" --query 'projects[*]' --output text 2>&1)
+        if [[ $(echo "${LIST_OF_PROJECTS}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+            textInfo "${regx}: Access Denied trying to list Codebuild projects" "${regx}"
+            continue
+        fi
+        for project in ${LIST_OF_PROJECTS}; do
+            buildspec_file=$("${AWSCLI}" codebuild batch-get-projects --name "${project}" --query 'projects[0].source.buildspec' --region "${regx}" --output text 2>&1)
+            if [[ $(echo "${project_id}" | grep -E 'AccessDenied|UnauthorizedOperation|AuthorizationError') ]]; then
+                textInfo "${regx}: Access Denied trying to Id for Codebuild project ${project} in" "${regx}"
+                continue
+            fi
+            if [[ $buildspec_file == *.yml ]];then
+                textFail "${regx}: Codebuild project ${project} uses a user controlled buildspec at ${buildspec_file}"
+            fi
+        done
+    done
+}

--- a/groups/group26_codebuild
+++ b/groups/group26_codebuild
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Prowler - the handy cloud security tool (copyright 2018) by Toni de la Fuente
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+GROUP_ID[26]='Codebuild'
+GROUP_NUMBER[26]='26.0'
+GROUP_TITLE[26]='CodeBuild Project last invoked greater then 90 days [group26] *'
+GROUP_RUN_BY_DEFAULT[26]='Y' # run it when execute_all is called
+GROUP_CHECKS[26]='check261,check262


### PR DESCRIPTION
### Context 

New group and checks for codebuild added.

### Description

Checks :-
1. Scans all codebuild projects and finds out the projects which have not been triggered for more then 90 days.
2. Scans all codebuild projects and shows projects with user controlled buildspec files


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
