### PR TITLE
fix(rds): get the db_instances values

### DIFF
--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -132,7 +132,7 @@ class RDS(AWSService):
     def __describe_db_certificate__(self, regional_client):
         logger.info("RDS - Describe DB Certificate...")
         try:
-            for instance in self.db_instances:
+            for instance in self.db_instances.values():
                 if instance.region == regional_client.region:
                     describe_db_certificates_paginator = regional_client.get_paginator(
                         "describe_certificates"

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -213,9 +213,7 @@ class Test_RDS_Service:
 
             rds = RDS(rds_client)
             assert len(rds.db_instances) == 1
-            print(rds.db_instances)
             db_instance_arn, db_instance = next(iter(rds.db_instances.items()))
-            print(db_instance.ca_cert)
             assert db_instance.id == "db-master-1"
             assert db_instance.region == AWS_REGION_US_EAST_1
             assert len(db_instance.cert) == 1

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -208,6 +208,8 @@ class Test_RDS_Service:
             "prowler.providers.aws.services.rds.rds_service.RDS",
             new=rds_client,
         ):
+            from prowler.providers.aws.services.rds.rds_service import RDS
+
             rds = RDS(rds_client)
             assert len(rds.db_instances) == 1
             db_instance_arn, db_instance = next(iter(rds.db_instances.items()))

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -1,11 +1,12 @@
 from datetime import datetime
+from unittest import mock
 from unittest.mock import patch
 
 import botocore
 from boto3 import client
 from moto import mock_aws
 
-from prowler.providers.aws.services.rds.rds_service import RDS
+from prowler.providers.aws.services.rds.rds_service import RDS, Certificate, DBInstance
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
@@ -161,31 +162,70 @@ class Test_RDS_Service:
 
     @mock_aws
     def test__describe_db_certificate__(self):
-        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
-        conn.create_db_parameter_group(
-            DBParameterGroupName="test",
-            DBParameterGroupFamily="default.postgres9.3",
-            Description="test parameter group",
-        )
-        conn.create_db_instance(
-            DBInstanceIdentifier="db-master-1",
-            AllocatedStorage=10,
-            Engine="postgres",
-            DBName="staging-postgres",
-            DBInstanceClass="db.m1.small",
-            DBParameterGroupName="test",
-            CACertificateIdentifier="rds-cert-2015",
-        )
+        rds_client = mock.MagicMock
+        rds_client.db_instances = {
+            "arn:aws:rds:us-east-1:123456789012:db:db-master-1": DBInstance(
+                id="db-master-1",
+                region=AWS_REGION_US_EAST_1,
+                endpoint={
+                    "Address": "db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com",
+                    "Port": 5432,
+                },
+                status="available",
+                public=True,
+                encrypted=True,
+                backup_retention_period=10,
+                cloudwatch_logs=["audit", "error"],
+                deletion_protection=True,
+                auto_minor_version_upgrade=True,
+                multi_az=True,
+                cluster_id="cluster-postgres",
+                tags=[{"Key": "test", "Value": "test"}],
+                parameter_groups=["test"],
+                copy_tags_to_snapshot=True,
+                ca_cert="rds-cert-2015",
+                arn="arn:aws:rds:us-east-1:123456789012:db:db-master-1",
+                engine="postgres",
+                engine_version="9.6.9",
+                username="test",
+                iam_auth=False,
+                cert=[
+                    Certificate(
+                        id="rds-cert-2015",
+                        arn="arn:aws:rds:us-east-1:123456789012:cert:rds-cert-2015",
+                        region=AWS_REGION_US_EAST_1,
+                        type="CA",
+                        valid_from=datetime(2015, 1, 1),
+                        valid_till=datetime(2025, 1, 1),
+                        customer_override=False,
+                        customer_override_valid_till=datetime(2025, 1, 1),
+                    )
+                ],
+            )
+        }
 
-        # RDS client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-        rds = RDS(aws_provider)
-        assert len(rds.db_instances) == 1
-        db_instance_arn, db_instance = next(iter(rds.db_instances.items()))
-        assert db_instance.id == "db-master-1"
-        assert db_instance.region == AWS_REGION_US_EAST_1
-        for cert in db_instance.cert:
-            assert cert["ValidTill"] < datetime.now()
+        with mock.patch(
+            "prowler.providers.aws.services.rds.rds_service.RDS",
+            new=rds_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.rds.rds_service import RDS
+
+            rds = RDS(rds_client)
+            assert len(rds.db_instances) == 1
+            print(rds.db_instances)
+            db_instance_arn, db_instance = next(iter(rds.db_instances.items()))
+            print(db_instance.ca_cert)
+            assert db_instance.id == "db-master-1"
+            assert db_instance.region == AWS_REGION_US_EAST_1
+            assert len(db_instance.cert) == 1
+            for cert in db_instance.cert:
+                assert cert.id == "rds-cert-2015"
+                assert cert.type == "CA"
+                assert cert.valid_from == datetime(2015, 1, 1)
+                assert cert.valid_till == datetime(2025, 1, 1)
+                assert not cert.customer_override
+                assert cert.customer_override_valid_till == datetime(2025, 1, 1)
 
     # Test RDS Describe DB Snapshots
     @mock_aws

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -208,9 +208,6 @@ class Test_RDS_Service:
             "prowler.providers.aws.services.rds.rds_service.RDS",
             new=rds_client,
         ):
-            # Test Check
-            from prowler.providers.aws.services.rds.rds_service import RDS
-
             rds = RDS(rds_client)
             assert len(rds.db_instances) == 1
             db_instance_arn, db_instance = next(iter(rds.db_instances.items()))


### PR DESCRIPTION
### Context
Fix #4865
### Description

`self.db_intances` is a `dict` so if we want to access to this `dict` values, `self.db_intances.values()` is needed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
