### PR TITLE
feat(s3): add `s3_bucket_lifecycle_enabled` check

### DIFF
--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -316,24 +316,6 @@ aws:
 
     ]
 
-  #AWS S3 Configuration
-  # Recommended LifeCycle expiration days
-  min_lifecycle_expiration_days: 1
-  max_lifecycle_expiration_days: 36500
-  # Recommended LifeCycle transition days
-  min_lifecycle_transition_days: 1
-  max_lifecycle_transition_days: 36500
-  # Recommended LifeCycle transition storage classes
-  lifecycle_transition_storage_classes:
-    [
-      "STANDARD_IA",
-      "INTELLIGENT_TIERING",
-      "ONEZONE_IA",
-      "GLACIER",
-      "GLACIER_IR",
-      "DEEP_ARCHIVE",
-    ]
-
 # Azure Configuration
 azure:
   # Azure Network Configuration

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -316,6 +316,26 @@ aws:
 
     ]
 
+  #AWS S3 Configuration
+  # Recommended LifeCycle expiration days
+  min_valid_lifecycle_expiration_days: 1
+  max_valid_lifecycle_expiration_days: 36500
+
+  # Recommended LifeCycle transition days
+  min_valid_lifecycle_transition_days: 1
+  max_valid_lifecycle_transition_days: 36500
+
+  # Recommended LifeCycle transition storage classes
+  valid_lifecycle_transition_storage_classes:
+    [
+      "STANDARD_IA",
+      "INTELLIGENT_TIERING",
+      "ONEZONE_IA",
+      "GLACIER",
+      "GLACIER_IR",
+      "DEEP_ARCHIVE",
+    ]
+
 # Azure Configuration
 azure:
   # Azure Network Configuration

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -318,15 +318,13 @@ aws:
 
   #AWS S3 Configuration
   # Recommended LifeCycle expiration days
-  min_valid_lifecycle_expiration_days: 1
-  max_valid_lifecycle_expiration_days: 36500
-
+  min_lifecycle_expiration_days: 1
+  max_lifecycle_expiration_days: 36500
   # Recommended LifeCycle transition days
-  min_valid_lifecycle_transition_days: 1
-  max_valid_lifecycle_transition_days: 36500
-
+  min_lifecycle_transition_days: 1
+  max_lifecycle_transition_days: 36500
   # Recommended LifeCycle transition storage classes
