### PR TITLE
chore(backport): Automate all the things!

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,14 @@
+{
+  "repoOwner": "prowler-cloud",
+  "repoName": "prowler",
+  "targetPRLabels": [
+    "backport"
+  ],
+  "sourcePRLabels": [
+    "was-backported"
+  ],
+  "copySourcePRLabels": false,
+  "copySourcePRReviewers": true,
+  "prTitle": "chore(backport): {{commitMessages}} backport for {{targetBranch}}",
+  "commitConflicts": true
+}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,26 @@
+name: Automatic Backport
+
+on:
+  pull_request_target:
+    branches: ['master']
+    types: ['labeled', 'closed']
+
+jobs:
+  backport:
+    name: Backport PR
+    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v9.5.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
### Context

Automate the backport process!

### Description

Automate the backport process.

- A PR that needs to be backported to an specific branch needs to be labeled as `backport-to-<BRANCH>`
- A successfully backported branch will have the `was-backported` label
- A backport PR will have the `backport` label
- All `backport-to-<BRANCH>` must use the red color

### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
