### PR TITLE
fix(tags): handle AWS dictionary type tags

### DIFF
--- a/prowler/lib/outputs/utils.py
+++ b/prowler/lib/outputs/utils.py
@@ -59,8 +59,14 @@ def unroll_tags(tags: list) -> dict:
         >>> tags = []
         >>> unroll_tags(tags)
         {}
+
+        >>> tags = {"name": "John", "age": "30"}
+        >>> unroll_tags(tags)
+        {'name': 'John', 'age': '30'}
     """
     if tags and tags != [{}] and tags != [None]:
+        if isinstance(tags, dict):
+            return tags
         if "key" in tags[0]:
             return {item["key"]: item["value"] for item in tags}
         elif "Key" in tags[0]:

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -106,6 +106,21 @@ class TestOutputs:
             "terraform": "true",
         }
 
+    def test_unroll_dict_tags(self):
+        tags_dict = {
+            "environment": "dev",
+            "name": "test",
+            "project": "prowler",
+            "terraform": "true",
+        }
+
+        assert unroll_tags(tags_dict) == {
+            "environment": "dev",
+            "name": "test",
+            "project": "prowler",
+            "terraform": "true",
+        }
+
     def test_unroll_tags_unique(self):
         unique_dict_list = [
             {


### PR DESCRIPTION
### Context

Fix #4655 

### Description

Handle AWS dictionary type tags in `unroll_tags` function.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
