### PR TITLE
feat(aws): Add new RDS check to ensure db clusters are configured for multiple availability zones

### DIFF
--- a/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_instance_multi_az",
+  "CheckTitle": "Check if RDS instances have multi-AZ enabled.",
+  "CheckType": [],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
+  "Severity": "medium",
+  "ResourceType": "AwsRdsDbInstance",
+  "Description": "Check if RDS instances have multi-AZ enabled.",
+  "Risk": "In case of failure, with a single-AZ deployment configuration, should an availability zone specific database failure occur, Amazon RDS can not automatically fail over to the standby availability zone.",
+  "RelatedUrl": "https://aws.amazon.com/rds/features/multi-az/",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws rds create-db-instance --db-instance-identifier <db_instance_id> --multi-az true",
+      "NativeIaC": "https://docs.prowler.com/checks/aws/general-policies/general_73#cloudformation",
+      "Other": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-multi-az.html",
+      "Terraform": "https://docs.prowler.com/checks/aws/general-policies/general_73#terraform"
+    },
+    "Recommendation": {
+      "Text": "Enable multi-AZ deployment for production databases.",
+      "Url": "https://aws.amazon.com/rds/features/multi-az/"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.metadata.json
@@ -1,21 +1,21 @@
 {
   "Provider": "aws",
-  "CheckID": "rds_instance_multi_az",
-  "CheckTitle": "Check if RDS instances have multi-AZ enabled.",
+  "CheckID": "rds_cluster_multi_az",
+  "CheckTitle": "Check if RDS clusters have multi-AZ enabled.",
   "CheckType": [],
   "ServiceName": "rds",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
   "Severity": "medium",
-  "ResourceType": "AwsRdsDbInstance",
-  "Description": "Check if RDS instances have multi-AZ enabled.",
+  "ResourceType": "AwsRdsDbCluster",
+  "Description": "Check if RDS clusters have multi-AZ enabled. Instances that belongs to a cluster are covered too by this check.",
   "Risk": "In case of failure, with a single-AZ deployment configuration, should an availability zone specific database failure occur, Amazon RDS can not automatically fail over to the standby availability zone.",
   "RelatedUrl": "https://aws.amazon.com/rds/features/multi-az/",
   "Remediation": {
     "Code": {
-      "CLI": "aws rds create-db-instance --db-instance-identifier <db_instance_id> --multi-az true",
+      "CLI": "aws rds create-db-cluster --db-cluster-identifier <db_cluster_id> --multi-az true",
       "NativeIaC": "https://docs.prowler.com/checks/aws/general-policies/general_73#cloudformation",
-      "Other": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-multi-az.html",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-15",
       "Terraform": "https://docs.prowler.com/checks/aws/general-policies/general_73#terraform"
     },
     "Recommendation": {

--- a/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.metadata.json
@@ -8,7 +8,7 @@
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
   "Severity": "medium",
   "ResourceType": "AwsRdsDbCluster",
-  "Description": "Check if RDS clusters have multi-AZ enabled. Instances that belongs to a cluster are covered too by this check.",
+  "Description": "Check if RDS clusters have multi-AZ enabled.",
   "Risk": "In case of failure, with a single-AZ deployment configuration, should an availability zone specific database failure occur, Amazon RDS can not automatically fail over to the standby availability zone.",
   "RelatedUrl": "https://aws.amazon.com/rds/features/multi-az/",
   "Remediation": {

--- a/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.py
@@ -5,17 +5,21 @@ from prowler.providers.aws.services.rds.rds_client import rds_client
 class rds_cluster_multi_az(Check):
     def execute(self):
         findings = []
-        for db_cluster in rds_client.db_clusters:
+        for db_cluster_arn, db_cluster in rds_client.db_clusters.items():
             report = Check_Report_AWS(self.metadata())
-            report.region = rds_client.db_clusters[db_cluster].region
-            report.resource_id = rds_client.db_clusters[db_cluster].id
-            report.resource_arn = db_cluster
-            report.resource_tags = rds_client.db_clusters[db_cluster].tags
+            report.region = db_cluster.region
+            report.resource_id = db_cluster.id
+            report.resource_arn = db_cluster_arn
+            report.resource_tags = db_cluster.tags
             report.status = "FAIL"
-            report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} does not have multi-AZ enabled."
-            if rds_client.db_clusters[db_cluster].multi_az:
+            report.status_extended = (
+                f"RDS Cluster {db_cluster.id} does not have multi-AZ enabled."
+            )
+            if db_cluster.multi_az:
                 report.status = "PASS"
-                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} has multi-AZ enabled."
+                report.status_extended = (
+                    f"RDS Cluster {db_cluster.id} has multi-AZ enabled."
+                )
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az.py
@@ -1,0 +1,22 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_cluster_multi_az(Check):
+    def execute(self):
+        findings = []
+        for db_cluster in rds_client.db_clusters:
+            report = Check_Report_AWS(self.metadata())
+            report.region = rds_client.db_clusters[db_cluster].region
+            report.resource_id = rds_client.db_clusters[db_cluster].id
+            report.resource_arn = db_cluster
+            report.resource_tags = rds_client.db_clusters[db_cluster].tags
+            report.status = "FAIL"
+            report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} does not have multi-AZ enabled."
+            if rds_client.db_clusters[db_cluster].multi_az:
+                report.status = "PASS"
+                report.status_extended = f"RDS Cluster {rds_client.db_clusters[db_cluster].id} has multi-AZ enabled."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.metadata.json
@@ -8,7 +8,7 @@
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
   "Severity": "medium",
   "ResourceType": "AwsRdsDbInstance",
-  "Description": "Check if RDS instances have multi-AZ enabled.",
+  "Description": "Check if RDS instances that are not clustered have multi-AZ enabled, the clustered ones are covered by the rds_cluster_multi_az check.",
   "Risk": "In case of failure, with a single-AZ deployment configuration, should an availability zone specific database failure occur, Amazon RDS can not automatically fail over to the standby availability zone.",
   "RelatedUrl": "https://aws.amazon.com/rds/features/multi-az/",
   "Remediation": {

--- a/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.metadata.json
@@ -8,7 +8,7 @@
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
   "Severity": "medium",
   "ResourceType": "AwsRdsDbInstance",
-  "Description": "Check if RDS instances that are not clustered have multi-AZ enabled, the clustered ones are covered by the rds_cluster_multi_az check.",
+  "Description": "Check if RDS instances have multi-AZ enabled.",
   "Risk": "In case of failure, with a single-AZ deployment configuration, should an availability zone specific database failure occur, Amazon RDS can not automatically fail over to the standby availability zone.",
   "RelatedUrl": "https://aws.amazon.com/rds/features/multi-az/",
   "Remediation": {

--- a/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.py
+++ b/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.py
@@ -6,19 +6,20 @@ class rds_instance_multi_az(Check):
     def execute(self):
         findings = []
         for db_instance in rds_client.db_instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = db_instance.region
-            report.resource_id = db_instance.id
-            report.resource_arn = db_instance.arn
-            report.resource_tags = db_instance.tags
             # Check if is member of a cluster
-            if not db_instance.cluster_id and db_instance.multi_az:
-                report.status = "PASS"
-                report.status_extended = f"RDS Instance {db_instance.id} which is not clustered has multi-AZ enabled."
-            else:
-                report.status = "FAIL"
-                report.status_extended = f"RDS Instance {db_instance.id} which is not clustered does not have multi-AZ enabled."
+            if not db_instance.cluster_id:
+                report = Check_Report_AWS(self.metadata())
+                report.region = db_instance.region
+                report.resource_id = db_instance.id
+                report.resource_arn = db_instance.arn
+                report.resource_tags = db_instance.tags
+                if db_instance.multi_az:
+                    report.status = "PASS"
+                    report.status_extended = f"RDS Instance {db_instance.id} which is not clustered has multi-AZ enabled."
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = f"RDS Instance {db_instance.id} which is not clustered does not have multi-AZ enabled."
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.py
+++ b/prowler/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az.py
@@ -12,27 +12,12 @@ class rds_instance_multi_az(Check):
             report.resource_arn = db_instance.arn
             report.resource_tags = db_instance.tags
             # Check if is member of a cluster
-            if db_instance.cluster_id:
-                if (
-                    db_instance.cluster_arn in rds_client.db_clusters
-                    and rds_client.db_clusters[db_instance.cluster_arn].multi_az
-                ):
-                    report.status = "PASS"
-                    report.status_extended = f"RDS Instance {db_instance.id} has multi-AZ enabled at cluster {db_instance.cluster_id} level."
-                else:
-                    report.status = "FAIL"
-                    report.status_extended = f"RDS Instance {db_instance.id} does not have multi-AZ enabled at cluster {db_instance.cluster_id} level."
+            if not db_instance.cluster_id and db_instance.multi_az:
+                report.status = "PASS"
+                report.status_extended = f"RDS Instance {db_instance.id} which is not clustered has multi-AZ enabled."
             else:
-                if db_instance.multi_az:
-                    report.status = "PASS"
-                    report.status_extended = (
-                        f"RDS Instance {db_instance.id} has multi-AZ enabled."
-                    )
-                else:
-                    report.status = "FAIL"
-                    report.status_extended = (
-                        f"RDS Instance {db_instance.id} does not have multi-AZ enabled."
-                    )
+                report.status = "FAIL"
+                report.status_extended = f"RDS Instance {db_instance.id} which is not clustered does not have multi-AZ enabled."
 
             findings.append(report)
 

--- a/tests/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_multi_az/rds_cluster_multi_az_test.py
@@ -1,0 +1,138 @@
+from unittest import mock
+
+from prowler.providers.aws.services.rds.rds_service import DBCluster
+from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
+
+
+class Test_rds_cluster_multi_az:
+    def test_rds_no_clusters(self):
+        rds_client = mock.MagicMock
+        rds_client.db_clusters = {}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_cluster_multi_az.rds_cluster_multi_az.rds_client",
+            new=rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_multi_az.rds_cluster_multi_az import (
+                rds_cluster_multi_az,
+            )
+
+            check = rds_cluster_multi_az()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_rds_cluster_no_multi_az(self):
+        rds_client = mock.MagicMock
+        cluster_arn = (
+            f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-cluster-1"
+        )
+        rds_client.db_clusters = {
+            cluster_arn: DBCluster(
+                id="db-cluster-1",
+                arn=cluster_arn,
+                endpoint="",
+                engine="aurora",
+                status="available",
+                public=False,
+                encrypted=False,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group="",
+                multi_az=False,
+                username="test",
+                iam_auth=False,
+                backtrack=0,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_cluster_multi_az.rds_cluster_multi_az.rds_client",
+            new=rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_multi_az.rds_cluster_multi_az import (
+                rds_cluster_multi_az,
+            )
+
+            check = rds_cluster_multi_az()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "RDS Cluster db-cluster-1 does not have multi-AZ enabled."
+            )
+            assert result[0].resource_id == "db-cluster-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-cluster-1"
+            )
+            assert result[0].resource_tags == []
+
+    def test_rds_cluster_multi_az(self):
+        rds_client = mock.MagicMock
+        cluster_arn = (
+            f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-cluster-1"
+        )
+        rds_client.db_clusters = {
+            cluster_arn: DBCluster(
+                id="db-cluster-1",
+                arn=cluster_arn,
+                endpoint="",
+                engine="aurora",
+                status="available",
+                public=False,
+                encrypted=False,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group="",
+                multi_az=True,
+                username="test",
+                iam_auth=False,
+                backtrack=0,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_cluster_multi_az.rds_cluster_multi_az.rds_client",
+            new=rds_client,
+        ):
+            from prowler.providers.aws.services.rds.rds_cluster_multi_az.rds_cluster_multi_az import (
+                rds_cluster_multi_az,
+            )
+
+            check = rds_cluster_multi_az()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "RDS Cluster db-cluster-1 has multi-AZ enabled."
+            )
+            assert result[0].resource_id == "db-cluster-1"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-cluster-1"
+            )
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
@@ -69,7 +69,7 @@ class Test_rds_instance_multi_az:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-1 does not have multi-AZ enabled."
+                    == "RDS Instance db-master-1 which is not clustered does not have multi-AZ enabled."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -115,7 +115,7 @@ class Test_rds_instance_multi_az:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-1 has multi-AZ enabled."
+                    == "RDS Instance db-master-1 which is not clustered has multi-AZ enabled."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 from boto3 import client
 from moto import mock_aws
 
+from prowler.providers.aws.services.rds.rds_service import DBCluster, DBInstance
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
@@ -69,7 +70,7 @@ class Test_rds_instance_multi_az:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-1 which is not clustered does not have multi-AZ enabled."
+                    == "RDS Instance db-master-1 does not have multi-AZ enabled."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -115,7 +116,7 @@ class Test_rds_instance_multi_az:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-1 which is not clustered has multi-AZ enabled."
+                    == "RDS Instance db-master-1 has multi-AZ enabled."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -124,3 +125,161 @@ class Test_rds_instance_multi_az:
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
                 )
                 assert result[0].resource_tags == []
+
+    def test_rds_instance_in_cluster_multi_az(self):
+        rds_client = mock.MagicMock
+        cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
+        rds_client.db_clusters = {
+            cluster_arn: DBCluster(
+                id="test-cluster",
+                arn=cluster_arn,
+                endpoint="",
+                engine="aurora",
+                status="available",
+                public=False,
+                encrypted=False,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group="",
+                multi_az=True,
+                username="test",
+                iam_auth=False,
+                backtrack=0,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        }
+        rds_client.db_instances = [
+            DBInstance(
+                id="test-instance",
+                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
+                endpoint="",
+                engine="aurora",
+                engine_version="1.0.0",
+                status="available",
+                public=False,
+                encrypted=False,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group=[],
+                multi_az=False,
+                username="test",
+                iam_auth=False,
+                cluster_id="test-cluster",
+                cluster_arn=cluster_arn,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        ]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az.rds_client",
+            new=rds_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az import (
+                rds_instance_multi_az,
+            )
+
+            check = rds_instance_multi_az()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "RDS Instance test-instance has multi-AZ enabled at cluster test-cluster level."
+            )
+            assert result[0].resource_id == "test-instance"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
+            )
+            assert result[0].resource_tags == []
+
+    def test_rds_instance_in_cluster_without_multi_az(self):
+        rds_client = mock.MagicMock
+        cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
+        rds_client.db_clusters = {
+            cluster_arn: DBCluster(
+                id="test-cluster",
+                arn=cluster_arn,
+                endpoint="",
+                engine="aurora",
+                status="available",
+                public=False,
+                encrypted=False,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group="",
+                multi_az=False,
+                username="test",
+                iam_auth=False,
+                backtrack=0,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        }
+        rds_client.db_instances = [
+            DBInstance(
+                id="test-instance",
+                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
+                endpoint="",
+                engine="aurora",
+                engine_version="1.0.0",
+                status="available",
+                public=False,
+                encrypted=False,
+                auto_minor_version_upgrade=False,
+                backup_retention_period=0,
+                cloudwatch_logs=[],
+                deletion_protection=False,
+                parameter_group=[],
+                multi_az=False,
+                username="test",
+                iam_auth=False,
+                cluster_id="test-cluster",
+                cluster_arn=cluster_arn,
+                region=AWS_REGION_US_EAST_1,
+                tags=[],
+            )
+        ]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            new=rds_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az.rds_client",
+            new=rds_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az import (
+                rds_instance_multi_az,
+            )
+
+            check = rds_instance_multi_az()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "RDS Instance test-instance does not have multi-AZ enabled at cluster test-cluster level."
+            )
+            assert result[0].resource_id == "test-instance"
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
+            )
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_multi_az/rds_instance_multi_az_test.py
@@ -1,35 +1,15 @@
 from unittest import mock
 
-import botocore
 from boto3 import client
 from moto import mock_aws
 
-from prowler.providers.aws.services.rds.rds_service import DBCluster, DBInstance
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_provider,
 )
 
