### PR TITLE
fix(autoscaling): change unexpected exception to error severity logger

### DIFF
--- a/prowler/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration.py
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration.py
@@ -40,7 +40,7 @@ class autoscaling_find_secrets_ec2_launch_configuration(Check):
                     )
                     continue
                 except Exception as error:
-                    logger.warning(
+                    logger.error(
                         f"{configuration.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                     continue


### PR DESCRIPTION
### Context

In this [PR](https://github.com/prowler-cloud/prowler/pull/4562) were added a manage exception in check `autoscaling_find_secrets_ec2_launch_configuration` with the logger printing warnings for every exception. Change to use warnings only for managed exceptions and error severity for unmanaged exceptions.


### Description

Change logger severity from warning to error.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
