### PR TITLE
fix(backport): Workaround not to fail if no backport is needed

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,16 +11,28 @@ jobs:
     if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
     runs-on: ubuntu-latest
     steps:
+      # Workaround not to fail the workflow if the PR does not need a backport
+      # https://github.com/sorenlouv/backport-github-action/issues/127#issuecomment-2258561266
+      - name: Check for backport labels
+        id: check_labels
+        run: |-
+          labels='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          echo "$labels"
+          matched=$(echo "${labels}" | jq '. | map(select(startswith("backport-to-"))) | length')
+          echo "matched=$matched"
+          echo "matched=$matched" >> $GITHUB_OUTPUT
+
       - name: Backport Action
+        if: fromJSON(steps.check_labels.outputs.matched) > 0
         uses: sorenlouv/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-to-
 
       - name: Info log
-        if: ${{ success() }}
+        if: ${{ success() && fromJSON(steps.check_labels.outputs.matched) > 0 }}
         run: cat ~/.backport/backport.info.log
 
       - name: Debug log
-        if: ${{ failure() }}
+        if: ${{ failure() && fromJSON(steps.check_labels.outputs.matched) > 0 }}
         run: cat ~/.backport/backport.debug.log


### PR DESCRIPTION
### Context

The `backport` action fails if the PR does not need a backport. The issue is known and reported in https://github.com/sorenlouv/backport-github-action/issues/127

### Description

Add a workaround to check first the labels included in the PR and if any starts with `backport-to-` the action will continue executing, if not it finishes.

### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
