### PR TITLE
feat(aws): Add new check to ensure RDS event notification subscriptions are configured for critical database instance events

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.metadata.json
@@ -1,31 +1,32 @@
 {
-    "Provider": "aws",
-    "CheckID": "rds_instance_event_subscription_security_groups",
-    "CheckTitle": "Check if RDS Security Group events are subscribed.",
-    "CheckType": [],
-    "ServiceName": "rds",
-    "SubServiceName": "",
-    "ResourceIdTemplate": "arn:aws:rds:region:account-id:es",
-    "Severity": "medium",
-    "ResourceType": "AwsRdsEventSubscription",
-    "Description": "Ensure that Amazon RDS event notification subscriptions are enabled for database security groups events.",
-    "Risk": "Amazon RDS event subscriptions for database security groups are designed to provide incident notification of events that may affect the security, availability, and reliability of the RDS database instances associated with these security groups.",
-    "RelatedUrl": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-22",
-    "Remediation": {
-      "Code": {
-        "CLI": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-db-security-groups-events.html#",
-        "NativeIaC": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-db-security-groups-events.html#",
-        "Other": "",
-        "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-db-security-groups-events.html#"
-      },
-      "Recommendation": {
-        "Text": "To subscribe to RDS instance event notifications, see Subscribing to Amazon RDS event notification in the Amazon RDS User Guide.",
-        "Url": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-22"
-      }
+  "Provider": "aws",
+  "CheckID": "rds_instance_critical_event_subscription",
+  "CheckTitle": "Check if RDS Instances events are subscribed.",
+  "CheckType": [
+    "Software and Configuration Checks, AWS Security Best Practices"
+  ],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
+  "Severity": "low",
+  "ResourceType": "AwsRdsEventSubscription",
+  "Description": "Ensure that Amazon RDS event notification subscriptions are enabled for database database events, particularly maintenance, configuration change and failure.",
+  "Risk": "Without event subscriptions for critical events, such as maintenance, configuration changes and failures, you may not be aware of issues affecting your RDS instances, leading to downtime or security vulnerabilities.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws rds create-event-subscription --source-type db-instance --event-categories 'failure' 'maintenance' 'configuration change' --sns-topic-arn <sns-topic-arn>",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-20",
+      "Terraform": ""
     },
-    "Categories": [],
-    "DependsOn": [],
-    "RelatedTo": [],
-    "Notes": ""
-  }
-  
+    "Recommendation": {
+      "Text": "To subscribe to RDS instance event notifications, see Subscribing to Amazon RDS event notification in the Amazon RDS User Guide.",
+      "Url": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.Subscribing.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.metadata.json
@@ -1,0 +1,31 @@
+{
+    "Provider": "aws",
+    "CheckID": "rds_instance_event_subscription_security_groups",
+    "CheckTitle": "Check if RDS Security Group events are subscribed.",
+    "CheckType": [],
+    "ServiceName": "rds",
+    "SubServiceName": "",
+    "ResourceIdTemplate": "arn:aws:rds:region:account-id:es",
+    "Severity": "medium",
+    "ResourceType": "AwsRdsEventSubscription",
+    "Description": "Ensure that Amazon RDS event notification subscriptions are enabled for database security groups events.",
+    "Risk": "Amazon RDS event subscriptions for database security groups are designed to provide incident notification of events that may affect the security, availability, and reliability of the RDS database instances associated with these security groups.",
+    "RelatedUrl": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-22",
+    "Remediation": {
+      "Code": {
+        "CLI": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-db-security-groups-events.html#",
+        "NativeIaC": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-db-security-groups-events.html#",
+        "Other": "",
+        "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/RDS/rds-db-security-groups-events.html#"
+      },
+      "Recommendation": {
+        "Text": "To subscribe to RDS instance event notifications, see Subscribing to Amazon RDS event notification in the Amazon RDS User Guide.",
+        "Url": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-22"
+      }
+    },
+    "Categories": [],
+    "DependsOn": [],
+    "RelatedTo": [],
+    "Notes": ""
+  }
+  

--- a/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.py
+++ b/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.py
@@ -1,0 +1,71 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_instance_critical_event_subscription(Check):
+    def execute(self):
+        findings = []
+        if rds_client.provider.scan_unused_services or rds_client.db_instances:
+            for db_event in rds_client.db_event_subscriptions:
+                report = Check_Report_AWS(self.metadata())
+                report.status = "FAIL"
+                report.status_extended = "RDS instance event categories of maintenance, configuration change, and failure are not subscribed."
+                report.resource_id = rds_client.audited_account
+                report.resource_arn = rds_client.__get_rds_arn_template__(
+                    db_event.region
+                )
+                report.region = db_event.region
+                if db_event.source_type == "db-instance" and db_event.enabled:
+                    if db_event.event_list == [] or set(db_event.event_list) == {
+                        "maintenance",
+                        "configuration change",
+                        "failure",
+                    }:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "PASS"
+                        report.status_extended = "RDS instance events are subscribed."
+                    elif set(db_event.event_list) == {"maintenance"}:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = "RDS instance event categories of configuration change and failure are not subscribed."
+                    elif set(db_event.event_list) == {"configuration change"}:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = "RDS instance event categories of maintenance and failure are not subscribed."
+                    elif set(db_event.event_list) == {"failure"}:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = "RDS instance event categories of maintenance and configuration change are not subscribed."
+                    elif set(db_event.event_list) == {
+                        "maintenance",
+                        "configuration change",
+                    }:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = (
+                            "RDS instance event category of failure is not subscribed."
+                        )
+                    elif set(db_event.event_list) == {
+                        "maintenance",
+                        "failure",
+                    }:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = "RDS instance event category of configuration change is not subscribed."
+                    elif set(db_event.event_list) == {
+                        "configuration change",
+                        "failure",
+                    }:
+                        report.resource_id = db_event.id
+                        report.resource_arn = db_event.arn
+                        report.status = "FAIL"
+                        report.status_extended = "RDS instance event category of maintenance is not subscribed."
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.py
+++ b/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.py
@@ -15,6 +15,7 @@ class rds_instance_critical_event_subscription(Check):
                     db_event.region
                 )
                 report.region = db_event.region
