### PR TITLE
fix(mutelist): change logic for tags in aws mutelist

### DIFF
--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -9,10 +9,6 @@ Mutelist option works along with other options and will modify the output in the
 
 ## How the Mutelist Works
 
-Here’s the improved version in English:
-
----
-
 The **Mutelist** uses both "AND" and "OR" logic to determine which resources, checks, regions, and tags should be muted. For each check, the Mutelist evaluates whether the account, region, and resource match the specified criteria using "AND" logic. If tags are specified, the Mutelist can apply either "AND" or "OR" logic:
 
 - **"AND" logic:** The Mutelist will mute all findings whose resource tags contain all the specified tags. Here’s an example:
@@ -46,9 +42,9 @@ The **Mutelist** uses both "AND" and "OR" logic to determine which resources, ch
             Resources:
               - "test"
             Tags:
-              - "test=test | project=test"
+              - "test=test|project=(test|dev)"
   ```
-  This will mute all findings that contain EITHER the `test=test` tag OR the `project=test` tag.
+  This will mute all findings that contain EITHER the `test=test` OR `project=test` OR `project=dev`.
 
 To use both logics simultaneously, here’s an example:
 
@@ -67,6 +63,9 @@ To use both logics simultaneously, here’s an example:
               - "project=test|project=stage"
   ```
 This will mute every resource containing the string "test" and the tags `test=test` and either `project=test` OR `project=stage` in every account and region.
+
+???+ note
+    Remember that mutelist can be used with regular expressions
 
 If any of the criteria do not match, the check is not muted.
 

--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -9,7 +9,7 @@ Mutelist option works along with other options and will modify the output in the
 
 ## How the Mutelist Works
 
-The Mutelist uses an "ANDed" and "ORed" logic to determine which resources, checks, regions, and tags should be muted. For each check, the Mutelist checks if the account, region, and resource match the specified criteria, using an "ANDed" logic. If tags are specified, the mutelist uses and "ORed" logic to see if at least one tag is present in the resource.
+The Mutelist uses an "ANDed" and "ORed" logic to determine which resources, checks, regions, and tags should be muted. For each check, the Mutelist checks if the account, region, and resource match the specified criteria, using an "ANDed" logic. If tags are specified, the mutelist uses an "ANDed" logic to see if all of the tags are present in the resource.
 
 If any of the criteria do not match, the check is not muted.
 

--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -65,7 +65,7 @@ To use both logics simultaneously, here’s an example:
 This will mute every resource containing the string "test" and the tags `test=test` and either `project=test` OR `project=stage` in every account and region.
 
 ???+ note
-    Remember that mutelist can be used with regular expressions
+    Remember that mutelist can be used with regular expressions.
 
 If any of the criteria do not match, the check is not muted.
 

--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -9,65 +9,12 @@ Mutelist option works along with other options and will modify the output in the
 
 ## How the Mutelist Works
 
-The **Mutelist** uses both "AND" and "OR" logic to determine which resources, checks, regions, and tags should be muted. For each check, the Mutelist evaluates whether the account, region, and resource match the specified criteria using "AND" logic. If tags are specified, the Mutelist can apply either "AND" or "OR" logic:
+The **Mutelist** uses both "AND" and "OR" logic to determine which resources, checks, regions, and tags should be muted. For each check, the Mutelist evaluates whether the account, region, and resource match the specified criteria using "AND" logic. If tags are specified, the Mutelist can apply either "AND" or "OR" logic.
 
-- **"AND" logic:** The Mutelist will mute all findings whose resource tags contain all the specified tags. Here’s an example:
-
-  ```yaml
-  Mutelist:
-    Accounts:
-      "*":
-        Checks:
-          "*":
-            Regions:
-              - "*"
-            Resources:
-              - "test"
-            Tags:
-              - "test=test"
-              - "project=test"
-  ```
-  This will mute all findings that contain BOTH tags at the same time.
-
-- **"OR" logic:** The Mutelist will mute findings that contain any of the specified resource tags. The `|` symbol is used to apply this logic:
-
-  ```yaml
-  Mutelist:
-    Accounts:
-      "*":
-        Checks:
-          "*":
-            Regions:
-              - "*"
-            Resources:
-              - "test"
-            Tags:
-              - "test=test|project=(test|dev)"
-  ```
-  This will mute all findings that contain EITHER the `test=test` OR `project=test` OR `project=dev`.
-
-To use both logics simultaneously, here’s an example:
-
-  ```yaml
-  Mutelist:
-    Accounts:
-      "*":
-        Checks:
-          "*":
-            Regions:
-              - "*"
-            Resources:
-              - "test"
-            Tags:
-              - "test=test"
-              - "project=test|project=stage"
-  ```
-This will mute every resource containing the string "test" and the tags `test=test` and either `project=test` OR `project=stage` in every account and region.
+If any of the criteria do not match, the check is not muted.
 
 ???+ note
     Remember that mutelist can be used with regular expressions.