-  valid_lifecycle_transition_storage_classes:
+  lifecycle_transition_storage_classes:
     [
       "STANDARD_IA",
       "INTELLIGENT_TIERING",

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "s3_bucket_lifecycle_enabled",
-  "CheckTitle": "Check if S3 buckets have object lock enabled",
+  "CheckTitle": "Check if S3 buckets have a Lifecycle configuration enabled",
   "CheckType": [
     "AWS Foundational Security Best Practices"
   ],
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:partition:s3:::bucket_name",
   "Severity": "low",
   "ResourceType": "AwsS3Bucket",
-  "Description": "Check if S3 buckets have object lock enabled",
+  "Description": "Check if S3 buckets have one unique Lifecycle configuration enabled.",
   "Risk": "The risks of not having lifecycle management enabled for S3 buckets include higher storage costs, unmanaged data retention, and potential non-compliance with data policies.",
   "RelatedUrl": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html",
   "Remediation": {

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "s3_bucket_lifecycle_enabled",
+  "CheckTitle": "Check if S3 buckets have object lock enabled",
+  "CheckType": [
+    "AWS Foundational Security Best Practices"
+  ],
+  "ServiceName": "s3",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:s3:::bucket_name",
+  "Severity": "low",
+  "ResourceType": "AwsS3Bucket",
+  "Description": "Check if S3 buckets have object lock enabled",
+  "Risk": "The risks of not having lifecycle management enabled for S3 buckets include higher storage costs, unmanaged data retention, and potential non-compliance with data policies.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-13",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable lifecycle policies on your S3 buckets to automatically manage the transition and expiration of data.",
+      "Url": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
@@ -18,7 +18,7 @@
       "CLI": "",
       "NativeIaC": "",
       "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-13",
-      "Terraform": ""
+      "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/S3/lifecycle-configuration.html"
     },
     "Recommendation": {
       "Text": "Enable lifecycle policies on your S3 buckets to automatically manage the transition and expiration of data.",

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.metadata.json
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:partition:s3:::bucket_name",
   "Severity": "low",
   "ResourceType": "AwsS3Bucket",
-  "Description": "Check if S3 buckets have one unique Lifecycle configuration enabled.",
+  "Description": "Check if S3 buckets have Lifecycle configuration enabled.",
   "Risk": "The risks of not having lifecycle management enabled for S3 buckets include higher storage costs, unmanaged data retention, and potential non-compliance with data policies.",
   "RelatedUrl": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html",
   "Remediation": {

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
@@ -14,15 +14,12 @@ class s3_bucket_lifecycle_enabled(Check):
             report.status = "FAIL"
             report.status_extended = f"S3 Bucket {bucket.name} does not have a lifecycle configuration enabled."
 
-            if (
-                bucket.lifecycle
-                and len(bucket.lifecycle) == 1
-                and bucket.lifecycle[0].status == "Enabled"
-            ):
-                report.status = "PASS"
-                report.status_extended = (
-                    f"S3 Bucket {bucket.name} has a lifecycle configuration enabled."
-                )
+            if bucket.lifecycle:
+                for configuration in bucket.lifecycle:
+                    if configuration.status == "Enabled":
+                        report.status = "PASS"
+                        report.status_extended = f"S3 Bucket {bucket.name} has a lifecycle configuration enabled."
+                        break
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
@@ -12,28 +12,18 @@ class s3_bucket_lifecycle_enabled(Check):
             report.resource_arn = arn
             report.resource_tags = bucket.tags
             report.status = "FAIL"
-            report.status_extended = f"S3 Bucket {bucket.name} does not have a correct Lifecycle Configuration."
+            report.status_extended = f"S3 Bucket {bucket.name} does not have a lifecycle configuration enabled."
 
-            if bucket.lifecycle and len(bucket.lifecycle) == 1:
-                rule = bucket.lifecycle[0]
-                if (
-                    rule.status == "Enabled"
-                    and 1 <= rule.expiration_days <= 36500
-                    and 1 <= rule.transition_days <= 36500
-                    and rule.transition_storage_class
-                    in [
-                        "STANDARD_IA",
-                        "INTELLIGENT_TIERING",
-                        "ONEZONE_IA",
-                        "GLACIER",
-                        "GLACIER_IR",
-                        "DEEP_ARCHIVE",
-                    ]
-                ):
-                    report.status = "PASS"
-                    report.status_extended = f"At least one LifeCycle Configuration is correct for S3 Bucket {bucket.name}."
-                    break
+            if (
+                bucket.lifecycle
+                and len(bucket.lifecycle) == 1
+                and bucket.lifecycle[0].status == "Enabled"
+            ):
+                report.status = "PASS"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} has a lifecycle configuration enabled."
+                )
 
-        findings.append(report)
+            findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
@@ -1,0 +1,37 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.s3.s3_client import s3_client
+from prowler.providers.aws.services.s3.s3_service import StorageClass
+
+
+class s3_bucket_lifecycle_enabled(Check):
+    def execute(self):
+        findings = []
+        for arn, bucket in s3_client.buckets.items():
+            report = Check_Report_AWS(self.metadata())
+            report.region = bucket.region
+            report.resource_id = bucket.name
+            report.resource_arn = arn
+            report.resource_tags = bucket.tags
+            report.status = "PASS"
+            report.status_extended = f"All S3 Bucket {bucket.name} Lifecycle configurations are valid and enabled."
+
+            if bucket.lifecycle:
+                for rule in bucket.lifecycle:
+                    if not (
+                        rule.status == "Enabled"
+                        and 1 <= rule.expiration_days <= 36500
+                        and 1 <= rule.transition_days <= 36500
+                        and rule.transition_storage_class in StorageClass
+                    ):
+                        report.status = "FAIL"
+                        report.status_extended = f"S3 Bucket {bucket.name} has Lifecycle rule {rule.id} disabled or misconfigurated."
+                        break
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} does not have Lifecycle Configuration."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
@@ -1,17 +1,32 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.logger import logger
 from prowler.providers.aws.services.s3.s3_client import s3_client
 
 
 class s3_bucket_lifecycle_enabled(Check):
     def execute(self):
         findings = []
