### PR TITLE
fix(gcp): handle error when Project ID is None

### DIFF
--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -359,7 +359,7 @@ GCP Account: {Fore.YELLOW}[{profile}]{Style.RESET_ALL}  GCP Project ID: {Fore.YE
             gcp_audit_info.credentials,
             gcp_audit_info.project_id,
         ) = gcp_provider.get_credentials()
-
+        print(gcp_provider.get_credentials())
         if not arguments.get("only_logs"):
             self.print_gcp_credentials(gcp_audit_info)
 

--- a/prowler/providers/common/audit_info.py
+++ b/prowler/providers/common/audit_info.py
@@ -359,7 +359,7 @@ GCP Account: {Fore.YELLOW}[{profile}]{Style.RESET_ALL}  GCP Project ID: {Fore.YE
             gcp_audit_info.credentials,
             gcp_audit_info.project_id,
         ) = gcp_provider.get_credentials()
-        print(gcp_provider.get_credentials())
+
         if not arguments.get("only_logs"):
             self.print_gcp_credentials(gcp_audit_info)
 

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -16,6 +16,9 @@ class GCP_Provider:
     ):
         logger.info("Instantiating GCP Provider ...")
         self.credentials, self.project_id = self.__set_credentials__(credentials_file)
+        if not self.project_id:
+            logger.critical("No Project ID associated to Google Credentials.")
+            sys.exit(1)
 
     def __set_credentials__(self, credentials_file):
         try:

--- a/tests/providers/common/audit_info_test.py
+++ b/tests/providers/common/audit_info_test.py
@@ -77,7 +77,7 @@ def mock_set_azure_credentials(*_):
 
 
 def mock_set_gcp_credentials(*_):
-    return (None, None)
+    return (None, "project")
 
 
 class Test_Set_Audit_Info:


### PR DESCRIPTION
### Description

Handle error when Project ID is None

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
