### PR TITLE
feat(cloudfront): refactor service function names

### DIFF
--- a/prowler/providers/aws/services/appstream/appstream_service.py
+++ b/prowler/providers/aws/services/appstream/appstream_service.py
@@ -14,7 +14,7 @@ class AppStream(AWSService):
         super().__init__(__class__.__name__, provider)
         self.fleets = []
         self.__threading_call__(self.__describe_fleets__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __describe_fleets__(self, regional_client):
         logger.info("AppStream - Describing Fleets...")
@@ -50,7 +50,7 @@ class AppStream(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("AppStream - List Tags...")
         try:
             for fleet in self.fleets:

--- a/prowler/providers/aws/services/athena/athena_service.py
+++ b/prowler/providers/aws/services/athena/athena_service.py
@@ -16,7 +16,7 @@ class Athena(AWSService):
         self.__threading_call__(self.__list_workgroups__)
         self.__get_workgroups__()
         self.__list_query_executions__()
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_workgroups__(self, regional_client):
         logger.info("Athena - Listing WorkGroups...")
@@ -109,7 +109,7 @@ class Athena(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Athena - Listing Tags...")
         try:
             for workgroup in self.workgroups.values():

--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -20,7 +20,7 @@ class Lambda(AWSService):
         super().__init__(__class__.__name__, provider)
         self.functions = {}
         self.__threading_call__(self.__list_functions__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
         self.__threading_call__(self.__get_policy__)
         self.__threading_call__(self.__get_function_url_config__)
 
@@ -153,7 +153,7 @@ class Lambda(AWSService):
                 f" {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Lambda - List Tags...")
         try:
             for function in self.functions.values():

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -8,17 +8,16 @@ from prowler.lib.scan_filters.scan_filters import is_resource_filtered
 from prowler.providers.aws.lib.service.service import AWSService
 
 
-################## CloudFront
 class CloudFront(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider, global_service=True)
         self.distributions = {}
-        self.__list_distributions__(self.client, self.region)
-        self.__get_distribution_config__(self.client, self.distributions, self.region)
-        self.__list_tags_for_resource__(self.client, self.distributions, self.region)
+        self._list_distributions(self.client, self.region)
+        self._get_distribution_config(self.client, self.distributions, self.region)
+        self._list_tags_for_resource(self.client, self.distributions, self.region)
 
-    def __list_distributions__(self, client, region) -> dict:
+    def _list_distributions(self, client, region) -> dict:
         logger.info("CloudFront - Listing Distributions...")
         try:
             list_ditributions_paginator = client.get_paginator("list_distributions")
@@ -44,7 +43,7 @@ class CloudFront(AWSService):
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_distribution_config__(self, client, distributions, region) -> dict:
+    def _get_distribution_config(self, client, distributions, region) -> dict:
         logger.info("CloudFront - Getting Distributions...")
         try:
             for distribution_id in distributions.keys():
@@ -87,7 +86,7 @@ class CloudFront(AWSService):
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self, client, distributions, region):
+    def _list_tags_for_resource(self, client, distributions, region):
         logger.info("CloudFront - List Tags...")
         try:
             for distribution in distributions.values():

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -21,7 +21,7 @@ class Cloudtrail(AWSService):
             self.__get_trail_status__()
             self.__get_insight_selectors__()
             self.__get_event_selectors__()
-            self.__list_tags_for_resource__()
+            self._list_tags_for_resource()
 
     def __get_trail_arn_template__(self, region):
         return (
@@ -208,7 +208,7 @@ class Cloudtrail(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("CloudTrail - List Tags...")
         try:
             for trail in self.trails.values():

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -17,7 +17,7 @@ class CloudWatch(AWSService):
         self.metric_alarms = []
         self.__threading_call__(self.__describe_alarms__)
         if self.metric_alarms:
-            self.__list_tags_for_resource__()
+            self._list_tags_for_resource()
 
     def __describe_alarms__(self, regional_client):
         logger.info("CloudWatch - Describing alarms...")
@@ -61,7 +61,7 @@ class CloudWatch(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("CloudWatch - List Tags...")
         try:
             for metric_alarm in self.metric_alarms:
@@ -95,7 +95,7 @@ class Logs(AWSService):
                     1000  # The threshold for number of events to return per log group.
                 )
                 self.__threading_call__(self.__get_log_events__)
-            self.__threading_call__(self.__list_tags_for_resource__, self.log_groups)
+            self.__threading_call__(self._list_tags_for_resource, self.log_groups)
 
     def __describe_metric_filters__(self, regional_client):
         logger.info("CloudWatch Logs - Describing metric filters...")
@@ -214,7 +214,7 @@ class Logs(AWSService):
             f"CloudWatch Logs - Finished retrieving log events in {regional_client.region}..."
         )
 
-    def __list_tags_for_resource__(self, log_group):
+    def _list_tags_for_resource(self, log_group):
         logger.info(f"CloudWatch Logs - List Tags for Log Group {log_group.name}...")
         try:
             regional_client = self.regional_clients[log_group.region]

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -18,7 +18,7 @@ class CodeArtifact(AWSService):
         self.repositories = {}
         self.__threading_call__(self.__list_repositories__)
         self.__threading_call__(self.__list_packages__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_repositories__(self, regional_client):
         logger.info("CodeArtifact - Listing Repositories...")
@@ -169,7 +169,7 @@ class CodeArtifact(AWSService):
                     f" {error}"
                 )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("CodeArtifact - List Tags...")
         try:
             for repository in self.repositories.values():

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -21,7 +21,7 @@ class DirectoryService(AWSService):
         self.__threading_call__(self.__describe_event_topics__)
         self.__threading_call__(self.__list_certificates__)
         self.__threading_call__(self.__get_snapshot_limits__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __describe_directories__(self, regional_client):
         logger.info("DirectoryService - Describing Directories...")
@@ -213,7 +213,7 @@ class DirectoryService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Directory Service - List Tags...")
         try:
             for directory in self.directories.values():

--- a/prowler/providers/aws/services/dynamodb/dynamodb_service.py
+++ b/prowler/providers/aws/services/dynamodb/dynamodb_service.py
@@ -19,7 +19,7 @@ class DynamoDB(AWSService):
         self.__describe_table__()
         self.__describe_continuous_backups__()
         self.__get_resource_policy__()
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_tables__(self, regional_client):
         logger.info("DynamoDB - Listing tables...")
@@ -124,7 +124,7 @@ class DynamoDB(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("DynamoDB - List Tags...")
         try:
             for table in self.tables:
@@ -157,7 +157,7 @@ class DAX(AWSService):
         super().__init__(__class__.__name__, provider)
         self.clusters = []
         self.__threading_call__(self.__describe_clusters__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __describe_clusters__(self, regional_client):
         logger.info("DynamoDB DAX - Describing clusters...")
@@ -189,7 +189,7 @@ class DAX(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("DAX - List Tags...")
         for cluster in self.clusters:
             try:

--- a/prowler/providers/aws/services/eventbridge/eventbridge_service.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_service.py
@@ -17,7 +17,7 @@ class EventBridge(AWSService):
         self.buses = {}
         self.__threading_call__(self.__list_event_buses__)
         self.__threading_call__(self.__describe_event_bus__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_event_buses__(self, regional_client):
         logger.info("EventBridge - Listing Event Buses...")
@@ -55,7 +55,7 @@ class EventBridge(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("EventBridge - Listing Tags...")
         try:
             for bus in self.buses.values():

--- a/prowler/providers/aws/services/guardduty/guardduty_service.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_service.py
@@ -18,7 +18,7 @@ class GuardDuty(AWSService):
         self.__list_findings__()
         self.__list_members__()
         self.__get_administrator_account__()
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_detectors__(self, regional_client):
         logger.info("GuardDuty - listing detectors...")
@@ -164,7 +164,7 @@ class GuardDuty(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Guardduty - List Tags...")
         try:
             for detector in self.detectors:

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -89,7 +89,7 @@ class IAM(AWSService):
         self.__list_inline_role_policies__()
         self.saml_providers = self.__list_saml_providers__()
         self.server_certificates = self.__list_server_certificates__()
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
         self.access_keys_metadata = {}
         self.__get_access_keys_metadata__()
         self.last_accessed_services = {}
@@ -768,7 +768,7 @@ class IAM(AWSService):
         finally:
             return server_certificates
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("IAM - List Tags...")
         try:
             if self.roles:

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -16,7 +16,7 @@ class Route53(AWSService):
         self.record_sets = []
         self.__list_hosted_zones__()
         self.__list_query_logging_configs__()
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
         self.__list_resource_record_sets__()
 
     def __list_hosted_zones__(self):
@@ -100,7 +100,7 @@ class Route53(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Route53Domains - List Tags...")
         for hosted_zone in self.hosted_zones.values():
             try:

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -22,7 +22,7 @@ class SageMaker(AWSService):
         self.__describe_model__(self.regional_clients)
         self.__describe_notebook_instance__(self.regional_clients)
         self.__describe_training_job__(self.regional_clients)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_notebook_instances__(self, regional_client):
         logger.info("SageMaker - listing notebook instances...")
@@ -188,7 +188,7 @@ class SageMaker(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("SageMaker - List Tags...")
         try:
             for model in self.sagemaker_models:

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -16,7 +16,7 @@ class SNS(AWSService):
         self.topics = []
         self.__threading_call__(self.__list_topics__)
         self.__get_topic_attributes__(self.regional_clients)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
         self.__list_subscriptions_by_topic__()
 
     def __list_topics__(self, regional_client):
@@ -61,7 +61,7 @@ class SNS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("SNS - List Tags...")
         try:
             for topic in self.topics:

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -23,7 +23,7 @@ class SSMIncidents(AWSService):
         self.__get_replication_set__()
         self.response_plans = []
         self.__threading_call__(self.__list_response_plans__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_replication_sets__(self):
         logger.info("SSMIncidents - Listing Replication Sets...")
@@ -120,7 +120,7 @@ class SSMIncidents(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("SSMIncidents - List Tags...")
         try:
             for response_plan in self.response_plans:

--- a/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
+++ b/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
@@ -15,7 +15,7 @@ class WellArchitected(AWSService):
         super().__init__(__class__.__name__, provider)
         self.workloads = []
         self.__threading_call__(self.__list_workloads__)
-        self.__list_tags_for_resource__()
+        self._list_tags_for_resource()
 
     def __list_workloads__(self, regional_client):
         logger.info("WellArchitected - Listing Workloads...")
@@ -41,7 +41,7 @@ class WellArchitected(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("WellArchitected - Listing Tags...")
         try:
             for workload in self.workloads:

--- a/tests/providers/aws/services/appstream/appstream_service_test.py
+++ b/tests/providers/aws/services/appstream/appstream_service_test.py
@@ -108,7 +108,7 @@ class Test_AppStream_Service:
         assert appstream.fleets[1].enable_default_internet_access is True
         assert appstream.fleets[1].region == AWS_REGION
 
-    def test__list_tags_for_resource__(self):
+    def test_list_tags_for_resource(self):
         # Set partition for the service
         appstream = AppStream(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert len(appstream.fleets) == 2

--- a/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
@@ -166,13 +166,13 @@ class Test_CloudFront_Service:
         assert cloudfront.service == "cloudfront"
 
     @mock_aws
-    def test__list_distributions__zero(self):
+    def test_list_distributionszero(self):
         cloudfront = CloudFront(set_mocked_aws_provider())
 
         assert len(cloudfront.distributions) == 0
 
     @mock_aws
-    def test__list_distributions__complete(self):
+    def test_list_distributionscomplete(self):
         cloudfront_client = client("cloudfront")
         config = example_distribution_config("ref")
         response = cloudfront_client.create_distribution(DistributionConfig=config)

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
@@ -316,7 +316,7 @@ class Test_Cloudtrail_Service:
         assert len(cloudtrail.trails) == len(aws_provider.identity.audited_regions)
 
     @mock_aws
-    def test__list_tags_for_resource__(self):
+    def test_list_tags_for_resource(self):
         tag = "test-tag"
         cloudtrail_client_us_east_1 = client(
             "cloudtrail", region_name=AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
+++ b/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
@@ -103,7 +103,7 @@ class Test_SSMIncidents_Service:
         assert ssmincidents.response_plans[0].region == AWS_REGION_US_EAST_1
         assert ssmincidents.response_plans[0].tags == {"tag_test": "tag_value"}
 
-    def test__list_tags_for_resource__(self):
+    def test_list_tags_for_resource(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         ssmincidents = SSMIncidents(aws_provider)
         assert len(ssmincidents.response_plans) == 1


### PR DESCRIPTION
### Context

Service functions in `cloudfront` service were updated to eliminate the use of magic method syntax, aiming to improve consistency and prevent future errors.

### Description

The change was made to avoid conflicts and ensure more reliable and predictable behavior in the service functions by removing that same syntax.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
