### PR TITLE
feat(aws): make check `eks_control_plane_logging_all_types_enabled` configurable

### DIFF
--- a/docs/tutorials/configuration_file.md
+++ b/docs/tutorials/configuration_file.md
@@ -43,6 +43,7 @@ The following list includes all the AWS checks with configurable variables that 
 | `ec2_securitygroup_allow_ingress_from_internet_to_any_port`   | `ec2_allowed_interface_types`                    | List of Strings |
 | `ec2_securitygroup_allow_ingress_from_internet_to_any_port`   | `ec2_allowed_instance_owners`                    | List of Strings |
 | `acm_certificates_expiration_check`                           | `days_to_expire_threshold`                       | Integer         |
+| `eks_control_plane_logging_all_types_enabled`                 | `eks_required_log_types`                         | List of Strings |
 
 
 ## Azure
@@ -354,6 +355,18 @@ aws:
   # AWS ACM Configuration
   # aws.acm_certificates_expiration_check
   days_to_expire_threshold: 7
+
+  # AWS EKS Configuration
+  # aws.eks_control_plane_logging_all_types_enabled
+  # EKS control plane logging types that must be enabled
+  eks_required_log_types:
+    [
+      "api",
+      "audit",
+      "authenticator",
+      "controllerManager",
+      "scheduler",
+    ]
 
 # Azure Configuration
 azure:

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -272,6 +272,18 @@ aws:
   # aws.acm_certificates_expiration_check
   days_to_expire_threshold: 7
 
+  # AWS EKS Configuration
+  # aws.eks_control_plane_logging_all_types_enabled
+  # EKS control plane logging types that must be enabled
+  eks_required_log_types:
+    [
+      "api",
+      "audit",
+      "authenticator",
+      "controllerManager",
+      "scheduler",
+    ]
+
 # Azure Configuration
 azure:
   # Azure Network Configuration

--- a/prowler/providers/aws/services/eks/eks_control_plane_logging_all_types_enabled/eks_control_plane_logging_all_types_enabled.metadata.json
+++ b/prowler/providers/aws/services/eks/eks_control_plane_logging_all_types_enabled/eks_control_plane_logging_all_types_enabled.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "eks_control_plane_logging_all_types_enabled",
-  "CheckTitle": "Ensure EKS Control Plane Audit Logging is enabled for all log types",
+  "CheckTitle": "Ensure EKS Control Plane Logging is enabled for all required log types",
   "CheckType": [
     "Logging and Monitoring"
   ],
@@ -10,8 +10,8 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "medium",
   "ResourceType": "AwsEksCluster",
-  "Description": "Ensure EKS Control Plane Audit Logging is enabled for all log types",
-  "Risk": "If logs are not enabled, monitoring of service use and threat analysis is not possible.",
+  "Description": "Ensure EKS Control Plane Logging is enabled for all required log types",
+  "Risk": "If logs are not enabled, monitoring of service use or threat analysis is not possible.",
   "RelatedUrl": "",
   "Remediation": {
     "Code": {
@@ -21,7 +21,7 @@
       "Terraform": "https://docs.prowler.com/checks/aws/kubernetes-policies-1/bc_aws_kubernetes_4#fix---buildtime"
     },
     "Recommendation": {
-      "Text": "Make sure you logging for EKS control plane is enabled.",
+      "Text": "Make sure logging for EKS control plane is enabled for all required log types.",
       "Url": "https://docs.aws.amazon.com/eks/latest/userguide/logging-monitoring.html"
     }
   },

--- a/prowler/providers/aws/services/eks/eks_control_plane_logging_all_types_enabled/eks_control_plane_logging_all_types_enabled.py
+++ b/prowler/providers/aws/services/eks/eks_control_plane_logging_all_types_enabled/eks_control_plane_logging_all_types_enabled.py
@@ -5,6 +5,9 @@ from prowler.providers.aws.services.eks.eks_client import eks_client
 class eks_control_plane_logging_all_types_enabled(Check):
     def execute(self):
         findings = []
+        required_log_types = eks_client.audit_config.get("eks_required_log_types", [])
+        required_log_types_str = ", ".join(required_log_types)
+
         for cluster in eks_client.clusters:
             report = Check_Report_AWS(self.metadata())
             report.region = cluster.region
@@ -12,24 +15,13 @@ class eks_control_plane_logging_all_types_enabled(Check):
             report.resource_arn = cluster.arn
             report.resource_tags = cluster.tags
             report.status = "FAIL"
-            report.status_extended = (
-                f"Control plane logging is not enabled for EKS cluster {cluster.name}."
-            )
+            report.status_extended = f"Control plane logging is not enabled for EKS cluster {cluster.name}. Required log types: {required_log_types_str}."
             if cluster.logging and cluster.logging.enabled:
-                if all(
-                    item in cluster.logging.types
-                    for item in [
-                        "api",
-                        "audit",
-                        "authenticator",
-                        "controllerManager",
-                        "scheduler",
-                    ]
-                ):
+                if all(item in cluster.logging.types for item in required_log_types):
                     report.status = "PASS"
-                    report.status_extended = f"Control plane logging enabled and correctly configured for EKS cluster {cluster.name}."
+                    report.status_extended = f"Control plane logging and all required log types are enabled for EKS cluster {cluster.name}."
                 else:
