### PR TITLE
fix(aws): run Prowler as IAM Root or Federated User

### DIFF
--- a/prowler/providers/aws/lib/arn/arn.py
+++ b/prowler/providers/aws/lib/arn/arn.py
@@ -46,6 +46,8 @@ def parse_iam_credentials_arn(arn: str) -> ARN:
             arn_parsed.resource_type != "role"
             and arn_parsed.resource_type != "user"
             and arn_parsed.resource_type != "assumed-role"
+            and arn_parsed.resource_type != "root"
+            and arn_parsed.resource_type != "federated-user"
         ):
             raise RoleArnParsingInvalidResourceType
         elif arn_parsed.resource == "":

--- a/tests/providers/aws/lib/arn/arn_test.py
+++ b/tests/providers/aws/lib/arn/arn_test.py
@@ -245,6 +245,73 @@ class Test_ARN_Parsing:
                     "resource": IAM_ROLE,
                 },
             },
+            # Root user
+            {
+                "input_arn": f"arn:aws:{IAM_SERVICE}::{ACCOUNT_ID}:root",
+                "expected": {
+                    "partition": COMMERCIAL_PARTITION,
+                    "service": IAM_SERVICE,
+                    "region": None,
+                    "account_id": ACCOUNT_ID,
+                    "resource_type": "root",
+                    "resource": "root",
+                },
+            },
+            {
+                "input_arn": f"arn:{CHINA_PARTITION}:{IAM_SERVICE}::{ACCOUNT_ID}:root",
+                "expected": {
+                    "partition": CHINA_PARTITION,
+                    "service": IAM_SERVICE,
+                    "region": None,
+                    "account_id": ACCOUNT_ID,
+                    "resource_type": "root",
+                    "resource": "root",
+                },
+            },
+            {
+                "input_arn": f"arn:{GOVCLOUD_PARTITION}:{IAM_SERVICE}::{ACCOUNT_ID}:root",
+                "expected": {
+                    "partition": GOVCLOUD_PARTITION,
+                    "service": IAM_SERVICE,
+                    "region": None,
+                    "account_id": ACCOUNT_ID,
+                    "resource_type": "root",
+                    "resource": "root",
+                },
+            },
+            {
+                "input_arn": f"arn:aws:sts::{ACCOUNT_ID}:federated-user/Bob",
+                "expected": {
+                    "partition": COMMERCIAL_PARTITION,
+                    "service": "sts",
+                    "region": None,
+                    "account_id": ACCOUNT_ID,
+                    "resource_type": "federated-user",
+                    "resource": "Bob",
+                },
+            },
+            {
+                "input_arn": f"arn:{CHINA_PARTITION}:sts::{ACCOUNT_ID}:federated-user/Bob",
+                "expected": {
+                    "partition": CHINA_PARTITION,
+                    "service": "sts",
+                    "region": None,
+                    "account_id": ACCOUNT_ID,
+                    "resource_type": "federated-user",
+                    "resource": "Bob",
+                },
+            },
+            {
+                "input_arn": f"arn:{GOVCLOUD_PARTITION}:sts::{ACCOUNT_ID}:federated-user/Bob",
+                "expected": {
+                    "partition": GOVCLOUD_PARTITION,
+                    "service": "sts",
+                    "region": None,
+                    "account_id": ACCOUNT_ID,
+                    "resource_type": "federated-user",
+                    "resource": "Bob",
+                },
+            },
         ]
         for test in test_cases:
             input_arn = test["input_arn"]
@@ -319,6 +386,7 @@ class Test_ARN_Parsing:
             "arn:aws:lambda:eu-west-1:123456789012:function:lambda-function"
         )
         assert is_valid_arn("arn:aws:sns:eu-west-1:123456789012:test.fifo")
+
         assert not is_valid_arn("arn:azure:::012345678910:user/test")
         assert not is_valid_arn("arn:aws:iam::account:user/test")
         assert not is_valid_arn("arn:aws:::012345678910:resource")

--- a/tests/providers/aws/lib/arn/arn_test.py
+++ b/tests/providers/aws/lib/arn/arn_test.py
@@ -386,7 +386,6 @@ class Test_ARN_Parsing:
             "arn:aws:lambda:eu-west-1:123456789012:function:lambda-function"
         )
         assert is_valid_arn("arn:aws:sns:eu-west-1:123456789012:test.fifo")
-
         assert not is_valid_arn("arn:azure:::012345678910:user/test")
         assert not is_valid_arn("arn:aws:iam::account:user/test")
         assert not is_valid_arn("arn:aws:::012345678910:resource")


### PR DESCRIPTION
### Description

Fix ARN lib so Prowler can be run as IAM Root or Federated User.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
