### PR TITLE
chore(actions): not launch linters for mkdocs.yml

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,6 +26,7 @@ jobs:
             README.md
             docs/**
             permissions/**
+            mkdocs.yml
       - name: Install poetry
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |


### PR DESCRIPTION
### Context

When opening a PR GHA were being launched when modifying file `mkdocs.yml`


### Description

Exclude that file from linters GHA scope


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
