### PR TITLE
feat(kubernetes): add a test_connection method

### DIFF
--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -190,7 +190,7 @@ class KubernetesProvider(Provider):
             input_context (str): Context name.
 
         Returns:
-            KubernetesSession: A Kubernetes session.
+            Connection: A Connection object.
         """
         try:
             KubernetesProvider.setup_session(kubeconfig_file, input_context)

--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -180,7 +180,9 @@ class KubernetesProvider(Provider):
 
     @staticmethod
     def test_connection(
-        kubeconfig_file: str, input_context: str, raise_on_exception: bool = True
+        kubeconfig_file: str = "~/.kube/config",
+        input_context: str = "",
+        raise_on_exception: bool = True,
     ) -> Connection:
         """
         Tests the connection to the Kubernetes cluster.


### PR DESCRIPTION
### Context

We need to be able to test the connection to each provider using one of the available authentication methods, starting from the environment variables.

### Description

Add a test_connection method for the Kubernetes provider.
Create a test_connection abstract method in the Provider class but not enforced for now not to break anything.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
