### PR TITLE
fix(azure): use finding location

### DIFF
--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -8,7 +8,7 @@ def stdout_report(finding, color, verbose, status, fix):
     if finding.check_metadata.Provider == "aws":
         details = finding.region
     if finding.check_metadata.Provider == "azure":
-        details = finding.check_metadata.ServiceName
+        details = finding.location
     if finding.check_metadata.Provider == "gcp":
         details = finding.location.lower()
     if finding.check_metadata.Provider == "kubernetes":


### PR DESCRIPTION
### Description

Use finding.location for Azure findings since we were using `finding.check_metadata.ServiceName`


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
