### PR TITLE
feat(aws): Add new RDS check to verify that cluster minor version upgrade is enabled

### DIFF
--- a/prowler/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_cluster_minor_version_upgrade_enabled",
+  "CheckTitle": "Ensure RDS clusters have minor version upgrade enabled.",
+  "CheckType": [],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
+  "Severity": "low",
+  "ResourceType": "AwsRdsDbCluster",
+  "Description": "Ensure RDS clusters have minor version upgrade enabled.",
+  "Risk": "Auto Minor Version Upgrade is a feature that you can enable to have your database automatically upgraded when a new minor database engine version is available. Minor version upgrades often patch security vulnerabilities and fix bugs and therefore should be applied.",
+  "RelatedUrl": "https://aws.amazon.com/blogs/database/best-practices-for-upgrading-amazon-rds-to-major-and-minor-versions-of-postgresql/",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws rds modify-db-cluster --db-cluster-identifier <db_cluster_id> --auto-minor-version-upgrade --apply-immediately",
+      "NativeIaC": "https://docs.prowler.com/checks/aws/general-policies/ensure-aws-db-instance-gets-all-minor-upgrades-automatically#cloudformation",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-35",
+      "Terraform": "https://docs.prowler.com/checks/aws/general-policies/ensure-aws-db-instance-gets-all-minor-upgrades-automatically#terraform"
+    },
+    "Recommendation": {
+      "Text": "Enable auto minor version upgrade for all databases and environments.",
+      "Url": "https://aws.amazon.com/blogs/database/best-practices-for-upgrading-amazon-rds-to-major-and-minor-versions-of-postgresql/"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled.py
@@ -1,0 +1,24 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_cluster_minor_version_upgrade_enabled(Check):
+    def execute(self):
+        findings = []
+        for db_cluster in rds_client.db_clusters:
+            if db_cluster.multi_az:
+                report = Check_Report_AWS(self.metadata())
+                report.region = db_cluster.region
+                report.resource_id = db_cluster.id
+                report.resource_arn = db_cluster.arn
+                report.resource_tags = db_cluster.tags
+                if db_cluster.auto_minor_version_upgrade:
+                    report.status = "PASS"
+                    report.status_extended = f"RDS Cluster {db_cluster.id} has minor version upgrade enabled."
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = f"RDS Cluster {db_cluster.id} does not have minor version upgrade enabled."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled.py
@@ -6,18 +6,18 @@ class rds_cluster_minor_version_upgrade_enabled(Check):
     def execute(self):
         findings = []
         for db_cluster in rds_client.db_clusters:
-            if db_cluster.multi_az:
+            if rds_client.db_clusters[db_cluster].multi_az:
                 report = Check_Report_AWS(self.metadata())
-                report.region = db_cluster.region
-                report.resource_id = db_cluster.id
-                report.resource_arn = db_cluster.arn
-                report.resource_tags = db_cluster.tags
-                if db_cluster.auto_minor_version_upgrade:
+                report.region = rds_client.db_clusters[db_cluster].region
+                report.resource_id = rds_client.db_clusters[db_cluster].id
+                report.resource_arn = rds_client.db_clusters[db_cluster].arn
+                report.resource_tags = rds_client.db_clusters[db_cluster].tags
+                if rds_client.db_clusters[db_cluster].auto_minor_version_upgrade:
                     report.status = "PASS"
-                    report.status_extended = f"RDS Cluster {db_cluster.id} has minor version upgrade enabled."
+                    report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} has minor version upgrade enabled."
                 else:
                     report.status = "FAIL"
-                    report.status_extended = f"RDS Cluster {db_cluster.id} does not have minor version upgrade enabled."
+                    report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} does not have minor version upgrade enabled."
 
                 findings.append(report)
 

--- a/tests/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_minor_version_upgrade_enabled/rds_cluster_minor_version_upgrade_enabled_test.py
@@ -1,0 +1,201 @@
+from unittest import mock
+
+import botocore
+from moto import mock_aws
+
+from prowler.providers.aws.services.rds.rds_service import DBCluster
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "DescribeDBEngineVersions":
+        return {
+            "DBEngineVersions": [
+                {
+                    "Engine": "aurora-mysql",
+                    "EngineVersion": "8.0.32",
+                    "DBEngineDescription": "description",
+                    "DBEngineVersionDescription": "description",
+                },
+            ]
+        }
+    return make_api_call(self, operation_name, kwarg)
+
+
+@mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+class Test_rds_cluster_minor_version_upgrade_enabled:
+    @mock_aws
+    def test_rds_no_clusters(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled import (
+                    rds_cluster_minor_version_upgrade_enabled,
+                )
+
+                check = rds_cluster_minor_version_upgrade_enabled()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    def test_rds_cluster_no_multi(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {
+            "db-cluster-1": DBCluster(
+                id="db-cluster-1",
+                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
+                endpoint="",
+                engine="aurora-postgresql",
+                status="available",
+                public=False,
+                encrypted=True,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=7,
+                backtrack=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group="default.aurora-postgresql10",
+                multi_az=False,
+                username="admin",
+                iam_auth=False,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled.rds_client",
+            new=rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled import (
+                rds_cluster_minor_version_upgrade_enabled,
+            )
+
+            check = rds_cluster_minor_version_upgrade_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_rds_cluster_no_auto_upgrade(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {
+            "db-cluster-1": DBCluster(
+                id="db-cluster-1",
+                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
+                endpoint="",
+                engine="aurora-postgresql",
+                status="available",
+                public=False,
+                encrypted=True,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=7,
+                backtrack=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group="default.aurora-postgresql10",
+                multi_az=True,
+                username="admin",
+                iam_auth=False,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled.rds_client",
+            new=rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled import (
+                rds_cluster_minor_version_upgrade_enabled,
+            )
+
+            check = rds_cluster_minor_version_upgrade_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "RDS Cluster db-cluster-1 does not have minor version upgrade enabled."
+            )
+            assert result[0].resource_id == "db-cluster-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+            )
+            assert result[0].resource_tags == []
+
+    def test_rds_cluster_with_auto_upgrade(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {
+            "db-cluster-1": DBCluster(
+                id="db-cluster-1",
+                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1",
+                endpoint="",
+                engine="aurora-postgresql",
+                status="available",
+                public=False,
+                encrypted=True,
+                auto_minor_version_upgrade=True,
+                backup_retention_period=7,
+                backtrack=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group="default.aurora-postgresql10",
+                multi_az=True,
+                username="admin",
+                iam_auth=False,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled.rds_client",
+            new=rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_minor_version_upgrade_enabled.rds_cluster_minor_version_upgrade_enabled import (
+                rds_cluster_minor_version_upgrade_enabled,
+            )
+
+            check = rds_cluster_minor_version_upgrade_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "RDS Cluster db-cluster-1 has minor version upgrade enabled."
+            )
+            assert result[0].resource_id == "db-cluster-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+            )
+            assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

This new check assesses whether automatic minor version upgrades are enabled for Amazon RDS Multi-AZ DB clusters. Enabling automatic upgrades ensures that the database clusters are promptly updated with the latest minor versions, which may include new features, bug fixes, security patches, and performance improvements. 

This check is already done for instances but it should be done for both because enabling this on clusters only verify that new instances created will have by default this option enabled, if an instance belongs to a cluster with minor upgrades enabled but it has minor upgrades disabled it won’t be updated so both checks are needed.

Also, Moto doesn’t support the parameter MultiAZ when creating a new cluster so I’ll be using Magic Mock for the test unit of the check.

### Description

I added `rds_cluster_minor_version_upgrade_enabled` with his respective unit test.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
