### PR TITLE
fix(ec2): Manage `UnicodeDecodeError` when reading user data

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
@@ -8,6 +8,7 @@ from detect_secrets.settings import default_settings
 
 from prowler.config.config import encoding_format_utf_8
 from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.logger import logger
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 
 
@@ -24,12 +25,23 @@ class ec2_instance_secrets_user_data(Check):
                 if instance.user_data:
                     temp_user_data_file = tempfile.NamedTemporaryFile(delete=False)
                     user_data = b64decode(instance.user_data)
-                    if user_data[0:2] == b"\x1f\x8b":  # GZIP magic number
-                        user_data = zlib.decompress(
-                            user_data, zlib.MAX_WBITS | 32
-                        ).decode(encoding_format_utf_8)
-                    else:
-                        user_data = user_data.decode(encoding_format_utf_8)
+                    try:
+                        if user_data[0:2] == b"\x1f\x8b":  # GZIP magic number
+                            user_data = zlib.decompress(
+                                user_data, zlib.MAX_WBITS | 32
+                            ).decode(encoding_format_utf_8)
+                        else:
+                            user_data = user_data.decode(encoding_format_utf_8)
+                    except UnicodeDecodeError as error:
+                        logger.warning(
+                            f"{instance.region} -- Unable to decode user data in EC2 instance {instance.id}: {error}"
+                        )
+                        continue
+                    except Exception as error:
+                        logger.error(
+                            f"{instance.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
+                        continue
 
                     temp_user_data_file.write(
                         bytes(user_data, encoding="raw_unicode_escape")

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
@@ -8,6 +8,7 @@ from detect_secrets.settings import default_settings
 
 from prowler.config.config import encoding_format_utf_8
 from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.logger import logger
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 
 
@@ -29,12 +30,23 @@ class ec2_launch_template_no_secrets(Check):
                 temp_user_data_file = tempfile.NamedTemporaryFile(delete=False)
                 user_data = b64decode(version.template_data["UserData"])
 
-                if user_data[0:2] == b"\x1f\x8b":  # GZIP magic number
-                    user_data = zlib.decompress(user_data, zlib.MAX_WBITS | 32).decode(
-                        encoding_format_utf_8
+                try:
+                    if user_data[0:2] == b"\x1f\x8b":  # GZIP magic number
+                        user_data = zlib.decompress(
+                            user_data, zlib.MAX_WBITS | 32
+                        ).decode(encoding_format_utf_8)
+                    else:
+                        user_data = user_data.decode(encoding_format_utf_8)
+                except UnicodeDecodeError as error:
+                    logger.warning(
+                        f"{template.region} -- Unable to decode User Data in EC2 Launch Template {template.name} version {version.version_number}: {error}"
                     )
-                else:
-                    user_data = user_data.decode(encoding_format_utf_8)
+                    continue
+                except Exception as error:
+                    logger.error(
+                        f"{template.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
+                    continue
 
                 temp_user_data_file.write(
                     bytes(user_data, encoding="raw_unicode_escape")

--- a/tests/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets_test.py
+++ b/tests/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets_test.py
@@ -444,3 +444,55 @@ class Test_ec2_launch_template_no_secrets:
             assert result[0].region == AWS_REGION_US_EAST_1
 
             assert result[1].status == "PASS"
+
+    @mock_aws
+    def test_one_launch_template_with_unicode_error(self):
+        launch_template_name = "tester"
+        invalid_utf8_bytes = b"\xc0\xaf"
+
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        ec2_client.create_launch_template(
+            LaunchTemplateName=launch_template_name,
+            VersionDescription="Launch Template with secrets",
+            LaunchTemplateData={
+                "InstanceType": "t1.micro",
+                "UserData": b64encode(invalid_utf8_bytes).decode(encoding_format_utf_8),
+            },
+        )
+
+        launch_template_id = ec2_client.describe_launch_templates()["LaunchTemplates"][
+            0
+        ]["LaunchTemplateId"]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_launch_template_no_secrets.ec2_launch_template_no_secrets.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ec2.ec2_launch_template_no_secrets.ec2_launch_template_no_secrets import (
+                ec2_launch_template_no_secrets,
+            )
+
+            check = ec2_launch_template_no_secrets()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"No secrets found in User Data of any version for EC2 Launch Template {launch_template_name}."
+            )
+            assert result[0].resource_id == launch_template_id
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

Manage error when decoding invalid UTF-8 user data:

`ec2_instance_secrets_user_data -- UnicodeDecodeError[32]: 'utf-8' codec can't decode byte 0xdf in position 0: invalid continuation byte`

### Description

- [x] Manage the error and log it with warning level instead an error
- [x] Add tests to cover this case

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
