### PR TITLE
chore(aws): add mixed regions test for `s3_access_point_public_access_block`

### DIFF
--- a/tests/providers/aws/services/s3/s3_access_point_public_access_block/s3_access_point_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_access_point_public_access_block/s3_access_point_public_access_block_test.py
@@ -316,3 +316,78 @@ class Test_s3_access_point_public_access_block:
                     == f"arn:aws:s3:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:accesspoint/{ap_name_eu}"
                 )
                 assert result[1].region == AWS_REGION_EU_WEST_1
+                
+    def test_access_points_mixed_regions(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1, "ap-southeast-2"])
+
+        ap_name_us = "test-access-point-us-east-1"
+        ap_name_eu = "test-access-point-eu-west-1"
+        ap_name_ap = "test-access-point-ap-southeast-2"
+        
+        arn_us = f"arn:aws:s3:us-east-1:{AWS_ACCOUNT_NUMBER}:accesspoint/{ap_name_us}"
+        arn_eu = f"arn:aws:s3:eu-west-1:{AWS_ACCOUNT_NUMBER}:accesspoint/{ap_name_eu}"
+        arn_ap = f"arn:aws:s3:ap-southeast-2:{AWS_ACCOUNT_NUMBER}:accesspoint/{ap_name_ap}"
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_access_point_public_access_block.s3_access_point_public_access_block.s3control_client",
+            new=S3Control(aws_provider),
+        ):
+            from prowler.providers.aws.services.s3.s3_access_point_public_access_block.s3_access_point_public_access_block import (
+                s3_access_point_public_access_block,
+            )
+
+            s3control_client = mock.MagicMock()
+            s3control_client.access_points = {
+                arn_us: AccessPoint(
+                    account_id=AWS_ACCOUNT_NUMBER,
+                    name=ap_name_us,
+                    bucket="bucket-us",
+                    region="us-east-1",
+                    public_access_block=PublicAccessBlock(
+                        block_public_acls=True,
+                        ignore_public_acls=True,
+                        block_public_policy=True,
+                        restrict_public_buckets=True,
+                    ),
+                ),
+                arn_eu: AccessPoint(
+                    account_id=AWS_ACCOUNT_NUMBER,
+                    name=ap_name_eu,
+                    bucket="bucket-eu",
+                    region="eu-west-1",
+                    public_access_block=PublicAccessBlock(
+                        block_public_acls=False,
+                        ignore_public_acls=False,
+                        block_public_policy=False,
+                        restrict_public_buckets=False,
+                    ),
+                ),
+                arn_ap: AccessPoint(
+                    account_id=AWS_ACCOUNT_NUMBER,
+                    name=ap_name_ap,
+                    bucket="bucket-ap",
+                    region="ap-southeast-2",
+                    public_access_block=PublicAccessBlock(
+                        block_public_acls=True,
+                        ignore_public_acls=False,
+                        block_public_policy=True,
+                        restrict_public_buckets=True,
+                    ),
+                ),
+            }
+
+            with patch(
+                "prowler.providers.aws.services.s3.s3_access_point_public_access_block.s3_access_point_public_access_block.s3control_client",
+                s3control_client,
+            ):
+                check = s3_access_point_public_access_block()
+                result = check.execute()
+
+                assert len(result) == 3
+                assert result[0].status == "PASS"
+                assert result[1].status == "FAIL"
+                assert result[2].status == "FAIL"
+                assert result[2].region == "ap-southeast-2"


### PR DESCRIPTION
### Description
This pull request adds a new test case to test_s3_access_point_public_access_block.py that checks the behavior of the s3_access_point_public_access_block check across multiple AWS regions.
Changes

Added test_access_points_mixed_regions function to test S3 access points in US East 1, EU West 1, and AP Southeast 2 regions
The new test case verifies correct handling of different public access block configurations across regions

### Motivation
This test enhances the coverage of the existing test suite by ensuring the check correctly handles:

Access points in multiple regions within a single execution
Varied public access block configurations across different regions
Correct region reporting in the check results

### Testing

Ran the new test case locally using pytest
Verified that all existing tests still pass
Checked that the new test fails appropriately when the check's logic is intentionally broken

### Additional Notes

This test case doesn't require any changes to the main check logic, only adds to the test coverage
Follows the existing pattern of mocking AWS services to avoid actual AWS API calls during testing

### Checklist

 My code follows the style guidelines of this project
 [] I have performed a self-review of my own code
 [] I have commented my code, particularly in hard-to-understand areas
 [] I have made corresponding changes to the documentation (if applicable)
 [] My changes generate no new warnings
 [] I have added tests that prove my fix is effective or that my feature works
 [] New and existing unit tests pass locally with my changes
