### PR TITLE
feat(aws): Add a test_connection method

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -1,10 +1,8 @@
 import os
 import pathlib
 from argparse import ArgumentTypeError, Namespace
-from dataclasses import dataclass
 from datetime import datetime
 from re import fullmatch
-from typing import Any
 
 from boto3 import client
 from boto3.session import Session
@@ -51,13 +49,7 @@ from prowler.providers.aws.models import (
 )
 from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.provider import Provider
-
-
-@dataclass
-class TestConnection:
-    connected: bool = False
-    error: Exception = None
-    result: Any = None
+from prowler.providers.common.test_connection_dataclass import TestConnection
 
 
 class AwsProvider(Provider):

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -4,11 +4,13 @@ import sys
 from argparse import ArgumentTypeError, Namespace
 from datetime import datetime
 from re import fullmatch
+from typing import Union
 
 from boto3 import client
 from boto3.session import Session
 from botocore.config import Config
 from botocore.credentials import RefreshableCredentials
+from botocore.session import Session as BotocoreSession
 from colorama import Fore, Style
 from pytz import utc
 from tzlocal import get_localzone
@@ -486,7 +488,7 @@ class AwsProvider(Provider):
             )
 
             # Here we need the botocore session since it needs to use refreshable credentials
-            assumed_session = Session()
+            assumed_session = BotocoreSession()
             assumed_session._credentials = assumed_refreshable_credentials
             assumed_session.set_config_variable("region", self._identity.profile_region)
             return Session(
@@ -902,7 +904,7 @@ class AwsProvider(Provider):
         session_duration: int = 3600,
         external_id: str = None,
         mfa_enabled: bool = False,
-    ) -> tuple[bool, AWSCallerIdentity | Exception]:
+    ) -> tuple[bool, Union[AWSCallerIdentity, Exception]]:
         """
         Validates AWS credentials using the provided session and AWS region.
 
@@ -978,7 +980,7 @@ class AwsProvider(Provider):
                 region=aws_region,
             )
         except Exception as error:
-            logger.error(
+            logger.critical(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return False, error

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -55,21 +55,9 @@ from prowler.providers.common.provider import Provider
 
 @dataclass
 class TestConnection:
-    _connected: bool = False
-    _error: Exception = None
-    _result: Any = None
-
-    @property
-    def connected(self) -> bool:
-        return self._connected
-
-    @property
-    def error(self) -> Exception:
-        return self._error
-
-    @property
-    def result(self) -> Any:
-        return self._result
+    connected: bool = False
+    error: Exception = None
+    result: Any = None
 
 
 class AwsProvider(Provider):
@@ -132,8 +120,8 @@ class AwsProvider(Provider):
         caller_identity = self.test_connection(
             session=self.session.current_session,
             aws_region=sts_region,
-            raise_exception=True,
-        )
+            raise_on_exception=True,
+        ).result
 
         logger.info("Credentials validated")
         ########
@@ -1157,22 +1145,3 @@ def validate_role_session_name(session_name) -> str:
         raise ArgumentTypeError(
             "Role Session Name must be 2-64 characters long and consist only of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
         )
-
-
-@dataclass
-class TestConnection:
-    _connected: bool = False
-    _error: Exception = None
-    _result: Any = None
-
-    @property
-    def connected(self) -> bool:
-        return self._connected
-
-    @property
-    def error(self) -> Exception:
-        return self._error
-
-    @property
-    def result(self) -> Any:
-        return self._result

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -904,29 +904,33 @@ class AwsProvider(Provider):
         external_id: str = None,
         mfa_enabled: bool = False,
     ) -> tuple[bool, Union[AWSCallerIdentity, Exception]]:
-        # TODO: update docsting
         """
         Validates AWS credentials using the provided session and AWS region.
 
         If no session is provided, the method will create a new session using the Boto3 default session.
 
-        If you are assuming a role you need to pass the session with the assumed role.
+        If you are assuming a role, you need to pass the session with the assumed role.
 
         Args:
             session (Session): The AWS session object.
+            profile (str): The AWS profile to use for the session.
             aws_region (str): The AWS region to validate the credentials in.
+            role_arn (str): The ARN of the IAM role to assume.
+            role_session_name (str): The name of the role session.
+            session_duration (int): The duration of the assumed role session in seconds.
+            external_id (str): The external ID to use when assuming the role.
+            mfa_enabled (bool): Whether MFA (Multi-Factor Authentication) is enabled.
 
         Returns:
