### PR TITLE
chore(aws): Remove token from log line

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -125,8 +125,7 @@ class AWS_Provider:
                 token=response["Credentials"]["SessionToken"],
                 expiry_time=response["Credentials"]["Expiration"].isoformat(),
             )
-            logger.info("Refreshed Credentials:")
-            logger.info(refreshed_credentials)
+            logger.info("Refreshed Credentials")
         return refreshed_credentials
 
 


### PR DESCRIPTION
### Description

We need to remove a log line in the AWS Provider that shows boto3 credentials, is not something critical because they are dynamic and short-lived, it lasts just one hour.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
