### PR TITLE
chore(aws_mutelist): Add more Control Tower resources and tests

### DIFF
--- a/prowler/config/aws_mutelist.yaml
+++ b/prowler/config/aws_mutelist.yaml
@@ -19,8 +19,11 @@ Mutelist:
             - "StackSet-AWSControlTowerSecurityResources-*"
             - "StackSet-AWSControlTowerLoggingResources-*"
             - "StackSet-AWSControlTowerExecutionRole-*"
-            - "AWSControlTowerBP-BASELINE-CLOUDTRAIL-MASTER"
-            - "AWSControlTowerBP-BASELINE-CONFIG-MASTER"
+            - "AWSControlTowerBP-BASELINE-CLOUDTRAIL-MASTER*"
+            - "AWSControlTowerBP-BASELINE-CONFIG-MASTER*"
+            - "StackSet-AWSControlTower*"
+            - "CLOUDTRAIL-ENABLED-ON-SHARED-ACCOUNTS-*"
+            - "AFT-Backend*"
         "cloudtrail_*":
           Regions:
             - "*"

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -1,5 +1,6 @@
 import io
 from json import dumps
+from os import path
 
 import botocore
 import yaml
@@ -840,6 +841,134 @@ class TestAWSMutelist:
             "check_test_1",
             AWS_REGION_EU_WEST_1,
             "resource_3",
+            "",
+        )
+
+    def test_is_muted_aws_default_mutelist(
+        self,
+    ):
+
+        mutelist = AWSMutelist(
+            mutelist_path=f"{path.dirname(path.realpath(__file__))}/../../../../../prowler/config/aws_mutelist.yaml"
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerBP-BASELINE-CONFIG-AAAAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerBP-BASELINE-CLOUDWATCH-AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerGuardrailAWS-GR-AUDIT-BUCKET-PUBLIC-READ-PROHIBITED-AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerGuardrailAWS-GR-DETECT",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "CLOUDTRAIL-ENABLED-ON-SHARED-ACCOUNTS-AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerBP-BASELINE-SERVICE-LINKED-ROLE-AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerBP-BASELINE-ROLES-AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerBP-SECURITY-TOPICS-AAAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerBP-BASELINE-SERVICE-ROLES-AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerSecurityResources-AAAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerGuardrailAWS-GR-AUDIT-BUCKET-PUBLIC-WRITE-PROHIBITED-AAAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "AFT-Backend/AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "AWSControlTowerBP-BASELINE-CONFIG-MASTER/AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "AWSControlTowerBP-BASELINE-CLOUDTRAIL-MASTER/AAA",
+            "",
+        )
+
+        assert mutelist.is_muted(
+            AWS_ACCOUNT_NUMBER,
+            "cloudformation_stacks_termination_protection_enabled",
+            AWS_REGION_EU_WEST_1,
+            "StackSet-AWSControlTowerBP-VPC-ACCOUNT-FACTORY-V1-AAA",
             "",
         )
 


### PR DESCRIPTION
### Context

Fix #4894 

### Description

- Add more AWS Control Tower resources in the AWS default Mutelist
- Add test cases to cover those resources

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
