### PR TITLE
feat(opensearch): Add domain inside VPC case for public domain check

### DIFF
--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -91,12 +91,16 @@ class OpenSearchService(AWSService):
                     DomainName=domain.name
                 )
                 domain.arn = describe_domain["DomainStatus"]["ARN"]
-                domain.endpoint_vpc = None
+                domain.vpc_endpoints = None
                 if "Endpoints" in describe_domain["DomainStatus"]:
                     if "vpc" in describe_domain["DomainStatus"]["Endpoints"]:
-                        domain.endpoint_vpc = describe_domain["DomainStatus"][
-                            "Endpoints"
-                        ]["vpc"]
+                        domain.vpc_endpoints = [
+                            vpc
+                            for vpc in describe_domain["DomainStatus"][
+                                "Endpoints"
+                            ].values()
+                        ]
+
                 domain.vpc_id = None
                 if "VPCOptions" in describe_domain["DomainStatus"]:
                     domain.vpc_id = describe_domain["DomainStatus"]["VPCOptions"][
@@ -156,7 +160,7 @@ class OpenSearchDomain(BaseModel):
     region: str
     arn: str = None
     logging: list[PublishingLoggingOption] = []
-    endpoint_vpc: str = None
+    vpc_endpoints: list[str] = None
     vpc_id: str = None
     access_policy: dict = None
     cognito_options: bool = None

--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -53,12 +53,9 @@ class OpenSearchService(AWSService):
                     "INDEX_SLOW_LOGS",
                     "AUDIT_LOGS",
                 ]:
