### PR TITLE
fix(status): Recover status filtering

### DIFF
--- a/docs/tutorials/misc.md
+++ b/docs/tutorials/misc.md
@@ -10,7 +10,7 @@ Execute Prowler in verbose mode (like in Version 2):
 prowler <provider> --verbose
 ```
 ## Filter findings by status
-Prowler can filter the findings by their status:
+Prowler can filter the findings by their status, so you can see only in the CLI and in the reports the findings with a specific status:
 ```console
 prowler <provider> --status [PASS, FAIL, MANUAL]
 ```

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -593,7 +593,6 @@ def prowler():
                 aws_partition=global_provider.identity.partition,
                 aws_session=global_provider.session.current_session,
                 findings=asff_output.data,
-                status=global_provider.output_options.status,
                 send_only_fails=global_provider.output_options.send_sh_only_fails,
                 aws_security_hub_available_regions=security_hub_regions,
             )

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -706,6 +706,13 @@ def execute(
             check_class, verbose, global_provider.output_options.only_logs
         )
 
+        # Exclude findings per status
+        check_findings = [
+            finding
+            for finding in check_findings
+            if finding.status in global_provider.output_options.status
+        ]
+
         # Update Audit Status
         services_executed.add(service)
         checks_executed.add(check_name)

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -707,11 +707,12 @@ def execute(
         )
 
         # Exclude findings per status
-        check_findings = [
-            finding
-            for finding in check_findings
-            if finding.status in global_provider.output_options.status
-        ]
+        if global_provider.output_options.status:
+            check_findings = [
+                finding
+                for finding in check_findings
+                if finding.status in global_provider.output_options.status
+            ]
 
         # Update Audit Status
         services_executed.add(service)

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -25,6 +25,7 @@ def stdout_report(finding, color, verbose, status, fix):
             )
 
 
+# TODO: Only pass check_findings, provider.output_options and provider.type
 def report(check_findings, provider):
     try:
         output_options = provider.output_options

--- a/tests/providers/aws/lib/security_hub/security_hub_test.py
+++ b/tests/providers/aws/lib/security_hub/security_hub_test.py
@@ -240,7 +240,7 @@ class TestSecurityHub:
             findings=asff.data,
         )
 
-        assert security_hub._findings_per_region is None
+        assert security_hub._findings_per_region == {}
 
     @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_filter_security_hub_findings_per_region_disabled_region(self):
@@ -260,24 +260,6 @@ class TestSecurityHub:
         assert security_hub._findings_per_region == {AWS_REGION_EU_WEST_1: []}
 
     @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
-    def test_filter_security_hub_findings_per_region_PASS_and_FAIL_statuses(self):
-        findings = [generate_finding_output(status="PASS", region=AWS_REGION_EU_WEST_1)]
-        asff = ASFF(findings=findings)
-
-        security_hub = SecurityHub(
-            aws_session=session.Session(
-                region_name=AWS_REGION_EU_WEST_1,
-            ),
-            aws_account_id=AWS_ACCOUNT_NUMBER,
-            aws_partition=AWS_COMMERCIAL_PARTITION,
-            aws_security_hub_available_regions=[AWS_REGION_EU_WEST_1],
-            findings=asff.data,
-            status=["FAIL"],
-        )
-
-        assert security_hub._findings_per_region == {AWS_REGION_EU_WEST_1: []}
-
-    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_filter_security_hub_findings_per_region_FAIL_and_FAIL_statuses(self):
         findings = [generate_finding_output(status="FAIL", region=AWS_REGION_EU_WEST_1)]
         asff = ASFF(findings=findings)
@@ -290,7 +272,6 @@ class TestSecurityHub:
             aws_partition=AWS_COMMERCIAL_PARTITION,
             aws_security_hub_available_regions=[AWS_REGION_EU_WEST_1],
             findings=asff.data,
-            status=["FAIL"],
         )
 
         assert security_hub._findings_per_region == {
@@ -310,7 +291,6 @@ class TestSecurityHub:
             aws_partition=AWS_COMMERCIAL_PARTITION,
             aws_security_hub_available_regions=[AWS_REGION_EU_WEST_1],
             findings=asff.data,
-            status=[],
             send_only_fails=True,
         )
 
@@ -329,7 +309,6 @@ class TestSecurityHub:
             aws_partition=AWS_COMMERCIAL_PARTITION,
             aws_security_hub_available_regions=[AWS_REGION_EU_WEST_1],
             findings=asff.data,
-            status=[],
             send_only_fails=True,
         )
 
@@ -350,11 +329,10 @@ class TestSecurityHub:
             aws_partition=AWS_COMMERCIAL_PARTITION,
             aws_security_hub_available_regions=[],
             findings=asff.data,
-            status=[],
             send_only_fails=True,
         )
 
-        assert security_hub._findings_per_region is None
+        assert security_hub._findings_per_region == {}
 
     @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_filter_security_hub_findings_per_region_muted_fail_with_send_sh_only_fails(
@@ -375,7 +353,6 @@ class TestSecurityHub:
             aws_partition=AWS_COMMERCIAL_PARTITION,
             aws_security_hub_available_regions=[AWS_REGION_EU_WEST_1],
             findings=asff.data,
-            status=[],
             send_only_fails=True,
         )
 
@@ -400,7 +377,6 @@ class TestSecurityHub:
             aws_partition=AWS_COMMERCIAL_PARTITION,
             aws_security_hub_available_regions=[AWS_REGION_EU_WEST_1],
             findings=asff.data,
-            status=["FAIL"],
             send_only_fails=True,
         )
 

--- a/tests/providers/aws/utils.py
+++ b/tests/providers/aws/utils.py
@@ -107,6 +107,7 @@ def set_mocked_aws_provider(
     original_session: session.Session = None,
     enabled_regions: set = None,
     arguments: Namespace = Namespace(),
+    status: list[str] = [],
     create_default_organization: bool = True,
 ) -> AwsProvider:
     if create_default_organization:
@@ -114,12 +115,13 @@ def set_mocked_aws_provider(
         create_default_aws_organization()
 
     # Default arguments
-    arguments = set_default_provider_arguments(arguments)
+    arguments = set_default_provider_arguments(arguments, status)
 
     # AWS Provider
     provider = AwsProvider(arguments)
 
     # Output options
+
     provider.output_options = arguments, {}
 
     # Mock Session
@@ -156,8 +158,10 @@ def set_mocked_aws_provider(
     return provider
 
 
-def set_default_provider_arguments(arguments: Namespace) -> Namespace:
-    arguments.status = []
+def set_default_provider_arguments(
+    arguments: Namespace, status: list = []
+) -> Namespace:
+    arguments.status = status
     arguments.output_formats = []
     arguments.output_directory = ""
     arguments.verbose = False


### PR DESCRIPTION
### Context

Fixes #4571

### Description

Recover the `status` filtering for findings.

TODO
- [x] Add tests to prevent this from happening again
- [x] Think about the current logic
- [x] Add a clear explanation of this logic to the documentation


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
