### PR TITLE
fix(docs): typo in reporting/csv

### DIFF
--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -43,7 +43,7 @@ Hereunder is the structure for each of the supported report formats by Prowler:
 ![HTML Output](../img/output-html.png)
 ### CSV
 
-CSV format has a set of common columns for all the providers, and then provider specific columns:
+CSV format has a set of common columns for all the providers, and then provider specific columns.  
 The common columns are the following:
 
 - ASSESSMENT_START_TIME


### PR DESCRIPTION
### Context

There was a typo in docs for the csv output format

### Description

Fix typo


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
