### PR TITLE
fix: handle empty input regions

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -79,7 +79,7 @@ class AwsProvider(Provider):
         # MFA Configuration (false by default)
         input_mfa = getattr(arguments, "mfa", None)
         input_profile = getattr(arguments, "profile", None)
-        input_regions = set(getattr(arguments, "region", set()))
+        input_regions = set(getattr(arguments, "region", []) or [])
         organizations_role_arn = getattr(arguments, "organizations_role", None)
 
         # Set if unused services must be scanned

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -759,6 +759,14 @@ aws:
         assert aws_provider.mutelist.mutelist_file_path == dynamodb_mutelist_path
 
     @mock_aws
+    def test_empty_input_regions_in_arguments(self):
+        arguments = Namespace()
+        arguments.region = None
+        aws_provider = AwsProvider(arguments)
+
+        assert isinstance(aws_provider, AwsProvider)
+
+    @mock_aws
     def test_generate_regional_clients_all_enabled_regions(self):
         arguments = Namespace()
         aws_provider = AwsProvider(arguments)


### PR DESCRIPTION
### Description

Handle empty input regions to solve the following TypeError:
`2024-08-22 16:43:11,270 [File: provider.py:175] 	[Module: provider]	 CRITICAL: TypeError[171]: 'NoneType' object is not iterable`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
