### PR TITLE
fix(mutelist): Fix tags match

### DIFF
--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -172,7 +172,9 @@ class Mutelist(ABC):
                     muted_in_resource = self.is_item_matched(
                         muted_resources, finding_resource
                     )
-                    muted_in_tags = self.is_item_matched(muted_tags, finding_tags)
+                    muted_in_tags = self.is_item_matched(
+                        muted_tags, finding_tags, tag=True
+                    )
 
                     # For a finding to be muted requires the following set to True:
                     # - muted_in_check -> True
@@ -240,7 +242,9 @@ class Mutelist(ABC):
                 )
 
                 excepted_tags = exceptions.get("Tags", [])
-                is_tag_excepted = self.is_item_matched(excepted_tags, finding_tags)
+                is_tag_excepted = self.is_item_matched(
+                    excepted_tags, finding_tags, tag=True
+                )
 
                 if (
                     not is_account_excepted
@@ -264,7 +268,7 @@ class Mutelist(ABC):
             return False
 
     @staticmethod
-    def is_item_matched(matched_items, finding_items):
+    def is_item_matched(matched_items, finding_items, tag=False):
         """
         Check if any of the items in matched_items are present in finding_items.
 
@@ -278,10 +282,15 @@ class Mutelist(ABC):
         try:
             is_item_matched = False
             if matched_items and (finding_items or finding_items == ""):
+                # If we use tags, we need to use re.search instead of re.match because we need to match the tags in the format key1=value1 | key2=value2
+                if tag:
+                    operation = re.search
+                else:
+                    operation = re.match
                 for item in matched_items:
                     if item.startswith("*"):
                         item = ".*" + item[1:]
-                    if re.match(item, finding_items):
+                    if operation(item, finding_items):
                         is_item_matched = True
                         break
             return is_item_matched

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -1223,35 +1223,32 @@ class TestAWSMutelist:
     def test_is_muted_in_tags(self):
         mutelist_tags = ["environment=dev", "project=prowler"]
 
-        assert AWSMutelist.is_item_matched(mutelist_tags, "environment=dev")
+        assert AWSMutelist.is_item_matched(mutelist_tags, "environment=dev", tag=True)
 
         assert AWSMutelist.is_item_matched(
-            mutelist_tags,
-            "environment=dev | project=prowler",
+            mutelist_tags, "environment=dev | project=prowler", tag=True
+        )
+
+        assert AWSMutelist.is_item_matched(
+            mutelist_tags, "environment=pro | project=prowler", tag=True
         )
 
         assert not (
-            AWSMutelist.is_item_matched(
-                mutelist_tags,
-                "environment=pro",
-            )
+            AWSMutelist.is_item_matched(mutelist_tags, "environment=pro", tag=True)
         )
 
     def test_is_muted_in_tags_regex(self):
         mutelist_tags = ["environment=(dev|test)", ".*=prowler"]
         assert AWSMutelist.is_item_matched(
-            mutelist_tags,
-            "environment=test | proj=prowler",
+            mutelist_tags, "environment=test | proj=prowler", tag=True
         )
 
         assert AWSMutelist.is_item_matched(
-            mutelist_tags,
-            "env=prod | project=prowler",
+            mutelist_tags, "env=prod | project=prowler", tag=True
         )
 
         assert not AWSMutelist.is_item_matched(
-            mutelist_tags,
-            "environment=prod | project=myproj",
+            mutelist_tags, "environment=prod | project=myproj", tag=True
         )
 
     def test_is_muted_in_tags_with_no_tags_in_finding(self):

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -1237,6 +1237,23 @@ class TestAWSMutelist:
             AWSMutelist.is_item_matched(mutelist_tags, "environment=pro", tag=True)
         )
 
+    def test_is_muted_in_tags_with_piped_tags(self):
+        mutelist_tags = ["environment=dev|project=prowler"]
+
+        assert AWSMutelist.is_item_matched(mutelist_tags, "environment=dev", tag=True)
+
+        assert AWSMutelist.is_item_matched(
+            mutelist_tags, "environment=dev | project=prowler", tag=True
+        )
+
+        assert AWSMutelist.is_item_matched(
+            mutelist_tags, "environment=pro | project=prowler", tag=True
+        )
+
+        assert not (
+            AWSMutelist.is_item_matched(mutelist_tags, "environment=pro", tag=True)
+        )
+
     def test_is_muted_in_tags_regex(self):
         mutelist_tags = ["environment=(dev|test)", ".*=prowler"]
         assert AWSMutelist.is_item_matched(


### PR DESCRIPTION
### Context

Fix #4597

### Description

Fix how the `finding.tags` are used when matching the Mutelist.

### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
