### PR TITLE
docs(Tutorials): include volume option when running dashboard in docker

### DIFF
--- a/docs/tutorials/dashboard.md
+++ b/docs/tutorials/dashboard.md
@@ -10,8 +10,10 @@ prowler dashboard
 To run Prowler local dashboard with Docker, use:
 
 ```sh
-docker run --env HOST=0.0.0.0 --publish 127.0.0.1:11666:11666 toniblyx/prowler:latest dashboard
+docker run -v /your/local/dir/prowler-output:/home/prowler/output --env HOST=0.0.0.0 --publish 127.0.0.1:11666:11666 toniblyx/prowler:latest dashboard
 ```
+
+Make sure you update the `/your/local/dir/prowler-output` to match the path that contains your prowler output.
 
 ???+ note
     **Remember that the `dashboard` server is not authenticated, if you expose it to the internet, you are running it at your own risk.**


### PR DESCRIPTION
### Context

The tutorial for running `prowler dashboard` in a Docker container does not show how to load prowler outputs into the container. 

Fix #4619

### Description

1. Updated docs to include an example `-v` docker `run` argument.
 
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