+                report.resource_tags = db_event.tags
                 if db_event.source_type == "db-instance" and db_event.enabled:
                     if db_event.event_list == [] or set(db_event.event_list) == {
                         "maintenance",

--- a/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.py
+++ b/prowler/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription.py
@@ -15,7 +15,6 @@ class rds_instance_critical_event_subscription(Check):
                     db_event.region
                 )
                 report.region = db_event.region
-                report.resource_tags = db_event.tags
                 if db_event.source_type == "db-instance" and db_event.enabled:
                     if db_event.event_list == [] or set(db_event.event_list) == {
                         "maintenance",

--- a/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
@@ -1,0 +1,362 @@
+from unittest import mock
+
+import botocore
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+RDS_ACCOUNT_ARN = f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:account"
+
+
+class Test_rds_instance_critical_event_subscription:
+    @mock_aws
+    def test_rds_no_events(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event categories of maintenance, configuration change, and failure are not subscribed."
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+                assert result[0].resource_arn == RDS_ACCOUNT_ARN
+
+    @mock_aws
+    def test_rds_no_events_ignoring(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        aws_provider._scan_unused_services = False
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_rds_instance_event_subscription_enabled(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["maintenance", "configuration change", "failure"],
+            Enabled=True,
+            Tags=[
+                {"Key": "test", "Value": "testing"},
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance events are subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+
+    @mock_aws
+    def test_rds_instance_event_failure_only_subscription(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["failure"],
+            Enabled=True,
+            Tags=[
+                {"Key": "test", "Value": "testing"},
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event categories of maintenance and configuration change are not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_instance_event_maintenance_only_subscription(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["maintenance"],
+            Enabled=True,
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event categories of configuration change and failure are not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+
+    @mock_aws
+    def test_rds_instance_event_configuration_change_only_subscription(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["configuration change"],
+            Enabled=True,
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event categories of maintenance and failure are not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+
+    @mock_aws
+    def test_rds_no_instance_event_subscription(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["configuration change"],
+            Enabled=True,
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event categories of maintenance, configuration change, and failure are not subscribed."
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+                assert result[0].resource_arn == RDS_ACCOUNT_ARN

--- a/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
@@ -46,6 +46,7 @@ class Test_rds_instance_critical_event_subscription:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == RDS_ACCOUNT_ARN
+                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_no_events_ignoring(self):
@@ -122,8 +123,7 @@ class Test_rds_instance_critical_event_subscription:
                 assert len(result) == 1
                 assert result[0].status == "PASS"
                 assert (
-                    result[0].status_extended
-                    == "RDS instance events are subscribed."
+                    result[0].status_extended == "RDS instance events are subscribed."
                 )
                 assert result[0].resource_id == "TestSub"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -131,6 +131,7 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
+                assert result[0].resource_tags == [{"Key": "test", "Value": "testing"}]
 
     @mock_aws
     def test_rds_instance_event_failure_only_subscription(self):
@@ -191,7 +192,7 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == []
+                assert result[0].resource_tags == [{"Key": "test", "Value": "testing"}]
 
     @mock_aws
     def test_rds_instance_event_maintenance_only_subscription(self):
@@ -249,6 +250,7 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
+                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_instance_event_configuration_change_only_subscription(self):
@@ -306,6 +308,7 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
+                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_no_instance_event_subscription(self):
@@ -360,3 +363,4 @@ class Test_rds_instance_critical_event_subscription:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == RDS_ACCOUNT_ARN
+                assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
@@ -304,3 +304,174 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
+
+    @mock_aws
+    def test_rds_instance_event_configuration_change_and_maintenance(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["maintenance", "configuration change"],
+            Enabled=True,
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event category of failure is not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+
+    @mock_aws
+    def test_rds_instance_event_configuration_change_and_failure(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["configuration change", "failure"],
+            Enabled=True,
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event category of maintenance is not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )
+
+    @mock_aws
+    def test_rds_instance_event_failure_and_maintenance(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-instance",
+            EventCategories=["failure", "maintenance"],
+            Enabled=True,
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
+                    rds_instance_critical_event_subscription,
+                )
+
+                check = rds_instance_critical_event_subscription()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS instance event category of configuration change is not subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )

--- a/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_critical_event_subscription/rds_instance_critical_event_subscription_test.py
@@ -46,7 +46,6 @@ class Test_rds_instance_critical_event_subscription:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == RDS_ACCOUNT_ARN
-                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_no_events_ignoring(self):
@@ -131,7 +130,6 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == [{"Key": "test", "Value": "testing"}]
 
     @mock_aws
     def test_rds_instance_event_failure_only_subscription(self):
@@ -192,7 +190,6 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == [{"Key": "test", "Value": "testing"}]
 
     @mock_aws
     def test_rds_instance_event_maintenance_only_subscription(self):
@@ -250,7 +247,6 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == []
 
     @mock_aws
     def test_rds_instance_event_configuration_change_only_subscription(self):
@@ -308,59 +304,3 @@ class Test_rds_instance_critical_event_subscription:
                     result[0].resource_arn
                     == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
                 )
-                assert result[0].resource_tags == []
-
-    @mock_aws
-    def test_rds_no_instance_event_subscription(self):
-        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
-        conn.create_db_parameter_group(
-            DBParameterGroupName="test",
-            DBParameterGroupFamily="default.aurora-postgresql14",
-            Description="test parameter group",
-        )
-        conn.create_db_instance(
-            DBInstanceIdentifier="db-master-1",
-            AllocatedStorage=10,
-            Engine="aurora-postgresql",
-            DBName="aurora-postgres",
-            DBInstanceClass="db.m1.small",
-            DBParameterGroupName="test",
-            DBClusterIdentifier="db-cluster-1",
-        )
-        conn.create_event_subscription(
-            SubscriptionName="TestSub",
-            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
-            SourceType="db-instance",
-            EventCategories=["configuration change"],
-            Enabled=True,
-        )
-        from prowler.providers.aws.services.rds.rds_service import RDS
-
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ):
-            with mock.patch(
-                "prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription.rds_client",
-                new=RDS(aws_provider),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.rds.rds_instance_critical_event_subscription.rds_instance_critical_event_subscription import (
-                    rds_instance_critical_event_subscription,
-                )
-
-                check = rds_instance_critical_event_subscription()
-                result = check.execute()
-
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert (
-                    result[0].status_extended
-                    == "RDS instance event categories of maintenance, configuration change, and failure are not subscribed."
-                )
-                assert result[0].region == AWS_REGION_US_EAST_1
-                assert result[0].resource_id == AWS_ACCOUNT_NUMBER
-                assert result[0].resource_arn == RDS_ACCOUNT_ARN
-                assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

This new check ensures that existing Amazon RDS event notification subscriptions for database instances are configured to alert on critical events, including maintenance, configuration changes, and failures. Leveraging Amazon SNS for these notifications improves situational awareness and enables quick responses to changes in the availability or configuration of RDS resources.

### Description

Added new `rds_instance_critical_event_subscription` check with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