-
-If any of the criteria do not match, the check is not muted.
 
 ## Mutelist Specification
 
@@ -108,6 +55,29 @@ Mutelist:
           Tags:
             - "test=test"         # Will mute every resource containing the string "test" and the tags 'test=test' and
             - "project=test|project=stage" # either of ('project=test' OR project=stage) in account 123456789012 and every region
+        "*":
+            Regions:
+              - "*"
+            Resources:
+              - "test"
+            Tags:
+              - "test=test"
+              - "project=test"    # This will mute every resource containing the string "test" and BOTH tags at the same time.
+        "*":
+            Regions:
+              - "*"
+            Resources:
+              - "test"
+            Tags:                 # This will mute every resource containing the string "test" and the ones that contain EITHER the `test=test` OR `project=test` OR `project=dev`
+              - "test=test|project=(test|dev)"
+        "*":
+            Regions:
+              - "*"
+            Resources:
+              - "test"
+            Tags:
+              - "test=test"       # This will mute every resource containing the string "test" and the tags `test=test` and either `project=test` OR `project=stage` in every account and region.
+              - "project=test|project=stage"
 
     "*":
       Checks:

--- a/docs/tutorials/mutelist.md
+++ b/docs/tutorials/mutelist.md
@@ -9,7 +9,64 @@ Mutelist option works along with other options and will modify the output in the
 
 ## How the Mutelist Works
 
-The Mutelist uses an "ANDed" and "ORed" logic to determine which resources, checks, regions, and tags should be muted. For each check, the Mutelist checks if the account, region, and resource match the specified criteria, using an "ANDed" logic. If tags are specified, the mutelist uses an "ANDed" logic to see if all of the tags are present in the resource.
+Here’s the improved version in English:
+
+---
+
+The **Mutelist** uses both "AND" and "OR" logic to determine which resources, checks, regions, and tags should be muted. For each check, the Mutelist evaluates whether the account, region, and resource match the specified criteria using "AND" logic. If tags are specified, the Mutelist can apply either "AND" or "OR" logic:
+
+- **"AND" logic:** The Mutelist will mute all findings whose resource tags contain all the specified tags. Here’s an example:
+
+  ```yaml
+  Mutelist:
+    Accounts:
+      "*":
+        Checks:
+          "*":
+            Regions:
+              - "*"
+            Resources:
+              - "test"
+            Tags:
+              - "test=test"
+              - "project=test"
+  ```
+  This will mute all findings that contain BOTH tags at the same time.
+
+- **"OR" logic:** The Mutelist will mute findings that contain any of the specified resource tags. The `|` symbol is used to apply this logic:
+
+  ```yaml
+  Mutelist:
+    Accounts:
+      "*":
+        Checks:
+          "*":
+            Regions:
+              - "*"
+            Resources:
+              - "test"
+            Tags:
+              - "test=test | project=test"
+  ```
+  This will mute all findings that contain EITHER the `test=test` tag OR the `project=test` tag.
+
+To use both logics simultaneously, here’s an example:
+
+  ```yaml
+  Mutelist:
+    Accounts:
+      "*":
+        Checks:
+          "*":
+            Regions:
+              - "*"
+            Resources:
+              - "test"
+            Tags:
+              - "test=test"
+              - "project=test|project=stage"
+  ```
+This will mute every resource containing the string "test" and the tags `test=test` and either `project=test` OR `project=stage` in every account and region.
 
 If any of the criteria do not match, the check is not muted.
 

--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -215,6 +215,10 @@ class Mutelist(ABC):
                         muted_tags, finding_tags, tag=True
                     )
 
+                    print(muted_in_tags)
+                    print(muted_tags)
+                    print(finding_tags)
+
                     # For a finding to be muted requires the following set to True:
                     # - muted_in_check -> True
                     # - muted_in_region -> True
@@ -327,6 +331,10 @@ class Mutelist(ABC):
                     if item.startswith("*"):
                         item = ".*" + item[1:]
                     if tag:
+                        print(item)
+                        print(finding_items)
+                        value = re.search(item, finding_items)
+                        print(value)
                         if not re.search(item, finding_items):
                             is_item_matched = False
                             break

