### PR TITLE
docs(audit_config): How to use it

### DIFF
--- a/docs/developer-guide/checks.md
+++ b/docs/developer-guide/checks.md
@@ -160,6 +160,38 @@ class Check(ABC, Check_Metadata_Model):
         """Execute the check's logic"""
 ```
 
+### Using the audit config
+
+Prowler has a [configuration file](../tutorials/configuration_file.md) which is used to pass certain configuration values to the checks, like the following:
+
+```python title="ec2_securitygroup_with_many_ingress_egress_rules.py"
+class ec2_securitygroup_with_many_ingress_egress_rules(Check):
+    def execute(self):
+        findings = []
+
+        # max_security_group_rules, default: 50
+        max_security_group_rules = ec2_client.audit_config.get(
+            "max_security_group_rules", 50
+        )
+        for security_group in ec2_client.security_groups:
+```
+
+```yaml title="config.yaml"
+# AWS Configuration
+aws:
+  # AWS EC2 Configuration
+
+  # aws.ec2_securitygroup_with_many_ingress_egress_rules
+  # The default value is 50 rules
+  max_security_group_rules: 50
+```
+
+As you can see in the above code, within the service client, in this case the `ec2_client`, there is an object called `audit_config` which is a Python dictionary containing the values read from the configuration file.
+
+In order to use it, you have to check first if the value is present in the configuration file. If the value is not present, you can create it in the `config.yaml` file and then, read it from the check.
+> It is mandatory to always use the `dictionary.get(value, default)` syntax to set a default value in the case the configuration value is not present.
+
+
 ## Check Metadata
 
 Each Prowler check has metadata associated which is stored at the same level of the check's folder in a file called A `check_name.metadata.json` containing the check's metadata.
@@ -275,34 +307,3 @@ class Check_Metadata_Model(BaseModel):
     # store the compliance later if supplied
     Compliance: list = None
 ```
-
-### Using the audit config
-
-Prowler has a [configuration file](../tutorials/configuration_file.md) which is used to pass certain configuration values to the checks, like the following:
-
-```python title="ec2_securitygroup_with_many_ingress_egress_rules.py"
-class ec2_securitygroup_with_many_ingress_egress_rules(Check):
-    def execute(self):
-        findings = []
-
-        # max_security_group_rules, default: 50
-        max_security_group_rules = ec2_client.audit_config.get(
-            "max_security_group_rules", 50
-        )
-        for security_group in ec2_client.security_groups:
-```
-
-```yaml title="config.yaml"
-# AWS Configuration
-aws:
-  # AWS EC2 Configuration
-
-  # aws.ec2_securitygroup_with_many_ingress_egress_rules
-  # The default value is 50 rules
-  max_security_group_rules: 50
-```
-
-As you can see in the above code, within the service client, in this case the `ec2_client`, there is an object called `audit_config` which is a Python dictionary containing the values read from the configuration file.
-
-In order to use it, you have to check first if the value is present in the configuration file. If the value is not present, you can create it in the `config.yaml` file and then, read it from the check. 
-> It is mandatory to always use the `dictionary.get(value, default)` syntax to set a default value in the case the configuration value is not present.

--- a/docs/developer-guide/checks.md
+++ b/docs/developer-guide/checks.md
@@ -20,7 +20,7 @@ Inside that folder, we need to create three files:
 The Prowler's check structure is very simple and following it there is nothing more to do to include a check in a provider's service because the load is done dynamically based on the paths.
 
 The following is the code for the `ec2_ami_public` check:
-```python
+```python title="Check Class"
 # At the top of the file we need to import the following:
 # - Check class which is in charge of the following:
 #   - Retrieve the check metadata and expose the `metadata()`
