### PR TITLE
docs(services): Fixed changed links

### DIFF
--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -23,8 +23,8 @@ The Prowler's service structure is the following and the way to initialise it is
 All the Prowler provider's services inherits from a base class depending on the provider used.
 
 - [AWS Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/aws/lib/service/service.py)
-- [GCP Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/lib/service/service.py)
-- [Azure Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/gcp/lib/service/service.py)
+- [GCP Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/gcp/lib/service/service.py)
+- [Azure Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/azure/lib/service/service.py)
 - [Kubernetes Service Base Class](https://github.com/prowler-cloud/prowler/blob/master/prowler/providers/kubernetes/lib/service/service.py)
 
 Each class is used to initialize the credentials and the API's clients to be used in the service. If some threading is used it must be coded there.


### PR DESCRIPTION
### Context

Mistakes between GCP and Azure link references in services related documentation.


### Description

Switch between Azure and GCP reference links in [services.md](https://docs.prowler.com/projects/prowler-open-source/en/latest/developer-guide/services/#:~:text=To%20create%20a%20new%20service%2C%20you%20will%20need%20to%20create,service%20folder%20as%20a%20package.).


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