--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -215,10 +215,6 @@ class Mutelist(ABC):
                         muted_tags, finding_tags, tag=True
                     )
 
-                    print(muted_in_tags)
-                    print(muted_tags)
-                    print(finding_tags)
-
                     # For a finding to be muted requires the following set to True:
                     # - muted_in_check -> True
                     # - muted_in_region -> True
@@ -331,10 +327,6 @@ class Mutelist(ABC):
                     if item.startswith("*"):
                         item = ".*" + item[1:]
                     if tag:
-                        print(item)
-                        print(finding_items)
-                        value = re.search(item, finding_items)
-                        print(value)
                         if not re.search(item, finding_items):
                             is_item_matched = False
                             break

--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -211,7 +211,9 @@ class Mutelist(ABC):
                     muted_in_resource = self.is_item_matched(
                         muted_resources, finding_resource
                     )
-                    muted_in_tags = self.is_item_matched(muted_tags, finding_tags)
+                    muted_in_tags = self.is_item_matched(
+                        muted_tags, finding_tags, tag=True
+                    )
 
                     # For a finding to be muted requires the following set to True:
                     # - muted_in_check -> True
@@ -279,7 +281,9 @@ class Mutelist(ABC):
                 )
 
                 excepted_tags = exceptions.get("Tags", [])
