### PR TITLE
fix(compliance): set the provider dynamically in Manual checks

### DIFF
--- a/prowler/lib/check/compliance.py
+++ b/prowler/lib/check/compliance.py
@@ -53,7 +53,7 @@ def update_checks_metadata_with_compliance(
                     check_compliance.append(compliance)
             # Create metadata for Manual Control
             manual_check_metadata = {
-                "Provider": "aws",
+                "Provider": framework.Provider,
                 "CheckID": "manual_check",
                 "CheckTitle": "Manual Check",
                 "CheckType": [],

--- a/prowler/lib/check/compliance.py
+++ b/prowler/lib/check/compliance.py
@@ -53,7 +53,7 @@ def update_checks_metadata_with_compliance(
                     check_compliance.append(compliance)
             # Create metadata for Manual Control
             manual_check_metadata = {
-                "Provider": framework.Provider,
+                "Provider": framework.Provider.lower(),
                 "CheckID": "manual_check",
                 "CheckTitle": "Manual Check",
                 "CheckType": [],


### PR DESCRIPTION
### Description

Set the provider dynamically in Manual checks since it was set AWS by default.
Thanks @pedrooot for the catch!

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