-        min_expiration_days = s3_client.config.get("min_expiration_days", 1)
-        max_expiration_days = s3_client.config.get("max_expiration_days", 36500)
-        min_transition_days = s3_client.config.get("min_transition_days", 1)
-        max_transition_days = s3_client.config.get("max_transition_days", 36500)
-        valid_storage_transition_classes = s3_client.config.get(
-            "valid_lifecycle_transition_storage_classes", {}
+        min_expiration_days = s3_client.audit_config.get("min_expiration_days", 1)
+        max_expiration_days = s3_client.audit_config.get("max_expiration_days", 36500)
+        min_transition_days = s3_client.audit_config.get("min_transition_days", 1)
+        max_transition_days = s3_client.audit_config.get("max_transition_days", 36500)
+        valid_storage_transition_classes = s3_client.audit_config.get(
+            "valid_lifecycle_transition_storage_classes",
+            [
+                "STANDARD_IA",
+                "INTELLIGENT_TIERING",
+                "ONEZONE_IA",
+                "GLACIER",
+                "GLACIER_IR",
+                "DEEP_ARCHIVE",
+            ],
         )
+
+        logger.error(min_expiration_days)
+        logger.error(max_expiration_days)
+        logger.error(min_transition_days)
+        logger.error(max_transition_days)
+        logger.error(valid_storage_transition_classes)
 
         for arn, bucket in s3_client.buckets.items():
             report = Check_Report_AWS(self.metadata())
@@ -19,31 +34,29 @@ class s3_bucket_lifecycle_enabled(Check):
             report.resource_id = bucket.name
             report.resource_arn = arn
             report.resource_tags = bucket.tags
+            report.status = "FAIL"
+            report.status_extended = f"S3 Bucket {bucket.name} does not have a correct Lifecycle Configuration."
 
             if bucket.lifecycle:
                 for rule in bucket.lifecycle:
-                    if not (
+                    if (
                         rule.status == "Enabled"
-                        and min_expiration_days
-                        <= rule.expiration_days
-                        <= max_expiration_days
-                        and min_transition_days
-                        <= rule.transition_days
-                        <= max_transition_days
+                        and (
+                            min_expiration_days
+                            <= rule.expiration_days
+                            <= max_expiration_days
+                        )
+                        and (
+                            min_transition_days
+                            <= rule.transition_days
+                            <= max_transition_days
+                        )
                         and rule.transition_storage_class
                         in valid_storage_transition_classes
                     ):
-                        report.status = "FAIL"
-                        report.status_extended = f"S3 Bucket {bucket.name} has Lifecycle rule {rule.id} disabled or misconfigurated."
-                    else:
                         report.status = "PASS"
                         report.status_extended = f"At least one LifeCycle Configuration is correct for S3 Bucket {bucket.name}."
                         break
-            else:
-                report.status = "FAIL"
-                report.status_extended = (
-                    f"S3 Bucket {bucket.name} does not have Lifecycle Configuration."
-                )
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled.py
@@ -1,30 +1,43 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.s3.s3_client import s3_client
-from prowler.providers.aws.services.s3.s3_service import StorageClass
 
 
 class s3_bucket_lifecycle_enabled(Check):
     def execute(self):
         findings = []
+        min_expiration_days = s3_client.config.get("min_expiration_days", 1)
+        max_expiration_days = s3_client.config.get("max_expiration_days", 36500)
+        min_transition_days = s3_client.config.get("min_transition_days", 1)
+        max_transition_days = s3_client.config.get("max_transition_days", 36500)
+        valid_storage_transition_classes = s3_client.config.get(
+            "valid_lifecycle_transition_storage_classes", {}
+        )
+
         for arn, bucket in s3_client.buckets.items():
             report = Check_Report_AWS(self.metadata())
             report.region = bucket.region
             report.resource_id = bucket.name
             report.resource_arn = arn
             report.resource_tags = bucket.tags
-            report.status = "PASS"
-            report.status_extended = f"All S3 Bucket {bucket.name} Lifecycle configurations are valid and enabled."
 
             if bucket.lifecycle:
                 for rule in bucket.lifecycle:
                     if not (
                         rule.status == "Enabled"
-                        and 1 <= rule.expiration_days <= 36500
-                        and 1 <= rule.transition_days <= 36500
-                        and rule.transition_storage_class in StorageClass
+                        and min_expiration_days
+                        <= rule.expiration_days
+                        <= max_expiration_days
+                        and min_transition_days
+                        <= rule.transition_days
+                        <= max_transition_days
+                        and rule.transition_storage_class
+                        in valid_storage_transition_classes
                     ):
                         report.status = "FAIL"
                         report.status_extended = f"S3 Bucket {bucket.name} has Lifecycle rule {rule.id} disabled or misconfigurated."
+                    else:
+                        report.status = "PASS"
+                        report.status_extended = f"At least one LifeCycle Configuration is correct for S3 Bucket {bucket.name}."
                         break
             else:
                 report.status = "FAIL"

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -406,7 +406,7 @@ class S3(AWSService):
                 logger.warning(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
-                
+
     def _get_bucket_replication(self, bucket):
         logger.info("S3 - Get buckets replication...")
         try:
@@ -564,6 +564,7 @@ class LifeCycleRule(BaseModel):
     expiration_days: int
     transition_days: int
     transition_storage_class: str
+
 
 class ReplicationRule(BaseModel):
     id: str

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -530,21 +530,12 @@ class AccessPoint(BaseModel):
     region: str
 
 
-class StorageClass(enumerate):
-    STANDARD_IA = "STANDARD_IA"
-    INTELLIGENT_TIERING = "INTELLIGENT_TIERING"
-    ONEZONE_IA = "ONEZONE_IA"
-    GLACIER = "GLACIER"
-    GLACIER_IR = "GLACIER_IR"
-    DEEP_ARCHIVE = "DEEP_ARCHIVE"
-
-
 class LifeCycleRule(BaseModel):
     id: str
     status: str
     expiration_days: int
     transition_days: int
-    transition_storage_class: StorageClass
+    transition_storage_class: str
 
 
 class Bucket(BaseModel):

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -392,11 +392,6 @@ class S3(AWSService):
                     LifeCycleRule(
                         id=rule["ID"],
                         status=rule["Status"],
-                        expiration_days=rule.get("Expiration", {}).get("Days", None),
-                        transition_days=rule.get("Transition", {}).get("Days", None),
-                        transition_storage_class=rule.get("Transition", {}).get(
-                            "StorageClass", None
-                        ),
                     )
                 )
         except ClientError as error:
@@ -561,9 +556,6 @@ class AccessPoint(BaseModel):
 class LifeCycleRule(BaseModel):
     id: str
     status: str
-    expiration_days: int
-    transition_days: int
-    transition_storage_class: str
 
 
 class ReplicationRule(BaseModel):

--- a/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
@@ -154,11 +154,11 @@ class Test_s3_bucket_lifecycle_enabled:
                     lifecycle=[
                         LifeCycleRule(
                             id="test-rule-1",
-                            status="Enabled",
+                            status="Disabled",
                         ),
                         LifeCycleRule(
                             id="test-rule-2",
-                            status="Disabled",
+                            status="Enabled",
                         ),
                     ],
                 )
@@ -172,10 +172,10 @@ class Test_s3_bucket_lifecycle_enabled:
                 result = check.execute()
 
                 assert len(result) == 1
-                assert result[0].status == "FAIL"
+                assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == f"S3 Bucket {bucket_name} does not have a lifecycle configuration enabled."
+                    == f"S3 Bucket {bucket_name} has a lifecycle configuration enabled."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn

--- a/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
@@ -72,7 +72,7 @@ class Test_s3_bucket_lifecycle_enabled:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Bucket {bucket_name} does not have Lifecycle Configuration."
+                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn
@@ -188,7 +188,7 @@ class Test_s3_bucket_lifecycle_enabled:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Bucket {bucket_name} has Lifecycle rule {rule_id} disabled or misconfigurated."
+                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn
@@ -243,7 +243,7 @@ class Test_s3_bucket_lifecycle_enabled:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Bucket {bucket_name} has Lifecycle rule {rule_id} disabled or misconfigurated."
+                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn
@@ -298,7 +298,7 @@ class Test_s3_bucket_lifecycle_enabled:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Bucket {bucket_name} has Lifecycle rule {rule_id} disabled or misconfigurated."
+                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn

--- a/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
@@ -93,14 +93,30 @@ class Test_s3_bucket_lifecycle_enabled:
                 s3_bucket_lifecycle_enabled,
             )
 
