### PR TITLE
fix(aws): update number of aws regions

### DIFF
--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -323,7 +323,7 @@ config_kubernetes = {
 
 class Test_Config:
     def test_get_aws_available_regions(self):
-        assert len(get_aws_available_regions()) == 33
+        assert len(get_aws_available_regions()) == 34
 
     @mock.patch(
         "prowler.config.config.requests.get", new=mock_prowler_get_latest_release


### PR DESCRIPTION
### Context

New AWS region -> https://aws.amazon.com/blogs/aws/now-open-aws-asia-pacific-malaysia-region/

### Description

We need to update `test_get_aws_available_regions` with the correct number of AWS regions.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