@@ -275,3 +275,34 @@ class Check_Metadata_Model(BaseModel):
     # store the compliance later if supplied
     Compliance: list = None
 ```
+
+### Using the audit config
+
+Prowler has a [configuration file](../tutorials/configuration_file.md) which is used to pass certain configuration values to the checks, like the following:
+
+```python title="ec2_securitygroup_with_many_ingress_egress_rules.py"
+class ec2_securitygroup_with_many_ingress_egress_rules(Check):
+    def execute(self):
+        findings = []
+
+        # max_security_group_rules, default: 50
+        max_security_group_rules = ec2_client.audit_config.get(
+            "max_security_group_rules", 50
+        )
+        for security_group in ec2_client.security_groups:
+```
+
+```yaml title="config.yaml"
+# AWS Configuration
+aws:
+  # AWS EC2 Configuration
+
+  # aws.ec2_securitygroup_with_many_ingress_egress_rules
+  # The default value is 50 rules
+  max_security_group_rules: 50
+```
+
+As you can see in the above code, within the service client, in this case the `ec2_client`, there is an object called `audit_config` which is a Python dictionary containing the values read from the configuration file.
+
+In order to use it, you have to check first if the value is present in the configuration file. If the value is not present, you can create it in the `config.yaml` file and then, read it from the check. 
+> It is mandatory to always use the `dictionary.get(value, default)` syntax to set a default value in the case the configuration value is not present.

--- a/docs/tutorials/configuration_file.md
+++ b/docs/tutorials/configuration_file.md
@@ -9,36 +9,35 @@ Also you can input a custom configuration file using the `--config-file` argumen
 ## AWS
 
 ### Configurable Checks
-The following list includes all the checks with configurable variables that can be changed in the mentioned configuration yaml file:
+The following list includes all the AWS checks with configurable variables that can be changed in the configuration yaml file:
 
-1. aws.ec2_elastic_ip_shodan
-    - shodan_api_key (String)
-- aws.ec2_securitygroup_with_many_ingress_egress_rules
-    - max_security_group_rules (Integer)
-- aws.ec2_instance_older_than_specific_days
-    - max_ec2_instance_age_in_days (Integer)
-- aws.vpc_endpoint_connections_trust_boundaries
-    - trusted_account_ids (List of Strings)
-- aws.vpc_endpoint_services_allowed_principals_trust_boundaries
-    - trusted_account_ids (List of Strings)
-- aws.cloudwatch_log_group_retention_policy_specific_days_enabled
-    - log_group_retention_days (Integer)
-- aws.appstream_fleet_session_idle_disconnect_timeout
-    - max_idle_disconnect_timeout_in_seconds (Integer)
-- aws.appstream_fleet_session_disconnect_timeout
-    - max_disconnect_timeout_in_seconds (Integer)
-- aws.appstream_fleet_maximum_session_duration
-    - max_session_duration_seconds (Integer)
-- aws.awslambda_function_using_supported_runtimes
-    - obsolete_lambda_runtimes (List of Strings)
+| Check Name  | Value  | Type  |
+|---|---|---|
+| `ec2_elastic_ip_shodan`  | `shodan_api_key`  | String |
+| `ec2_securitygroup_with_many_ingress_egress_rules`  | `max_security_group_rules`  | Integer |
+| `ec2_instance_older_than_specific_days` | `max_ec2_instance_age_in_days`  | Integer |
+| `vpc_endpoint_connections_trust_boundaries`  | `trusted_account_ids`  | List of Strings |
+| `vpc_endpoint_services_allowed_principals_trust_boundaries`  | `trusted_account_ids`  | List of Strings |
+| `cloudwatch_log_group_retention_policy_specific_days_enabled` | `log_group_retention_days` | Integer |
+| `appstream_fleet_session_idle_disconnect_timeout`  | `max_idle_disconnect_timeout_in_seconds`  | Integer |
+| `appstream_fleet_session_disconnect_timeout`  |  `max_disconnect_timeout_in_seconds` | Integer |
+| `appstream_fleet_maximum_session_duration`  | `max_session_duration_seconds`  | Integer |
+| `awslambda_function_using_supported_runtimes` | `obsolete_lambda_runtimes`  | Integer |
+| `organizations_scp_check_deny_regions` | `organizations_enabled_regions`  | List of Strings |
+| `organizations_delegated_administrators` |  `organizations_trusted_delegated_administrators` | List of Strings |
 
 ## Azure
 
+### Configurable Checks
+
 ## GCP
+
+### Configurable Checks
 
 ## Config YAML File Structure
 > This is the new Prowler configuration file format. The old one without provider keys is still compatible just for the AWS provider.
-```yaml
+
+```yaml title="config.yaml"
 # AWS Configuration
 aws:
   # AWS EC2 Configuration


### PR DESCRIPTION
### Description

How to use the `audit_config` from a Prowler check reading from the `config.yaml`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
