### PR TITLE
feat(aws): Add new check to ensure RDS event notification subscriptions are configured for critical cluster events

### DIFF
--- a/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "aws",
-  "CheckID": "rds_cluster_event_subscription_critical_events",
+  "CheckID": "rds_cluster_critical_event_subscription",
   "CheckTitle": "Check if RDS Cluster critical events are subscribed.",
   "CheckType": [
     "Software and Configuration Checks, AWS Security Best Practices"

--- a/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_cluster_event_subscription_critical_events",
+  "CheckTitle": "Check if RDS Cluster critical events are subscribed.",
+  "CheckType": [
+    "Software and Configuration Checks, AWS Security Best Practices"
+  ],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
+  "Severity": "low",
+  "ResourceType": "AwsRdsEventSubscription",
+  "Description": "Ensure that Amazon RDS event notification subscriptions are enabled for database cluster events, particularly maintenance and failure.",
+  "Risk": "Without event subscriptions for critical events, such as maintenance and failures, you may not be aware of issues affecting your RDS clusters, leading to downtime or security vulnerabilities.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws rds create-event-subscription --source-type db-cluster --event-categories 'failure' 'maintenance' --sns-topic-arn <sns-topic-arn>",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-19",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "To subscribe to RDS cluster event notifications, see Subscribing to Amazon RDS event notification in the Amazon RDS User Guide.",
+      "Url": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.Subscribing.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
@@ -16,10 +16,10 @@ class rds_cluster_critical_event_subscription(Check):
                 )
                 report.region = db_event.region
                 if db_event.source_type == "db-cluster" and db_event.enabled:
-                    if db_event.event_list == [] or db_event.event_list == [
+                    if db_event.event_list == [] or set(db_event.event_list) == {
                         "maintenance",
                         "failure",
-                    ]:
+                    }:
                         report.resource_id = db_event.id
                         report.resource_arn = db_event.arn
                         report.status = "PASS"

--- a/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
@@ -15,6 +15,7 @@ class rds_cluster_critical_event_subscription(Check):
                     db_event.region
                 )
                 report.region = db_event.region
+                report.resource_tags = db_event.tags
                 if db_event.source_type == "db-cluster" and db_event.enabled:
                     if db_event.event_list == [] or set(db_event.event_list) == {
                         "maintenance",

--- a/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
@@ -15,7 +15,6 @@ class rds_cluster_critical_event_subscription(Check):
                     db_event.region
                 )
                 report.region = db_event.region
-                report.resource_tags = db_event.tags
                 if db_event.source_type == "db-cluster" and db_event.enabled:
                     if db_event.event_list == [] or set(db_event.event_list) == {
                         "maintenance",

--- a/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription.py
@@ -1,0 +1,44 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_cluster_critical_event_subscription(Check):
+    def execute(self):
+        findings = []
+        if rds_client.provider.scan_unused_services or rds_client.db_clusters:
+            for db_event in rds_client.db_event_subscriptions:
+                report = Check_Report_AWS(self.metadata())
+                report.status = "FAIL"
+                report.status_extended = "RDS cluster event categories of maintenance and failure are not subscribed."
+                report.resource_id = rds_client.audited_account
+                report.resource_arn = rds_client.__get_rds_arn_template__(
+                    db_event.region
+                )
+                report.region = db_event.region
+                if db_event.source_type == "db-cluster" and db_event.enabled:
+                    if db_event.event_list == [] or db_event.event_list == [
+                        "maintenance",
+                        "failure",
+                    ]:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "PASS"
+                        report.status_extended = "RDS cluster events are subscribed."
+
+                    elif db_event.event_list == ["maintenance"]:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = (
+                            "RDS cluster event category of failure is not subscribed."
+                        )
+
+                    elif db_event.event_list == ["failure"]:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = "RDS cluster event category of maintenance is not subscribed."
+
+                findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription_test.py
@@ -44,6 +44,7 @@ class Test_rds_cluster_critical_event_subscription:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == RDS_ACCOUNT_ARN
+                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_cluster_event_subscription_enabled(self):

--- a/tests/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription_test.py
@@ -44,7 +44,6 @@ class Test_rds_cluster_critical_event_subscription:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == RDS_ACCOUNT_ARN
-                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_cluster_event_subscription_enabled(self):
@@ -94,7 +93,6 @@ class Test_rds_cluster_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_cluster_event_failure_only_subscription(self):
@@ -147,7 +145,6 @@ class Test_rds_cluster_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_cluster_event_maintenance_only_subscription(self):
@@ -197,4 +194,3 @@ class Test_rds_cluster_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_critical_event_subscription/rds_cluster_critical_event_subscription_test.py
@@ -1,0 +1,199 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+RDS_ACCOUNT_ARN = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:account"
+
+
+class Test_rds_cluster_critical_event_subscription:
+    @mock_aws
+    def test_rds_no_events(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription import (
+                    rds_cluster_critical_event_subscription,
+                )
+
+                check = rds_cluster_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS cluster event categories of maintenance and failure are not subscribed."
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+                assert result[0].resource_arn == RDS_ACCOUNT_ARN
+
+    @mock_aws
+    def test_rds_cluster_event_subscription_enabled(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            Engine="aurora-postgresql",
+            MasterUsername="admin",
+            MasterUserPassword="password",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-cluster",
+            Enabled=True,
+            EventCategories=["maintenance", "failure"],
+            Tags=[
+                {"Key": "test", "Value": "testing"},
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription import (
+                    rds_cluster_critical_event_subscription,
+                )
+
+                check = rds_cluster_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert result[0].status_extended == "RDS cluster events are subscribed."
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_cluster_event_failure_only_subscription(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            Engine="aurora-postgresql",
+            MasterUsername="admin",
+            MasterUserPassword="password",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-cluster",
+            EventCategories=["failure"],
+            Enabled=True,
+            Tags=[
+                {"Key": "test", "Value": "testing"},
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription import (
+                    rds_cluster_critical_event_subscription,
+                )
+
+                check = rds_cluster_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS cluster event category of maintenance is not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_cluster_event_maintenance_only_subscription(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            Engine="aurora-postgresql",
+            MasterUsername="admin",
+            MasterUserPassword="password",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-cluster",
+            EventCategories=["maintenance"],
+            Enabled=True,
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_critical_event_subscription.rds_cluster_critical_event_subscription import (
+                    rds_cluster_critical_event_subscription,
+                )
+
+                check = rds_cluster_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS cluster event category of failure is not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+                assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

This new check verifies that existing Amazon RDS event notification subscriptions are set up to alert on critical cluster events, specifically for maintenance and failure categories. RDS uses Amazon SNS for event notifications, enhancing awareness of changes in availability or configuration and facilitating quick response to potential issues.

### Description

Added new `rds_cluster_critical_event_subscription` check with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