-            tuple[bool, AWSCallerIdentity]: A tuple containing a boolean value indicating
-            the success of the validation and an AWSCallerIdentity object representing
-            the caller's identity.
+            tuple[bool, Union[AWSCallerIdentity, Exception]]: A tuple containing a boolean value indicating
+            the success of the validation and either an AWSCallerIdentity object representing
+            the caller's identity or an Exception object if an error occurs.
 
         Raises:
             Exception: If an error occurs during the validation process.
-
         """
         try:
-            # Create first the default session if no session is given
+            # Create the default session if no session is given
             session = (
                 session if session else AwsProvider.setup_session(mfa_enabled, profile)
             )

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -972,11 +972,17 @@ class AwsProvider(Provider):
                 region=aws_region,
             )
 
-        except (ClientError, ProfileNotFound, ArgumentTypeError) as error:
+        except (ClientError, ProfileNotFound) as credentials_error:
             logger.error(
-                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"{credentials_error.__class__.__name__}[{credentials_error.__traceback__.tb_lineno}]: {credentials_error}"
             )
-            raise error
+            raise credentials_error
+
+        except ArgumentTypeError as validation_error:
+            logger.error(
+                f"{validation_error.__class__.__name__}[{validation_error.__traceback__.tb_lineno}]: {validation_error}"
+            )
+            raise validation_error
 
         except Exception as error:
             logger.critical(
@@ -1005,7 +1011,7 @@ class AwsProvider(Provider):
         try:
             sts_endpoint_url = (
                 f"https://sts.{aws_region}.amazonaws.com"
-                if "cn-" not in aws_region
+                if not aws_region.startswith("cn-")
                 else f"https://sts.{aws_region}.amazonaws.com.cn"
             )
             return session.client("sts", aws_region, endpoint_url=sts_endpoint_url)

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -933,7 +933,7 @@ class AwsProvider(Provider):
         raise_on_exception: bool = True,
     ) -> Connection:
         """
-        Test the connection to AWS.
+        Test the connection to AWS with one of the Boto3 credentials methods.
 
         Args:
             profile (str): The AWS profile to use for the session.
@@ -951,7 +951,11 @@ class AwsProvider(Provider):
                 - error (Exception): An exception object if an error occurs during the validation.
 
         Raises:
-            Exception: If an error occurs during the validation process.
+            ClientError: If there is an error with the AWS client.
+            ProfileNotFound: If the specified profile is not found.
+            NoCredentialsError: If there are no AWS credentials found.
+            ArgumentTypeError: If there is a validation error with the arguments.
+            Exception: If there is an unexpected error.
 
         Examples:
             >>> AwsProvider.test_connection(

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -1,7 +1,11 @@
 from argparse import ArgumentTypeError, Namespace
-from re import fullmatch, search
+from re import search
 
-from prowler.providers.aws.aws_provider import get_aws_available_regions
+from prowler.providers.aws.aws_provider import (
+    get_aws_available_regions,
+    validate_role_session_name,
+    validate_session_duration,
+)
 from prowler.providers.aws.config import ROLE_SESSION_NAME
 from prowler.providers.aws.lib.arn.arn import arn_type
 
@@ -168,15 +172,6 @@ def init_parser(self):
     )
 
 
-def validate_session_duration(duration):
-    """validate_session_duration validates that the AWS STS Assume Role Session Duration is between 900 and 43200 seconds."""
-    duration = int(duration)
-    # Since the range(i,j) goes from i to j-1 we have to j+1
-    if duration not in range(900, 43201):
-        raise ArgumentTypeError("Session duration must be between 900 and 43200")
-    return duration
-
-
 def validate_arguments(arguments: Namespace) -> tuple[bool, str]:
     """validate_arguments returns {True, "} if the provider arguments passed are valid and can be used together. It performs an extra validation, specific for the AWS provider, apart from the argparse lib."""
 
