### PR TITLE
chore(cloudsql): Change default cases for CloudSQL checks and remaining tests

### DIFF
--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_mysql_local_infile_flag/cloudsql_instance_mysql_local_infile_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_mysql_local_infile_flag/cloudsql_instance_mysql_local_infile_flag.py
@@ -15,7 +15,10 @@ class cloudsql_instance_mysql_local_infile_flag(Check):
                 report.status = "FAIL"
                 report.status_extended = f"MySQL Instance {instance.name} does not have 'local_infile' flag set to 'off'."
                 for flag in instance.flags:
-                    if flag["name"] == "local_infile" and flag["value"] == "off":
+                    if (
+                        flag.get("name", "") == "local_infile"
+                        and flag.get("value", "on") == "off"
+                    ):
                         report.status = "PASS"
                         report.status_extended = f"MySQL Instance {instance.name} has 'local_infile' flag set to 'off'."
                         break

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_mysql_skip_show_database_flag/cloudsql_instance_mysql_skip_show_database_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_mysql_skip_show_database_flag/cloudsql_instance_mysql_skip_show_database_flag.py
@@ -15,7 +15,10 @@ class cloudsql_instance_mysql_skip_show_database_flag(Check):
                 report.status = "FAIL"
                 report.status_extended = f"MySQL Instance {instance.name} does not have 'skip_show_database' flag set to 'on'."
                 for flag in instance.flags:
-                    if flag["name"] == "skip_show_database" and flag["value"] == "on":
+                    if (
+                        flag.get("name", "") == "skip_show_database"
+                        and flag.get("value", "off") == "on"
+                    ):
                         report.status = "PASS"
                         report.status_extended = f"MySQL Instance {instance.name} has 'skip_show_database' flag set to 'on'."
                         break

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_enable_pgaudit_flag/cloudsql_instance_postgres_enable_pgaudit_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_enable_pgaudit_flag/cloudsql_instance_postgres_enable_pgaudit_flag.py
@@ -16,8 +16,8 @@ class cloudsql_instance_postgres_enable_pgaudit_flag(Check):
                 report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'cloudsql.enable_pgaudit' flag set to 'on'."
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "cloudsql.enable_pgaudit"
-                        and flag["value"] == "on"
+                        flag.get("name", "") == "cloudsql.enable_pgaudit"
+                        and flag.get("value", "off") == "on"
                     ):
                         report.status = "PASS"
                         report.status_extended = f"PostgreSQL Instance {instance.name} has 'cloudsql.enable_pgaudit' flag set to 'on'."

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_connections_flag/cloudsql_instance_postgres_log_connections_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_connections_flag/cloudsql_instance_postgres_log_connections_flag.py
@@ -15,7 +15,10 @@ class cloudsql_instance_postgres_log_connections_flag(Check):
                 report.status = "FAIL"
                 report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_connections' flag set to 'on'."
                 for flag in instance.flags:
-                    if flag["name"] == "log_connections" and flag["value"] == "on":
+                    if (
+                        flag.get("name", "") == "log_connections"
+                        and flag.get("value", "off") == "on"
+                    ):
                         report.status = "PASS"
                         report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_connections' flag set to 'on'."
                         break

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_disconnections_flag/cloudsql_instance_postgres_log_disconnections_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_disconnections_flag/cloudsql_instance_postgres_log_disconnections_flag.py
@@ -15,7 +15,10 @@ class cloudsql_instance_postgres_log_disconnections_flag(Check):
                 report.status = "FAIL"
                 report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_disconnections' flag set to 'on'."
                 for flag in instance.flags:
-                    if flag["name"] == "log_disconnections" and flag["value"] == "on":
+                    if (
+                        flag.get("name", "") == "log_disconnections"
+                        and flag.get("value", "off") == "on"
+                    ):
                         report.status = "PASS"
                         report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_disconnections' flag set to 'on'."
                         break

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_error_verbosity_flag/cloudsql_instance_postgres_log_error_verbosity_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_error_verbosity_flag/cloudsql_instance_postgres_log_error_verbosity_flag.py
@@ -12,15 +12,15 @@ class cloudsql_instance_postgres_log_error_verbosity_flag(Check):
                 report.resource_id = instance.name
                 report.resource_name = instance.name
                 report.location = instance.region
-                report.status = "FAIL"
-                report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_error_verbosity' flag set to 'default'."
+                report.status = "PASS"
+                report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_error_verbosity' flag set to 'default'."
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "log_error_verbosity"
-                        and flag["value"] == "default"
+                        flag.get("name", "") == "log_error_verbosity"
+                        and flag.get("value", "default") != "default"
                     ):
