### PR TITLE
fix(aws): handle AWS key-only tags

### DIFF
--- a/prowler/lib/outputs/utils.py
+++ b/prowler/lib/outputs/utils.py
@@ -52,6 +52,14 @@ def unroll_tags(tags: list) -> dict:
         >>> unroll_tags(tags)
         {'name': 'John', 'age': '30'}
 
+        >>> tags = [{"key": "name"}]
+        >>> unroll_tags(tags)
+        {'name': ''}
+
+        >>> tags = [{"Key": "name"}]
+        >>> unroll_tags(tags)
+        {'name': ''}
+
         >>> tags = [{"name": "John", "age": "30"}]
         >>> unroll_tags(tags)
         {'name': 'John', 'age': '30'}
@@ -74,9 +82,9 @@ def unroll_tags(tags: list) -> dict:
         if isinstance(tags[0], str) and len(tags) > 0:
             return {tag: "" for tag in tags}
         if "key" in tags[0]:
-            return {item["key"]: item["value"] for item in tags}
+            return {item["key"]: item.get("value", "") for item in tags}
         elif "Key" in tags[0]:
-            return {item["Key"]: item["Value"] for item in tags}
+            return {item["Key"]: item.get("Value", "") for item in tags}
         else:
             return {key: value for d in tags for key, value in d.items()}
     return {}

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -159,6 +159,11 @@ class TestOutputs:
             "tag3": "",
         }
 
+    def test_unroll_tags_with_key_only(self):
+        tags = [{"key": "name"}]
+
+        assert unroll_tags(tags) == {"name": ""}
+
     def test_unroll_dict(self):
         test_compliance_dict = {
             "CISA": ["your-systems-3", "your-data-1", "your-data-2"],


### PR DESCRIPTION
### Description
Handle AWS Tags that only have keys and non-existing values so no KeyError can raise.
 ```
>>> tags = [{"Key": "name"}]
>>> unroll_tags(tags)
{'name': ''}
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
