### PR TITLE
fix(outputs): refactor unroll_tags to use str as tags

### DIFF
--- a/prowler/lib/outputs/utils.py
+++ b/prowler/lib/outputs/utils.py
@@ -63,10 +63,16 @@ def unroll_tags(tags: list) -> dict:
         >>> tags = {"name": "John", "age": "30"}
         >>> unroll_tags(tags)
         {'name': 'John', 'age': '30'}
+
+        >>> tags = ["name", "age"]
+        >>> unroll_tags(tags)
+        {'name': '', 'age': ''}
     """
-    if tags and tags != [{}] and tags != [None]:
+    if tags and tags != [{}] and tags != [None] and tags != []:
         if isinstance(tags, dict):
             return tags
+        if isinstance(tags[0], str) and len(tags) > 0:
+            return {tag: "" for tag in tags}
         if "key" in tags[0]:
             return {item["key"]: item["value"] for item in tags}
         elif "Key" in tags[0]:

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -150,6 +150,15 @@ class TestOutputs:
             "terraform": "true",
         }
 
+    def test_unroll_tags_only_list(self):
+        tags_list = ["tag1", "tag2", "tag3"]
+
+        assert unroll_tags(tags_list) == {
+            "tag1": "",
+            "tag2": "",
+            "tag3": "",
+        }
+
     def test_unroll_dict(self):
         test_compliance_dict = {
             "CISA": ["your-systems-3", "your-data-1", "your-data-2"],


### PR DESCRIPTION
### Context

The tags can also be unique strings; until now, they were expected to have the key: value format.

Fix #4740
Fix #4799

### Description

`unroll_tags` method has been modified to manage `str` as tags for resources:
```python
>>> tags = ["name", "age"]
>>> unroll_tags(tags)
{'tag0': 'name', 'tag1': 'age'}
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
