### PR TITLE
fix(gcp): use KMS key id in checks

### DIFF
--- a/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -8,7 +8,7 @@ class kms_key_not_publicly_accessible(Check):
         for key in kms_client.crypto_keys:
             report = Check_Report_GCP(self.metadata())
             report.project_id = key.project_id
-            report.resource_id = key.name
+            report.resource_id = key.id
             report.resource_name = key.name
             report.location = key.location
             report.status = "PASS"

--- a/prowler/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled.py
+++ b/prowler/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled.py
@@ -8,7 +8,7 @@ class kms_key_rotation_enabled(Check):
         for key in kms_client.crypto_keys:
             report = Check_Report_GCP(self.metadata())
             report.project_id = key.project_id
-            report.resource_id = key.name
+            report.resource_id = key.id
             report.resource_name = key.name
             report.location = key.location
             report.status = "FAIL"

--- a/prowler/providers/gcp/services/kms/kms_service.py
+++ b/prowler/providers/gcp/services/kms/kms_service.py
@@ -88,6 +88,7 @@ class KMS(GCPService):
                     for key in response.get("cryptoKeys", []):
                         self.crypto_keys.append(
                             CriptoKey(
+                                id=key["name"],
                                 name=key["name"].split("/")[-1],
                                 location=key["name"].split("/")[3],
                                 rotation_period=key.get("rotationPeriod"),
@@ -139,6 +140,7 @@ class KeyRing(BaseModel):
 
 
 class CriptoKey(BaseModel):
+    id: str
     name: str
     location: str
     rotation_period: Optional[str]

--- a/tests/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_gcp_test.py
+++ b/tests/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible_gcp_test.py
@@ -65,6 +65,7 @@ class Test_kms_key_not_publicly_accessible_gcp:
             kms_client.crypto_keys = [
                 CriptoKey(
                     name="key1",
+                    id="projects/123/locations/us-central1/keyRings/keyring1/cryptoKeys/key1",
                     project_id=GCP_PROJECT_ID,
                     rotation_period="7776000s",
                     key_ring=keyring.name,
@@ -81,7 +82,7 @@ class Test_kms_key_not_publicly_accessible_gcp:
                 result[0].status_extended
                 == f"Key {kms_client.crypto_keys[0].name} may be publicly accessible."
             )
-            assert result[0].resource_id == kms_client.crypto_keys[0].name
+            assert result[0].resource_id == kms_client.crypto_keys[0].id
             assert result[0].resource_name == kms_client.crypto_keys[0].name
             assert result[0].location == kms_client.crypto_keys[0].location
             assert result[0].project_id == kms_client.crypto_keys[0].project_id
@@ -121,6 +122,7 @@ class Test_kms_key_not_publicly_accessible_gcp:
             kms_client.crypto_keys = [
                 CriptoKey(
                     name="key1",
+                    id="projects/123/locations/us-central1/keyRings/keyring1/cryptoKeys/key1",
                     project_id=GCP_PROJECT_ID,
                     rotation_period="7776000s",
                     key_ring=keyring.name,
@@ -137,7 +139,7 @@ class Test_kms_key_not_publicly_accessible_gcp:
                 result[0].status_extended
                 == f"Key {kms_client.crypto_keys[0].name} is not exposed to Public."
             )
-            assert result[0].resource_id == kms_client.crypto_keys[0].name
+            assert result[0].resource_id == kms_client.crypto_keys[0].id
             assert result[0].resource_name == kms_client.crypto_keys[0].name
             assert result[0].location == kms_client.crypto_keys[0].location
             assert result[0].project_id == kms_client.crypto_keys[0].project_id
@@ -177,6 +179,7 @@ class Test_kms_key_not_publicly_accessible_gcp:
             kms_client.crypto_keys = [
                 CriptoKey(
                     name="key1",
+                    id="projects/123/locations/us-central1/keyRings/keyring1/cryptoKeys/key1",
                     project_id=GCP_PROJECT_ID,
                     rotation_period="7776000s",
                     key_ring=keyring.name,
@@ -193,7 +196,7 @@ class Test_kms_key_not_publicly_accessible_gcp:
                 result[0].status_extended
                 == f"Key {kms_client.crypto_keys[0].name} is not exposed to Public."
             )
-            assert result[0].resource_id == kms_client.crypto_keys[0].name
+            assert result[0].resource_id == kms_client.crypto_keys[0].id
             assert result[0].resource_name == kms_client.crypto_keys[0].name
             assert result[0].location == kms_client.crypto_keys[0].location
             assert result[0].project_id == kms_client.crypto_keys[0].project_id

--- a/tests/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled_test.py
+++ b/tests/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled_test.py
@@ -65,6 +65,7 @@ class Test_kms_key_rotation_enabled:
             kms_client.crypto_keys = [
                 CriptoKey(
                     name="key1",
+                    id="projects/123/locations/us-central1/keyRings/keyring1/cryptoKeys/key1",
                     project_id=GCP_PROJECT_ID,
                     key_ring=keyring.name,
                     location=keylocation.name,
@@ -80,7 +81,7 @@ class Test_kms_key_rotation_enabled:
                 result[0].status_extended
                 == f"Key {kms_client.crypto_keys[0].name} is not rotated every 90 days or less."
             )
-            assert result[0].resource_id == kms_client.crypto_keys[0].name
+            assert result[0].resource_id == kms_client.crypto_keys[0].id
             assert result[0].resource_name == kms_client.crypto_keys[0].name
             assert result[0].location == kms_client.crypto_keys[0].location
             assert result[0].project_id == kms_client.crypto_keys[0].project_id
@@ -120,6 +121,7 @@ class Test_kms_key_rotation_enabled:
             kms_client.crypto_keys = [
                 CriptoKey(
                     name="key1",
+                    id="projects/123/locations/us-central1/keyRings/keyring1/cryptoKeys/key1",
                     project_id=GCP_PROJECT_ID,
                     rotation_period="8776000s",
                     key_ring=keyring.name,
@@ -136,7 +138,7 @@ class Test_kms_key_rotation_enabled:
                 result[0].status_extended
                 == f"Key {kms_client.crypto_keys[0].name} is not rotated every 90 days or less."
             )
-            assert result[0].resource_id == kms_client.crypto_keys[0].name
+            assert result[0].resource_id == kms_client.crypto_keys[0].id
             assert result[0].resource_name == kms_client.crypto_keys[0].name
             assert result[0].location == kms_client.crypto_keys[0].location
             assert result[0].project_id == kms_client.crypto_keys[0].project_id
@@ -176,6 +178,7 @@ class Test_kms_key_rotation_enabled:
             kms_client.crypto_keys = [
                 CriptoKey(
                     name="key1",
+                    id="projects/123/locations/us-central1/keyRings/keyring1/cryptoKeys/key1",
                     project_id=GCP_PROJECT_ID,
                     rotation_period="7776000s",
                     key_ring=keyring.name,
@@ -192,7 +195,7 @@ class Test_kms_key_rotation_enabled:
                 result[0].status_extended
                 == f"Key {kms_client.crypto_keys[0].name} is rotated every 90 days or less."
             )
-            assert result[0].resource_id == kms_client.crypto_keys[0].name
+            assert result[0].resource_id == kms_client.crypto_keys[0].id
             assert result[0].resource_name == kms_client.crypto_keys[0].name
             assert result[0].location == kms_client.crypto_keys[0].location
             assert result[0].project_id == kms_client.crypto_keys[0].project_id


### PR DESCRIPTION
### Context

Fix #4600

### Description

Use KMS key IDs in GCP KMS checks.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
