### PR TITLE
fix(global services): fixed global services region

### DIFF
--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -1,15 +1,19 @@
+from prowler.providers.aws.aws_provider import generate_regional_clients
+
+
 ################## Account
-
-
 class Account:
     def __init__(self, audit_info):
         self.service = "account"
         self.session = audit_info.audit_session
         self.audited_account = audit_info.audited_account
+        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # If the region is not set in the audit profile,
+        # we pick the first region from the regional clients list
         self.region = (
             audit_info.profile_region
             if audit_info.profile_region
-            else self.regional_clients[0].region
+            else list(self.regional_clients.keys())[0]
         )
 
     def __get_session__(self):

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -6,7 +6,11 @@ class Account:
         self.service = "account"
         self.session = audit_info.audit_session
         self.audited_account = audit_info.audited_account
-        self.region = audit_info.profile_region
+        self.region = (
+            audit_info.profile_region
+            if audit_info.profile_region
+            else self.regional_clients[0].region
+        )
 
     def __get_session__(self):
         return self.session

--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
@@ -10,7 +10,7 @@ class backup_plans_exist(Check):
         report.status_extended = "No Backup Plan Exist"
         report.resource_arn = ""
         report.resource_id = "No Backups"
-        report.region = backup_client.general_region
+        report.region = backup_client.region
         if backup_client.backup_plans:
             report.status = "PASS"
             report.status_extended = f"At least one backup plan exists: { backup_client.backup_plans[0].name}"

--- a/prowler/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist.py
@@ -10,7 +10,7 @@ class backup_reportplans_exist(Check):
         report.status_extended = "No Backup Report Plan Exist"
         report.resource_arn = ""
         report.resource_id = "No Backups"
-        report.region = backup_client.general_region
+        report.region = backup_client.region
         if backup_client.backup_report_plans:
             report.status = "PASS"
             report.status_extended = f"At least one backup report plan exists: { backup_client.backup_report_plans[0].name}"

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -16,10 +16,12 @@ class Backup:
         self.audited_account = audit_info.audited_account
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # If the region is not set in the audit profile,
+        # we pick the first region from the regional clients list
         self.region = (
             audit_info.profile_region
             if audit_info.profile_region
-            else self.regional_clients[0].region
+            else list(self.regional_clients.keys())[0]
         )
         self.backup_vaults = []
         self.__threading_call__(self.__list_backup_vaults__)

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -16,7 +16,11 @@ class Backup:
         self.audited_account = audit_info.audited_account
         self.audit_resources = audit_info.audit_resources
         self.regional_clients = generate_regional_clients(self.service, audit_info)
-        self.general_region = audit_info.profile_region
+        self.region = (
+            audit_info.profile_region
+            if audit_info.profile_region
+            else self.regional_clients[0].region
+        )
         self.backup_vaults = []
         self.__threading_call__(self.__list_backup_vaults__)
         self.backup_plans = []

--- a/prowler/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist.py
+++ b/prowler/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist.py
@@ -10,7 +10,7 @@ class backup_vaults_exist(Check):
         report.status_extended = "No Backup Vault Exist"
         report.resource_arn = ""
         report.resource_id = "No Backups"
-        report.region = backup_client.general_region
+        report.region = backup_client.region
         if backup_client.backup_vaults:
             report.status = "PASS"
             report.status_extended = f"At least one backup vault exists: { backup_client.backup_vaults[0].name}"

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -17,7 +17,11 @@ class Cloudtrail:
         self.audited_account = audit_info.audited_account
         self.audit_resources = audit_info.audit_resources
         self.audited_partition = audit_info.audited_partition
-        self.region = audit_info.profile_region
+        self.region = (
+            audit_info.profile_region
+            if audit_info.profile_region
+            else self.regional_clients[0].region
+        )
         self.regional_clients = generate_regional_clients(self.service, audit_info)
         self.trails = []
         self.__threading_call__(self.__get_trails__)

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -17,12 +17,14 @@ class Cloudtrail:
         self.audited_account = audit_info.audited_account
         self.audit_resources = audit_info.audit_resources
         self.audited_partition = audit_info.audited_partition
+        self.regional_clients = generate_regional_clients(self.service, audit_info)
+        # If the region is not set in the audit profile,
+        # we pick the first region from the regional clients list
         self.region = (
             audit_info.profile_region
             if audit_info.profile_region
-            else self.regional_clients[0].region
+            else list(self.regional_clients.keys())[0]
         )
-        self.regional_clients = generate_regional_clients(self.service, audit_info)
         self.trails = []
         self.__threading_call__(self.__get_trails__)
         self.__get_trail_status__()

--- a/tests/providers/aws/services/backup/backup_plans_exist/backup_plans_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_plans_exist/backup_plans_exist_test.py
@@ -9,7 +9,7 @@ AWS_REGION = "eu-west-1"
 class Test_backup_plans_exist:
     def test_no_backup_plans(self):
         backup_client = mock.MagicMock
-        backup_client.general_region = AWS_REGION
+        backup_client.region = AWS_REGION
         backup_client.backup_plans = []
         with mock.patch(
             "prowler.providers.aws.services.backup.backup_service.Backup",
@@ -32,7 +32,7 @@ class Test_backup_plans_exist:
 
     def test_one_backup_plan(self):
         backup_client = mock.MagicMock
-        backup_client.general_region = AWS_REGION
+        backup_client.region = AWS_REGION
         backup_client.backup_plans = [
             BackupPlan(
                 arn="ARN",

--- a/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_reportplans_exist/backup_reportplans_exist_test.py
@@ -9,7 +9,7 @@ AWS_REGION = "eu-west-1"
 class Test_backup_reportplans_exist:
     def test_no_backup_report_plans(self):
         backup_client = mock.MagicMock
-        backup_client.general_region = AWS_REGION
+        backup_client.region = AWS_REGION
         backup_client.backup_report_plans = []
         with mock.patch(
             "prowler.providers.aws.services.backup.backup_service.Backup",
@@ -32,7 +32,7 @@ class Test_backup_reportplans_exist:
 
     def test_one_backup_report_plan(self):
         backup_client = mock.MagicMock
-        backup_client.general_region = AWS_REGION
+        backup_client.region = AWS_REGION
         backup_client.backup_report_plans = [
             BackupReportPlan(
                 arn="ARN",

--- a/tests/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist_test.py
+++ b/tests/providers/aws/services/backup/backup_vaults_exist/backup_vaults_exist_test.py
@@ -8,7 +8,7 @@ AWS_REGION = "eu-west-1"
 class Test_backup_vaults_exist:
     def test_no_backup_vaults(self):
         backup_client = mock.MagicMock
-        backup_client.general_region = AWS_REGION
+        backup_client.region = AWS_REGION
         backup_client.backup_vaults = []
         with mock.patch(
             "prowler.providers.aws.services.backup.backup_service.Backup",
@@ -31,7 +31,7 @@ class Test_backup_vaults_exist:
 
     def test_one_backup_vault(self):
         backup_client = mock.MagicMock
-        backup_client.general_region = AWS_REGION
+        backup_client.region = AWS_REGION
         backup_client.backup_vaults = [
             BackupVault(
                 arn="ARN",


### PR DESCRIPTION
### Context

There were various global services in Prowler with a bad region assignation


### Description

Change default region assignation for the services:
- `cloudtrail`
- `account`
- `backup`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