@@ -202,17 +197,4 @@ def validate_bucket(bucket_name):
     else:
         raise ArgumentTypeError(
             "Bucket name must be valid (https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html)"
-        )
-
-
-def validate_role_session_name(session_name):
-    """
-    validates that the role session name is valid
-    Documentation: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
-    """
-    if fullmatch(r"[\w+=,.@-]{2,64}", session_name):
-        return session_name
-    else:
-        raise ArgumentTypeError(
-            "Role Session Name must be 2-64 characters long and consist only of upper- and lower-case alphanumeric characters with no spaces. You can also include underscores or any of the following characters: =,.@-"
         )

--- a/prowler/providers/aws/models.py
+++ b/prowler/providers/aws/models.py
@@ -5,6 +5,7 @@ from boto3.session import Session
 from botocore.config import Config
 
 from prowler.config.config import output_file_timestamp
+from prowler.providers.aws.config import AWS_STS_GLOBAL_ENDPOINT_REGION
 from prowler.providers.aws.lib.arn.models import ARN
 from prowler.providers.common.models import ProviderOutputOptions
 
@@ -34,7 +35,7 @@ class AWSAssumeRoleInfo:
     external_id: str
     mfa_enabled: bool
     role_session_name: str
-    sts_region: str
+    sts_region: str = AWS_STS_GLOBAL_ENDPOINT_REGION
 
 
 @dataclass

--- a/prowler/providers/common/models.py
+++ b/prowler/providers/common/models.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from os import makedirs
 from os.path import isdir
 
@@ -55,3 +56,16 @@ class ProviderOutputOptions:
             if not isdir(arguments.output_directory + "/compliance"):
                 if arguments.output_formats:
                     makedirs(arguments.output_directory + "/compliance", exist_ok=True)
+
+
+@dataclass
+class Connection:
+    """
+    Represents a test connection object.
+    Attributes:
+        is_connected (bool): Indicates whether the connection is established or not.
+        error (Exception): The exception object if an error occurred during the connection test.
+    """
+
+    is_connected: bool = False
+    error: Exception = None

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -136,9 +136,9 @@ class Provider(ABC):
         """
         raise NotImplementedError()
 
-    # TODO: uncomment this once all the providers have implemented the is_connected method
+    # TODO: uncomment this once all the providers have implemented the test_connection method
     # @abstractmethod
-    def is_connected(self) -> tuple[bool, Any]:
+    def test_connection(self) -> Any:
         """
         test_connection tests the connection to the provider.
 

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -136,6 +136,16 @@ class Provider(ABC):
         """
         raise NotImplementedError()
 
+    # TODO: uncomment this once all the providers have implemented the test_connection method
+    # @abstractmethod
+    def test_connection(self) -> tuple[bool, Any]:
+        """
+        test_connection tests the connection to the provider.
+
+        This method needs to be created in each provider.
+        """
+        raise NotImplementedError()
+
     # TODO: probably this won't be here since we want to do the arguments validation during the parse()
     def validate_arguments(self) -> None:
         """
@@ -145,6 +155,7 @@ class Provider(ABC):
         """
         raise NotImplementedError()
 
+    # TODO: review this since it is only used for AWS
     def get_checks_to_execute_by_audit_resources(self) -> set:
         """
         get_checks_to_execute_by_audit_resources returns a set of checks based on the input resources to scan.

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -136,9 +136,9 @@ class Provider(ABC):
         """
         raise NotImplementedError()
 
-    # TODO: uncomment this once all the providers have implemented the test_connection method
+    # TODO: uncomment this once all the providers have implemented the is_connected method
     # @abstractmethod
-    def test_connection(self) -> tuple[bool, Any]:
+    def is_connected(self) -> tuple[bool, Any]:
         """
         test_connection tests the connection to the provider.
 
@@ -178,6 +178,7 @@ class Provider(ABC):
             provider_class = getattr(
                 import_module(provider_class_path), provider_class_name
             )
+
             if not isinstance(Provider._global, provider_class):
                 global_provider = provider_class(arguments)
 

--- a/prowler/providers/common/test_connection_dataclass.py
+++ b/prowler/providers/common/test_connection_dataclass.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class TestConnection:
+    connected: bool = False
+    error: Exception = None
+    result: Any = None

--- a/prowler/providers/common/test_connection_dataclass.py
+++ b/prowler/providers/common/test_connection_dataclass.py
@@ -1,9 +1,0 @@
-from dataclasses import dataclass
-from typing import Any
-
-
-@dataclass
-class TestConnection:
-    connected: bool = False
-    error: Exception = None
-    result: Any = None

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -18,6 +18,7 @@ from tzlocal import get_localzone
 
 from prowler.providers.aws.aws_provider import (
     AwsProvider,
+    TestConnection,
     get_aws_available_regions,
     get_aws_region_for_sts,
 )