+            s3_client = mock.MagicMock()
+            s3_client.audit_config = {
+                "min_lifecycle_expiration_days": 1,
+                "max_lifecycle_expiration_days": 36500,
+                "min_lifecycle_transition_days": 1,
+                "max_lifecycle_transition_days": 36500,
+                "lifecycle_transition_storage_classes": [
+                    "STANDARD_IA",
+                    "INTELLIGENT_TIERING",
+                    "ONEZONE_IA",
+                    "GLACIER",
+                    "GLACIER_IR",
+                    "DEEP_ARCHIVE",
+                ],
+            }
+
             bucket_name = "bucket-test"
             bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
-            s3_client = mock.MagicMock()
             s3_client.buckets = {
                 bucket_arn: Bucket(
                     name=bucket_name,
                     region=AWS_REGION_US_EAST_1,
                     lifecycle=[
+                        # Valid Lifecycle Configuration
                         LifeCycleRule(
                             id="test-rule-1",
                             status="Enabled",
@@ -108,6 +124,7 @@ class Test_s3_bucket_lifecycle_enabled:
                             transition_days=30,
                             transition_storage_class="STANDARD_IA",
                         ),
+                        # Invalid Lifecycle Configuration
                         LifeCycleRule(
                             id="test-rule-2",
                             status="Enabled",
@@ -154,10 +171,25 @@ class Test_s3_bucket_lifecycle_enabled:
                 s3_bucket_lifecycle_enabled,
             )
 
+            s3_client = mock.MagicMock()
+            s3_client.audit_config = {
+                "min_lifecycle_expiration_days": 1,
+                "max_lifecycle_expiration_days": 36500,
+                "min_lifecycle_transition_days": 1,
+                "max_lifecycle_transition_days": 36500,
+                "lifecycle_transition_storage_classes": [
+                    "STANDARD_IA",
+                    "INTELLIGENT_TIERING",
+                    "ONEZONE_IA",
+                    "GLACIER",
+                    "GLACIER_IR",
+                    "DEEP_ARCHIVE",
+                ],
+            }
+
             bucket_name = "bucket-test"
             bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
             rule_id = "test-rule"
-            s3_client = mock.MagicMock()
             s3_client.buckets = {
                 bucket_arn: Bucket(
                     name=bucket_name,
@@ -209,10 +241,25 @@ class Test_s3_bucket_lifecycle_enabled:
                 s3_bucket_lifecycle_enabled,
             )
 
+            s3_client = mock.MagicMock()
+            s3_client.audit_config = {
+                "min_lifecycle_expiration_days": 1,
+                "max_lifecycle_expiration_days": 36500,
+                "min_lifecycle_transition_days": 1,
+                "max_lifecycle_transition_days": 36500,
+                "lifecycle_transition_storage_classes": [
+                    "STANDARD_IA",
+                    "INTELLIGENT_TIERING",
+                    "ONEZONE_IA",
+                    "GLACIER",
+                    "GLACIER_IR",
+                    "DEEP_ARCHIVE",
+                ],
+            }
+
             bucket_name = "bucket-test"
             bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
             rule_id = "test-rule"
-            s3_client = mock.MagicMock()
             s3_client.buckets = {
                 bucket_arn: Bucket(
                     name=bucket_name,
@@ -264,10 +311,25 @@ class Test_s3_bucket_lifecycle_enabled:
                 s3_bucket_lifecycle_enabled,
             )
 
+            s3_client = mock.MagicMock()
+            s3_client.audit_config = {
+                "min_lifecycle_expiration_days": 1,
+                "max_lifecycle_expiration_days": 36500,
+                "min_lifecycle_transition_days": 1,
+                "max_lifecycle_transition_days": 36500,
+                "lifecycle_transition_storage_classes": [
+                    "STANDARD_IA",
+                    "INTELLIGENT_TIERING",
+                    "ONEZONE_IA",
+                    "GLACIER",
+                    "GLACIER_IR",
+                    "DEEP_ARCHIVE",
+                ],
+            }
+
             bucket_name = "bucket-test"
             bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
             rule_id = "test-rule"
-            s3_client = mock.MagicMock()
             s3_client.buckets = {
                 bucket_arn: Bucket(
                     name=bucket_name,

--- a/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
@@ -75,7 +75,7 @@ class Test_s3_bucket_lifecycle_enabled:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
+                    == f"S3 Bucket {bucket_name} does not have a lifecycle configuration enabled."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn
@@ -107,9 +107,6 @@ class Test_s3_bucket_lifecycle_enabled:
                         LifeCycleRule(
                             id="test-rule-1",
                             status="Enabled",
-                            expiration_days=30,
-                            transition_days=30,
-                            transition_storage_class="STANDARD_IA",
                         ),
                     ],
                 )
@@ -126,7 +123,7 @@ class Test_s3_bucket_lifecycle_enabled:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == f"At least one LifeCycle Configuration is correct for S3 Bucket {bucket_name}."
+                    == f"S3 Bucket {bucket_name} has a lifecycle configuration enabled."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn
@@ -155,21 +152,13 @@ class Test_s3_bucket_lifecycle_enabled:
                     name=bucket_name,
                     region=AWS_REGION_US_EAST_1,
                     lifecycle=[
-                        # Valid Lifecycle Configuration
                         LifeCycleRule(
                             id="test-rule-1",
                             status="Enabled",
-                            expiration_days=30,
-                            transition_days=30,
-                            transition_storage_class="STANDARD_IA",
                         ),
-                        # Invalid Lifecycle Configuration
                         LifeCycleRule(
                             id="test-rule-2",
-                            status="Enabled",
-                            expiration_days=0,
-                            transition_days=0,
-                            transition_storage_class="",
+                            status="Disabled",
                         ),
                     ],
                 )
@@ -186,163 +175,7 @@ class Test_s3_bucket_lifecycle_enabled:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
-                )
-                assert result[0].resource_id == bucket_name
-                assert result[0].resource_arn == bucket_arn
-                assert result[0].region == AWS_REGION_US_EAST_1
-
-    def test_invalid_expiration_days(self):
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
-            new=S3(aws_provider),
-        ):
-            # Test Check
-            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
-                s3_bucket_lifecycle_enabled,
-            )
-
-            s3_client = mock.MagicMock()
-            bucket_name = "bucket-test"
-            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
-            rule_id = "test-rule"
-            s3_client.buckets = {
-                bucket_arn: Bucket(
-                    name=bucket_name,
-                    region=AWS_REGION_US_EAST_1,
-                    lifecycle=[
-                        LifeCycleRule(
-                            id=rule_id,
-                            status="Enabled",
-                            expiration_days=0,
-                            transition_days=30,
-                            transition_storage_class="STANDARD_IA",
-                        ),
-                    ],
-                )
-            }
-
-            with patch(
-                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
-                s3_client,
-            ):
-                check = s3_bucket_lifecycle_enabled()
-                result = check.execute()
-
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert (
-                    result[0].status_extended
-                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
-                )
-                assert result[0].resource_id == bucket_name
-                assert result[0].resource_arn == bucket_arn
-                assert result[0].region == AWS_REGION_US_EAST_1
-
-    def test_invalid_transition_days(self):
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
-            new=S3(aws_provider),
-        ):
-            # Test Check
-            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
-                s3_bucket_lifecycle_enabled,
-            )
-
-            s3_client = mock.MagicMock()
-            bucket_name = "bucket-test"
-            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
-            rule_id = "test-rule"
-            s3_client.buckets = {
-                bucket_arn: Bucket(
-                    name=bucket_name,
-                    region=AWS_REGION_US_EAST_1,
-                    lifecycle=[
-                        LifeCycleRule(
-                            id=rule_id,
-                            status="Enabled",
-                            expiration_days=30,
-                            transition_days=0,
-                            transition_storage_class="STANDARD_IA",
-                        ),
-                    ],
-                )
-            }
-
-            with patch(
-                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
-                s3_client,
-            ):
-                check = s3_bucket_lifecycle_enabled()
-                result = check.execute()
-
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert (
-                    result[0].status_extended
-                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
-                )
-                assert result[0].resource_id == bucket_name
-                assert result[0].resource_arn == bucket_arn
-                assert result[0].region == AWS_REGION_US_EAST_1
-
-    def test_invalid_transition_storage(self):
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
-            new=S3(aws_provider),
-        ):
-            # Test Check
-            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
-                s3_bucket_lifecycle_enabled,
-            )
-
-            s3_client = mock.MagicMock()
-            bucket_name = "bucket-test"
-            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
-            rule_id = "test-rule"
-            s3_client.buckets = {
-                bucket_arn: Bucket(
-                    name=bucket_name,
-                    region=AWS_REGION_US_EAST_1,
-                    lifecycle=[
-                        LifeCycleRule(
-                            id=rule_id,
-                            status="Enabled",
-                            expiration_days=30,
-                            transition_days=30,
-                            transition_storage_class="",
-                        ),
-                    ],
-                )
-            }
-
-            with patch(
-                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
-                s3_client,
-            ):
-                check = s3_bucket_lifecycle_enabled()
-                result = check.execute()
-
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert (
-                    result[0].status_extended
-                    == f"S3 Bucket {bucket_name} does not have a correct Lifecycle Configuration."
+                    == f"S3 Bucket {bucket_name} does not have a lifecycle configuration enabled."
                 )
                 assert result[0].resource_id == bucket_name
                 assert result[0].resource_arn == bucket_arn