-                        report.status = "PASS"
-                        report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_error_verbosity' flag set to 'default'."
+                        report.status = "FAIL"
+                        report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_error_verbosity' flag set to 'default'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_duration_statement_flag/cloudsql_instance_postgres_log_min_duration_statement_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_duration_statement_flag/cloudsql_instance_postgres_log_min_duration_statement_flag.py
@@ -12,15 +12,15 @@ class cloudsql_instance_postgres_log_min_duration_statement_flag(Check):
                 report.resource_id = instance.name
                 report.resource_name = instance.name
                 report.location = instance.region
-                report.status = "FAIL"
-                report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_min_duration_statement' flag set to '-1'."
+                report.status = "PASS"
+                report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_duration_statement' flag set to '-1'."
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "log_min_duration_statement"
-                        and flag["value"] == "-1"
+                        flag.get("name", "") == "log_min_duration_statement"
+                        and flag.get("value", "-1") != "-1"
                     ):
-                        report.status = "PASS"
-                        report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_duration_statement' flag set to '-1'."
+                        report.status = "FAIL"
+                        report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_min_duration_statement' flag set to '-1'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_error_statement_flag/cloudsql_instance_postgres_log_min_error_statement_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_error_statement_flag/cloudsql_instance_postgres_log_min_error_statement_flag.py
@@ -13,15 +13,17 @@ class cloudsql_instance_postgres_log_min_error_statement_flag(Check):
                 report.resource_id = instance.name
                 report.resource_name = instance.name
                 report.location = instance.region
-                report.status = "FAIL"
-                report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_min_error_statement' flag set minimum to '{desired_log_min_error_statement}'."
+                report.status = "PASS"
+                report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_error_statement' flag set minimum to '{desired_log_min_error_statement}'."
+
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "log_min_error_statement"
-                        and flag["value"] == desired_log_min_error_statement
+                        flag.get("name", "") == "log_min_error_statement"
+                        and flag.get("value", "error")
+                        != desired_log_min_error_statement
                     ):
-                        report.status = "PASS"
-                        report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_error_statement' flag set minimum to '{desired_log_min_error_statement}'."
+                        report.status = "FAIL"
+                        report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_min_error_statement' flag set minimum to '{desired_log_min_error_statement}'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag.py
@@ -17,8 +17,8 @@ class cloudsql_instance_postgres_log_min_messages_flag(Check):
                 report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_min_messages' flag set minimum to '{desired_log_min_messages}'."
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "log_min_messages"
-                        and flag["value"] == desired_log_min_messages
+                        flag.get("name", "") == "log_min_messages"
+                        and flag.get("value", "warning") == desired_log_min_messages
                     ):
                         report.status = "PASS"
                         report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_messages' flag set minimum to '{desired_log_min_messages}'."

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_statement_flag/cloudsql_instance_postgres_log_statement_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_statement_flag/cloudsql_instance_postgres_log_statement_flag.py
@@ -17,8 +17,8 @@ class cloudsql_instance_postgres_log_statement_flag(Check):
                 report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_statement' flag set to '{desired_log_statement}'."
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "log_statement"
-                        and flag["value"] == desired_log_statement
+                        flag.get("name", "") == "log_statement"
+                        and flag.get("value", "none") == desired_log_statement
                     ):
                         report.status = "PASS"
                         report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_statement' flag set to '{desired_log_statement}'."

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag.py
@@ -16,8 +16,8 @@ class cloudsql_instance_sqlserver_contained_database_authentication_flag(Check):
                 report.status_extended = f"SQL Server Instance {instance.name} has 'contained database authentication' flag set to 'off'."
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "contained database authentication"
-                        and flag["value"] == "on"
+                        flag.get("name", "") == "contained database authentication"
+                        and flag.get("value", "off") == "on"
                     ):
                         report.status = "FAIL"
                         report.status_extended = f"SQL Server Instance {instance.name} has 'contained database authentication' flag set to 'on'."

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.py
@@ -13,11 +13,14 @@ class cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag(Check):
                 report.resource_name = instance.name
                 report.location = instance.region
                 report.status = "PASS"
-                report.status_extended = f"SQL Server Instance {instance.name} has 'cross db ownership' flag set to 'off'."
+                report.status_extended = f"SQL Server Instance {instance.name} has 'cross db ownership chaining' flag set to 'off'."
                 for flag in instance.flags:
-                    if flag["name"] == "cross db ownership" and flag["value"] == "on":
+                    if (
+                        flag.get("name", "") == "cross db ownership chaining"
+                        and flag.get("value", "off") == "on"
+                    ):
                         report.status = "FAIL"
-                        report.status_extended = f"SQL Server Instance {instance.name} does not have 'cross db ownership' flag set to 'off'."
+                        report.status_extended = f"SQL Server Instance {instance.name} does not have 'cross db ownership chaining' flag set to 'off'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_external_scripts_enabled_flag/cloudsql_instance_sqlserver_external_scripts_enabled_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_external_scripts_enabled_flag/cloudsql_instance_sqlserver_external_scripts_enabled_flag.py
@@ -16,8 +16,8 @@ class cloudsql_instance_sqlserver_external_scripts_enabled_flag(Check):
                 report.status_extended = f"SQL Server Instance {instance.name} has 'external scripts enabled' flag set to 'off'."
                 for flag in instance.flags:
                     if (
-                        flag["name"] == "external scripts enabled"
-                        and flag["value"] == "on"
+                        flag.get("name", "") == "external scripts enabled"
+                        and flag.get("value", "off") == "on"
                     ):
                         report.status = "FAIL"
                         report.status_extended = f"SQL Server Instance {instance.name} does not have 'external scripts enabled' flag set to 'off'."

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_remote_access_flag/cloudsql_instance_sqlserver_remote_access_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_remote_access_flag/cloudsql_instance_sqlserver_remote_access_flag.py
@@ -12,12 +12,15 @@ class cloudsql_instance_sqlserver_remote_access_flag(Check):
                 report.resource_id = instance.name
                 report.resource_name = instance.name
                 report.location = instance.region
-                report.status = "PASS"
-                report.status_extended = f"SQL Server Instance {instance.name} does not have 'remote access' flag set to 'on'."
+                report.status = "FAIL"
+                report.status_extended = f"SQL Server Instance {instance.name} has 'remote access' flag set to 'on'."
                 for flag in instance.flags:
-                    if flag["name"] == "remote access" and flag["value"] == "on":
-                        report.status = "FAIL"
-                        report.status_extended = f"SQL Server Instance {instance.name} has 'remote access' flag set to 'on'."
+                    if (
+                        flag.get("name", "") == "remote access"
+                        and flag.get("value", "on") != "on"
+                    ):
+                        report.status = "PASS"
+                        report.status_extended = f"SQL Server Instance {instance.name} does not have 'remote access' flag set to 'on'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag.py
@@ -12,12 +12,16 @@ class cloudsql_instance_sqlserver_trace_flag(Check):
                 report.resource_id = instance.name
                 report.resource_name = instance.name
                 report.location = instance.region
-                report.status = "PASS"
-                report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'on'."
+                report.status = "FAIL"
+                report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'off'."
+
                 for flag in instance.flags:
-                    if flag["name"] == "3625" and flag["value"] == "off":
-                        report.status = "FAIL"
-                        report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'off'."
+                    if (
+                        flag.get("name", "") == "3625"
+                        and flag.get("value", "off") == "on"
+                    ):
+                        report.status = "PASS"
+                        report.status_extended = f"SQL Server Instance {instance.name} has '3625 (trace flag)' flag set to 'on'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag.py
@@ -12,12 +12,16 @@ class cloudsql_instance_sqlserver_user_connections_flag(Check):
                 report.resource_id = instance.name
                 report.resource_name = instance.name
                 report.location = instance.region
-                report.status = "FAIL"
-                report.status_extended = f"SQL Server Instance {instance.name} does not have 'user connections' flag set to '0'."
+                report.status = "PASS"
+                report.status_extended = f"SQL Server Instance {instance.name} has 'user connections' flag set to '0'."
+
                 for flag in instance.flags:
-                    if flag["name"] == "user connections" and flag["value"] == "0":
-                        report.status = "PASS"
-                        report.status_extended = f"SQL Server Instance {instance.name} has 'user connections' flag set to '0'."
+                    if (
+                        flag.get("name", "") == "user connections"
+                        and flag.get("value", "0") != "0"
+                    ):
+                        report.status = "FAIL"
+                        report.status_extended = f"SQL Server Instance {instance.name} does not have 'user connections' flag set to '0'."
                         break
                 findings.append(report)
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_options_flag/cloudsql_instance_sqlserver_user_options_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_options_flag/cloudsql_instance_sqlserver_user_options_flag.py
@@ -15,7 +15,10 @@ class cloudsql_instance_sqlserver_user_options_flag(Check):
                 report.status = "PASS"
                 report.status_extended = f"SQL Server Instance {instance.name} does not have 'user options' flag set."
                 for flag in instance.flags:
-                    if flag["name"] == "user options" and flag["value"] != "":
+                    if (
+                        flag.get("name", "") == "user options"
+                        and flag.get("value", "") != ""
+                    ):
                         report.status = "FAIL"
                         report.status_extended = f"SQL Server Instance {instance.name} has 'user options' flag set."
                         break

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_error_verbosity_flag/cloudsql_instance_postgres_log_error_verbosity_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_error_verbosity_flag/cloudsql_instance_postgres_log_error_verbosity_flag_test.py
@@ -99,10 +99,10 @@ class Test_cloudsql_instance_postgres_log_error_verbosity_flag:
             check = cloudsql_instance_postgres_log_error_verbosity_flag()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "PostgreSQL Instance instance1 does not have 'log_error_verbosity' flag set to 'default'."
+                == "PostgreSQL Instance instance1 has 'log_error_verbosity' flag set to 'default'."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_duration_statement_flag/cloudsql_instance_postgres_log_min_duration_statement_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_duration_statement_flag/cloudsql_instance_postgres_log_min_duration_statement_flag_test.py
@@ -99,10 +99,10 @@ class Test_cloudsql_instance_postgres_log_min_duration_statement_flag:
             check = cloudsql_instance_postgres_log_min_duration_statement_flag()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "PostgreSQL Instance instance1 does not have 'log_min_duration_statement' flag set to '-1'."
+                == "PostgreSQL Instance instance1 has 'log_min_duration_statement' flag set to '-1'."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_error_statement_flag/cloudsql_instance_postgres_log_min_error_statement_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_error_statement_flag/cloudsql_instance_postgres_log_min_error_statement_flag_test.py
@@ -99,10 +99,10 @@ class Test_cloudsql_instance_postgres_log_min_error_statement_flag:
             check = cloudsql_instance_postgres_log_min_error_statement_flag()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "PostgreSQL Instance instance1 does not have 'log_min_error_statement' flag set minimum to 'error'."
+                == "PostgreSQL Instance instance1 has 'log_min_error_statement' flag set minimum to 'error'."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_contained_database_authentication_flag/cloudsql_instance_sqlserver_contained_database_authentication_flag_test.py
@@ -64,6 +64,51 @@ class Test_cloudsql_instance_sqlserver_contained_database_authentication_flag:
             result = check.execute()
             assert len(result) == 0
 
+    def test_cloudsql_instance_no_flags(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_contained_database_authentication_flag.cloudsql_instance_sqlserver_contained_database_authentication_flag import (
+                cloudsql_instance_sqlserver_contained_database_authentication_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019_STANDARD",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_contained_database_authentication_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'contained database authentication' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_cloudsql_instance_contained_database_authentication_flag_on(self):
         cloudsql_client = mock.MagicMock
 

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag/cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag_test.py
@@ -64,6 +64,51 @@ class Test_cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag:
             result = check.execute()
             assert len(result) == 0
 
+    def test_cloudsql_instance_no_flags(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag.cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag import (
+                cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019_STANDARD",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'cross db ownership chaining' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_cloudsql_instance_cross_db_ownership_flag_on(self):
         cloudsql_client = mock.MagicMock
 
@@ -91,7 +136,7 @@ class Test_cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag:
                     ssl=False,
                     automated_backups=True,
                     authorized_networks=[],
-                    flags=[{"name": "cross db ownership", "value": "on"}],
+                    flags=[{"name": "cross db ownership chaining", "value": "on"}],
                     project_id=GCP_PROJECT_ID,
                 )
             ]
@@ -102,7 +147,7 @@ class Test_cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "SQL Server Instance instance1 does not have 'cross db ownership' flag set to 'off'."
+                == "SQL Server Instance instance1 does not have 'cross db ownership chaining' flag set to 'off'."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"
@@ -136,7 +181,7 @@ class Test_cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag:
                     ssl=False,
                     automated_backups=True,
                     authorized_networks=[],
-                    flags=[{"name": "cross db ownership", "value": "off"}],
+                    flags=[{"name": "cross db ownership chaining", "value": "off"}],
                     project_id=GCP_PROJECT_ID,
                 )
             ]
