### PR TITLE
fix(iam_policy_no_administrative_privileges): check only *:* permissions

### DIFF
--- a/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges.py
@@ -18,15 +18,15 @@ class iam_policy_no_administrative_privileges(Check):
             else:
                 policy_statements = policy["PolicyDocument"]["Statement"]
             for statement in policy_statements:
+                # Check policies with "Effect": "Allow" with "Action": "*" over "Resource": "*".
                 if (
                     statement["Effect"] == "Allow"
                     and "Action" in statement
-                    and "*" in statement["Action"]
-                    and "*" in statement["Resource"]
+                    and (statement["Action"] == "*" or statement["Action"] == ["*"])
+                    and (statement["Resource"] == "*" or statement["Resource"] == ["*"])
                 ):
                     report.status = "FAIL"
                     report.status_extended = f"Policy {policy['PolicyName']} allows '*:*' administrative privileges"
                     break
-
             findings.append(report)
         return findings

--- a/tests/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_no_administrative_privileges/iam_policy_no_administrative_privileges_test.py
@@ -83,7 +83,7 @@ class Test_iam_policy_no_administrative_privileges_test:
         policy_document_non_administrative = {
             "Version": "2012-10-17",
             "Statement": [
-                {"Effect": "Allow", "Action": "logs:CreateLogGroup", "Resource": "*"},
+                {"Effect": "Allow", "Action": "logs:*", "Resource": "*"},
             ],
         }
         policy_name_administrative = "policy2"


### PR DESCRIPTION
### Description

Regarding https://github.com/prowler-cloud/prowler/issues/1789, check only *:* permissions according to [AWS Docs](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls-1.4.0.html#securityhub-cis1.4-controls-1.16:~:text=days%20or%20less-,1.16%20%E2%80%93%20Ensure%20IAM%20policies%20that%20allow%20full%20%22*%3A*%22%20administrative%20privileges%20are%20not%20attached,-1.17%20%2D%20Ensure%20a).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
