### PR TITLE
fix(ssm): add missing ResourceArn to SSM check

### DIFF
--- a/prowler/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching.py
+++ b/prowler/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching.py
@@ -10,7 +10,7 @@ class ssm_managed_compliant_patching(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = resource.region
             report.resource_id = resource.id
-
+            report.resource_arn = resource.arn
             if resource.status == ResourceStatus.COMPLIANT:
                 report.status = "PASS"
                 report.status_extended = (

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -115,11 +115,11 @@ class SSM(AWSService):
             )
             for page in list_resource_compliance_summaries_paginator.paginate():
                 for item in page["ResourceComplianceSummaryItems"]:
-                    resource_arn = f"arn:{self.audited_partition}:ec2:{regional_client.region}:{self.audited_account}:instance/{item["ResourceId"]}"
+                    resource_id = item["ResourceId"]
+                    resource_arn = f"arn:{self.audited_partition}:ec2:{regional_client.region}:{self.audited_account}:instance/{resource_id}"
                     if not self.audit_resources or (
                         is_resource_filtered(resource_arn, self.audit_resources)
                     ):
-                        resource_id = item["ResourceId"]
                         resource_status = item["Status"]
 
                         self.compliance_resources[resource_id] = ComplianceResource(

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -115,14 +115,19 @@ class SSM(AWSService):
             )
             for page in list_resource_compliance_summaries_paginator.paginate():
                 for item in page["ResourceComplianceSummaryItems"]:
-                    resource_id = item["ResourceId"]
-                    resource_status = item["Status"]
+                    resource_arn = f"arn:{self.audited_partition}:ec2:{regional_client.region}:{self.audited_account}:instance/{item["ResourceId"]}"
+                    if not self.audit_resources or (
+                        is_resource_filtered(resource_arn, self.audit_resources)
+                    ):
+                        resource_id = item["ResourceId"]
+                        resource_status = item["Status"]
 
-                    self.compliance_resources[resource_id] = ComplianceResource(
-                        id=resource_id,
-                        status=resource_status,
-                        region=regional_client.region,
-                    )
+                        self.compliance_resources[resource_id] = ComplianceResource(
+                            id=resource_id,
+                            arn=resource_arn,
+                            status=resource_status,
+                            region=regional_client.region,
+                        )
 
         except Exception as error:
             logger.error(
@@ -166,6 +171,7 @@ class ResourceStatus(Enum):
 
 class ComplianceResource(BaseModel):
     id: str
+    arn: str
     region: str
     status: ResourceStatus
 

--- a/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
+++ b/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
@@ -32,6 +32,7 @@ class Test_ssm_managed_compliant_patching:
         ssm_client.compliance_resources = {
             instance_id: ComplianceResource(
                 id="i-1234567890abcdef0",
+                arn=f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{instance_id}",
                 region=AWS_REGION_US_EAST_1,
                 status=ResourceStatus.COMPLIANT,
             )
@@ -52,6 +53,10 @@ class Test_ssm_managed_compliant_patching:
             assert len(result) == 1
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == instance_id
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{instance_id}"
+            )
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
@@ -65,6 +70,7 @@ class Test_ssm_managed_compliant_patching:
         ssm_client.compliance_resources = {
             instance_id: ComplianceResource(
                 id="i-1234567890abcdef0",
+                arn=f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{instance_id}",
                 region=AWS_REGION_US_EAST_1,
                 status=ResourceStatus.NON_COMPLIANT,
             )
@@ -85,6 +91,10 @@ class Test_ssm_managed_compliant_patching:
             assert len(result) == 1
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_id == instance_id
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{instance_id}"
+            )
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended

--- a/tests/providers/aws/services/ssm/ssm_service_test.py
+++ b/tests/providers/aws/services/ssm/ssm_service_test.py
@@ -196,5 +196,9 @@ class Test_SSM_Service:
         assert ssm.compliance_resources
         assert ssm.compliance_resources[instance_id]
         assert ssm.compliance_resources[instance_id].id == instance_id
+        assert (
+            ssm.compliance_resources[instance_id].arn
+            == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:instance/{instance_id}"
+        )
         assert ssm.compliance_resources[instance_id].region == AWS_REGION_US_EAST_1
         assert ssm.compliance_resources[instance_id].status == ResourceStatus.COMPLIANT


### PR DESCRIPTION
### Description

Add missing ResourceArn to SSM check `ssm_managed_compliant_patching` so it is a valid finding for SecurityHub.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
