### PR TITLE
chore(quick inventory): add warning message

### DIFF
--- a/docs/tutorials/quick-inventory.md
+++ b/docs/tutorials/quick-inventory.md
@@ -16,4 +16,5 @@ prowler <provider> -i
 
 ![Quick Inventory Example](../img/quick-inventory.jpg)
 
-> The inventorying process is done with `resourcegroupstaggingapi` calls (except for the IAM resources which are done with Boto3 API calls.)
+## Objections
+The inventorying process is done with `resourcegroupstaggingapi` calls which means that only resources they have or have had tags will appear (except for the IAM and S3 resources which are done with Boto3 API calls).

--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -271,7 +271,9 @@ def create_output(resources: list, audit_info: AWS_Audit_Info, args):
         csv_writer.writerow(data.values())
 
     csv_file.close()
-
+    print(
+        f"\n{Fore.YELLOW}WARNING: Only resources that have or have had tags will appear (except for IAM and S3).\nSee more in https://docs.prowler.cloud/en/latest/tutorials/quick-inventory/#objections{Style.RESET_ALL}"
+    )
     print("\nMore details in files:")
     print(f" - CSV: {args.output_directory}/{output_file+csv_file_suffix}")
     print(f" - JSON: {args.output_directory}/{output_file+json_file_suffix}")


### PR DESCRIPTION
### Description

Add warning message since only resources that have or have had tags will appear (except for IAM and S3).
See more in https://docs.prowler.cloud/en/latest/tutorials/quick-inventory/#objections

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
