### PR TITLE
fix(ecr): handle non-existing findingSeverityCounts key

### DIFF
--- a/prowler/providers/aws/services/ecr/ecr_service.py
+++ b/prowler/providers/aws/services/ecr/ecr_service.py
@@ -206,7 +206,7 @@ class ECR(AWSService):
                                             )
                                             finding_severity_counts = image[
                                                 image_scan_findings_field_name
-                                            ]["findingSeverityCounts"]
+                                            ].get("findingSeverityCounts", {})
                                             severity_counts.critical = (
                                                 finding_severity_counts.get(
                                                     "CRITICAL", 0


### PR DESCRIPTION
### Description

Handle non-existing `findingSeverityCounts` key when an image has no findings and getting the following error:

`KeyError[207]: 'findingSeverityCounts'`
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