--- a/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_lifecycle_enabled/s3_bucket_lifecycle_enabled_test.py
@@ -1,0 +1,305 @@
+from unittest import mock
+from unittest.mock import patch
+
+from prowler.providers.aws.services.s3.s3_service import S3, Bucket, LifeCycleRule
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_s3_bucket_lifecycle_enabled:
+    def test_no_buckets(self):
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
+                    s3_bucket_lifecycle_enabled,
+                )
+
+                check = s3_bucket_lifecycle_enabled()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    def test_no_lifecycle_configuration(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
+                s3_bucket_lifecycle_enabled,
+            )
+
+            bucket_name = "bucket-test"
+            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
+            s3_client = mock.MagicMock()
+            s3_client.buckets = {
+                bucket_arn: Bucket(
+                    name=bucket_name,
+                    region=AWS_REGION_US_EAST_1,
+                )
+            }
+
+            with patch(
+                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+                s3_client,
+            ):
+                check = s3_bucket_lifecycle_enabled()
+                result = check.execute()
+
+                # ALL REGIONS
+                assert len(result) == 1
+
+                # AWS_REGION_US_EAST_1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} does not have Lifecycle Configuration."
+                )
+                assert result[0].resource_id == bucket_name
+                assert result[0].resource_arn == bucket_arn
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_one_valid_lifecycle_configuration(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
+                s3_bucket_lifecycle_enabled,
+            )
+
+            bucket_name = "bucket-test"
+            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
+            s3_client = mock.MagicMock()
+            s3_client.buckets = {
+                bucket_arn: Bucket(
+                    name=bucket_name,
+                    region=AWS_REGION_US_EAST_1,
+                    lifecycle=[
+                        LifeCycleRule(
+                            id="test-rule-1",
+                            status="Enabled",
+                            expiration_days=30,
+                            transition_days=30,
+                            transition_storage_class="STANDARD_IA",
+                        ),
+                        LifeCycleRule(
+                            id="test-rule-2",
+                            status="Enabled",
+                            expiration_days=0,
+                            transition_days=0,
+                            transition_storage_class="",
+                        ),
+                    ],
+                )
+            }
+
+            with patch(
+                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+                s3_client,
+            ):
+                check = s3_bucket_lifecycle_enabled()
+                result = check.execute()
+
+                # ALL REGIONS
+                assert len(result) == 1
+
+                # AWS_REGION_US_EAST_1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"At least one LifeCycle Configuration is correct for S3 Bucket {bucket_name}."
+                )
+                assert result[0].resource_id == bucket_name
+                assert result[0].resource_arn == bucket_arn
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_invalid_expiration_days(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
+                s3_bucket_lifecycle_enabled,
+            )
+
+            bucket_name = "bucket-test"
+            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
+            rule_id = "test-rule"
+            s3_client = mock.MagicMock()
+            s3_client.buckets = {
+                bucket_arn: Bucket(
+                    name=bucket_name,
+                    region=AWS_REGION_US_EAST_1,
+                    lifecycle=[
+                        LifeCycleRule(
+                            id=rule_id,
+                            status="Enabled",
+                            expiration_days=0,
+                            transition_days=30,
+                            transition_storage_class="STANDARD_IA",
+                        ),
+                    ],
+                )
+            }
+
+            with patch(
+                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+                s3_client,
+            ):
+                check = s3_bucket_lifecycle_enabled()
+                result = check.execute()
+
+                # ALL REGIONS
+                assert len(result) == 1
+
+                # AWS_REGION_US_EAST_1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} has Lifecycle rule {rule_id} disabled or misconfigurated."
+                )
+                assert result[0].resource_id == bucket_name
+                assert result[0].resource_arn == bucket_arn
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_invalid_transition_days(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
+                s3_bucket_lifecycle_enabled,
+            )
+
+            bucket_name = "bucket-test"
+            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
+            rule_id = "test-rule"
+            s3_client = mock.MagicMock()
+            s3_client.buckets = {
+                bucket_arn: Bucket(
+                    name=bucket_name,
+                    region=AWS_REGION_US_EAST_1,
+                    lifecycle=[
+                        LifeCycleRule(
+                            id=rule_id,
+                            status="Enabled",
+                            expiration_days=30,
+                            transition_days=0,
+                            transition_storage_class="STANDARD_IA",
+                        ),
+                    ],
+                )
+            }
+
+            with patch(
+                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+                s3_client,
+            ):
+                check = s3_bucket_lifecycle_enabled()
+                result = check.execute()
+
+                # ALL REGIONS
+                assert len(result) == 1
+
+                # AWS_REGION_US_EAST_1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} has Lifecycle rule {rule_id} disabled or misconfigurated."
+                )
+                assert result[0].resource_id == bucket_name
+                assert result[0].resource_arn == bucket_arn
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    def test_invalid_transition_storage(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled import (
+                s3_bucket_lifecycle_enabled,
+            )
+
+            bucket_name = "bucket-test"
+            bucket_arn = f"arn:aws:s3::{AWS_ACCOUNT_NUMBER}:{bucket_name}"
+            rule_id = "test-rule"
+            s3_client = mock.MagicMock()
+            s3_client.buckets = {
+                bucket_arn: Bucket(
+                    name=bucket_name,
+                    region=AWS_REGION_US_EAST_1,
+                    lifecycle=[
+                        LifeCycleRule(
+                            id=rule_id,
+                            status="Enabled",
+                            expiration_days=30,
+                            transition_days=30,
+                            transition_storage_class="",
+                        ),
+                    ],
+                )
+            }
+
+            with patch(
+                "prowler.providers.aws.services.s3.s3_bucket_lifecycle_enabled.s3_bucket_lifecycle_enabled.s3_client",
+                s3_client,
+            ):
+                check = s3_bucket_lifecycle_enabled()
+                result = check.execute()
+
+                # ALL REGIONS
+                assert len(result) == 1
+
+                # AWS_REGION_US_EAST_1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} has Lifecycle rule {rule_id} disabled or misconfigurated."
+                )
+                assert result[0].resource_id == bucket_name
+                assert result[0].resource_arn == bucket_arn
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/s3/s3_service_test.py
+++ b/tests/providers/aws/services/s3/s3_service_test.py
@@ -35,8 +35,6 @@ def mock_make_api_call(self, operation_name, kwarg):
                     "ID": "test",
                     "Status": "Enabled",
                     "Prefix": "test",
