### PR TITLE
fix(organizations): Fix types errors related to policies and `json.loads` function

### DIFF
--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -143,7 +143,7 @@ class Organizations(AWSService):
                 if isinstance(policy_content, str):
                     policy_content = json.loads(policy_content)
 
-                return policy_content  # This could be not be a dict, because json.loads could return a list or a string depending on the content of policy_content object.
+            return policy_content  # This could be not be a dict, because json.loads could return a list or a string depending on the content of policy_content object.
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -149,6 +149,7 @@ class Organizations(AWSService):
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+            return {}
 
     def __list_targets_for_policy__(self, policy_id) -> list:
         logger.info("Organizations - List Targets for policy: %s ...", policy_id)
@@ -159,12 +160,14 @@ class Organizations(AWSService):
                 targets_for_policy = self.client.list_targets_for_policy(
                     PolicyId=policy_id
                 )["Targets"]
+
+            return targets_for_policy
+
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
-        finally:
-            return targets_for_policy
+            return []
 
     def __list_delegated_administrators__(self):
         logger.info("Organizations - List Delegated Administrators")

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -140,14 +140,15 @@ class Organizations(AWSService):
                     .get("Policy", {})
                     .get("Content", "")
                 )
+
+                if isinstance(policy_content, str):
+                    policy_content = json.loads(policy_content)
+
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
-            if isinstance(policy_content, str):
-                policy_content = json.loads(policy_content)
-
             return policy_content if isinstance(policy_content, dict) else {}
 
     def __list_targets_for_policy__(self, policy_id) -> list:

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -128,7 +128,7 @@ class Organizations(AWSService):
         finally:
             return self.policies
 
-    def __describe_policy__(self, policy_id):
+    def __describe_policy__(self, policy_id) -> dict:
         logger.info("Organizations - Describe policy: %s ...", policy_id)
 
         # This operation can be called only from the organization’s management account or by a member account that is a delegated administrator for an Amazon Web Services service.
@@ -145,9 +145,12 @@ class Organizations(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
-            return json.loads(policy_content)
+            if isinstance(policy_content, str):
+                policy_content = json.loads(policy_content)
 
-    def __list_targets_for_policy__(self, policy_id):
+            return policy_content if isinstance(policy_content, dict) else {}
+
+    def __list_targets_for_policy__(self, policy_id) -> list:
         logger.info("Organizations - List Targets for policy: %s ...", policy_id)
 
         try:
@@ -161,7 +164,7 @@ class Organizations(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
-            return targets_for_policy
+            return targets_for_policy if isinstance(targets_for_policy, list) else []
 
     def __list_delegated_administrators__(self):
         logger.info("Organizations - List Delegated Administrators")

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -140,16 +140,15 @@ class Organizations(AWSService):
                     .get("Policy", {})
                     .get("Content", "")
                 )
-
                 if isinstance(policy_content, str):
                     policy_content = json.loads(policy_content)
+
+                return policy_content  # This could be not be a dict, because json.loads could return a list or a string depending on the content of policy_content object.
 
         except Exception as error:
             logger.error(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
-        finally:
-            return policy_content if isinstance(policy_content, dict) else {}
 
     def __list_targets_for_policy__(self, policy_id) -> list:
         logger.info("Organizations - List Targets for policy: %s ...", policy_id)
@@ -165,7 +164,7 @@ class Organizations(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
-            return targets_for_policy if isinstance(targets_for_policy, list) else []
+            return targets_for_policy
 
     def __list_delegated_administrators__(self):
         logger.info("Organizations - List Delegated Administrators")

--- a/tests/providers/aws/services/organizations/organizations_service_test.py
+++ b/tests/providers/aws/services/organizations/organizations_service_test.py
@@ -52,6 +52,12 @@ class Test_Organizations_Service:
             Name="Test",
             Type="SERVICE_CONTROL_POLICY",
         )
+        response_unexpected_policy = conn.create_policy(
+            Content='"Version":"2012-10-17","Statement":[]',
+            Description="Test",
+            Name="TestInvalid",
+            Type="SERVICE_CONTROL_POLICY",
+        )
         # Mock
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         organizations = Organizations(aws_provider)
@@ -61,4 +67,12 @@ class Test_Organizations_Service:
                 assert policy.type == "SERVICE_CONTROL_POLICY"
                 assert policy.aws_managed is False
                 assert policy.content == json.loads(response["Policy"]["Content"])
+                assert policy.targets == []
+            elif (
+                policy.arn
+                == response_unexpected_policy["Policy"]["PolicySummary"]["Arn"]
+            ):
+                assert policy.type == "SERVICE_CONTROL_POLICY"
+                assert policy.aws_managed is False
+                assert policy.content == {}
                 assert policy.targets == []

--- a/tests/providers/aws/services/organizations/organizations_service_test.py
+++ b/tests/providers/aws/services/organizations/organizations_service_test.py
@@ -52,12 +52,6 @@ class Test_Organizations_Service:
             Name="Test",
             Type="SERVICE_CONTROL_POLICY",
         )
-        response_unexpected_policy = conn.create_policy(
-            Content='"Version":"2012-10-17","Statement":[]',
-            Description="Test",
-            Name="TestInvalid",
-            Type="SERVICE_CONTROL_POLICY",
-        )
         # Mock
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         organizations = Organizations(aws_provider)
@@ -67,12 +61,4 @@ class Test_Organizations_Service:
                 assert policy.type == "SERVICE_CONTROL_POLICY"
                 assert policy.aws_managed is False
                 assert policy.content == json.loads(response["Policy"]["Content"])
-                assert policy.targets == []
-            elif (
-                policy.arn
-                == response_unexpected_policy["Policy"]["PolicySummary"]["Arn"]
-            ):
-                assert policy.type == "SERVICE_CONTROL_POLICY"
-                assert policy.aws_managed is False
-                assert policy.content == {}
                 assert policy.targets == []


### PR DESCRIPTION
### Context

`eu-west-1 -- TypeError[106]: the JSON object must be str, bytes or bytearray, not dict`


### Description

Add controls to ensure that in function `__describe_policy__` a dict is not passed to a `json.loads` function. 


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