@@ -1118,9 +1119,13 @@ aws:
             region_name=AWS_REGION_EU_WEST_1,
         )
 
-        get_caller_identity = AwsProvider.test_connection(
+        test_connection = AwsProvider.test_connection(
             session=current_session, aws_region=AWS_REGION_EU_WEST_1
-        ).result
+        )
+
+        assert isinstance(test_connection, TestConnection)
+
+        get_caller_identity = test_connection.result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1159,9 +1164,13 @@ aws:
         # To use GovCloud or China it is either required:
         # - Set the AWS profile region with a valid partition region
         # - Use the -f/--region with a valid partition region
-        get_caller_identity = AwsProvider.test_connection(
+        test_connection = AwsProvider.test_connection(
             session=current_session, aws_region=AWS_REGION_CN_NORTH_1
-        ).result
+        )
+
+        assert isinstance(test_connection, TestConnection)
+
+        get_caller_identity = test_connection.result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1201,9 +1210,13 @@ aws:
         # To use GovCloud or China it is either required:
         # - Set the AWS profile region with a valid partition region
         # - Use the -f/--region with a valid partition region
-        get_caller_identity = AwsProvider.test_connection(
+        test_connection = AwsProvider.test_connection(
             session=current_session, aws_region=AWS_REGION_GOV_CLOUD_US_EAST_1
-        ).result
+        )
+
+        assert isinstance(test_connection, TestConnection)
+
+        get_caller_identity = test_connection.result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1230,7 +1243,11 @@ aws:
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key["AccessKeyId"])
         monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", access_key["SecretAccessKey"])
 
-        get_caller_identity = AwsProvider.test_connection().result
+        test_connection = AwsProvider.test_connection()
+
+        assert isinstance(test_connection, TestConnection)
+
+        get_caller_identity = test_connection.result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1262,7 +1279,11 @@ aws:
             f"arn:{AWS_COMMERCIAL_PARTITION}:iam::{AWS_ACCOUNT_NUMBER}:role/{role_name}"
         )
 
-        get_caller_identity = AwsProvider.test_connection(role_arn=role_arn).result
+        test_connection = AwsProvider.test_connection(role_arn=role_arn)
+
+        assert isinstance(test_connection, TestConnection)
+
+        get_caller_identity = test_connection.result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -18,7 +18,6 @@ from tzlocal import get_localzone
 
 from prowler.providers.aws.aws_provider import (
     AwsProvider,
-    TestConnection,
     get_aws_available_regions,
     get_aws_region_for_sts,
 )
@@ -39,6 +38,7 @@ from prowler.providers.aws.models import (
     AWSOutputOptions,
 )
 from prowler.providers.common.provider import Provider