-                    "Expiration": {"Days": 1},
-                    "Transition": {"Days": 1, "StorageClass": "STANDARD_IA"},
                 }
             ]
         }
@@ -465,8 +463,6 @@ class Test_S3_Service:
                         "ID": "test",
                         "Status": "Enabled",
                         "Prefix": "test",
-                        "Expiration": {"Days": 1},
-                        "Transition": {"Days": 1, "StorageClass": "STANDARD_IA"},
                     }
                 ]
             },
@@ -481,12 +477,6 @@ class Test_S3_Service:
         assert len(s3.buckets[bucket_arn].lifecycle) == 1
         assert s3.buckets[bucket_arn].lifecycle[0].id == "test"
         assert s3.buckets[bucket_arn].lifecycle[0].status == "Enabled"
-        assert s3.buckets[bucket_arn].lifecycle[0].expiration_days == 1
-        assert s3.buckets[bucket_arn].lifecycle[0].transition_days == 1
-        assert (
-            s3.buckets[bucket_arn].lifecycle[0].transition_storage_class
-            == "STANDARD_IA"
-        )
 
     # Test S3 List Access Points
     @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)

--- a/tests/providers/aws/services/s3/s3_service_test.py
+++ b/tests/providers/aws/services/s3/s3_service_test.py
@@ -396,7 +396,7 @@ class Test_S3_Service:
         assert s3.buckets[bucket_arn].name == bucket_name
         assert s3.buckets[bucket_arn].region == AWS_REGION_US_EAST_1
         assert s3.buckets[bucket_arn].object_lock
