### PR TITLE
chore(safety-v3): ignore pip vulnerability

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Safety
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |
-          poetry run safety check
+          poetry run safety check --ignore 67599
       - name: Vulture
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
       - id: safety
         name: safety
         description: "Safety is a tool that checks your installed dependencies for known security vulnerabilities"
-        entry: bash -c 'safety check'
+        entry: bash -c 'safety check --ignore 67599'
         language: system
 
       - id: vulture


### PR DESCRIPTION
### Context

Ignore Safety vulnerability https://data.safetycli.com/v/67599/97c/ since it does not apply as we do not use -extra-index-url flag with pip.

### Description

Add `--ignore 67599` flag to safety check.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
