### PR TITLE
test(cloudstorage): Add remaining GCP tests for CloudStorage checks

### DIFF
--- a/tests/providers/gcp/gcp_fixtures.py
+++ b/tests/providers/gcp/gcp_fixtures.py
@@ -7,6 +7,9 @@ from prowler.providers.gcp.models import GCPIdentityInfo
 
 GCP_PROJECT_ID = "123456789012"
 
+GCP_EU1_LOCATION = "europe-west1"
+GCP_US_CENTER1_LOCATION = "us-central1"
+
 
 def set_mocked_gcp_provider(
     project_ids: list[str] = [], profile: str = ""

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
@@ -61,7 +61,7 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has a Retention Policy with Bucket Lock"
+                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has a Retention Policy with Bucket Lock."
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"
@@ -121,7 +121,7 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy but without Bucket Lock"
+                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy but without Bucket Lock."
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"
@@ -181,7 +181,7 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy"
+                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy."
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
@@ -1,7 +1,11 @@
 import re
 from unittest import mock
 
-from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_PROJECT_ID,
+    GCP_US_CENTER1_LOCATION,
+    set_mocked_gcp_provider,
+)
 
 
 class TestCloudStorageBucketLogRetentionPolicyLock:
@@ -22,30 +26,28 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
                 cloudstorage_bucket_log_retention_policy_lock,
             )
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+            from prowler.providers.gcp.services.logging.logging_service import Sink
 
             cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