-              
+
     # Test S3 Get Bucket Replication
     @mock_aws
     def test_get_bucket_replication(self):
@@ -439,7 +439,7 @@ class Test_S3_Service:
         assert s3.buckets[bucket_arn].region == AWS_REGION_US_EAST_1
         assert s3.buckets[bucket_arn].replication_rules[0].status == "Enabled"
         assert s3.buckets[bucket_arn].replication_rules[0].destination == bucket_arn
-              
+
     # Test S3 Get Bucket Lifecycle
     @mock_aws
     @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)

--- a/tests/providers/aws/services/s3/s3_service_test.py
+++ b/tests/providers/aws/services/s3/s3_service_test.py
@@ -34,8 +34,9 @@ def mock_make_api_call(self, operation_name, kwarg):
                 {
                     "ID": "test",
                     "Status": "Enabled",
+                    "Prefix": "test",
                     "Expiration": {"Days": 1},
-                    "Transitions": [{"Days": 1, "StorageClass": "STANDARD_IA"}],
+                    "Transition": {"Days": 1, "StorageClass": "STANDARD_IA"},
                 }
             ]
         }
@@ -397,15 +398,36 @@ class Test_S3_Service:
         assert s3.buckets[bucket_arn].object_lock
 
     # Test S3 Get Bucket Lifecycle
