### PR TITLE
fix(iam): handle KeyError in service_last_accessed

### DIFF
--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -796,9 +796,9 @@ class IAM(AWSService):
                         response = self.client.get_service_last_accessed_details(
                             JobId=details["JobId"]
                         )
-                    self.last_accessed_services[(user.name, user.arn)] = response[
-                        "ServicesLastAccessed"
-                    ]
+                    self.last_accessed_services[(user.name, user.arn)] = response.get(
+                        "ServicesLastAccessed", {}
+                    )
 
                 except ClientError as error:
                     if error.response["Error"]["Code"] == "NoSuchEntity":


### PR DESCRIPTION
### Description

Handle KeyError in `service_last_accessed` function:
```
eu-west-1 -- KeyError[794]: 'ServicesLastAccessed'
```
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
