### PR TITLE
fix(aws): enhance resource arn filtering

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -79,7 +79,7 @@ class AwsProvider(Provider):
         # MFA Configuration (false by default)
         input_mfa = getattr(arguments, "mfa", None)
         input_profile = getattr(arguments, "profile", None)
-        input_regions = getattr(arguments, "region", set())
+        input_regions = set(getattr(arguments, "region", set()))
         organizations_role_arn = getattr(arguments, "organizations_role", None)
 
         # Set if unused services must be scanned
@@ -124,7 +124,7 @@ class AwsProvider(Provider):
         self._identity = self.set_identity(
             caller_identity=caller_identity,
             input_profile=input_profile,
-            input_regions=set(input_regions),
+            input_regions=input_regions,
             profile_region=profile_region,
         )
         ########
@@ -1114,7 +1114,7 @@ def get_aws_region_for_sts(session_region: str, input_regions: set[str]) -> str:
             aws_region = AWS_STS_GLOBAL_ENDPOINT_REGION
     else:
         # Get the first region passed to the -f/--region
-        aws_region = input_regions[0]
+        aws_region = list(input_regions)[0]
 
     return aws_region
 

--- a/prowler/providers/aws/lib/arn/arn.py
+++ b/prowler/providers/aws/lib/arn/arn.py
@@ -58,5 +58,5 @@ def parse_iam_credentials_arn(arn: str) -> ARN:
 
 def is_valid_arn(arn: str) -> bool:
     """is_valid_arn returns True or False whether the given AWS ARN (Amazon Resource Name) is valid or not."""
-    regex = r"^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$"
+    regex = r"^arn:aws(-cn|-us-gov|-iso|-iso-b)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/:\.\*]+(:\d+)?$"
     return re.match(regex, arn) is not None

--- a/prowler/providers/aws/lib/arn/arn.py
+++ b/prowler/providers/aws/lib/arn/arn.py
@@ -58,5 +58,5 @@ def parse_iam_credentials_arn(arn: str) -> ARN:
 
 def is_valid_arn(arn: str) -> bool:
     """is_valid_arn returns True or False whether the given AWS ARN (Amazon Resource Name) is valid or not."""
-    regex = r"^arn:aws(-cn|-us-gov|-iso|-iso-b)?:[a-zA-Z0-9\-]+:([a-z]{2}-[a-z]+-\d{1})?:(\d{12})?:[a-zA-Z0-9\-_\/:\.]+(:\d+)?$"
+    regex = r"^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$"
     return re.match(regex, arn) is not None

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -822,11 +822,11 @@ aws:
     @mock_aws
     def test_get_default_region_with_audited_regions(self):
         arguments = Namespace()
-        arguments.region = [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        arguments.region = [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
         aws_provider = AwsProvider(arguments)
         aws_provider._identity.profile_region = None
 
-        assert aws_provider.get_default_region("ec2") == AWS_REGION_EU_WEST_1
+        assert aws_provider.get_default_region("ec2") == AWS_REGION_US_EAST_1
 
     @mock_aws
     def test_get_default_region_profile_region_not_audited(self):

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -820,15 +820,6 @@ aws:
         assert aws_provider.get_default_region("ec2") == AWS_REGION_EU_WEST_1
 
     @mock_aws
-    def test_get_default_region_with_audited_regions(self):
-        arguments = Namespace()
-        arguments.region = [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-        aws_provider = AwsProvider(arguments)
-        aws_provider._identity.profile_region = None
-
-        assert aws_provider.get_default_region("ec2") == AWS_REGION_US_EAST_1
-
-    @mock_aws
     def test_get_default_region_profile_region_not_audited(self):
         arguments = Namespace()
         arguments.region = [AWS_REGION_EU_WEST_1]

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -820,6 +820,15 @@ aws:
         assert aws_provider.get_default_region("ec2") == AWS_REGION_EU_WEST_1
 
     @mock_aws
+    def test_get_default_region_with_audited_regions(self):
+        arguments = Namespace()
+        arguments.region = [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        aws_provider = AwsProvider(arguments)
+        aws_provider._identity.profile_region = None
+
+        assert aws_provider.get_default_region("ec2") == AWS_REGION_EU_WEST_1
+
+    @mock_aws
     def test_get_default_region_profile_region_not_audited(self):
         arguments = Namespace()
         arguments.region = [AWS_REGION_EU_WEST_1]

--- a/tests/providers/aws/lib/arn/arn_test.py
+++ b/tests/providers/aws/lib/arn/arn_test.py
@@ -386,6 +386,7 @@ class Test_ARN_Parsing:
             "arn:aws:lambda:eu-west-1:123456789012:function:lambda-function"
         )
         assert is_valid_arn("arn:aws:sns:eu-west-1:123456789012:test.fifo")
+        assert is_valid_arn("arn:aws:logs:eu-west-1:123456789012:log-group:/ecs/test:")
         assert not is_valid_arn("arn:azure:::012345678910:user/test")
         assert not is_valid_arn("arn:aws:iam::account:user/test")
         assert not is_valid_arn("arn:aws:::012345678910:resource")


### PR DESCRIPTION
### Description

The flag `--resource-arn` was not working because we were handling the audited regions as a list and not as a set and getting the error:

`2024-08-21 13:55:44,520 [File: aws_provider.py:761]     [Module: aws_provider]   CRITICAL: TypeError[758]: 'set' object is not subscriptable`

Also, the regex pattern of the ARN was not valid for the ARN of CloudWatch log groups, e.g. `arn:aws:logs:eu-west-1:123456789012:log-group:/ecs/test:*`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