-                    if (
-                        logging_key
-                        in describe_domain["DomainConfig"]["LogPublishingOptions"][
-                            "Options"
-                        ]
-                    ):
+                    if logging_key in describe_domain["DomainConfig"].get(
+                        "LogPublishingOptions", {}
+                    ).get("Options", {}):
                         domain.logging.append(
                             PublishingLoggingOption(
                                 name=logging_key,

--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible.py
@@ -19,8 +19,7 @@ class opensearch_service_domains_not_publicly_accessible(Check):
             )
 
             if domain.vpc_id:
-                report.status = "PASS"
-                report.status_extended = f"Opensearch domain {domain.name} is in a VPC."
+                report.status_extended = f"Opensearch domain {domain.name} is in a VPC, then it is not publicly accessible."
             elif domain.access_policy:
                 for statement in domain.access_policy["Statement"]:
                     # look for open policies

--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible.py
@@ -17,7 +17,11 @@ class opensearch_service_domains_not_publicly_accessible(Check):
             report.status_extended = (
                 f"Opensearch domain {domain.name} does not allow anonymous access."
             )
-            if domain.access_policy:
+
+            if domain.vpc_id:
+                report.status = "PASS"
+                report.status_extended = f"Opensearch domain {domain.name} is in a VPC."
+            elif domain.access_policy:
                 for statement in domain.access_policy["Statement"]:
                     # look for open policies
                     if (

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_audit_logging_enabled/opensearch_service_domains_audit_logging_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_audit_logging_enabled/opensearch_service_domains_audit_logging_enabled_test.py
@@ -15,9 +15,13 @@ class Test_opensearch_service_domains_audit_logging_enabled:
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_audit_logging_enabled.opensearch_service_domains_audit_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_audit_logging_enabled.opensearch_service_domains_audit_logging_enabled import (
                 opensearch_service_domains_audit_logging_enabled,
@@ -39,7 +43,10 @@ class Test_opensearch_service_domains_audit_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_audit_logging_enabled.opensearch_service_domains_audit_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_audit_logging_enabled.opensearch_service_domains_audit_logging_enabled import (
                 opensearch_service_domains_audit_logging_enabled,
@@ -68,7 +75,10 @@ class Test_opensearch_service_domains_audit_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_audit_logging_enabled.opensearch_service_domains_audit_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_audit_logging_enabled.opensearch_service_domains_audit_logging_enabled import (
                 opensearch_service_domains_audit_logging_enabled,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_cloudwatch_logging_enabled/opensearch_service_domains_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_cloudwatch_logging_enabled/opensearch_service_domains_cloudwatch_logging_enabled_test.py
@@ -15,9 +15,13 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled import (
                 opensearch_service_domains_cloudwatch_logging_enabled,
@@ -39,7 +43,10 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled import (
                 opensearch_service_domains_cloudwatch_logging_enabled,
@@ -71,7 +78,10 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled import (
                 opensearch_service_domains_cloudwatch_logging_enabled,
@@ -103,7 +113,10 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled import (
                 opensearch_service_domains_cloudwatch_logging_enabled,
@@ -137,7 +150,10 @@ class Test_opensearch_service_domains_cloudwatch_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_cloudwatch_logging_enabled.opensearch_service_domains_cloudwatch_logging_enabled import (
                 opensearch_service_domains_cloudwatch_logging_enabled,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_encryption_at_rest_enabled/opensearch_service_domains_encryption_at_rest_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_encryption_at_rest_enabled/opensearch_service_domains_encryption_at_rest_enabled_test.py
@@ -14,9 +14,13 @@ class Test_opensearch_service_domains_encryption_at_rest_enabled:
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_encryption_at_rest_enabled.opensearch_service_domains_encryption_at_rest_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_encryption_at_rest_enabled.opensearch_service_domains_encryption_at_rest_enabled import (
                 opensearch_service_domains_encryption_at_rest_enabled,
@@ -41,7 +45,10 @@ class Test_opensearch_service_domains_encryption_at_rest_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_encryption_at_rest_enabled.opensearch_service_domains_encryption_at_rest_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_encryption_at_rest_enabled.opensearch_service_domains_encryption_at_rest_enabled import (
                 opensearch_service_domains_encryption_at_rest_enabled,
@@ -72,7 +79,10 @@ class Test_opensearch_service_domains_encryption_at_rest_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_encryption_at_rest_enabled.opensearch_service_domains_encryption_at_rest_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_encryption_at_rest_enabled.opensearch_service_domains_encryption_at_rest_enabled import (
                 opensearch_service_domains_encryption_at_rest_enabled,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_https_communications_enforced/opensearch_service_domains_https_communications_enforced_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_https_communications_enforced/opensearch_service_domains_https_communications_enforced_test.py
@@ -14,9 +14,13 @@ class Test_opensearch_service_domains_https_communications_enforced:
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_https_communications_enforced.opensearch_service_domains_https_communications_enforced.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_https_communications_enforced.opensearch_service_domains_https_communications_enforced import (
                 opensearch_service_domains_https_communications_enforced,
@@ -41,7 +45,10 @@ class Test_opensearch_service_domains_https_communications_enforced:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_https_communications_enforced.opensearch_service_domains_https_communications_enforced.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_https_communications_enforced.opensearch_service_domains_https_communications_enforced import (
                 opensearch_service_domains_https_communications_enforced,
@@ -72,7 +79,10 @@ class Test_opensearch_service_domains_https_communications_enforced:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_https_communications_enforced.opensearch_service_domains_https_communications_enforced.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_https_communications_enforced.opensearch_service_domains_https_communications_enforced import (
                 opensearch_service_domains_https_communications_enforced,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_internal_user_database_enabled/opensearch_service_domains_internal_user_database_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_internal_user_database_enabled/opensearch_service_domains_internal_user_database_enabled_test.py
@@ -14,9 +14,13 @@ class Test_opensearch_service_domains_internal_user_database_enabled:
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_internal_user_database_enabled.opensearch_service_domains_internal_user_database_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_internal_user_database_enabled.opensearch_service_domains_internal_user_database_enabled import (
                 opensearch_service_domains_internal_user_database_enabled,
@@ -41,7 +45,10 @@ class Test_opensearch_service_domains_internal_user_database_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_internal_user_database_enabled.opensearch_service_domains_internal_user_database_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_internal_user_database_enabled.opensearch_service_domains_internal_user_database_enabled import (
                 opensearch_service_domains_internal_user_database_enabled,
@@ -73,7 +80,10 @@ class Test_opensearch_service_domains_internal_user_database_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_internal_user_database_enabled.opensearch_service_domains_internal_user_database_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_internal_user_database_enabled.opensearch_service_domains_internal_user_database_enabled import (
                 opensearch_service_domains_internal_user_database_enabled,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_node_to_node_encryption_enabled/opensearch_service_domains_node_to_node_encryption_enabled_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_node_to_node_encryption_enabled/opensearch_service_domains_node_to_node_encryption_enabled_test.py
@@ -14,9 +14,13 @@ class Test_opensearch_service_domains_node_to_node_encryption_enabled:
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_service_domains_node_to_node_encryption_enabled import (
                 opensearch_service_domains_node_to_node_encryption_enabled,
@@ -41,7 +45,10 @@ class Test_opensearch_service_domains_node_to_node_encryption_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_service_domains_node_to_node_encryption_enabled import (
                 opensearch_service_domains_node_to_node_encryption_enabled,
@@ -73,7 +80,10 @@ class Test_opensearch_service_domains_node_to_node_encryption_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_node_to_node_encryption_enabled.opensearch_service_domains_node_to_node_encryption_enabled import (
                 opensearch_service_domains_node_to_node_encryption_enabled,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -308,14 +308,14 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             assert result[0].resource_tags == []
 
     def test_domain_inside_vpc(self):
-        domain_arn = f"arn:aws:es:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
+        opensearch_domain_arn = f"arn:aws:es:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(
             OpenSearchDomain(
                 name=domain_name,
                 region=AWS_REGION_EU_WEST_1,
-                arn=domain_arn,
+                arn=opensearch_domain_arn,
                 vpc_id="vpc-123456",
             )
         )
@@ -338,6 +338,6 @@ class Test_opensearch_service_domains_not_publicly_accessible:
                 == f"Opensearch domain {domain_name} is in a VPC, then it is not publicly accessible."
             )
             assert result[0].resource_id == domain_name
-            assert result[0].resource_arn == domain_arn
+            assert result[0].resource_arn == opensearch_domain_arn
             assert result[0].region == AWS_REGION_EU_WEST_1
             assert result[0].resource_tags == []

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -246,3 +246,35 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
+
+    def test_domain_inside_vpc(self):
+        opensearch_client = mock.MagicMock
+        opensearch_client.opensearch_domains = []
+        opensearch_client.opensearch_domains.append(
+            OpenSearchDomain(
+                name=domain_name,
+                region=AWS_REGION_EU_WEST_1,
+                arn=domain_arn,
+                vpc_id="vpc-123456",
+            )
+        )
+        opensearch_client.opensearch_domains[0].logging = []
+
+        with mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
+            opensearch_client,
+        ):
+            from prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible import (
+                opensearch_service_domains_not_publicly_accessible,
+            )
+
+            check = opensearch_service_domains_not_publicly_accessible()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Opensearch domain {domain_name} is in a VPC."
+            )
+            assert result[0].resource_id == domain_name
+            assert result[0].resource_arn == domain_arn

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -118,6 +118,8 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].resource_tags == []
 
     def test_policy_data_not_restricted_with_principal_AWS(self):
         opensearch_client = mock.MagicMock
@@ -150,6 +152,8 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].resource_tags == []
 
     def test_policy_data_not_restricted_with_principal_no_AWS(self):
         opensearch_client = mock.MagicMock
@@ -182,6 +186,8 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].resource_tags == []
 
     def test_policy_data_not_restricted_ip_full(self):
         opensearch_client = mock.MagicMock
@@ -214,6 +220,8 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].resource_tags == []
 
     def test_policy_data_not_restricted_whole_internet(self):
         opensearch_client = mock.MagicMock
@@ -246,6 +254,8 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].resource_tags == []
 
     def test_domain_inside_vpc(self):
         opensearch_client = mock.MagicMock
@@ -278,3 +288,5 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -304,14 +304,18 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             assert result[0].region == AWS_REGION_US_WEST_2
             assert result[0].resource_tags == []
 
-    @mock_aws
     def test_domain_inside_vpc(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
 
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
+
         with mock.patch(
-            "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service import (
                 OpenSearchDomain,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -274,7 +274,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Opensearch domain {domain_name} is in a VPC."
+                == f"Opensearch domain {domain_name} is in a VPC, then it is not publicly accessible."
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -308,7 +308,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             assert result[0].resource_tags == []
 
     def test_domain_inside_vpc(self):
-        domain_arn = f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
+        domain_arn = f"arn:aws:es:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
         opensearch_client.opensearch_domains.append(

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_test.py
@@ -4,12 +4,9 @@ from unittest import mock
 from boto3 import client
 from moto import mock_aws
 
-from prowler.providers.aws.services.opensearch.opensearch_service import (
-    OpenSearchDomain,
-)
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
-    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_WEST_2,
     set_mocked_aws_provider,
 )
 
@@ -81,7 +78,7 @@ policy_data_source_whole_internet = {
 class Test_opensearch_service_domains_not_publicly_accessible:
     @mock_aws
     def test_no_domains(self):
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         from prowler.providers.aws.services.opensearch.opensearch_service import (
             OpenSearchService,
@@ -104,7 +101,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
 
     @mock_aws
     def test_policy_data_restricted(self):
-        opensearch_client = client("opensearch", region_name=AWS_REGION_EU_WEST_1)
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
         domain_arn = opensearch_client.create_domain(DomainName=domain_name)[
             "DomainStatus"
         ]["ARN"]
@@ -113,7 +110,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             AccessPolicies=str(policy_data_restricted),
         )
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         from prowler.providers.aws.services.opensearch.opensearch_service import (
             OpenSearchService,
@@ -140,12 +137,12 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_WEST_2
             assert result[0].resource_tags == []
 
     @mock_aws
     def test_policy_data_not_restricted_with_principal_AWS(self):
-        opensearch_client = client("opensearch", region_name=AWS_REGION_EU_WEST_1)
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
         domain_arn = opensearch_client.create_domain(DomainName=domain_name)[
             "DomainStatus"
         ]["ARN"]
@@ -154,7 +151,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             AccessPolicies=dumps(policy_data_not_restricted),
         )
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         from prowler.providers.aws.services.opensearch.opensearch_service import (
             OpenSearchService,
@@ -181,12 +178,12 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_WEST_2
             assert result[0].resource_tags == []
 
     @mock_aws
     def test_policy_data_not_restricted_with_principal_no_AWS(self):
-        opensearch_client = client("opensearch", region_name=AWS_REGION_EU_WEST_1)
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
         domain_arn = opensearch_client.create_domain(DomainName=domain_name)[
             "DomainStatus"
         ]["ARN"]
@@ -195,7 +192,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             AccessPolicies=dumps(policy_data_not_restricted_principal),
         )
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         from prowler.providers.aws.services.opensearch.opensearch_service import (
             OpenSearchService,
@@ -222,12 +219,12 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_WEST_2
             assert result[0].resource_tags == []
 
     @mock_aws
     def test_policy_data_not_restricted_ip_full(self):
-        opensearch_client = client("opensearch", region_name=AWS_REGION_EU_WEST_1)
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
         domain_arn = opensearch_client.create_domain(DomainName=domain_name)[
             "DomainStatus"
         ]["ARN"]
@@ -236,7 +233,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             AccessPolicies=dumps(policy_data_source_ip_full),
         )
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         from prowler.providers.aws.services.opensearch.opensearch_service import (
             OpenSearchService,
@@ -263,12 +260,12 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_WEST_2
             assert result[0].resource_tags == []
 
     @mock_aws
     def test_policy_data_not_restricted_whole_internet(self):
-        opensearch_client = client("opensearch", region_name=AWS_REGION_EU_WEST_1)
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
         domain_arn = opensearch_client.create_domain(DomainName=domain_name)[
             "DomainStatus"
         ]["ARN"]
@@ -277,7 +274,7 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             AccessPolicies=dumps(policy_data_source_whole_internet),
         )
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         from prowler.providers.aws.services.opensearch.opensearch_service import (
             OpenSearchService,
@@ -304,29 +301,32 @@ class Test_opensearch_service_domains_not_publicly_accessible:
             )
             assert result[0].resource_id == domain_name
             assert result[0].resource_arn == domain_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_WEST_2
             assert result[0].resource_tags == []
 
+    @mock_aws
     def test_domain_inside_vpc(self):
-        opensearch_domain_arn = f"arn:aws:es:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
-        opensearch_client.opensearch_domains.append(
-            OpenSearchDomain(
-                name=domain_name,
-                region=AWS_REGION_EU_WEST_1,
-                arn=opensearch_domain_arn,
-                vpc_id="vpc-123456",
-            )
-        )
-        opensearch_client.opensearch_domains[0].logging = []
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
             opensearch_client,
         ):
+            from prowler.providers.aws.services.opensearch.opensearch_service import (
+                OpenSearchDomain,
+            )
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible import (
                 opensearch_service_domains_not_publicly_accessible,
+            )
+
+            opensearch_client.opensearch_domains.append(
+                OpenSearchDomain(
+                    name=domain_name,
+                    region=AWS_REGION_US_WEST_2,
+                    arn=f"arn:aws:es:{AWS_REGION_US_WEST_2}:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}",
+                    vpc_id="vpc-123456",
+                )
             )
 
             check = opensearch_service_domains_not_publicly_accessible()
@@ -338,6 +338,9 @@ class Test_opensearch_service_domains_not_publicly_accessible:
                 == f"Opensearch domain {domain_name} is in a VPC, then it is not publicly accessible."
             )
             assert result[0].resource_id == domain_name
-            assert result[0].resource_arn == opensearch_domain_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:es:{AWS_REGION_US_WEST_2}:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}"
+            )
+            assert result[0].region == AWS_REGION_US_WEST_2
             assert result[0].resource_tags == []

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_updated_to_the_latest_service_software_version/opensearch_service_domains_updated_to_the_latest_service_software_version_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_updated_to_the_latest_service_software_version/opensearch_service_domains_updated_to_the_latest_service_software_version_test.py
@@ -14,9 +14,13 @@ class Test_opensearch_service_domains_updated_to_the_latest_service_software_ver
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_service_domains_updated_to_the_latest_service_software_version import (
                 opensearch_service_domains_updated_to_the_latest_service_software_version,
@@ -43,7 +47,10 @@ class Test_opensearch_service_domains_updated_to_the_latest_service_software_ver
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_service_domains_updated_to_the_latest_service_software_version import (
                 opensearch_service_domains_updated_to_the_latest_service_software_version,
@@ -76,7 +83,10 @@ class Test_opensearch_service_domains_updated_to_the_latest_service_software_ver
 
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
-            opensearch_client,
+            new=opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_updated_to_the_latest_service_software_version.opensearch_service_domains_updated_to_the_latest_service_software_version import (
                 opensearch_service_domains_updated_to_the_latest_service_software_version,

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_use_cognito_authentication_for_kibana/opensearch_service_domains_use_cognito_authentication_for_kibana_test.py
@@ -13,9 +13,13 @@ class Test_opensearch_service_domains_use_cognito_authentication_for_kibana:
     def test_no_domains(self):
         opensearch_client = mock.MagicMock
         opensearch_client.opensearch_domains = []
+
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
             opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana import (
                 opensearch_service_domains_use_cognito_authentication_for_kibana,
@@ -41,6 +45,9 @@ class Test_opensearch_service_domains_use_cognito_authentication_for_kibana:
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
             opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana import (
                 opensearch_service_domains_use_cognito_authentication_for_kibana,
@@ -74,6 +81,9 @@ class Test_opensearch_service_domains_use_cognito_authentication_for_kibana:
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
             opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana import (
                 opensearch_service_domains_use_cognito_authentication_for_kibana,
@@ -108,6 +118,9 @@ class Test_opensearch_service_domains_use_cognito_authentication_for_kibana:
         with mock.patch(
             "prowler.providers.aws.services.opensearch.opensearch_service.OpenSearchService",
             opensearch_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_client",
+            new=opensearch_client,
         ):
             from prowler.providers.aws.services.opensearch.opensearch_service_domains_use_cognito_authentication_for_kibana.opensearch_service_domains_use_cognito_authentication_for_kibana import (
                 opensearch_service_domains_use_cognito_authentication_for_kibana,

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -159,10 +159,9 @@ class Test_OpenSearchService_Service:
         assert opensearch.opensearch_domains[0].region == AWS_REGION_EU_WEST_1
         assert opensearch.opensearch_domains[0].arn == domain_arn
         assert opensearch.opensearch_domains[0].access_policy
-        assert (
-            opensearch.opensearch_domains[0].vpc_endpoints
-            == "vpc-endpoint-h2dsd34efgyghrtguk5gt6j2foh4.us-east-1.es.amazonaws.com"
-        )
+        assert opensearch.opensearch_domains[0].vpc_endpoints == [
+            "vpc-endpoint-h2dsd34efgyghrtguk5gt6j2foh4.us-east-1.es.amazonaws.com"
+        ]
         assert opensearch.opensearch_domains[0].vpc_id == "test-vpc-id"
         assert opensearch.opensearch_domains[0].cognito_options
         assert opensearch.opensearch_domains[0].encryption_at_rest

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -160,7 +160,7 @@ class Test_OpenSearchService_Service:
         assert opensearch.opensearch_domains[0].arn == domain_arn
         assert opensearch.opensearch_domains[0].access_policy
         assert (
-            opensearch.opensearch_domains[0].endpoint_vpc
+            opensearch.opensearch_domains[0].vpc_endpoints
             == "vpc-endpoint-h2dsd34efgyghrtguk5gt6j2foh4.us-east-1.es.amazonaws.com"
         )
         assert opensearch.opensearch_domains[0].vpc_id == "test-vpc-id"


### PR DESCRIPTION
### Context

Check `opensearch_service_domains_not_publicly_accessible` did not take into account that a domain was inside a VPC, which would make it non-publicly accessible regardless of the policies.

Fixes https://github.com/prowler-cloud/prowler/issues/4494
### Description

- Change `endpoint_vpc` to `vpc_endpoints` and support for multiple endpoints
- Add new verification if domain is inside of VPC
- Add new check with this case

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