-                is_tag_excepted = self.is_item_matched(excepted_tags, finding_tags)
+                is_tag_excepted = self.is_item_matched(
+                    excepted_tags, finding_tags, tag=True
+                )
 
                 if (
                     not is_account_excepted
@@ -303,7 +307,7 @@ class Mutelist(ABC):
             return False
 
     @staticmethod
-    def is_item_matched(matched_items, finding_items):
+    def is_item_matched(matched_items, finding_items, tag=False) -> bool:
         """
         Check if any of the items in matched_items are present in finding_items.
 
@@ -317,12 +321,19 @@ class Mutelist(ABC):
         try:
             is_item_matched = False
             if matched_items and (finding_items or finding_items == ""):
+                if tag:
+                    is_item_matched = True
                 for item in matched_items:
                     if item.startswith("*"):
                         item = ".*" + item[1:]
-                    if re.search(item, finding_items):
-                        is_item_matched = True
-                        break
+                    if tag:
+                        if not re.search(item, finding_items):
+                            is_item_matched = False
+                            break
+                    else:
+                        if re.search(item, finding_items):
+                            is_item_matched = True
+                            break
             return is_item_matched
         except Exception as error:
             logger.error(

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -1115,7 +1115,7 @@ class TestAWSMutelist:
             "",
         )
 
-    def test_is_muted_tags(self):
+    def test_is_muted_tags_example1(self):
         # Mutelist
         mutelist_content = {
             "Accounts": {
@@ -1158,6 +1158,55 @@ class TestAWSMutelist:
             )
         )
 
+    def test_is_muted_tags_example2(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+                            "Resources": ["*"],
+                            "Tags": ["environment=dev", "project=test(?!\.)"],
+                        }
+                    }
+                }
+            }
+        }
+        mutelist = AWSMutelist(mutelist_content=mutelist_content)
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler",
+            "environment=dev | project=test",
+        )
+
+        assert not mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler",
+            "environment=dev",
+        )
+
+        assert not mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "environment=dev | project=prowler",
+        )
+
+        assert not mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "environment=dev | project=test.",
+        )
+
     def test_is_muted_tags_and_logic(self):
         # Mutelist
         mutelist_content = {
@@ -1191,7 +1240,7 @@ class TestAWSMutelist:
             "environment=dev | project=myproj",
         )
 
-    def test_is_muted_tags_or_logic(self):
+    def test_is_muted_tags_or_logic_example1(self):
         # Mutelist
         mutelist_content = {
             "Accounts": {
@@ -1222,6 +1271,31 @@ class TestAWSMutelist:
             AWS_REGION_US_EAST_1,
             "prowler-test",
             "project=prowler",
+        )
+
+    def test_is_muted_tags_or_logic_example2(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+                            "Resources": ["*"],
+                            "Tags": ["project=(test|stage)"],
+                        }
+                    }
+                }
+            }
+        }
+        mutelist = AWSMutelist(mutelist_content=mutelist_content)
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "project=test",
         )
 
     def test_is_muted_tags_and_or_logic(self):

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -1132,7 +1132,7 @@ class TestAWSMutelist:
         }
         mutelist = AWSMutelist(mutelist_content=mutelist_content)
 
-        assert mutelist.is_muted(
+        assert not mutelist.is_muted(
             AWS_ACCOUNT_NUMBER,
             "check_test",
             AWS_REGION_US_EAST_1,
@@ -1321,7 +1321,7 @@ class TestAWSMutelist:
             AWS_ACCOUNT_NUMBER,
             "eu-central-1",
             "test",
-            "environment=test",
+            "environment=test | project=prowler",
         )
 
         assert mutelist.is_excepted(
@@ -1329,7 +1329,7 @@ class TestAWSMutelist:
             AWS_ACCOUNT_NUMBER,
             "eu-south-3",
             "test",
-            "environment=test",
+            "environment=test | project=prowler",
         )
 
         assert mutelist.is_excepted(
@@ -1337,7 +1337,7 @@ class TestAWSMutelist:
             AWS_ACCOUNT_NUMBER,
             "eu-south-3",
             "test123",
-            "environment=test",
+            "environment=test | project=prowler",
         )
 
     def test_is_excepted_only_in_account(self):
@@ -1413,7 +1413,7 @@ class TestAWSMutelist:
             "Accounts": [AWS_ACCOUNT_NUMBER],
             "Regions": [],
             "Resources": [],
-            "Tags": ["environment=test"],
+            "Tags": ["environment=test", "project=example"],
         }
         mutelist = AWSMutelist(mutelist_content={})
 
@@ -1422,7 +1422,7 @@ class TestAWSMutelist:
             AWS_ACCOUNT_NUMBER,
             AWS_REGION_EU_CENTRAL_1,
             "resource_1",
-            "environment=test",
+            "environment=test | project=example",
         )
 
         assert not mutelist.is_excepted(

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -1158,6 +1158,129 @@ class TestAWSMutelist:
             )
         )
 
+    def test_is_muted_tags_and_logic(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+                            "Resources": ["*"],
+                            "Tags": ["environment=dev", "project=prowler"],
+                        }
+                    }
+                }
+            }
+        }
+        mutelist = AWSMutelist(mutelist_content=mutelist_content)
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "environment=dev | project=prowler",
+        )
+
+        assert not mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "environment=dev | project=myproj",
+        )
+
+    def test_is_muted_tags_or_logic(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+                            "Resources": ["*"],
+                            "Tags": ["environment=dev|project=.*"],
+                        }
+                    }
+                }
+            }
+        }
+        mutelist = AWSMutelist(mutelist_content=mutelist_content)
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "environment=dev",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "project=prowler",
+        )
+
+    def test_is_muted_tags_and_or_logic(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "*": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1],
+                            "Resources": ["*"],
+                            "Tags": ["team=dev", "environment=dev|project=.*"],
+                        }
+                    }
+                }
+            }
+        }
+        mutelist = AWSMutelist(mutelist_content=mutelist_content)
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "team=dev | environment=dev",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "team=dev | project=prowler",
+        )
+
+        assert not mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "team=ops",
+        )
+
+        assert not mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "environment=dev",
+        )
+
+        assert not mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "check_test",
+            AWS_REGION_US_EAST_1,
+            "prowler-test",
+            "project=myproj",
+        )
+
     def test_is_muted_specific_account_with_other_account_excepted(self):
         # Mutelist
         mutelist_content = {
@@ -1315,29 +1438,28 @@ class TestAWSMutelist:
             "Tags": ["environment=test", "project=.*"],
         }
         mutelist = AWSMutelist(mutelist_content={})
-
-        assert mutelist.is_excepted(
+        assert not mutelist.is_excepted(
             exceptions,
             AWS_ACCOUNT_NUMBER,
             "eu-central-1",
             "test",
-            "environment=test | project=prowler",
+            "environment=test",
         )
 
-        assert mutelist.is_excepted(
+        assert not mutelist.is_excepted(
             exceptions,
             AWS_ACCOUNT_NUMBER,
             "eu-south-3",
             "test",
-            "environment=test | project=prowler",
+            "environment=test",
         )
 
-        assert mutelist.is_excepted(
+        assert not mutelist.is_excepted(
             exceptions,
             AWS_ACCOUNT_NUMBER,
             "eu-south-3",
             "test123",
-            "environment=test | project=prowler",
+            "environment=test",
         )
 
     def test_is_excepted_only_in_account(self):


### PR DESCRIPTION
### Context

Mutelist allow the user to mute certain findings.

Fix #4782

### Description

To mute a finding, all the tags should be in the mutelist. In this PR this logic is applied and docs are updated.

Thanks @dlouzan for the report!

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