-    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     @mock_aws
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_get_bucket_lifecycle(self):
         # Generate S3 Client
         s3_client = client("s3")
+
         # Create S3 Bucket
         bucket_name = "test-bucket"
         bucket_arn = f"arn:aws:s3:::{bucket_name}"
-        s3_client.create_bucket(Bucket=bucket_name)
+        s3_client.create_bucket(
+            Bucket=bucket_name,
+            ObjectOwnership="BucketOwnerEnforced",
+            ObjectLockEnabledForBucket=True,
+        )
+
+        # DEPRECATED: Put Bucket LifeCycle
+        s3_client.put_bucket_lifecycle(
+            Bucket=bucket_name,
+            LifecycleConfiguration={
+                "Rules": [
+                    {
+                        "ID": "test",
+                        "Status": "Enabled",
+                        "Prefix": "test",
+                        "Expiration": {"Days": 1},
+                        "Transition": {"Days": 1, "StorageClass": "STANDARD_IA"},
+                    }
+                ]
+            },
+        )
 
         # S3 client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
@@ -413,6 +435,7 @@ class Test_S3_Service:
         assert len(s3.buckets) == 1
         assert s3.buckets[bucket_arn].name == bucket_name
         assert s3.buckets[bucket_arn].region == AWS_REGION_US_EAST_1
+        assert len(s3.buckets[bucket_arn].lifecycle) == 1
         assert s3.buckets[bucket_arn].lifecycle[0].id == "test"
         assert s3.buckets[bucket_arn].lifecycle[0].status == "Enabled"
         assert s3.buckets[bucket_arn].lifecycle[0].expiration_days == 1


### PR DESCRIPTION
### Context

Amazon S3 general-purpose buckets should be configured with a Lifecycle policy to efficiently manage the storage and lifecycle of objects. This configuration plays a critical role in optimizing storage costs, ensuring data compliance, and automating the management of stored objects.

### Description

By configuring a Lifecycle policy, you can define specific actions for objects stored in an S3 bucket throughout their lifecycle. These actions include transitioning objects to more cost-effective storage classes, archiving data for long-term storage, or automatically deleting objects after a specified retention period.

Implementing this check ensures that a Lifecycle configuration is present and correctly set up by validating that the parameters, such as storage class, deletion time, or transition time, meet the expected or custom-defined criteria (by Amazon or the user respectively). 

### Checklist

- Are there new checks included in this PR? Yes
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
