### PR TITLE
fix(ecr): change log level of non-scanned images

### DIFF
--- a/prowler/providers/aws/services/ecr/ecr_service.py
+++ b/prowler/providers/aws/services/ecr/ecr_service.py
@@ -189,6 +189,13 @@ class ECR(AWSService):
                                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                                 )
                                                 continue
+                                            except (
+                                                client.exceptions.ScanNotFoundException
+                                            ) as error:
+                                                logger.warning(
+                                                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                                )
+                                                continue
                                             except Exception as error:
                                                 logger.error(
                                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Description

Change log level of non-scanned images to WARNING since it is expected for images that have not been scanned:

`ScanNotFoundException[172]: An error occurred (ScanNotFoundException) when calling the DescribeImageScanFindings operation: Image scan does not exist`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