-            from prowler.providers.gcp.services.logging.logging_service import Sink
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
 
             logging_client.sinks = [
                 Sink(
                     name="sink1",
-                    destination="storage.googleapis.com/bucket1",
+                    destination="storage.googleapis.com/example-bucket",
                     filter="all",
                     project_id=GCP_PROJECT_ID,
                 )
             ]
 
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
-                Bucket,
-            )
-
             cloudstorage_client.buckets = [
                 Bucket(
-                    name="bucket1",
-                    id="bucket1",
-                    region="US",
+                    name="example-bucket",
+                    id="example-bucket",
+                    region=GCP_US_CENTER1_LOCATION,
                     uniform_bucket_level_access=True,
                     public=True,
                     retention_policy={"isLocked": True},
@@ -59,11 +61,12 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert re.search(
-                "Retention Policy with Bucket Lock", result[0].status_extended
+                f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has a Retention Policy with Bucket Lock",
+                result[0].status_extended,
             )
-            assert result[0].resource_id == "bucket1"
-            assert result[0].resource_name == "bucket1"
-            assert result[0].location == "US"
+            assert result[0].resource_id == "example-bucket"
+            assert result[0].resource_name == "example-bucket"
+            assert result[0].location == GCP_US_CENTER1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_bucket_with_retention_policy_without_lock(self):
@@ -83,30 +86,28 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
                 cloudstorage_bucket_log_retention_policy_lock,
             )
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+            from prowler.providers.gcp.services.logging.logging_service import Sink
 
             cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
-            from prowler.providers.gcp.services.logging.logging_service import Sink
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
 
             logging_client.sinks = [
                 Sink(
                     name="sink1",
-                    destination="storage.googleapis.com/bucket1",
+                    destination="storage.googleapis.com/example-bucket",
                     filter="all",
                     project_id=GCP_PROJECT_ID,
                 )
             ]
 
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
-                Bucket,
-            )
-
             cloudstorage_client.buckets = [
                 Bucket(
-                    name="bucket1",
-                    id="bucket1",
-                    region="US",
+                    name="example-bucket",
+                    id="example-bucket",
+                    region=GCP_US_CENTER1_LOCATION,
                     uniform_bucket_level_access=True,
                     public=True,
                     retention_policy={"isLocked": False},
@@ -120,11 +121,12 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert re.search(
-                "no Retention Policy but without Bucket Lock", result[0].status_extended
+                f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy but without Bucket Lock",
+                result[0].status_extended,
             )
-            assert result[0].resource_id == "bucket1"
-            assert result[0].resource_name == "bucket1"
-            assert result[0].location == "US"
+            assert result[0].resource_id == "example-bucket"
+            assert result[0].resource_name == "example-bucket"
+            assert result[0].location == GCP_US_CENTER1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_bucket_without_retention_policy(self):
@@ -144,30 +146,28 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
                 cloudstorage_bucket_log_retention_policy_lock,
             )
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+            from prowler.providers.gcp.services.logging.logging_service import Sink
 
             cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
-            from prowler.providers.gcp.services.logging.logging_service import Sink
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
 
             logging_client.sinks = [
                 Sink(
                     name="sink1",
-                    destination="storage.googleapis.com/bucket1",
+                    destination="storage.googleapis.com/example-bucket",
                     filter="all",
                     project_id=GCP_PROJECT_ID,
                 )
             ]
 
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
-                Bucket,
-            )
-
             cloudstorage_client.buckets = [
                 Bucket(
-                    name="bucket1",
-                    id="bucket1",
-                    region="US",
+                    name="example-bucket",
+                    id="example-bucket",
+                    region=GCP_US_CENTER1_LOCATION,
                     uniform_bucket_level_access=True,
                     public=True,
                     retention_policy=None,
@@ -180,10 +180,13 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert re.search("no Retention Policy", result[0].status_extended)
-            assert result[0].resource_id == "bucket1"
-            assert result[0].resource_name == "bucket1"
-            assert result[0].location == "US"
+            assert re.search(
+                f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == "example-bucket"
+            assert result[0].resource_name == "example-bucket"
+            assert result[0].location == GCP_US_CENTER1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_no_buckets(self):
@@ -203,16 +206,15 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
                 cloudstorage_bucket_log_retention_policy_lock,
             )
+            from prowler.providers.gcp.services.logging.logging_service import Sink
 
             cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
-            from prowler.providers.gcp.services.logging.logging_service import Sink
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
 
             logging_client.sinks = [
                 Sink(
                     name="sink1",
-                    destination="storage.googleapis.com/bucket1",
+                    destination="storage.googleapis.com/example-bucket",
                     filter="all",
                     project_id=GCP_PROJECT_ID,
                 )
@@ -244,7 +246,7 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             )
 
             cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
 
             logging_client.sinks = []
 

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
@@ -1,4 +1,3 @@
-import re
 from unittest import mock
 
 from tests.providers.gcp.gcp_fixtures import (
@@ -60,9 +59,9 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert re.search(
-                f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has a Retention Policy with Bucket Lock",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has a Retention Policy with Bucket Lock"
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"
@@ -120,9 +119,9 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert re.search(
-                f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy but without Bucket Lock",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy but without Bucket Lock"
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"
@@ -180,9 +179,9 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert re.search(
-                f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Log Sink Bucket {cloudstorage_client.buckets[0].name} has no Retention Policy"
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
@@ -1,28 +1,13 @@
-from unittest import mock
 import re
+from unittest import mock
 
 from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+
 
 class TestCloudStorageBucketLogRetentionPolicyLock:
     def test_bucket_with_retention_policy_and_lock(self):
         cloudstorage_client = mock.MagicMock()
         logging_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
-
-        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
-
-        cloudstorage_client.buckets = [Bucket(
-            name="bucket1",
-            id="bucket1",
-            region="US",
-            uniform_bucket_level_access=True,
-            public=True,
-            retention_policy={"isLocked": True},
-            project_id=GCP_PROJECT_ID,
-        )]
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -37,34 +22,53 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
                 cloudstorage_bucket_log_retention_policy_lock,
             )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.logging.logging_service import Sink
+
+            logging_client.sinks = [
+                Sink(
+                    name="sink1",
+                    destination="storage.googleapis.com/bucket1",
+                    filter="all",
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+
+            cloudstorage_client.buckets = [
+                Bucket(
+                    name="bucket1",
+                    id="bucket1",
+                    region="US",
+                    uniform_bucket_level_access=True,
+                    public=True,
+                    retention_policy={"isLocked": True},
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
 
             check = cloudstorage_bucket_log_retention_policy_lock()
             result = check.execute()
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert re.search("Retention Policy with Bucket Lock", result[0].status_extended)
+            assert re.search(
+                "Retention Policy with Bucket Lock", result[0].status_extended
+            )
             assert result[0].resource_id == "bucket1"
+            assert result[0].resource_name == "bucket1"
+            assert result[0].location == "US"
+            assert result[0].project_id == GCP_PROJECT_ID
 
     def test_bucket_with_retention_policy_without_lock(self):
         cloudstorage_client = mock.MagicMock()
         logging_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
-
-        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
-
-        cloudstorage_client.buckets = [Bucket(
-            name="bucket1",
-            id="bucket1",
-            region="US",
-            uniform_bucket_level_access=True,
-            public=True,
-            retention_policy={"isLocked": False},
-            project_id=GCP_PROJECT_ID,
-        )]
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -79,34 +83,53 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
                 cloudstorage_bucket_log_retention_policy_lock,
             )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.logging.logging_service import Sink
+
+            logging_client.sinks = [
+                Sink(
+                    name="sink1",
+                    destination="storage.googleapis.com/bucket1",
+                    filter="all",
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+
+            cloudstorage_client.buckets = [
+                Bucket(
+                    name="bucket1",
+                    id="bucket1",
+                    region="US",
+                    uniform_bucket_level_access=True,
+                    public=True,
+                    retention_policy={"isLocked": False},
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
 
             check = cloudstorage_bucket_log_retention_policy_lock()
             result = check.execute()
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert re.search("no Retention Policy but without Bucket Lock", result[0].status_extended)
+            assert re.search(
+                "no Retention Policy but without Bucket Lock", result[0].status_extended
+            )
             assert result[0].resource_id == "bucket1"
-    
+            assert result[0].resource_name == "bucket1"
+            assert result[0].location == "US"
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_bucket_without_retention_policy(self):
         cloudstorage_client = mock.MagicMock()
         logging_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
-
-        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
-
-        cloudstorage_client.buckets = [Bucket(
-            name="bucket1",
-            id="bucket1",
-            region="US",
-            uniform_bucket_level_access=True,
-            public=True,
-            retention_policy=None,
-            project_id=GCP_PROJECT_ID,
-        )]
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -121,6 +144,36 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
                 cloudstorage_bucket_log_retention_policy_lock,
             )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.logging.logging_service import Sink
+
+            logging_client.sinks = [
+                Sink(
+                    name="sink1",
+                    destination="storage.googleapis.com/bucket1",
+                    filter="all",
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+
+            cloudstorage_client.buckets = [
+                Bucket(
+                    name="bucket1",
+                    id="bucket1",
+                    region="US",
+                    uniform_bucket_level_access=True,
+                    public=True,
+                    retention_policy=None,
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
 
             check = cloudstorage_bucket_log_retention_policy_lock()
             result = check.execute()
@@ -129,17 +182,13 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
             assert result[0].status == "FAIL"
             assert re.search("no Retention Policy", result[0].status_extended)
             assert result[0].resource_id == "bucket1"
+            assert result[0].resource_name == "bucket1"
+            assert result[0].location == "US"
+            assert result[0].project_id == GCP_PROJECT_ID
 
- 
     def test_no_buckets(self):
         cloudstorage_client = mock.MagicMock()
         logging_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
-
-        cloudstorage_client.buckets = []
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -155,8 +204,53 @@ class TestCloudStorageBucketLogRetentionPolicyLock:
                 cloudstorage_bucket_log_retention_policy_lock,
             )
 
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.logging.logging_service import Sink
+
+            logging_client.sinks = [
+                Sink(
+                    name="sink1",
+                    destination="storage.googleapis.com/bucket1",
+                    filter="all",
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            cloudstorage_client.buckets = []
+
             check = cloudstorage_bucket_log_retention_policy_lock()
             result = check.execute()
 
             assert len(result) == 0
 
+    def test_no_buckets_no_sinks(self):
+        cloudstorage_client = mock.MagicMock()
+        logging_client = mock.MagicMock()
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_client",
+            new=cloudstorage_client,
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.logging_client",
+            new=logging_client,
+        ):
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
+                cloudstorage_bucket_log_retention_policy_lock,
+            )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            logging_client.sinks = []
+
+            cloudstorage_client.buckets = []
+
+            check = cloudstorage_bucket_log_retention_policy_lock()
+            result = check.execute()
+
+            assert len(result) == 0

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock_test.py
@@ -1,0 +1,162 @@
+from unittest import mock
+import re
+
+from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+
+class TestCloudStorageBucketLogRetentionPolicyLock:
+    def test_bucket_with_retention_policy_and_lock(self):
+        cloudstorage_client = mock.MagicMock()
+        logging_client = mock.MagicMock()
+        
+        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+        cloudstorage_client.region = "global"
+        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
+
+        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
+
+        cloudstorage_client.buckets = [Bucket(
+            name="bucket1",
+            id="bucket1",
+            region="US",
+            uniform_bucket_level_access=True,
+            public=True,
+            retention_policy={"isLocked": True},
+            project_id=GCP_PROJECT_ID,
+        )]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_client",
+            new=cloudstorage_client,
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.logging_client",
+            new=logging_client,
+        ):
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
+                cloudstorage_bucket_log_retention_policy_lock,
+            )
+
+            check = cloudstorage_bucket_log_retention_policy_lock()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert re.search("Retention Policy with Bucket Lock", result[0].status_extended)
+            assert result[0].resource_id == "bucket1"
+
+    def test_bucket_with_retention_policy_without_lock(self):
+        cloudstorage_client = mock.MagicMock()
+        logging_client = mock.MagicMock()
+        
+        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+        cloudstorage_client.region = "global"
+        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
+
+        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
+
+        cloudstorage_client.buckets = [Bucket(
+            name="bucket1",
+            id="bucket1",
+            region="US",
+            uniform_bucket_level_access=True,
+            public=True,
+            retention_policy={"isLocked": False},
+            project_id=GCP_PROJECT_ID,
+        )]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_client",
+            new=cloudstorage_client,
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.logging_client",
+            new=logging_client,
+        ):
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
+                cloudstorage_bucket_log_retention_policy_lock,
+            )
+
+            check = cloudstorage_bucket_log_retention_policy_lock()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert re.search("no Retention Policy but without Bucket Lock", result[0].status_extended)
+            assert result[0].resource_id == "bucket1"
+    
+    def test_bucket_without_retention_policy(self):
+        cloudstorage_client = mock.MagicMock()
+        logging_client = mock.MagicMock()
+        
+        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+        cloudstorage_client.region = "global"
+        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
+
+        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
+
+        cloudstorage_client.buckets = [Bucket(
+            name="bucket1",
+            id="bucket1",
+            region="US",
+            uniform_bucket_level_access=True,
+            public=True,
+            retention_policy=None,
+            project_id=GCP_PROJECT_ID,
+        )]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_client",
+            new=cloudstorage_client,
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.logging_client",
+            new=logging_client,
+        ):
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
+                cloudstorage_bucket_log_retention_policy_lock,
+            )
+
+            check = cloudstorage_bucket_log_retention_policy_lock()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert re.search("no Retention Policy", result[0].status_extended)
+            assert result[0].resource_id == "bucket1"
+
+ 
+    def test_no_buckets(self):
+        cloudstorage_client = mock.MagicMock()
+        logging_client = mock.MagicMock()
+        
+        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+        cloudstorage_client.region = "global"
+        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
+
+        cloudstorage_client.buckets = []
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_client",
+            new=cloudstorage_client,
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock.logging_client",
+            new=logging_client,
+        ):
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_log_retention_policy_lock.cloudstorage_bucket_log_retention_policy_lock import (
+                cloudstorage_bucket_log_retention_policy_lock,
+            )
+
+            check = cloudstorage_bucket_log_retention_policy_lock()
+            result = check.execute()
+
+            assert len(result) == 0
+

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
@@ -1,7 +1,11 @@
 import re
 from unittest import mock
 
-from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_PROJECT_ID,
+    GCP_US_CENTER1_LOCATION,
+    set_mocked_gcp_provider,
+)
 
 
 class TestCloudStorageBucketPublicAccess:
@@ -18,19 +22,18 @@ class TestCloudStorageBucketPublicAccess:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import (
                 cloudstorage_bucket_public_access,
             )
-
-            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
                 Bucket,
             )
 
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
+
             cloudstorage_client.buckets = [
                 Bucket(
-                    name="bucket1",
-                    id="bucket1",
-                    region="US",
+                    name="example-bucket",
+                    id="example-bucket",
+                    region=GCP_US_CENTER1_LOCATION,
                     uniform_bucket_level_access=True,
                     public=True,
                     project_id=GCP_PROJECT_ID,
@@ -43,11 +46,12 @@ class TestCloudStorageBucketPublicAccess:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert re.search(
-                "Bucket .* is publicly accessible", result[0].status_extended
+                f"Bucket {cloudstorage_client.buckets[0].name} is publicly accessible",
+                result[0].status_extended,
             )
-            assert result[0].resource_id == "bucket1"
-            assert result[0].resource_name == "bucket1"
-            assert result[0].location == "US"
+            assert result[0].resource_id == "example-bucket"
+            assert result[0].resource_name == "example-bucket"
+            assert result[0].location == GCP_US_CENTER1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_bucket_no_public_access(self):
@@ -63,19 +67,18 @@ class TestCloudStorageBucketPublicAccess:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import (
                 cloudstorage_bucket_public_access,
             )
-
-            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
                 Bucket,
             )
 
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
+
             cloudstorage_client.buckets = [
                 Bucket(
-                    name="bucket2",
-                    id="bucket2",
-                    region="US",
+                    name="example-bucket",
+                    id="example-bucket",
+                    region=GCP_US_CENTER1_LOCATION,
                     uniform_bucket_level_access=True,
                     public=False,
                     project_id=GCP_PROJECT_ID,
@@ -88,11 +91,12 @@ class TestCloudStorageBucketPublicAccess:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert re.search(
-                "Bucket .* is not publicly accessible", result[0].status_extended
+                f"Bucket {cloudstorage_client.buckets[0].name} is not publicly accessible",
+                result[0].status_extended,
             )
-            assert result[0].resource_id == "bucket2"
-            assert result[0].resource_name == "bucket2"
-            assert result[0].location == "US"
+            assert result[0].resource_id == "example-bucket"
+            assert result[0].resource_name == "example-bucket"
+            assert result[0].location == GCP_US_CENTER1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_no_buckets(self):
@@ -110,7 +114,7 @@ class TestCloudStorageBucketPublicAccess:
             )
 
             cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
             cloudstorage_client.buckets = []
 
             check = cloudstorage_bucket_public_access()

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
@@ -46,7 +46,7 @@ class TestCloudStorageBucketPublicAccess:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Bucket {cloudstorage_client.buckets[0].name} is publicly accessible"
+                == f"Bucket {cloudstorage_client.buckets[0].name} is publicly accessible."
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"
@@ -91,7 +91,7 @@ class TestCloudStorageBucketPublicAccess:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Bucket {cloudstorage_client.buckets[0].name} is not publicly accessible"
+                == f"Bucket {cloudstorage_client.buckets[0].name} is not publicly accessible."
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
@@ -1,25 +1,12 @@
-from unittest import mock
 import re
+from unittest import mock
 
 from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+
 
 class TestCloudStorageBucketPublicAccess:
     def test_bucket_public_access(self):
         cloudstorage_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-
-        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
-
-        cloudstorage_client.buckets = [Bucket(
-            name="bucket1",
-            id="bucket1",
-            region="US",
-            uniform_bucket_level_access=True,
-            public=True,
-            project_id=GCP_PROJECT_ID,
-        )]
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -28,32 +15,43 @@ class TestCloudStorageBucketPublicAccess:
             "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import cloudstorage_bucket_public_access
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import (
+                cloudstorage_bucket_public_access,
+            )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+
+            cloudstorage_client.buckets = [
+                Bucket(
+                    name="bucket1",
+                    id="bucket1",
+                    region="US",
+                    uniform_bucket_level_access=True,
+                    public=True,
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
 
             check = cloudstorage_bucket_public_access()
             result = check.execute()
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert re.search("Bucket .* is publicly accessible", result[0].status_extended)
+            assert re.search(
+                "Bucket .* is publicly accessible", result[0].status_extended
+            )
             assert result[0].resource_id == "bucket1"
+            assert result[0].resource_name == "bucket1"
+            assert result[0].location == "US"
+            assert result[0].project_id == GCP_PROJECT_ID
 
     def test_bucket_no_public_access(self):
         cloudstorage_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-
-        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
-
-        cloudstorage_client.buckets = [Bucket(
-            name="bucket2",
-            id="bucket2",
-            region="US",
-            uniform_bucket_level_access=True,
-            public=False,
-            project_id=GCP_PROJECT_ID,
-        )]
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -62,23 +60,46 @@ class TestCloudStorageBucketPublicAccess:
             "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import cloudstorage_bucket_public_access
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import (
+                cloudstorage_bucket_public_access,
+            )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+
+            cloudstorage_client.buckets = [
+                Bucket(
+                    name="bucket2",
+                    id="bucket2",
+                    region="US",
+                    uniform_bucket_level_access=True,
+                    public=False,
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
 
             check = cloudstorage_bucket_public_access()
             result = check.execute()
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert re.search("Bucket .* is not publicly accessible", result[0].status_extended)
+            assert re.search(
+                "Bucket .* is not publicly accessible", result[0].status_extended
+            )
             assert result[0].resource_id == "bucket2"
+            assert result[0].resource_name == "bucket2"
+            assert result[0].location == "US"
+            assert result[0].project_id == GCP_PROJECT_ID
 
     def test_no_buckets(self):
         cloudstorage_client = mock.MagicMock()
-        logging_client = mock.MagicMock()
-        
+
         cloudstorage_client.project_ids = [GCP_PROJECT_ID]
         cloudstorage_client.region = "global"
-        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
 
         cloudstorage_client.buckets = []
 
@@ -96,4 +117,4 @@ class TestCloudStorageBucketPublicAccess:
             check = cloudstorage_bucket_public_access()
             result = check.execute()
 
-            assert len(result) == 0        
+            assert len(result) == 0

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
@@ -1,4 +1,3 @@
-import re
 from unittest import mock
 
 from tests.providers.gcp.gcp_fixtures import (
@@ -45,9 +44,9 @@ class TestCloudStorageBucketPublicAccess:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert re.search(
-                f"Bucket {cloudstorage_client.buckets[0].name} is publicly accessible",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Bucket {cloudstorage_client.buckets[0].name} is publicly accessible"
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"
@@ -90,9 +89,9 @@ class TestCloudStorageBucketPublicAccess:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert re.search(
-                f"Bucket {cloudstorage_client.buckets[0].name} is not publicly accessible",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Bucket {cloudstorage_client.buckets[0].name} is not publicly accessible"
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
@@ -98,11 +98,6 @@ class TestCloudStorageBucketPublicAccess:
     def test_no_buckets(self):
         cloudstorage_client = mock.MagicMock()
 
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-
-        cloudstorage_client.buckets = []
-
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=set_mocked_gcp_provider(),
@@ -113,6 +108,10 @@ class TestCloudStorageBucketPublicAccess:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import (
                 cloudstorage_bucket_public_access,
             )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+            cloudstorage_client.buckets = []
 
             check = cloudstorage_bucket_public_access()
             result = check.execute()

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_public_access/cloudstorage_bucket_public_access_test.py
@@ -1,0 +1,73 @@
+from unittest import mock
+import re
+
+from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+
+class TestCloudStorageBucketPublicAccess:
+    def test_bucket_public_access(self):
+        cloudstorage_client = mock.MagicMock()
+        
+        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+        cloudstorage_client.region = "global"
+
+        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
+
+        cloudstorage_client.buckets = [Bucket(
+            name="bucket1",
+            id="bucket1",
+            region="US",
+            uniform_bucket_level_access=True,
+            public=True,
+            project_id=GCP_PROJECT_ID,
+        )]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access.cloudstorage_client",
+            new=cloudstorage_client,
+        ):
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import cloudstorage_bucket_public_access
+
+            check = cloudstorage_bucket_public_access()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert re.search("Bucket .* is publicly accessible", result[0].status_extended)
+            assert result[0].resource_id == "bucket1"
+
+    def test_bucket_no_public_access(self):
+        cloudstorage_client = mock.MagicMock()
+        
+        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+        cloudstorage_client.region = "global"
+
+        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
+
+        cloudstorage_client.buckets = [Bucket(
+            name="bucket2",
+            id="bucket2",
+            region="US",
+            uniform_bucket_level_access=True,
+            public=False,
+            project_id=GCP_PROJECT_ID,
+        )]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access.cloudstorage_client",
+            new=cloudstorage_client,
+        ):
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import cloudstorage_bucket_public_access
+
+            check = cloudstorage_bucket_public_access()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert re.search("Bucket .* is not publicly accessible", result[0].status_extended)
+            assert result[0].resource_id == "bucket2"

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
@@ -1,24 +1,12 @@
+import re
 from unittest import mock
 
 from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
 
+
 class TestCloudStorageBucketUniformBucketLevelAccess:
     def test_bucket_with_uniform_bucket_level_access_enabled(self):
         cloudstorage_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-
-        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
-
-        cloudstorage_client.buckets = [Bucket(
-            name="bucket1",
-            id="bucket1",
-            region="US",
-            uniform_bucket_level_access=True,
-            public=False,
-            project_id=GCP_PROJECT_ID,
-        )]
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -27,32 +15,44 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import cloudstorage_bucket_uniform_bucket_level_access
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import (
+                cloudstorage_bucket_uniform_bucket_level_access,
+            )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+
+            cloudstorage_client.buckets = [
+                Bucket(
+                    name="bucket1",
+                    id="bucket1",
+                    region="US",
+                    uniform_bucket_level_access=True,
+                    public=False,
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
 
             check = cloudstorage_bucket_uniform_bucket_level_access()
             result = check.execute()
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert "Bucket bucket1 has uniform Bucket Level Access enabled." in result[0].status_extended
+            assert re.search(
+                "Bucket .* has uniform Bucket Level Access enabled.",
+                result[0].status_extended,
+            )
             assert result[0].resource_id == "bucket1"
+            assert result[0].resource_name == "bucket1"
+            assert result[0].location == "US"
+            assert result[0].project_id == GCP_PROJECT_ID
 
     def test_bucket_with_uniform_bucket_level_access_disabled(self):
         cloudstorage_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-
-        from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import Bucket
-
-        cloudstorage_client.buckets = [Bucket(
-            name="bucket2",
-            id="bucket2",
-            region="US",
-            uniform_bucket_level_access=False,
-            public=False,
-            project_id=GCP_PROJECT_ID,
-        )]
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -61,22 +61,44 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import cloudstorage_bucket_uniform_bucket_level_access
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import (
+                cloudstorage_bucket_uniform_bucket_level_access,
+            )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
+                Bucket,
+            )
+
+            cloudstorage_client.buckets = [
+                Bucket(
+                    name="bucket2",
+                    id="bucket2",
+                    region="US",
+                    uniform_bucket_level_access=False,
+                    public=False,
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
 
             check = cloudstorage_bucket_uniform_bucket_level_access()
             result = check.execute()
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert "Bucket bucket2 has uniform Bucket Level Access disabled." in result[0].status_extended
+            assert re.search(
+                "Bucket bucket2 has uniform Bucket Level Access disabled.",
+                result[0].status_extended,
+            )
             assert result[0].resource_id == "bucket2"
+            assert result[0].resource_name == "bucket2"
+            assert result[0].location == "US"
+            assert result[0].project_id == GCP_PROJECT_ID
 
     def test_no_buckets(self):
         cloudstorage_client = mock.MagicMock()
-        
-        cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-        cloudstorage_client.region = "global"
-        cloudstorage_client.buckets = []
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -85,7 +107,13 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import cloudstorage_bucket_uniform_bucket_level_access
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import (
+                cloudstorage_bucket_uniform_bucket_level_access,
+            )
+
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = "global"
+            cloudstorage_client.buckets = []
 
             check = cloudstorage_bucket_uniform_bucket_level_access()
             result = check.execute()

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
@@ -1,7 +1,11 @@
 import re
 from unittest import mock
 
-from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_PROJECT_ID,
+    GCP_US_CENTER1_LOCATION,
+    set_mocked_gcp_provider,
+)
 
 
 class TestCloudStorageBucketUniformBucketLevelAccess:
@@ -18,19 +22,18 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import (
                 cloudstorage_bucket_uniform_bucket_level_access,
             )
-
-            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
                 Bucket,
             )
 
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
+
             cloudstorage_client.buckets = [
                 Bucket(
-                    name="bucket1",
-                    id="bucket1",
-                    region="US",
+                    name="example-bucket",
+                    id="example-bucket",
+                    region=GCP_US_CENTER1_LOCATION,
                     uniform_bucket_level_access=True,
                     public=False,
                     project_id=GCP_PROJECT_ID,
@@ -43,12 +46,12 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert re.search(
-                "Bucket .* has uniform Bucket Level Access enabled.",
+                f"Bucket {cloudstorage_client.buckets[0].name} has uniform Bucket Level Access enabled.",
                 result[0].status_extended,
             )
-            assert result[0].resource_id == "bucket1"
-            assert result[0].resource_name == "bucket1"
-            assert result[0].location == "US"
+            assert result[0].resource_id == "example-bucket"
+            assert result[0].resource_name == "example-bucket"
+            assert result[0].location == GCP_US_CENTER1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_bucket_with_uniform_bucket_level_access_disabled(self):
@@ -64,19 +67,18 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import (
                 cloudstorage_bucket_uniform_bucket_level_access,
             )
-
-            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
-
             from prowler.providers.gcp.services.cloudstorage.cloudstorage_service import (
                 Bucket,
             )
 
+            cloudstorage_client.project_ids = [GCP_PROJECT_ID]
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
+
             cloudstorage_client.buckets = [
                 Bucket(
-                    name="bucket2",
-                    id="bucket2",
-                    region="US",
+                    name="example-bucket",
+                    id="example-bucket",
+                    region=GCP_US_CENTER1_LOCATION,
                     uniform_bucket_level_access=False,
                     public=False,
                     project_id=GCP_PROJECT_ID,
@@ -89,12 +91,12 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert re.search(
-                "Bucket bucket2 has uniform Bucket Level Access disabled.",
+                f"Bucket {cloudstorage_client.buckets[0].name} has uniform Bucket Level Access disabled.",
                 result[0].status_extended,
             )
-            assert result[0].resource_id == "bucket2"
-            assert result[0].resource_name == "bucket2"
-            assert result[0].location == "US"
+            assert result[0].resource_id == "example-bucket"
+            assert result[0].resource_name == "example-bucket"
+            assert result[0].location == GCP_US_CENTER1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_no_buckets(self):
@@ -112,7 +114,7 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
             )
 
             cloudstorage_client.project_ids = [GCP_PROJECT_ID]
-            cloudstorage_client.region = "global"
+            cloudstorage_client.region = GCP_US_CENTER1_LOCATION
             cloudstorage_client.buckets = []
 
             check = cloudstorage_bucket_uniform_bucket_level_access()

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
@@ -1,10 +1,9 @@
 from unittest import mock
-import re
 
 from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
 
-class TestCloudStorageBucketPublicAccess:
-    def test_bucket_public_access(self):
+class TestCloudStorageBucketUniformBucketLevelAccess:
+    def test_bucket_with_uniform_bucket_level_access_enabled(self):
         cloudstorage_client = mock.MagicMock()
         
         cloudstorage_client.project_ids = [GCP_PROJECT_ID]
@@ -17,7 +16,7 @@ class TestCloudStorageBucketPublicAccess:
             id="bucket1",
             region="US",
             uniform_bucket_level_access=True,
-            public=True,
+            public=False,
             project_id=GCP_PROJECT_ID,
         )]
 
@@ -25,20 +24,20 @@ class TestCloudStorageBucketPublicAccess:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=set_mocked_gcp_provider(),
         ), mock.patch(
-            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access.cloudstorage_client",
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import cloudstorage_bucket_public_access
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import cloudstorage_bucket_uniform_bucket_level_access
 
-            check = cloudstorage_bucket_public_access()
+            check = cloudstorage_bucket_uniform_bucket_level_access()
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].status == "FAIL"
-            assert re.search("Bucket .* is publicly accessible", result[0].status_extended)
+            assert result[0].status == "PASS"
+            assert "Bucket bucket1 has uniform Bucket Level Access enabled." in result[0].status_extended
             assert result[0].resource_id == "bucket1"
 
-    def test_bucket_no_public_access(self):
+    def test_bucket_with_uniform_bucket_level_access_disabled(self):
         cloudstorage_client = mock.MagicMock()
         
         cloudstorage_client.project_ids = [GCP_PROJECT_ID]
@@ -50,7 +49,7 @@ class TestCloudStorageBucketPublicAccess:
             name="bucket2",
             id="bucket2",
             region="US",
-            uniform_bucket_level_access=True,
+            uniform_bucket_level_access=False,
             public=False,
             project_id=GCP_PROJECT_ID,
         )]
@@ -59,41 +58,36 @@ class TestCloudStorageBucketPublicAccess:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=set_mocked_gcp_provider(),
         ), mock.patch(
-            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access.cloudstorage_client",
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import cloudstorage_bucket_public_access
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import cloudstorage_bucket_uniform_bucket_level_access
 
-            check = cloudstorage_bucket_public_access()
+            check = cloudstorage_bucket_uniform_bucket_level_access()
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].status == "PASS"
-            assert re.search("Bucket .* is not publicly accessible", result[0].status_extended)
+            assert result[0].status == "FAIL"
+            assert "Bucket bucket2 has uniform Bucket Level Access disabled." in result[0].status_extended
             assert result[0].resource_id == "bucket2"
 
     def test_no_buckets(self):
         cloudstorage_client = mock.MagicMock()
-        logging_client = mock.MagicMock()
         
         cloudstorage_client.project_ids = [GCP_PROJECT_ID]
         cloudstorage_client.region = "global"
-        logging_client.sinks = [mock.MagicMock(destination="storage.googleapis.com/bucket1")]
-
         cloudstorage_client.buckets = []
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=set_mocked_gcp_provider(),
         ), mock.patch(
-            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access.cloudstorage_client",
+            "prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_client",
             new=cloudstorage_client,
         ):
-            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_public_access.cloudstorage_bucket_public_access import (
-                cloudstorage_bucket_public_access,
-            )
+            from prowler.providers.gcp.services.cloudstorage.cloudstorage_bucket_uniform_bucket_level_access.cloudstorage_bucket_uniform_bucket_level_access import cloudstorage_bucket_uniform_bucket_level_access
 
-            check = cloudstorage_bucket_public_access()
+            check = cloudstorage_bucket_uniform_bucket_level_access()
             result = check.execute()
 
-            assert len(result) == 0        
+            assert len(result) == 0

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_bucket_uniform_bucket_level_access/cloudstorage_bucket_uniform_bucket_level_access_test.py
@@ -1,4 +1,3 @@
-import re
 from unittest import mock
 
 from tests.providers.gcp.gcp_fixtures import (
@@ -45,9 +44,9 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
 
             assert len(result) == 1
             assert result[0].status == "PASS"
-            assert re.search(
-                f"Bucket {cloudstorage_client.buckets[0].name} has uniform Bucket Level Access enabled.",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Bucket {cloudstorage_client.buckets[0].name} has uniform Bucket Level Access enabled."
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"
@@ -90,9 +89,9 @@ class TestCloudStorageBucketUniformBucketLevelAccess:
 
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert re.search(
-                f"Bucket {cloudstorage_client.buckets[0].name} has uniform Bucket Level Access disabled.",
-                result[0].status_extended,
+            assert (
+                result[0].status_extended
+                == f"Bucket {cloudstorage_client.buckets[0].name} has uniform Bucket Level Access disabled."
             )
             assert result[0].resource_id == "example-bucket"
             assert result[0].resource_name == "example-bucket"


### PR DESCRIPTION
### Context

There was some checks without tests for CloudStorage in GCP provider.

### Description

Added new tests for:

- [x] `cloudstorage_bucket_log_retention_policy_lock` check
- [x] `cloudstorage_bucket_public_access` check
- [x] `cloudstorage_bucket_uniform_bucket_level_access` check


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
