### PR TITLE
fix(iam): update logic of Root Hardware MFA check

### DIFF
--- a/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
@@ -15,9 +15,9 @@ class iam_root_hardware_mfa_enabled(Check):
                 report.resource_arn = iam_client.mfa_arn_template
 
                 if iam_client.account_summary["SummaryMap"]["AccountMFAEnabled"] > 0:
-                    virtual_mfas = iam_client.virtual_mfa_devices
-                    for mfa in virtual_mfas:
-                        if "root" in mfa["SerialNumber"]:
+                    for mfa in iam_client.virtual_mfa_devices:
+                        # If the ARN of the associated IAM user of the Virtual MFA device is "arn:aws:iam::[aws-account-id]:root", your AWS root account is not using a hardware-based MFA device for MFA protection.
+                        if "root" in mfa.get("User", {}).get("Arn", ""):
                             virtual_mfa = True
                             report.status = "FAIL"
                             report.status_extended = "Root account has a virtual MFA instead of a hardware MFA device enabled."

--- a/tests/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled_test.py
+++ b/tests/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled_test.py
@@ -1,9 +1,6 @@
 from re import search
 from unittest import mock
 
-from boto3 import client
-from moto import mock_aws
-
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
@@ -19,13 +16,20 @@ class Test_iam_root_hardware_mfa_enabled_test:
         set_mocked_aws_provider,
     )
 
-    @mock_aws
-    def test_root_hardware_virtual_mfa_enabled(self):
-        iam = client("iam")
-        mfa_device_name = "mfa-test"
-        iam.create_virtual_mfa_device(VirtualMFADeviceName=mfa_device_name)
-
-        from prowler.providers.aws.services.iam.iam_service import IAM
+    def test_root_virtual_mfa_enabled(self):
+        iam_client = mock.MagicMock
+        iam_client.account_summary = {
+            "SummaryMap": {"AccountMFAEnabled": 1},
+        }
+        iam_client.virtual_mfa_devices = [
+            {
+                "SerialNumber": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:mfa/mfa",
+                "User": {"Arn": f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"},
+            }
+        ]
+        iam_client.audited_partition = "aws"
+        iam_client.region = AWS_REGION_US_EAST_1
+        iam_client.mfa_arn_template = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:mfa"
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
@@ -34,14 +38,11 @@ class Test_iam_root_hardware_mfa_enabled_test:
             return_value=aws_provider,
         ), mock.patch(
             "prowler.providers.aws.services.iam.iam_root_hardware_mfa_enabled.iam_root_hardware_mfa_enabled.iam_client",
-            new=IAM(aws_provider),
-        ) as service_client:
+            new=iam_client,
+        ):
             from prowler.providers.aws.services.iam.iam_root_hardware_mfa_enabled.iam_root_hardware_mfa_enabled import (
                 iam_root_hardware_mfa_enabled,
             )
-
-            service_client.account_summary["SummaryMap"]["AccountMFAEnabled"] = 1
-            service_client.virtual_mfa_devices[0]["SerialNumber"] = "sddfaf-root-sfsfds"
 
             check = iam_root_hardware_mfa_enabled()
             result = check.execute()
@@ -52,13 +53,15 @@ class Test_iam_root_hardware_mfa_enabled_test:
             )
             assert result[0].resource_id == "<root_account>"
 
-    @mock_aws
-    def test_root_hardware_virtual_hardware_mfa_enabled(self):
-        iam = client("iam")
-        mfa_device_name = "mfa-test"
-        iam.create_virtual_mfa_device(VirtualMFADeviceName=mfa_device_name)
-
-        from prowler.providers.aws.services.iam.iam_service import IAM
+    def test_root_hardware_mfa_enabled(self):
+        iam_client = mock.MagicMock
+        iam_client.account_summary = {
+            "SummaryMap": {"AccountMFAEnabled": 1},
+        }
+        iam_client.virtual_mfa_devices = []
+        iam_client.audited_partition = "aws"
+        iam_client.region = AWS_REGION_US_EAST_1
+        iam_client.mfa_arn_template = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:mfa"
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
@@ -67,14 +70,11 @@ class Test_iam_root_hardware_mfa_enabled_test:
             return_value=aws_provider,
         ), mock.patch(
             "prowler.providers.aws.services.iam.iam_root_hardware_mfa_enabled.iam_root_hardware_mfa_enabled.iam_client",
-            new=IAM(aws_provider),
-        ) as service_client:
+            new=iam_client,
+        ):
             from prowler.providers.aws.services.iam.iam_root_hardware_mfa_enabled.iam_root_hardware_mfa_enabled import (
                 iam_root_hardware_mfa_enabled,
             )
-
-            service_client.account_summary["SummaryMap"]["AccountMFAEnabled"] = 1
-            service_client.virtual_mfa_devices[0]["SerialNumber"] = ""
 
             check = iam_root_hardware_mfa_enabled()
             result = check.execute()
@@ -84,7 +84,3 @@ class Test_iam_root_hardware_mfa_enabled_test:
                 result[0].status_extended,
             )
             assert result[0].resource_id == "<root_account>"
-            assert (
-                result[0].resource_arn
-                == f"arn:aws:iam:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:mfa"
-            )


### PR DESCRIPTION
### Context

Fix #4652 

### Description

Update logic of `iam_root_hardware_mfa_enabled` check so if the ARN of the associated IAM user of the Virtual MFA device is "arn:aws:iam::[aws-account-id]:root", the AWS root account is not using a hardware-based MFA device for MFA protection.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
