### PR TITLE
fix(action): remove cache in setup python action

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -45,7 +45,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: ${{ env.CACHE }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6


### PR DESCRIPTION
### Description

Remove cache in setup python action to avoid false errors in releasing Prowler to PyPi:
`Error: Cache folder path is retrieved for poetry but doesn't exist on disk: /home/runner/.cache/pypoetry/virtualenvs`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
