### PR TITLE
fix(iam): handle no arn serial numbers for MFA devices

### DIFF
--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -386,7 +386,7 @@ class IAM(AWSService):
                         mfa_serial_number = mfa_device["SerialNumber"]
                         try:
                             mfa_type = mfa_serial_number.split(":")[5].split("/")[0]
-                        except Exception:
+                        except IndexError:
                             mfa_type = "unknown"
                         mfa_devices.append(
                             MFADevice(serial_number=mfa_serial_number, type=mfa_type)

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -387,7 +387,7 @@ class IAM(AWSService):
                         try:
                             mfa_type = mfa_serial_number.split(":")[5].split("/")[0]
                         except IndexError:
-                            mfa_type = "unknown"
+                            mfa_type = "hardware"
                         mfa_devices.append(
                             MFADevice(serial_number=mfa_serial_number, type=mfa_type)
                         )

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -384,9 +384,10 @@ class IAM(AWSService):
                 for page in list_mfa_devices_paginator.paginate(UserName=user.name):
                     for mfa_device in page["MFADevices"]:
                         mfa_serial_number = mfa_device["SerialNumber"]
-                        mfa_type = (
-                            mfa_device["SerialNumber"].split(":")[5].split("/")[0]
-                        )
+                        try:
+                            mfa_type = mfa_serial_number.split(":")[5].split("/")[0]
+                        except Exception:
+                            mfa_type = "unknown"
                         mfa_devices.append(
                             MFADevice(serial_number=mfa_serial_number, type=mfa_type)
                         )

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -424,7 +424,7 @@ class Test_IAM_Service:
 
     # Test IAM List MFA Device
     @mock_aws
-    def test__list_mfa_devices__(self):
+    def test__list_mfa_devices_arn__(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Generate IAM user
@@ -454,6 +454,33 @@ class Test_IAM_Service:
             == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:mfa/{mfa_device_name}"
         )
         assert iam.users[0].mfa_devices[0].type == "mfa"
+
+    # Test IAM List MFA Device
+    @mock_aws
+    def test__list_mfa_devices_number__(self):
+        # Generate IAM Client
+        iam_client = client("iam")
+        # Generate IAM user
+        iam_client.create_user(
+            UserName="user1",
+        )
+        # Create Unknown MFA device
+        virtual_mfa_device = "XXXXXXXXX"
+        iam_client.enable_mfa_device(
+            UserName="user1",
+            SerialNumber=virtual_mfa_device,
+            AuthenticationCode1="123456",
+            AuthenticationCode2="123456",
+        )
+
+        # IAM client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        assert len(iam.users) == 1
+        assert len(iam.users[0].mfa_devices) == 1
+        assert iam.users[0].mfa_devices[0].serial_number == virtual_mfa_device
+        assert iam.users[0].mfa_devices[0].type == "unknown"
 
     # Test IAM List Virtual MFA Device
     @mock_aws

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -465,10 +465,10 @@ class Test_IAM_Service:
             UserName="user1",
         )
         # Create Unknown MFA device
-        virtual_mfa_device = "XXXXXXXXX"
+        hardware_mfa_devide = "XXXXXXXXX"
         iam_client.enable_mfa_device(
             UserName="user1",
-            SerialNumber=virtual_mfa_device,
+            SerialNumber=hardware_mfa_devide,
             AuthenticationCode1="123456",
             AuthenticationCode2="123456",
         )
@@ -479,7 +479,7 @@ class Test_IAM_Service:
 
         assert len(iam.users) == 1
         assert len(iam.users[0].mfa_devices) == 1
-        assert iam.users[0].mfa_devices[0].serial_number == virtual_mfa_device
+        assert iam.users[0].mfa_devices[0].serial_number == hardware_mfa_devide
         assert iam.users[0].mfa_devices[0].type == "hardware"
 
     # Test IAM List Virtual MFA Device

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -480,7 +480,7 @@ class Test_IAM_Service:
         assert len(iam.users) == 1
         assert len(iam.users[0].mfa_devices) == 1
         assert iam.users[0].mfa_devices[0].serial_number == virtual_mfa_device
-        assert iam.users[0].mfa_devices[0].type == "unknown"
+        assert iam.users[0].mfa_devices[0].type == "hardware"
 
     # Test IAM List Virtual MFA Device
     @mock_aws


### PR DESCRIPTION
### Description

MFA serial numbers used to be an arn but in some cases are IDs. The logic provides this information:

- If `mfa` in `SerialNumber` -> mfa_type: `mfa`
- If `u2f`in `SerialNumber` -> mfa_type: `u2f`
- If the `SerialNumber` does not contain an ARN, mfa_type: `hardware`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
