### PR TITLE
chore(cloudtrail): add remediation link to check `cloudtrail_s3_dataevents_read_enabled`

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled.metadata.json
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_s3_dataevents_read_enabled/cloudtrail_s3_dataevents_read_enabled.metadata.json
@@ -17,7 +17,7 @@
     "Code": {
       "CLI": "aws cloudtrail put-event-selectors --trail-name <YOUR_TRAIL_NAME_HERE> --event-selectors '[{ 'ReadWriteType': 'ReadOnly', 'IncludeManagementEvents':true, 'DataResources': [{ 'Type': 'AWS::S3::Object', 'Values': ['arn:aws:s3'] }] }]'",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-23",
       "Terraform": ""
     },
     "Recommendation": {


### PR DESCRIPTION
### Context

While updating the `CloudTrail` service coverage, I discovered that the check I was about to implement was already in place under the name `cloudtrail_s3_dataevents_read_enabled`.

### Description

 added the correct reference link to its respective SecurityHub control [3.23](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-23).

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