-make_api_call = botocore.client.BaseClient._make_api_call
 
-
-def mock_make_api_call(self, operation_name, kwarg):
-    if operation_name == "DescribeDBEngineVersions":
-        return {
-            "DBEngineVersions": [
-                {
-                    "Engine": "mysql",
-                    "EngineVersion": "8.0.32",
-                    "DBEngineDescription": "description",
-                    "DBEngineVersionDescription": "description",
-                },
-            ]
-        }
-    return make_api_call(self, operation_name, kwarg)
-
-
-@mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_rds_instance_multi_az:
     @mock_aws
     def test_rds_no_instances(self):
@@ -142,169 +122,5 @@ class Test_rds_instance_multi_az:
                 assert (
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
-                )
-                assert result[0].resource_tags == []
-
-    def test_rds_instance_in_cluster_multi_az(self):
-        rds_client = mock.MagicMock
-        cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
-        rds_client.db_clusters = {
-            cluster_arn: DBCluster(
-                id="test-cluster",
-                arn=cluster_arn,
-                endpoint="",
-                engine="aurora",
-                status="available",
-                public=False,
-                encrypted=False,
-                auto_minor_version_upgrade=False,
-                backup_retention_period=0,
-                cloudwatch_logs=[],
-                deletion_protection=False,
-                parameter_group="",
-                multi_az=True,
-                username="test",
-                iam_auth=False,
-                backtrack=0,
-                region=AWS_REGION_US_EAST_1,
-                tags=[],
-            )
-        }
-        rds_client.db_instances = [
-            DBInstance(
-                id="test-instance",
-                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
-                endpoint="",
-                engine="aurora",
-                engine_version="1.0.0",
-                status="available",
-                public=False,
-                encrypted=False,
-                auto_minor_version_upgrade=False,
-                backup_retention_period=0,
-                cloudwatch_logs=[],
-                deletion_protection=False,
-                parameter_group=[],
-                multi_az=False,
-                username="test",
-                iam_auth=False,
-                cluster_id="test-cluster",
-                cluster_arn=cluster_arn,
-                region=AWS_REGION_US_EAST_1,
-                tags=[],
-            )
-        ]
-
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ):
-            with mock.patch(
-                "prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az.rds_client",
-                new=rds_client,
-            ):
-                # Test Check
-                from prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az import (
-                    rds_instance_multi_az,
-                )
-
-                check = rds_instance_multi_az()
-                result = check.execute()
-
-                assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert (
-                    result[0].status_extended
-                    == "RDS Instance test-instance has multi-AZ enabled at cluster test-cluster level."
-                )
-                assert result[0].resource_id == "test-instance"
-                assert result[0].region == AWS_REGION_US_EAST_1
-                assert (
-                    result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
-                )
-                assert result[0].resource_tags == []
-
-    def test_rds_instance_in_cluster_without_multi_az(self):
-        rds_client = mock.MagicMock
-        cluster_arn = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:test-cluster"
-        rds_client.db_clusters = {
-            cluster_arn: DBCluster(
-                id="test-cluster",
-                arn=cluster_arn,
-                endpoint="",
-                engine="aurora",
-                status="available",
-                public=False,
-                encrypted=False,
-                auto_minor_version_upgrade=False,
-                backup_retention_period=0,
-                cloudwatch_logs=[],
-                deletion_protection=False,
-                parameter_group="",
-                multi_az=False,
-                username="test",
-                iam_auth=False,
-                backtrack=0,
-                region=AWS_REGION_US_EAST_1,
-                tags=[],
-            )
-        }
-        rds_client.db_instances = [
-            DBInstance(
-                id="test-instance",
-                arn=f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance",
-                endpoint="",
-                engine="aurora",
-                engine_version="1.0.0",
-                status="available",
-                public=False,
-                encrypted=False,
-                auto_minor_version_upgrade=False,
-                backup_retention_period=0,
-                cloudwatch_logs=[],
-                deletion_protection=False,
-                parameter_group=[],
-                multi_az=False,
-                username="test",
-                iam_auth=False,
-                cluster_id="test-cluster",
-                cluster_arn=cluster_arn,
-                region=AWS_REGION_US_EAST_1,
-                tags=[],
-            )
-        ]
-
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ):
-            with mock.patch(
-                "prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az.rds_client",
-                new=rds_client,
-            ):
-                # Test Check
-                from prowler.providers.aws.services.rds.rds_instance_multi_az.rds_instance_multi_az import (
-                    rds_instance_multi_az,
-                )
-
-                check = rds_instance_multi_az()
-                result = check.execute()
-
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert (
-                    result[0].status_extended
-                    == "RDS Instance test-instance does not have multi-AZ enabled at cluster test-cluster level."
-                )
-                assert result[0].resource_id == "test-instance"
-                assert result[0].region == AWS_REGION_US_EAST_1
-                assert (
-                    result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:test-instance"
                 )
                 assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

This new check verifies that Amazon RDS DB clusters are configured to operate across multiple Availability Zones (AZs), enhancing high availability and resilience.

Since the Multi-AZ attribute is heritable from clusters to instances, I've modified the instance check to only scan instances that are not part of a cluster. Instances that are clustered are already covered by this new check.

For testing, while Moto supports the creation of instances with MultiAZ, it does not support MultiAZ on clusters. Therefore, I've had to use MagicMock for the cluster tests.


### Description

I added `rds_cluster_multi_az` with its respective unit test and modified `rds_instance_multi_az`and its respective unit test.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