+from prowler.providers.common.test_connection_dataclass import TestConnection
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_ARN,
     AWS_ACCOUNT_NUMBER,

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -414,7 +414,7 @@ class TestAWSProvider:
         arguments.external_id = "test-external-id"
 
         with patch(
-            "prowler.providers.aws.aws_provider.AwsProvider.__input_role_mfa_token_and_code__",
+            "prowler.providers.aws.aws_provider.AwsProvider.input_role_mfa_token_and_code",
             return_value=AWSMFAInfo(
                 arn=f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:mfa/test-role-mfa",
                 totp="111111",

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1098,7 +1098,7 @@ aws:
             rmdir(arguments.output_directory)
 
     @mock_aws
-    def test_validate_credentials_commercial_partition_with_regions(self):
+    def test_test_connection_commercial_partition_with_regions(self):
         # Create a mock IAM user
         iam_client = client("iam", region_name=AWS_REGION_EU_WEST_1)
         iam_user = iam_client.create_user(UserName="test-user")["User"]
@@ -1137,7 +1137,7 @@ aws:
     @patch(
         "botocore.client.BaseClient._make_api_call", new=mock_get_caller_identity_china
     )
-    def test_validate_credentials_china_partition(self):
+    def test_test_connection_china_partition(self):
         # Create a mock IAM user
         iam_client = client("iam", region_name=AWS_REGION_CN_NORTH_1)
         iam_user = iam_client.create_user(UserName="test-user")["User"]
@@ -1180,7 +1180,7 @@ aws:
         "botocore.client.BaseClient._make_api_call",
         new=mock_get_caller_identity_gov_cloud,
     )
-    def test_validate_credentials_gov_cloud_partition(self):
+    def test_test_connection_gov_cloud_partition(self):
         # Create a mock IAM user
         iam_client = client("iam", region_name=AWS_REGION_GOV_CLOUD_US_EAST_1)
         iam_user = iam_client.create_user(UserName="test-user")["User"]
@@ -1219,7 +1219,7 @@ aws:
         assert get_caller_identity.arn.resource_type == "user"
 
     @mock_aws
-    def test_validate_credentials_without_a_session(self, monkeypatch):
+    def test_test_connection_without_a_session(self, monkeypatch):
         # Create a mock IAM user
         iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
         iam_user = iam_client.create_user(UserName="test-user")["User"]
@@ -1247,7 +1247,7 @@ aws:
         assert get_caller_identity.arn.resource_type == "user"
 
     @mock_aws
-    def test_test_connection_with_role_from_env_without_mfa(self, monkeypatch):
+    def test_test_connection_with_role_from_env(self, monkeypatch):
         # Create a mock IAM user
         iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
         iam_user = iam_client.create_user(UserName="test-user")["User"]

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1120,7 +1120,7 @@ aws:
 
         get_caller_identity = AwsProvider.test_connection(
             session=current_session, aws_region=AWS_REGION_EU_WEST_1
-        )
+        ).result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1161,7 +1161,7 @@ aws:
         # - Use the -f/--region with a valid partition region
         get_caller_identity = AwsProvider.test_connection(
             session=current_session, aws_region=AWS_REGION_CN_NORTH_1
-        )
+        ).result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1203,7 +1203,7 @@ aws:
         # - Use the -f/--region with a valid partition region
         get_caller_identity = AwsProvider.test_connection(
             session=current_session, aws_region=AWS_REGION_GOV_CLOUD_US_EAST_1
-        )
+        ).result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1230,7 +1230,7 @@ aws:
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", access_key["AccessKeyId"])
         monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", access_key["SecretAccessKey"])
 
-        get_caller_identity = AwsProvider.test_connection()
+        get_caller_identity = AwsProvider.test_connection().result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 
@@ -1262,7 +1262,7 @@ aws:
             f"arn:{AWS_COMMERCIAL_PARTITION}:iam::{AWS_ACCOUNT_NUMBER}:role/{role_name}"
         )
 
-        get_caller_identity = AwsProvider.test_connection(role_arn=role_arn)
+        get_caller_identity = AwsProvider.test_connection(role_arn=role_arn).result
 
         assert isinstance(get_caller_identity, AWSCallerIdentity)
 


### PR DESCRIPTION
### Context

We need to be able to test the connection to each provider using one of the available authentication methods, starting from the environment variables.


### Description

- Add a `test_connection` method for the AWS provider.
- Create a `test_connection` abstract method in the `Provider` class but not enforced for now not to break anything.

### Notes for reviewers
- Review the removal of `sys.exit()` in favor of catching the exceptions during the `__init__`.
- You can test it with the following:
```python
from prowler.providers.aws.aws_provider import AwsProvider


# - Using environment variables
t = AwsProvider.test_connection()
print(t)

# - Using profile
t = AwsProvider.test_connection(profile="dev")
print(t)


# - With MFA
t = AwsProvider.test_connection(profile="dev", mfa_enabled=True)
print(t)


# - With Role without external ID
t = AwsProvider.test_connection(
    role_arn="arn:aws:iam::111122223333:role/ProwlerRole"
)
print(t)

# - With Role with external ID from ENV
t = AwsProvider.test_connection(
    role_arn="arn:aws:iam::111122223333:role/ProwlerRole",
    external_id="8eabb29e-e591-4828-919f-a9b2839a137d",
)
print(t)


t = AwsProvider.test_connection(
    role_arn="arn:aws:iam::111122223333:role/ProwlerRole",
    external_id="8eabb29e-e591-4828-919f-a9b2839a137d",
    session_duration=900,
    profile="test",
)
print(t)
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
