### PR TITLE
docs(developer-guide): add info about docstrings

### DIFF
--- a/docs/developer-guide/introduction.md
+++ b/docs/developer-guide/introduction.md
@@ -50,6 +50,8 @@ You can see all dependencies in file `pyproject.toml`.
 
 Moreover, you would need to install [`TruffleHog`](https://github.com/trufflesecurity/trufflehog) on the latest version to check for secrets in the code. You can install it using the official installation guide [here](https://github.com/trufflesecurity/trufflehog?tab=readme-ov-file#floppy_disk-installation).
 
+Additionally, please ensure to follow the code documentation practices outlined in this guide: [Google Python Style Guide - Comments and Docstrings](https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings).
+
 ???+ note
     If you have any trouble when committing to the Prowler repository, add the `--no-verify` flag to the `git commit` command.
 


### PR DESCRIPTION
### Description

Info from https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings it's added to the dev guide.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