@@ -147,7 +192,7 @@ class Test_cloudsql_instance_sqlserver_cross_db_ownership_chaining_flag:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "SQL Server Instance instance1 has 'cross db ownership' flag set to 'off'."
+                == "SQL Server Instance instance1 has 'cross db ownership chaining' flag set to 'off'."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_external_scripts_enabled_flag/cloudsql_instance_sqlserver_external_scripts_enabled_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_external_scripts_enabled_flag/cloudsql_instance_sqlserver_external_scripts_enabled_flag_test.py
@@ -64,6 +64,51 @@ class Test_cloudsql_instance_sqlserver_external_scripts_enabled_flag:
             result = check.execute()
             assert len(result) == 0
 
+    def test_cloudsql_sqlserver_instance_no_flags(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_external_scripts_enabled_flag.cloudsql_instance_sqlserver_external_scripts_enabled_flag import (
+                cloudsql_instance_sqlserver_external_scripts_enabled_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_external_scripts_enabled_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'external scripts enabled' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_cloudsql_sqlserver_instance_external_scripts_enabled_flag_on(self):
         cloudsql_client = mock.MagicMock
 

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_remote_access_flag/cloudsql_instance_sqlserver_remote_access_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_remote_access_flag/cloudsql_instance_sqlserver_remote_access_flag_test.py
@@ -64,6 +64,51 @@ class Test_cloudsql_instance_sqlserver_remote_access_flag:
             result = check.execute()
             assert len(result) == 0
 
+    def test_cloudsql_instance_no_flags(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_remote_access_flag.cloudsql_instance_sqlserver_remote_access_flag import (
+                cloudsql_instance_sqlserver_remote_access_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_remote_access_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'remote access' flag set to 'on'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_cloudsql_instance_remote_access_flag_on(self):
         cloudsql_client = mock.MagicMock
 

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_trace_flag/cloudsql_instance_sqlserver_trace_flag_test.py
@@ -64,6 +64,51 @@ class Test_cloudsql_instance_sqlserver_trace_flag:
             result = check.execute()
             assert len(result) == 0
 
+    def test_cloudsql_instance_no_flags(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_trace_flag.cloudsql_instance_sqlserver_trace_flag import (
+                cloudsql_instance_sqlserver_trace_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_trace_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has '3625 (trace flag)' flag set to 'off'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_cloudsql_instance_trace_flag_off(self):
         cloudsql_client = mock.MagicMock
 

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_connections_flag/cloudsql_instance_sqlserver_user_connections_flag_test.py
@@ -64,6 +64,51 @@ class Test_cloudsql_instance_sqlserver_user_connections_flag:
             result = check.execute()
             assert len(result) == 0
 
+    def test_cloudsql_sqlserver_instance_no_flags(self):
+        cloudsql_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_sqlserver_user_connections_flag.cloudsql_instance_sqlserver_user_connections_flag import (
+                cloudsql_instance_sqlserver_user_connections_flag,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="SQLSERVER_2019",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    ssl=False,
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_sqlserver_user_connections_flag()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "SQL Server Instance instance1 has 'user connections' flag set to '0'."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_cloudsql_sqlserver_instance_user_connections_flag_off(self):
         cloudsql_client = mock.MagicMock
 

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_options_flag/cloudsql_instance_sqlserver_user_options_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_sqlserver_user_options_flag/cloudsql_instance_sqlserver_user_options_flag_test.py
@@ -181,7 +181,7 @@ class Test_cloudsql_instance_sqlserver_user_options_flag:
                     ssl=False,
                     automated_backups=True,
                     authorized_networks=[],
-                    flags=[{"name": "user options", "value": "some_value"}],
+                    flags=[{"name": "user options", "value": "0"}],
                     project_id=GCP_PROJECT_ID,
                 )
             ]


### PR DESCRIPTION
### Context

This pull request addresses updates to the base cases for PASS or FAIL checks related to CloudSQL instances, aligning them with the default values provided by Google Cloud. Additionally, the remaining tests without flags have been added to ensure comprehensive coverage and validation of the checks.

### Description

This PR makes the following changes:

1. Adjusted the base cases for PASS or FAIL checks for CloudSQL instances to match the actual default values set by Google Cloud. This ensures that the checks are accurately aligned with the expected configuration and behavior of CloudSQL instances by default.
2. Added the remaining tests without flags to the test suite. This addition ensures that all possible configurations and scenarios are tested, improving the robustness and reliability of the checks.

The default values was extracted from [GCP Documentation](https://cloud.google.com/sql/docs/mysql/flags)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