-                    report.status_extended = f"Control plane logging enabled but not all log types collected for EKS cluster {cluster.name}."
+                    report.status_extended = f"Control plane logging is enabled but not all required log types are enabled for EKS cluster {cluster.name}. Required log types: {required_log_types_str}. Enabled log types: {', '.join(cluster.logging.types)}."
             findings.append(report)
 
         return findings

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -62,6 +62,13 @@ old_config_aws = {
     "organizations_trusted_delegated_administrators": [],
     "check_rds_instance_replicas": False,
     "days_to_expire_threshold": 7,
+    "eks_required_log_types": [
+        "api",
+        "audit",
+        "authenticator",
+        "controllerManager",
+        "scheduler",
+    ],
 }
 config_aws = {
     "mute_non_default_regions": False,
@@ -255,6 +262,13 @@ config_aws = {
     ],
     "check_rds_instance_replicas": False,
     "days_to_expire_threshold": 7,
+    "eks_required_log_types": [
+        "api",
+        "audit",
+        "authenticator",
+        "controllerManager",
+        "scheduler",
+    ],
 }
 
 config_azure = {

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -272,6 +272,19 @@ aws:
   # aws.acm_certificates_expiration_check
   days_to_expire_threshold: 7
 
+  # AWS EKS Configuration
+  # aws.eks_control_plane_logging_all_types_enabled
+  # EKS control plane logging types that must be enabled
+  eks_required_log_types:
+    [
+        "api",
+        "audit",
+        "authenticator",
+        "controllerManager",
+        "scheduler",
+    ]
+
+
 # Azure Configuration
 azure:
   # Azure Network Configuration

--- a/tests/config/fixtures/config_old.yaml
+++ b/tests/config/fixtures/config_old.yaml
@@ -80,3 +80,16 @@ check_rds_instance_replicas: False
 # AWS ACM Configuration
 # aws.acm_certificates_expiration_check
 days_to_expire_threshold: 7
+
+# AWS EKS Configuration
+# aws.eks_control_plane_logging_all_types_enabled
+# EKS control plane logging types that must be enabled
+eks_required_log_types:
+  [
+      "api",
+      "audit",
+      "authenticator",
+      "controllerManager",
+      "scheduler",
+  ]
+

--- a/tests/providers/aws/services/eks/eks_control_plane_logging_all_types_enabled/eks_control_plane_logging_all_types_enabled_test.py
+++ b/tests/providers/aws/services/eks/eks_control_plane_logging_all_types_enabled/eks_control_plane_logging_all_types_enabled_test.py
@@ -74,6 +74,15 @@ class Test_eks_control_plane_logging_all_types_enabled:
                 ),
             )
         )
+        eks_client.audit_config = {
+            "eks_required_log_types": [
+                "api",
+                "audit",
+                "authenticator",
+                "controllerManager",
+                "scheduler",
+            ]
+        }
 
         with mock.patch(
             "prowler.providers.aws.services.eks.eks_service.EKS",
@@ -88,7 +97,7 @@ class Test_eks_control_plane_logging_all_types_enabled:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert search(
-                "Control plane logging enabled but not all log types collected",
+                "Control plane logging is enabled but not all required log types are enabled for EKS cluster cluster_test. Required log types: api, audit, authenticator, controllerManager, scheduler. Enabled log types: api, audit, authenticator, controllerManager.",
                 result[0].status_extended,
             )
             assert result[0].resource_id == cluster_name
@@ -114,6 +123,15 @@ class Test_eks_control_plane_logging_all_types_enabled:
                 ),
             )
         )
+        eks_client.audit_config = {
+            "eks_required_log_types": [
+                "api",
+                "audit",
+                "authenticator",
+                "controllerManager",
+                "scheduler",
+            ]
+        }
 
         with mock.patch(
             "prowler.providers.aws.services.eks.eks_service.EKS",
@@ -128,7 +146,7 @@ class Test_eks_control_plane_logging_all_types_enabled:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert search(
-                "Control plane logging enabled and correctly configured",
+                "Control plane logging and all required log types are enabled for EKS cluster",
                 result[0].status_extended,
             )
             assert result[0].resource_id == cluster_name


### PR DESCRIPTION
### Context

The prowler check `eks_control_plane_logging_all_types_enabled` verifies that **all** possible AWS EKS control plan logging types are enabled and fails if not.

### Description

AWS EKS Control plane has five different log types:
- API server
  - Logs pertaining to API requests to the cluster.
- Audit
  - Logs pertaining to cluster access via the Kubernetes API.
- Authenticator
  - Logs pertaining to authentication requests into the cluster.
- Controller manager
  - Logs pertaining to state of cluster controllers.
- Scheduler 
  - Logs pertaining to scheduling decisions.

While we understand that all five log types can be beneficial to improve IT security, they are of varying importance for IT security. Since logging can be expensive depending on the use case, companies should be able to decide which log types they require for optimum IT security at balanced cost. 
Therefore the check `eks_control_plane_logging_all_types_enabled` should be configurable, which this PR implements.
The default configuration is still that all log types must be enabled to PASS the check, so nothing changes, unless the user decides otherwise by customizing their prowler configuration specifically to their needs.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
