### PR TITLE
chore(prowler): change all methods from services from format double underscore to single underscore

### DIFF
--- a/docs/developer-guide/unit-testing.md
+++ b/docs/developer-guide/unit-testing.md
@@ -592,7 +592,7 @@ is following the actual format, add one function where the client is passed to b
 `mock_api_<endpoint>_calls` (*endpoint* refers to the first attribute pointed after *client*).
 
 In the example of BigQuery the function is called `mock_api_dataset_calls`. And inside of this function we found an assignation to
-be used in the `__get_datasets__` method in BigQuery class:
+be used in the `_get_datasets` method in BigQuery class:
 
 ```python
 # Mocking datasets
@@ -765,7 +765,7 @@ from tests.providers.azure.azure_fixtures import (
     set_mocked_azure_provider,
 )
 
-# Function to mock the service function __get_components__, this function task is to return a possible value that real function could returns
+# Function to mock the service function _get_components, this function task is to return a possible value that real function could returns
 def mock_appinsights_get_components(_):
     return {
         AZURE_SUBSCRIPTION_ID: {
@@ -779,12 +779,12 @@ def mock_appinsights_get_components(_):
 
 # Patch decorator to use the mocked function instead the function with the real API call
 @patch(
-    "prowler.providers.azure.services.appinsights.appinsights_service.AppInsights.__get_components__",
+    "prowler.providers.azure.services.appinsights.appinsights_service.AppInsights._get_components",
     new=mock_appinsights_get_components,
 )
 class Test_AppInsights_Service:
     # Mandatory test for every service, this method test the instance of the client is correct
-    def test__get_client__(self):
+    def test_get_client(self):
         app_insights = AppInsights(set_mocked_azure_provider())
         assert (
             app_insights.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
@@ -794,8 +794,8 @@ class Test_AppInsights_Service:
     def test__get_subscriptions__(self):
         app_insights = AppInsights(set_mocked_azure_provider())
         assert app_insights.subscriptions.__class__.__name__ == "dict"
-    # Test for the function __get_components__, inside this client is used the mocked function
-    def test__get_components__(self):
+    # Test for the function _get_components, inside this client is used the mocked function
+    def test_get_components(self):
         appinsights = AppInsights(set_mocked_azure_provider())
         assert len(appinsights.components) == 1
         assert (

--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
@@ -14,11 +14,11 @@ class AccessAnalyzer(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.analyzers = []
-        self.__threading_call__(self.__list_analyzers__)
-        self.__list_findings__()
-        self.__get_finding_status__()
+        self.__threading_call__(self._list_analyzers)
+        self._list_findings()
+        self._get_finding_status()
 
-    def __list_analyzers__(self, regional_client):
+    def _list_analyzers(self, regional_client):
         logger.info("AccessAnalyzer - Listing Analyzers...")
         try:
             list_analyzers_paginator = regional_client.get_paginator("list_analyzers")
@@ -57,7 +57,7 @@ class AccessAnalyzer(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_finding_status__(self):
+    def _get_finding_status(self):
         logger.info("AccessAnalyzer - Get Finding status...")
         try:
             for analyzer in self.analyzers:
@@ -87,7 +87,7 @@ class AccessAnalyzer(AWSService):
 
     # TODO: We need to include ListFindingsV2
     # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/accessanalyzer/client/list_findings_v2.html
-    def __list_findings__(self):
+    def _list_findings(self):
         logger.info("AccessAnalyzer - Listing Findings per Analyzer...")
         try:
             for analyzer in self.analyzers:

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -13,10 +13,10 @@ class Account(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.number_of_contacts = 4
-        self.contact_base = self.__get_contact_information__()
-        self.contacts_billing = self.__get_alternate_contact__("BILLING")
-        self.contacts_security = self.__get_alternate_contact__("SECURITY")
-        self.contacts_operations = self.__get_alternate_contact__("OPERATIONS")
+        self.contact_base = self._get_contact_information()
+        self.contacts_billing = self._get_alternate_contact("BILLING")
+        self.contacts_security = self._get_alternate_contact("SECURITY")
+        self.contacts_operations = self._get_alternate_contact("OPERATIONS")
 
         if self.contact_base:
             # Set of contact phone numbers
@@ -42,7 +42,7 @@ class Account(AWSService):
                 self.contacts_operations.email,
             }
 
-    def __get_contact_information__(self):
+    def _get_contact_information(self):
         try:
             primary_account_contact = self.client.get_contact_information()[
                 "ContactInformation"
@@ -65,7 +65,7 @@ class Account(AWSService):
                 )
                 return Contact(type="PRIMARY")
 
-    def __get_alternate_contact__(self, contact_type: str):
+    def _get_alternate_contact(self, contact_type: str):
         try:
             account_contact = self.client.get_alternate_contact(
                 AlternateContactType=contact_type

--- a/prowler/providers/aws/services/apigateway/apigateway_service.py
+++ b/prowler/providers/aws/services/apigateway/apigateway_service.py
@@ -14,13 +14,13 @@ class APIGateway(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.rest_apis = []
-        self.__threading_call__(self.__get_rest_apis__)
-        self.__get_authorizers__()
-        self.__get_rest_api__()
-        self.__get_stages__()
-        self.__get_resources__()
+        self.__threading_call__(self._get_rest_apis)
+        self._get_authorizers()
+        self._get_rest_api()
+        self._get_stages()
+        self._get_resources()
 
-    def __get_rest_apis__(self, regional_client):
+    def _get_rest_apis(self, regional_client):
         logger.info("APIGateway - Getting Rest APIs...")
         try:
             get_rest_apis_paginator = regional_client.get_paginator("get_rest_apis")
@@ -44,7 +44,7 @@ class APIGateway(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_authorizers__(self):
+    def _get_authorizers(self):
         logger.info("APIGateway - Getting Rest APIs authorizer...")
         try:
             for rest_api in self.rest_apis:
@@ -75,7 +75,7 @@ class APIGateway(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_rest_api__(self):
+    def _get_rest_api(self):
         logger.info("APIGateway - Describing Rest API...")
         try:
             for rest_api in self.rest_apis:
@@ -103,7 +103,7 @@ class APIGateway(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_stages__(self):
+    def _get_stages(self):
         logger.info("APIGateway - Getting stages for Rest APIs...")
         try:
             for rest_api in self.rest_apis:
@@ -151,7 +151,7 @@ class APIGateway(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_resources__(self):
+    def _get_resources(self):
         logger.info("APIGateway - Getting API resources...")
         try:
             for rest_api in self.rest_apis:

--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -13,11 +13,11 @@ class ApiGatewayV2(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.apis = []
-        self.__threading_call__(self.__get_apis__)
-        self.__get_authorizers__()
-        self.__get_stages__()
+        self.__threading_call__(self._get_apis)
+        self._get_authorizers()
+        self._get_stages()
 
-    def __get_apis__(self, regional_client):
+    def _get_apis(self, regional_client):
         logger.info("APIGatewayv2 - Getting APIs...")
         try:
             get_apis_paginator = regional_client.get_paginator("get_apis")
@@ -41,7 +41,7 @@ class ApiGatewayV2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_authorizers__(self):
+    def _get_authorizers(self):
         logger.info("APIGatewayv2 - Getting APIs authorizer...")
         try:
             for api in self.apis:
@@ -54,7 +54,7 @@ class ApiGatewayV2(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __get_stages__(self):
+    def _get_stages(self):
         logger.info("APIGatewayv2 - Getting stages for APIs...")
         try:
             for api in self.apis:

--- a/prowler/providers/aws/services/appstream/appstream_service.py
+++ b/prowler/providers/aws/services/appstream/appstream_service.py
@@ -13,10 +13,10 @@ class AppStream(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.fleets = []
-        self.__threading_call__(self.__describe_fleets__)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._describe_fleets)
+        self._list_tags_for_resource()
 
-    def __describe_fleets__(self, regional_client):
+    def _describe_fleets(self, regional_client):
         logger.info("AppStream - Describing Fleets...")
         try:
             describe_fleets_paginator = regional_client.get_paginator("describe_fleets")
@@ -50,7 +50,7 @@ class AppStream(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("AppStream - List Tags...")
         try:
             for fleet in self.fleets:

--- a/prowler/providers/aws/services/athena/athena_service.py
+++ b/prowler/providers/aws/services/athena/athena_service.py
@@ -13,12 +13,12 @@ class Athena(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.workgroups = {}
-        self.__threading_call__(self.__list_workgroups__)
-        self.__get_workgroups__()
-        self.__list_query_executions__()
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_workgroups)
+        self._get_workgroups()
+        self._list_query_executions()
+        self._list_tags_for_resource()
 
-    def __list_workgroups__(self, regional_client):
+    def _list_workgroups(self, regional_client):
         logger.info("Athena - Listing WorkGroups...")
         try:
             list_workgroups = regional_client.list_work_groups()
@@ -44,7 +44,7 @@ class Athena(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_workgroups__(self):
+    def _get_workgroups(self):
         logger.info("Athena - Getting WorkGroups...")
         try:
             for workgroup in self.workgroups.values():
@@ -88,7 +88,7 @@ class Athena(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_query_executions__(self):
+    def _list_query_executions(self):
         logger.info("Athena - Listing Queries...")
         try:
             for workgroup in self.workgroups.values():
@@ -109,7 +109,7 @@ class Athena(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Athena - Listing Tags...")
         try:
             for workgroup in self.workgroups.values():

--- a/prowler/providers/aws/services/autoscaling/autoscaling_service.py
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_service.py
@@ -11,11 +11,11 @@ class AutoScaling(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.launch_configurations = []
-        self.__threading_call__(self.__describe_launch_configurations__)
+        self.__threading_call__(self._describe_launch_configurations)
         self.groups = []
-        self.__threading_call__(self.__describe_auto_scaling_groups__)
+        self.__threading_call__(self._describe_auto_scaling_groups)
 
-    def __describe_launch_configurations__(self, regional_client):
+    def _describe_launch_configurations(self, regional_client):
         logger.info("AutoScaling - Describing Launch Configurations...")
         try:
             describe_launch_configurations_paginator = regional_client.get_paginator(
@@ -44,7 +44,7 @@ class AutoScaling(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_auto_scaling_groups__(self, regional_client):
+    def _describe_auto_scaling_groups(self, regional_client):
         logger.info("AutoScaling - Describing AutoScaling Groups...")
         try:
             describe_auto_scaling_groups_paginator = regional_client.get_paginator(

--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code.py
@@ -12,7 +12,7 @@ class awslambda_function_no_secrets_in_code(Check):
     def execute(self):
         findings = []
         if awslambda_client.functions:
-            for function, function_code in awslambda_client.__get_function_code__():
+            for function, function_code in awslambda_client._get_function_code():
                 if function_code:
                     report = Check_Report_AWS(self.metadata())
                     report.region = function.region

--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -19,12 +19,12 @@ class Lambda(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.functions = {}
-        self.__threading_call__(self.__list_functions__)
-        self.__list_tags_for_resource__()
-        self.__threading_call__(self.__get_policy__)
-        self.__threading_call__(self.__get_function_url_config__)
+        self.__threading_call__(self._list_functions)
+        self._list_tags_for_resource()
+        self.__threading_call__(self._get_policy)
+        self.__threading_call__(self._get_function_url_config)
 
-    def __list_functions__(self, regional_client):
+    def _list_functions(self, regional_client):
         logger.info("Lambda - Listing Functions...")
         try:
             list_functions_paginator = regional_client.get_paginator("list_functions")
@@ -61,12 +61,12 @@ class Lambda(AWSService):
                 f" {error}"
             )
 
-    def __get_function_code__(self):
+    def _get_function_code(self):
         logger.info("Lambda - Getting Function Code...")
-        # Use a thread pool handle the queueing and execution of the __fetch_function_code__ tasks, up to max_workers tasks concurrently.
+        # Use a thread pool handle the queueing and execution of the _fetch_function_code tasks, up to max_workers tasks concurrently.
         lambda_functions_to_fetch = {
             self.thread_pool.submit(
-                self.__fetch_function_code__, function.name, function.region
+                self._fetch_function_code, function.name, function.region
             ): function
             for function in self.functions.values()
         }
@@ -82,7 +82,7 @@ class Lambda(AWSService):
                     f"{function.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __fetch_function_code__(self, function_name, function_region):
+    def _fetch_function_code(self, function_name, function_region):
         try:
             regional_client = self.regional_clients[function_region]
             function_information = regional_client.get_function(
@@ -101,7 +101,7 @@ class Lambda(AWSService):
             )
             raise
 
-    def __get_policy__(self, regional_client):
+    def _get_policy(self, regional_client):
         logger.info("Lambda - Getting Policy...")
         try:
             for function in self.functions.values():
@@ -124,7 +124,7 @@ class Lambda(AWSService):
                 f" {error}"
             )
 
-    def __get_function_url_config__(self, regional_client):
+    def _get_function_url_config(self, regional_client):
         logger.info("Lambda - Getting Function URL Config...")
         try:
             for function in self.functions.values():
@@ -153,7 +153,7 @@ class Lambda(AWSService):
                 f" {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Lambda - List Tags...")
         try:
             for function in self.functions.values():

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -18,13 +18,13 @@ class Backup(AWSService):
         self.report_plan_arn_template = f"arn:{self.audited_partition}:backup:{self.region}:{self.audited_account}:report-plan"
         self.backup_vault_arn_template = f"arn:{self.audited_partition}:backup:{self.region}:{self.audited_account}:backup-vault"
         self.backup_vaults = []
-        self.__threading_call__(self.__list_backup_vaults__)
+        self.__threading_call__(self._list_backup_vaults)
         self.backup_plans = []
-        self.__threading_call__(self.__list_backup_plans__)
+        self.__threading_call__(self._list_backup_plans)
         self.backup_report_plans = []
-        self.__threading_call__(self.__list_backup_report_plans__)
+        self.__threading_call__(self._list_backup_report_plans)
 
-    def __list_backup_vaults__(self, regional_client):
+    def _list_backup_vaults(self, regional_client):
         logger.info("Backup - Listing Backup Vaults...")
         try:
             list_backup_vaults_paginator = regional_client.get_paginator(
@@ -70,7 +70,7 @@ class Backup(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_backup_plans__(self, regional_client):
+    def _list_backup_plans(self, regional_client):
         logger.info("Backup - Listing Backup Plans...")
         try:
             list_backup_plans_paginator = regional_client.get_paginator(
@@ -105,7 +105,7 @@ class Backup(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_backup_report_plans__(self, regional_client):
+    def _list_backup_report_plans(self, regional_client):
         logger.info("Backup - Listing Backup Report Plans...")
 
         try:

--- a/prowler/providers/aws/services/cloudformation/cloudformation_service.py
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_service.py
@@ -14,10 +14,10 @@ class CloudFormation(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.stacks = []
-        self.__threading_call__(self.__describe_stacks__)
-        self.__describe_stack__()
+        self.__threading_call__(self._describe_stacks)
+        self._describe_stack()
 
-    def __describe_stacks__(self, regional_client):
+    def _describe_stacks(self, regional_client):
         """Get ALL CloudFormation Stacks"""
         logger.info("CloudFormation - Describing Stacks...")
         try:
@@ -47,7 +47,7 @@ class CloudFormation(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_stack__(self):
+    def _describe_stack(self):
         """Get Details for a CloudFormation Stack"""
         logger.info("CloudFormation - Describing Stack to get specific details...")
         for stack in self.stacks:

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -14,11 +14,11 @@ class CloudFront(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider, global_service=True)
         self.distributions = {}
-        self.__list_distributions__(self.client, self.region)
-        self.__get_distribution_config__(self.client, self.distributions, self.region)
-        self.__list_tags_for_resource__(self.client, self.distributions, self.region)
+        self._list_distributions(self.client, self.region)
+        self._get_distribution_config(self.client, self.distributions, self.region)
+        self._list_tags_for_resource(self.client, self.distributions, self.region)
 
-    def __list_distributions__(self, client, region) -> dict:
+    def _list_distributions(self, client, region) -> dict:
         logger.info("CloudFront - Listing Distributions...")
         try:
             list_ditributions_paginator = client.get_paginator("list_distributions")
@@ -44,7 +44,7 @@ class CloudFront(AWSService):
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_distribution_config__(self, client, distributions, region) -> dict:
+    def _get_distribution_config(self, client, distributions, region) -> dict:
         logger.info("CloudFront - Getting Distributions...")
         try:
             for distribution_id in distributions.keys():
@@ -87,7 +87,7 @@ class CloudFront(AWSService):
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self, client, distributions, region):
+    def _list_tags_for_resource(self, client, distributions, region):
         logger.info("CloudFront - List Tags...")
         try:
             for distribution in distributions.values():

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
@@ -32,7 +32,7 @@ class cloudtrail_multi_region_enabled(Check):
                                 "No CloudTrail trails enabled with logging were found."
                             )
                             report.resource_arn = (
-                                cloudtrail_client.__get_trail_arn_template__(region)
+                                cloudtrail_client._get_trail_arn_template(region)
                             )
                             report.resource_id = cloudtrail_client.audited_account
                 # If there are no trails logging it is needed to store the FAIL once all the trails have been checked

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events.py
@@ -14,9 +14,7 @@ class cloudtrail_multi_region_enabled_logging_management_events(Check):
                 report.status_extended = "No CloudTrail trails enabled and logging management events were found."
                 report.region = region
                 report.resource_id = cloudtrail_client.audited_account
-                report.resource_arn = cloudtrail_client.__get_trail_arn_template__(
-                    region
-                )
+                report.resource_arn = cloudtrail_client._get_trail_arn_template(region)
                 trail_is_logging_management_events = False
                 for trail in cloudtrail_client.trails.values():
                     if trail.region == region or trail.is_multiregion:

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -16,21 +16,21 @@ class Cloudtrail(AWSService):
         super().__init__(__class__.__name__, provider)
         self.trail_arn_template = f"arn:{self.audited_partition}:cloudtrail:{self.region}:{self.audited_account}:trail"
         self.trails = {}
-        self.__threading_call__(self.__get_trails__)
+        self.__threading_call__(self._get_trails)
         if self.trails:
-            self.__get_trail_status__()
-            self.__get_insight_selectors__()
-            self.__get_event_selectors__()
-            self.__list_tags_for_resource__()
+            self._get_trail_status()
+            self._get_insight_selectors()
+            self._get_event_selectors()
+            self._list_tags_for_resource()
 
-    def __get_trail_arn_template__(self, region):
+    def _get_trail_arn_template(self, region):
         return (
             f"arn:{self.audited_partition}:cloudtrail:{region}:{self.audited_account}:trail"
             if region
             else f"arn:{self.audited_partition}:cloudtrail:{self.region}:{self.audited_account}:trail"
         )
 
-    def __get_trails__(self, regional_client):
+    def _get_trails(self, regional_client):
         logger.info("Cloudtrail - Getting trails...")
         try:
             describe_trails = regional_client.describe_trails()["trailList"]
@@ -70,7 +70,7 @@ class Cloudtrail(AWSService):
             if trails_count == 0:
                 if self.trails is None:
                     self.trails = {}
-                self.trails[self.__get_trail_arn_template__(regional_client.region)] = (
+                self.trails[self._get_trail_arn_template(regional_client.region)] = (
                     Trail(
                         region=regional_client.region,
                     )
@@ -91,7 +91,7 @@ class Cloudtrail(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_trail_status__(self):
+    def _get_trail_status(self):
         logger.info("Cloudtrail - Getting trail status")
         try:
             for trail in self.trails.values():
@@ -109,7 +109,7 @@ class Cloudtrail(AWSService):
                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_event_selectors__(self):
+    def _get_event_selectors(self):
         logger.info("Cloudtrail - Getting event selector")
         try:
             for trail in self.trails.values():
@@ -142,7 +142,7 @@ class Cloudtrail(AWSService):
                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_insight_selectors__(self):
+    def _get_insight_selectors(self):
         logger.info("Cloudtrail - Getting trail insight selectors...")
 
         try:
@@ -192,7 +192,7 @@ class Cloudtrail(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __lookup_events__(self, trail, event_name, minutes):
+    def _lookup_events(self, trail, event_name, minutes):
         logger.info("CloudTrail - Lookup Events...")
         try:
             regional_client = self.regional_clients[trail.region]
@@ -208,7 +208,7 @@ class Cloudtrail(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("CloudTrail - List Tags...")
         try:
             for trail in self.trails.values():

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration.py
@@ -33,7 +33,7 @@ class cloudtrail_threat_detection_enumeration(Check):
         )
         for trail in trails_to_scan:
             for event_name in enumeration_actions:
-                for event_log in cloudtrail_client.__lookup_events__(
+                for event_log in cloudtrail_client._lookup_events(
                     trail=trail,
                     event_name=event_name,
                     minutes=threat_detection_minutes,
@@ -52,7 +52,7 @@ class cloudtrail_threat_detection_enumeration(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.region = cloudtrail_client.region
                 report.resource_id = cloudtrail_client.audited_account
-                report.resource_arn = cloudtrail_client.__get_trail_arn_template__(
+                report.resource_arn = cloudtrail_client._get_trail_arn_template(
                     cloudtrail_client.region
                 )
                 report.status = "FAIL"
@@ -62,7 +62,7 @@ class cloudtrail_threat_detection_enumeration(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = cloudtrail_client.region
             report.resource_id = cloudtrail_client.audited_account
-            report.resource_arn = cloudtrail_client.__get_trail_arn_template__(
+            report.resource_arn = cloudtrail_client._get_trail_arn_template(
                 cloudtrail_client.region
             )
             report.status = "PASS"

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_privilege_escalation/cloudtrail_threat_detection_privilege_escalation.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_privilege_escalation/cloudtrail_threat_detection_privilege_escalation.py
@@ -34,7 +34,7 @@ class cloudtrail_threat_detection_privilege_escalation(Check):
         )
         for trail in trails_to_scan:
             for event_name in privilege_escalation_actions:
-                for event_log in cloudtrail_client.__lookup_events__(
+                for event_log in cloudtrail_client._lookup_events(
                     trail=trail,
                     event_name=event_name,
                     minutes=threat_detection_minutes,
@@ -58,7 +58,7 @@ class cloudtrail_threat_detection_privilege_escalation(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.region = cloudtrail_client.region
                 report.resource_id = cloudtrail_client.audited_account
-                report.resource_arn = cloudtrail_client.__get_trail_arn_template__(
+                report.resource_arn = cloudtrail_client._get_trail_arn_template(
                     cloudtrail_client.region
                 )
                 report.status = "FAIL"
@@ -68,7 +68,7 @@ class cloudtrail_threat_detection_privilege_escalation(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = cloudtrail_client.region
             report.resource_id = cloudtrail_client.audited_account
-            report.resource_arn = cloudtrail_client.__get_trail_arn_template__(
+            report.resource_arn = cloudtrail_client._get_trail_arn_template(
                 cloudtrail_client.region
             )
             report.status = "PASS"

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -15,11 +15,11 @@ class CloudWatch(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.metric_alarms = []
-        self.__threading_call__(self.__describe_alarms__)
+        self.__threading_call__(self._describe_alarms)
         if self.metric_alarms:
-            self.__list_tags_for_resource__()
+            self._list_tags_for_resource()
 
-    def __describe_alarms__(self, regional_client):
+    def _describe_alarms(self, regional_client):
         logger.info("CloudWatch - Describing alarms...")
         try:
             describe_alarms_paginator = regional_client.get_paginator("describe_alarms")
@@ -61,7 +61,7 @@ class CloudWatch(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("CloudWatch - List Tags...")
         try:
             for metric_alarm in self.metric_alarms:
@@ -84,8 +84,8 @@ class Logs(AWSService):
         self.log_group_arn_template = f"arn:{self.audited_partition}:logs:{self.region}:{self.audited_account}:log-group"
         self.metric_filters = []
         self.log_groups = []
-        self.__threading_call__(self.__describe_metric_filters__)
-        self.__threading_call__(self.__describe_log_groups__)
+        self.__threading_call__(self._describe_metric_filters)
+        self.__threading_call__(self._describe_log_groups)
         if self.log_groups:
             if (
                 "cloudwatch_log_group_no_secrets_in_logs"
@@ -94,10 +94,10 @@ class Logs(AWSService):
                 self.events_per_log_group_threshold = (
                     1000  # The threshold for number of events to return per log group.
                 )
-                self.__threading_call__(self.__get_log_events__)
-            self.__threading_call__(self.__list_tags_for_resource__, self.log_groups)
+                self.__threading_call__(self._get_log_events)
+            self.__threading_call__(self._list_tags_for_resource, self.log_groups)
 
-    def __describe_metric_filters__(self, regional_client):
+    def _describe_metric_filters(self, regional_client):
         logger.info("CloudWatch Logs - Describing metric filters...")
         try:
             describe_metric_filters_paginator = regional_client.get_paginator(
@@ -137,7 +137,7 @@ class Logs(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_log_groups__(self, regional_client):
+    def _describe_log_groups(self, regional_client):
         logger.info("CloudWatch Logs - Describing log groups...")
         try:
             describe_log_groups_paginator = regional_client.get_paginator(
@@ -182,7 +182,7 @@ class Logs(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_log_events__(self, regional_client):
+    def _get_log_events(self, regional_client):
         regional_log_groups = [
             log_group
             for log_group in self.log_groups
@@ -214,7 +214,7 @@ class Logs(AWSService):
             f"CloudWatch Logs - Finished retrieving log events in {regional_client.region}..."
         )
 
-    def __list_tags_for_resource__(self, log_group):
+    def _list_tags_for_resource(self, log_group):
         logger.info(f"CloudWatch Logs - List Tags for Log Group {log_group.name}...")
         try:
             regional_client = self.regional_clients[log_group.region]

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -16,11 +16,11 @@ class CodeArtifact(AWSService):
         super().__init__(__class__.__name__, provider)
         # repositories is a dictionary containing all the codeartifact service information
         self.repositories = {}
-        self.__threading_call__(self.__list_repositories__)
-        self.__threading_call__(self.__list_packages__)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_repositories)
+        self.__threading_call__(self._list_packages)
+        self._list_tags_for_resource()
 
-    def __list_repositories__(self, regional_client):
+    def _list_repositories(self, regional_client):
         logger.info("CodeArtifact - Listing Repositories...")
         try:
             list_repositories_paginator = regional_client.get_paginator(
@@ -52,7 +52,7 @@ class CodeArtifact(AWSService):
                 f" {error}"
             )
 
-    def __list_packages__(self, regional_client):
+    def _list_packages(self, regional_client):
         logger.info("CodeArtifact - Listing Packages and retrieving information...")
         for repository in self.repositories:
             try:
@@ -169,7 +169,7 @@ class CodeArtifact(AWSService):
                     f" {error}"
                 )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("CodeArtifact - List Tags...")
         try:
             for repository in self.repositories.values():

--- a/prowler/providers/aws/services/cognito/cognito_service.py
+++ b/prowler/providers/aws/services/cognito/cognito_service.py
@@ -14,14 +14,14 @@ class CognitoIDP(AWSService):
         super().__init__("cognito-idp", provider)
 
         self.user_pools = {}
-        self.__threading_call__(self.__list_user_pools__)
-        self.__describe_user_pools__()
-        self.__list_user_pool_clients__()
-        self.__describe_user_pool_clients__()
-        self.__get_user_pool_mfa_config__()
-        self.__get_user_pool_risk_configuration__()
+        self.__threading_call__(self._list_user_pools)
+        self._describe_user_pools()
+        self._list_user_pool_clients()
+        self._describe_user_pool_clients()
+        self._get_user_pool_mfa_config()
+        self._get_user_pool_risk_configuration()
 
-    def __list_user_pools__(self, regional_client):
+    def _list_user_pools(self, regional_client):
         logger.info("Cognito - Listing User Pools...")
         try:
             user_pools_paginator = regional_client.get_paginator("list_user_pools")
@@ -51,7 +51,7 @@ class CognitoIDP(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_user_pools__(self):
+    def _describe_user_pools(self):
         logger.info("Cognito - Describing User Pools...")
         try:
             for user_pool in self.user_pools.values():
@@ -114,7 +114,7 @@ class CognitoIDP(AWSService):
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_user_pool_clients__(self):
+    def _list_user_pool_clients(self):
         logger.info("Cognito - Listing User Pool Clients...")
         try:
             for user_pool in self.user_pools.values():
@@ -143,7 +143,7 @@ class CognitoIDP(AWSService):
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_user_pool_clients__(self):
+    def _describe_user_pool_clients(self):
         logger.info("Cognito - Describing User Pool Clients...")
         try:
             for user_pool in self.user_pools.values():
@@ -175,7 +175,7 @@ class CognitoIDP(AWSService):
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_user_pool_mfa_config__(self):
+    def _get_user_pool_mfa_config(self):
         logger.info("Cognito - Getting User Pool MFA Configuration...")
         try:
             for user_pool in self.user_pools.values():
@@ -202,7 +202,7 @@ class CognitoIDP(AWSService):
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_user_pool_risk_configuration__(self):
+    def _get_user_pool_risk_configuration(self):
         logger.info("Cognito - Getting User Pool Risk Configuration...")
         try:
             for user_pool in self.user_pools.values():
@@ -265,11 +265,11 @@ class CognitoIdentity(AWSService):
     def __init__(self, provider):
         super().__init__("cognito-identity", provider)
         self.identity_pools = {}
-        self.__threading_call__(self.__list_identity_pools__)
-        self.__describe_identity_pools__()
-        self.__get_identity_pool_roles__()
+        self.__threading_call__(self._list_identity_pools)
+        self._describe_identity_pools()
+        self._get_identity_pool_roles()
 
-    def __list_identity_pools__(self, regional_client):
+    def _list_identity_pools(self, regional_client):
         logger.info("Cognito - Listing Identity Pools...")
         try:
             identity_pools_paginator = regional_client.get_paginator(
@@ -297,7 +297,7 @@ class CognitoIdentity(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_identity_pools__(self):
+    def _describe_identity_pools(self):
         logger.info("Cognito - Describing Identity Pools...")
         try:
             for identity_pool in self.identity_pools.values():
@@ -325,7 +325,7 @@ class CognitoIdentity(AWSService):
                 f"{identity_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_identity_pool_roles__(self):
+    def _get_identity_pool_roles(self):
         logger.info("Cognito - Getting Identity Pool Roles...")
         try:
             for identity_pool in self.identity_pools.values():

--- a/prowler/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled.py
+++ b/prowler/providers/aws/services/config/config_recorder_all_regions_enabled/config_recorder_all_regions_enabled.py
@@ -8,7 +8,7 @@ class config_recorder_all_regions_enabled(Check):
         for recorder in config_client.recorders:
             report = Check_Report_AWS(self.metadata())
             report.region = recorder.region
-            report.resource_arn = config_client.__get_recorder_arn_template__(
+            report.resource_arn = config_client._get_recorder_arn_template(
                 recorder.region
             )
             report.resource_id = (

--- a/prowler/providers/aws/services/config/config_service.py
+++ b/prowler/providers/aws/services/config/config_service.py
@@ -13,12 +13,12 @@ class Config(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.recorders = []
-        self.__threading_call__(self.__describe_configuration_recorder_status__)
+        self.__threading_call__(self._describe_configuration_recorder_status)
 
-    def __get_recorder_arn_template__(self, region):
+    def _get_recorder_arn_template(self, region):
         return f"arn:{self.audited_partition}:config:{region}:{self.audited_account}:recorder"
 
-    def __describe_configuration_recorder_status__(self, regional_client):
+    def _describe_configuration_recorder_status(self, regional_client):
         logger.info("Config - Listing Recorders...")
         try:
             recorders = regional_client.describe_configuration_recorder_status()[

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -16,14 +16,14 @@ class DirectoryService(AWSService):
         # Call AWSService's __init__
         super().__init__("ds", provider)
         self.directories = {}
-        self.__threading_call__(self.__describe_directories__)
-        self.__threading_call__(self.__list_log_subscriptions__)
-        self.__threading_call__(self.__describe_event_topics__)
-        self.__threading_call__(self.__list_certificates__)
-        self.__threading_call__(self.__get_snapshot_limits__)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._describe_directories)
+        self.__threading_call__(self._list_log_subscriptions)
+        self.__threading_call__(self._describe_event_topics)
+        self.__threading_call__(self._list_certificates)
+        self.__threading_call__(self._get_snapshot_limits)
+        self._list_tags_for_resource()
 
-    def __describe_directories__(self, regional_client):
+    def _describe_directories(self, regional_client):
         logger.info("DirectoryService - Describing Directories...")
         try:
             describe_fleets_paginator = regional_client.get_paginator(
@@ -71,7 +71,7 @@ class DirectoryService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_log_subscriptions__(self, regional_client):
+    def _list_log_subscriptions(self, regional_client):
         logger.info("DirectoryService - Listing Log Subscriptions...")
         try:
             for directory in self.directories.values():
@@ -101,7 +101,7 @@ class DirectoryService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_event_topics__(self, regional_client):
+    def _describe_event_topics(self, regional_client):
         logger.info("DirectoryService - Describing Event Topics...")
         try:
             for directory in self.directories.values():
@@ -128,7 +128,7 @@ class DirectoryService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_certificates__(self, regional_client):
+    def _list_certificates(self, regional_client):
         logger.info("DirectoryService - Listing Certificates...")
         try:
             for directory in self.directories.values():
@@ -178,7 +178,7 @@ class DirectoryService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_snapshot_limits__(self, regional_client):
+    def _get_snapshot_limits(self, regional_client):
         logger.info("DirectoryService - Getting Snapshot Limits...")
         try:
             for directory in self.directories.values():
@@ -213,7 +213,7 @@ class DirectoryService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Directory Service - List Tags...")
         try:
             for directory in self.directories.values():

--- a/prowler/providers/aws/services/dlm/dlm_ebs_snapshot_lifecycle_policy_exists/dlm_ebs_snapshot_lifecycle_policy_exists.py
+++ b/prowler/providers/aws/services/dlm/dlm_ebs_snapshot_lifecycle_policy_exists/dlm_ebs_snapshot_lifecycle_policy_exists.py
@@ -16,7 +16,7 @@ class dlm_ebs_snapshot_lifecycle_policy_exists(Check):
                 report.status_extended = "No EBS Snapshot lifecycle policies found."
                 report.region = region
                 report.resource_id = dlm_client.audited_account
-                report.resource_arn = dlm_client.__get_lifecycle_policy_arn_template__(
+                report.resource_arn = dlm_client._get_lifecycle_policy_arn_template(
                     region
                 )
                 if dlm_client.lifecycle_policies[region]:

--- a/prowler/providers/aws/services/dlm/dlm_service.py
+++ b/prowler/providers/aws/services/dlm/dlm_service.py
@@ -10,14 +10,14 @@ class DLM(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.lifecycle_policies = {}
-        self.__threading_call__(self.__get_lifecycle_policies__)
+        self.__threading_call__(self._get_lifecycle_policies)
 
-    def __get_lifecycle_policy_arn_template__(self, region):
+    def _get_lifecycle_policy_arn_template(self, region):
         return (
             f"arn:{self.audited_partition}:dlm:{region}:{self.audited_account}:policy"
         )
 
-    def __get_lifecycle_policies__(self, regional_client):
+    def _get_lifecycle_policies(self, regional_client):
         logger.info("DLM - Getting EBS Snapshots Lifecycle Policies...")
         try:
             lifecycle_policies = regional_client.get_lifecycle_policies()

--- a/prowler/providers/aws/services/dms/dms_service.py
+++ b/prowler/providers/aws/services/dms/dms_service.py
@@ -11,9 +11,9 @@ class DMS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.instances = []
-        self.__threading_call__(self.__describe_replication_instances__)
+        self.__threading_call__(self._describe_replication_instances)
 
-    def __describe_replication_instances__(self, regional_client):
+    def _describe_replication_instances(self, regional_client):
         logger.info("DMS - Describing DMS Replication Instances...")
         try:
             describe_replication_instances_paginator = regional_client.get_paginator(

--- a/prowler/providers/aws/services/drs/drs_job_exist/drs_job_exist.py
+++ b/prowler/providers/aws/services/drs/drs_job_exist/drs_job_exist.py
@@ -11,9 +11,7 @@ class drs_job_exist(Check):
             report.status_extended = "DRS is not enabled for this region."
             report.region = drs.region
             report.resource_tags = []
-            report.resource_arn = drs_client.__get_recovery_job_arn_template__(
-                drs.region
-            )
+            report.resource_arn = drs_client._get_recovery_job_arn_template(drs.region)
             report.resource_id = drs_client.audited_account
             if drs.status == "ENABLED":
                 report.status_extended = "DRS is enabled for this region without jobs."

--- a/prowler/providers/aws/services/drs/drs_service.py
+++ b/prowler/providers/aws/services/drs/drs_service.py
@@ -12,12 +12,12 @@ class DRS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.drs_services = []
-        self.__threading_call__(self.__describe_jobs__)
+        self.__threading_call__(self._describe_jobs)
 
-    def __get_recovery_job_arn_template__(self, region):
+    def _get_recovery_job_arn_template(self, region):
         return f"arn:{self.audited_partition}:drs:{region}:{self.audited_account}:recovery-job"
 
-    def __describe_jobs__(self, regional_client):
+    def _describe_jobs(self, regional_client):
         logger.info("DRS - Describe Jobs...")
         try:
             try:

--- a/prowler/providers/aws/services/dynamodb/dynamodb_service.py
+++ b/prowler/providers/aws/services/dynamodb/dynamodb_service.py
@@ -15,13 +15,13 @@ class DynamoDB(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.tables = []
-        self.__threading_call__(self.__list_tables__)
-        self.__describe_table__()
-        self.__describe_continuous_backups__()
-        self.__get_resource_policy__()
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_tables)
+        self._describe_table()
+        self._describe_continuous_backups()
+        self._get_resource_policy()
+        self._list_tags_for_resource()
 
-    def __list_tables__(self, regional_client):
+    def _list_tables(self, regional_client):
         logger.info("DynamoDB - Listing tables...")
         try:
             list_tables_paginator = regional_client.get_paginator("list_tables")
@@ -45,7 +45,7 @@ class DynamoDB(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_table__(self):
+    def _describe_table(self):
         logger.info("DynamoDB - Describing Table...")
         try:
             for table in self.tables:
@@ -63,7 +63,7 @@ class DynamoDB(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __describe_continuous_backups__(self):
+    def _describe_continuous_backups(self):
         logger.info("DynamoDB - Describing Continuous Backups...")
         try:
             for table in self.tables:
@@ -95,7 +95,7 @@ class DynamoDB(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __get_resource_policy__(self):
+    def _get_resource_policy(self):
         logger.info("DynamoDB - Get Resource Policy...")
         try:
             for table in self.tables:
@@ -124,7 +124,7 @@ class DynamoDB(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("DynamoDB - List Tags...")
         try:
             for table in self.tables:
@@ -156,10 +156,10 @@ class DAX(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.clusters = []
-        self.__threading_call__(self.__describe_clusters__)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._describe_clusters)
+        self._list_tags_for_resource()
 
-    def __describe_clusters__(self, regional_client):
+    def _describe_clusters(self, regional_client):
         logger.info("DynamoDB DAX - Describing clusters...")
         try:
             describe_clusters_paginator = regional_client.get_paginator(
@@ -189,7 +189,7 @@ class DAX(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("DAX - List Tags...")
         for cluster in self.clusters:
             try:

--- a/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption.py
@@ -9,7 +9,7 @@ class ec2_ebs_default_encryption(Check):
             if ebs_encryption.volumes or ec2_client.provider.scan_unused_services:
                 report = Check_Report_AWS(self.metadata())
                 report.region = ebs_encryption.region
-                report.resource_arn = ec2_client.__get_volume_arn_template__(
+                report.resource_arn = ec2_client._get_volume_arn_template(
                     ebs_encryption.region
                 )
                 report.resource_id = ec2_client.audited_account

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -45,7 +45,7 @@ class EC2(AWSService):
         self.instance_metadata_defaults = []
         self.__threading_call__(self._get_instance_metadata_defaults)
         self.launch_templates = []
-        self.__threading_call__(self.__describe_launch_templates)
+        self.__threading_call__(self._describe_launch_templates)
         self.__threading_call__(
             self._get_launch_template_versions, self.launch_templates
         )
@@ -459,7 +459,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_launch_templates(self, regional_client):
+    def _describe_launch_templates(self, regional_client):
         try:
             describe_launch_templates_paginator = regional_client.get_paginator(
                 "describe_launch_templates"

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -16,50 +16,50 @@ class EC2(AWSService):
         super().__init__(__class__.__name__, provider)
         self.account_arn_template = f"arn:{self.audited_partition}:ec2:{self.region}:{self.audited_account}:account"
         self.instances = []
-        self.__threading_call__(self.__describe_instances__)
-        self.__threading_call__(self.__get_instance_user_data__, self.instances)
+        self.__threading_call__(self._describe_instances)
+        self.__threading_call__(self._get_instance_user_data, self.instances)
         self.security_groups = {}
         self.regions_with_sgs = []
-        self.__threading_call__(self.__describe_security_groups__)
+        self.__threading_call__(self._describe_security_groups)
         self.network_acls = []
-        self.__threading_call__(self.__describe_network_acls__)
+        self.__threading_call__(self._describe_network_acls)
         self.snapshots = []
         self.volumes_with_snapshots = {}
         self.regions_with_snapshots = {}
-        self.__threading_call__(self.__describe_snapshots__)
-        self.__threading_call__(self.__determine_public_snapshots__, self.snapshots)
+        self.__threading_call__(self._describe_snapshots)
+        self.__threading_call__(self._determine_public_snapshots, self.snapshots)
         self.network_interfaces = []
-        self.__threading_call__(self.__describe_network_interfaces__)
+        self.__threading_call__(self._describe_network_interfaces)
         self.images = []
-        self.__threading_call__(self.__describe_images__)
+        self.__threading_call__(self._describe_images)
         self.volumes = []
-        self.__threading_call__(self.__describe_volumes__)
+        self.__threading_call__(self._describe_volumes)
         self.attributes_for_regions = {}
-        self.__threading_call__(self.__get_resources_for_regions__)
+        self.__threading_call__(self._get_resources_for_regions)
         self.ebs_encryption_by_default = []
-        self.__threading_call__(self.__get_ebs_encryption_settings__)
+        self.__threading_call__(self._get_ebs_encryption_settings)
         self.elastic_ips = []
-        self.__threading_call__(self.__describe_ec2_addresses__)
+        self.__threading_call__(self._describe_ec2_addresses)
         self.ebs_block_public_access_snapshots_states = []
-        self.__threading_call__(self.__get_snapshot_block_public_access_state__)
+        self.__threading_call__(self._get_snapshot_block_public_access_state)
         self.instance_metadata_defaults = []
-        self.__threading_call__(self.__get_instance_metadata_defaults__)
+        self.__threading_call__(self._get_instance_metadata_defaults)
         self.launch_templates = []
         self.__threading_call__(self.__describe_launch_templates)
         self.__threading_call__(
-            self.__get_launch_template_versions__, self.launch_templates
+            self._get_launch_template_versions, self.launch_templates
         )
         self.vpn_endpoints = {}
         self.__threading_call__(self._describe_vpn_endpoints)
         self.transit_gateways = {}
         self.__threading_call__(self._describe_transit_gateways)
 
-    def __get_volume_arn_template__(self, region):
+    def _get_volume_arn_template(self, region):
         return (
             f"arn:{self.audited_partition}:ec2:{region}:{self.audited_account}:volume"
         )
 
-    def __describe_instances__(self, regional_client):
+    def _describe_instances(self, regional_client):
         try:
             describe_instances_paginator = regional_client.get_paginator(
                 "describe_instances"
@@ -107,7 +107,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_security_groups__(self, regional_client):
+    def _describe_security_groups(self, regional_client):
         try:
             describe_security_groups_paginator = regional_client.get_paginator(
                 "describe_security_groups"
@@ -141,7 +141,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_network_acls__(self, regional_client):
+    def _describe_network_acls(self, regional_client):
         try:
             describe_network_acls_paginator = regional_client.get_paginator(
                 "describe_network_acls"
@@ -171,7 +171,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_snapshots__(self, regional_client):
+    def _describe_snapshots(self, regional_client):
         try:
             snapshots_in_region = False
             describe_snapshots_paginator = regional_client.get_paginator(
@@ -204,7 +204,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __determine_public_snapshots__(self, snapshot):
+    def _determine_public_snapshots(self, snapshot):
         try:
             regional_client = self.regional_clients[snapshot.region]
             snapshot_public = regional_client.describe_snapshot_attribute(
@@ -227,7 +227,7 @@ class EC2(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_network_interfaces__(self, regional_client):
+    def _describe_network_interfaces(self, regional_client):
         try:
             # Get Network Interfaces with Public IPs
             describe_network_interfaces_paginator = regional_client.get_paginator(
@@ -254,7 +254,7 @@ class EC2(AWSService):
                     #         'GroupName': 'default',
                     #     },
                     # ],
-                    self.__add_network_interfaces_to_security_groups__(
+                    self._add_network_interfaces_to_security_groups(
                         eni, interface.get("Groups", [])
                     )
 
@@ -263,7 +263,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __add_network_interfaces_to_security_groups__(
+    def _add_network_interfaces_to_security_groups(
         self, interface, interface_security_groups
     ):
         try:
@@ -276,7 +276,7 @@ class EC2(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_instance_user_data__(self, instance):
+    def _get_instance_user_data(self, instance):
         try:
             regional_client = self.regional_clients[instance.region]
             user_data = regional_client.describe_instance_attribute(
@@ -294,7 +294,7 @@ class EC2(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_images__(self, regional_client):
+    def _describe_images(self, regional_client):
         try:
             for image in regional_client.describe_images(Owners=["self"])["Images"]:
                 arn = f"arn:{self.audited_partition}:ec2:{regional_client.region}:{self.audited_account}:image/{image['ImageId']}"
@@ -316,7 +316,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_volumes__(self, regional_client):
+    def _describe_volumes(self, regional_client):
         try:
             describe_volumes_paginator = regional_client.get_paginator(
                 "describe_volumes"
@@ -341,7 +341,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_ec2_addresses__(self, regional_client):
+    def _describe_ec2_addresses(self, regional_client):
         try:
             for address in regional_client.describe_addresses()["Addresses"]:
                 public_ip = None
@@ -372,7 +372,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_ebs_encryption_settings__(self, regional_client):
+    def _get_ebs_encryption_settings(self, regional_client):
         try:
             volumes_in_region = self.attributes_for_regions.get(
                 regional_client.region, []
@@ -392,7 +392,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_snapshot_block_public_access_state__(self, regional_client):
+    def _get_snapshot_block_public_access_state(self, regional_client):
         try:
             snapshots_in_region = self.attributes_for_regions.get(
                 regional_client.region, []
@@ -412,7 +412,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_instance_metadata_defaults__(self, regional_client):
+    def _get_instance_metadata_defaults(self, regional_client):
         try:
             instances_in_region = self.attributes_for_regions.get(
                 regional_client.region, []
@@ -432,7 +432,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_resources_for_regions__(self, regional_client):
+    def _get_resources_for_regions(self, regional_client):
         try:
             has_instances = False
             for instance in self.instances:
@@ -486,7 +486,7 @@ class EC2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_launch_template_versions__(self, launch_template):
+    def _get_launch_template_versions(self, launch_template):
         try:
             regional_client = self.regional_clients[launch_template.region]
             describe_launch_template_versions_paginator = regional_client.get_paginator(

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -14,10 +14,10 @@ class ECS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.task_definitions = []
-        self.__threading_call__(self.__list_task_definitions__)
-        self.__describe_task_definition__()
+        self.__threading_call__(self._list_task_definitions)
+        self._describe_task_definition()
 
-    def __list_task_definitions__(self, regional_client):
+    def _list_task_definitions(self, regional_client):
         logger.info("ECS - Listing Task Definitions...")
         try:
             list_ecs_paginator = regional_client.get_paginator("list_task_definitions")
@@ -41,7 +41,7 @@ class ECS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_task_definition__(self):
+    def _describe_task_definition(self):
         logger.info("ECS - Describing Task Definitions...")
         try:
             for task_definition in self.task_definitions:

--- a/prowler/providers/aws/services/efs/efs_service.py
+++ b/prowler/providers/aws/services/efs/efs_service.py
@@ -15,10 +15,10 @@ class EFS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.filesystems = []
-        self.__threading_call__(self.__describe_file_systems__)
-        self.__describe_file_system_policies__()
+        self.__threading_call__(self._describe_file_systems)
+        self._describe_file_system_policies()
 
-    def __describe_file_systems__(self, regional_client):
+    def _describe_file_systems(self, regional_client):
         logger.info("EFS - Describing file systems...")
         try:
             describe_efs_paginator = regional_client.get_paginator(
@@ -47,7 +47,7 @@ class EFS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_file_system_policies__(self):
+    def _describe_file_system_policies(self):
         logger.info("EFS - Describing file system policies...")
         try:
             for filesystem in self.filesystems:

--- a/prowler/providers/aws/services/eks/eks_service.py
+++ b/prowler/providers/aws/services/eks/eks_service.py
@@ -13,10 +13,10 @@ class EKS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.clusters = []
-        self.__threading_call__(self.__list_clusters__)
-        self.__describe_cluster__(self.regional_clients)
+        self.__threading_call__(self._list_clusters)
+        self._describe_cluster(self.regional_clients)
 
-    def __list_clusters__(self, regional_client):
+    def _list_clusters(self, regional_client):
         logger.info("EKS listing clusters...")
         try:
             list_clusters_paginator = regional_client.get_paginator("list_clusters")
@@ -39,7 +39,7 @@ class EKS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_cluster__(self, regional_clients):
+    def _describe_cluster(self, regional_clients):
         logger.info("EKS listing clusters...")
         try:
             for cluster in self.clusters:

--- a/prowler/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled.py
+++ b/prowler/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled.py
@@ -9,7 +9,7 @@ class emr_cluster_account_public_block_enabled(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = region
             report.resource_id = emr_client.audited_account
-            report.resource_arn = emr_client.__get_cluster_arn_template__(region)
+            report.resource_arn = emr_client._get_cluster_arn_template(region)
             if emr_client.block_public_access_configuration[
                 region
             ].block_public_security_group_rules:

--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -16,14 +16,14 @@ class EMR(AWSService):
         super().__init__(__class__.__name__, provider)
         self.clusters = {}
         self.block_public_access_configuration = {}
-        self.__threading_call__(self.__list_clusters__)
-        self.__threading_call__(self.__describe_cluster__)
-        self.__threading_call__(self.__get_block_public_access_configuration__)
+        self.__threading_call__(self._list_clusters)
+        self.__threading_call__(self._describe_cluster)
+        self.__threading_call__(self._get_block_public_access_configuration)
 
-    def __get_cluster_arn_template__(self, region):
+    def _get_cluster_arn_template(self, region):
         return f"arn:{self.audited_partition}:elasticmapreduce:{region}:{self.audited_account}:cluster"
 
-    def __list_clusters__(self, regional_client):
+    def _list_clusters(self, regional_client):
         logger.info("EMR - Listing Clusters...")
         try:
             list_clusters_paginator = regional_client.get_paginator("list_clusters")
@@ -54,7 +54,7 @@ class EMR(AWSService):
                 f" {error}"
             )
 
-    def __describe_cluster__(self, regional_client):
+    def _describe_cluster(self, regional_client):
         logger.info("EMR - Describing Clusters...")
         try:
             for cluster in self.clusters.values():
@@ -131,7 +131,7 @@ class EMR(AWSService):
                 f" {error}"
             )
 
-    def __get_block_public_access_configuration__(self, regional_client):
+    def _get_block_public_access_configuration(self, regional_client):
         """Returns the Amazon EMR block public access configuration for your Amazon Web Services account in the current Region."""
         logger.info("EMR - Getting Block Public Access Configuration...")
         try:

--- a/prowler/providers/aws/services/eventbridge/eventbridge_service.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_service.py
@@ -15,11 +15,11 @@ class EventBridge(AWSService):
         # Call AWSService's __init__
         super().__init__("events", provider)
         self.buses = {}
-        self.__threading_call__(self.__list_event_buses__)
-        self.__threading_call__(self.__describe_event_bus__)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_event_buses)
+        self.__threading_call__(self._describe_event_bus)
+        self._list_tags_for_resource()
 
-    def __list_event_buses__(self, regional_client):
+    def _list_event_buses(self, regional_client):
         logger.info("EventBridge - Listing Event Buses...")
         try:
             for bus in regional_client.list_event_buses()["EventBuses"]:
@@ -37,7 +37,7 @@ class EventBridge(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_event_bus__(self, regional_client):
+    def _describe_event_bus(self, regional_client):
         logger.info("EventBridge - Describing Event Buses...")
         try:
             for bus in self.buses.values():
@@ -55,7 +55,7 @@ class EventBridge(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("EventBridge - Listing Tags...")
         try:
             for bus in self.buses.values():
@@ -98,10 +98,10 @@ class Schema(AWSService):
         # Call AWSService's __init__
         super().__init__("schemas", provider)
         self.registries = {}
-        self.__threading_call__(self.__list_registries__)
-        self.__threading_call__(self.__get_resource_policy__)
+        self.__threading_call__(self._list_registries)
+        self.__threading_call__(self._get_resource_policy)
 
-    def __list_registries__(self, regional_client):
+    def _list_registries(self, regional_client):
         logger.info("EventBridge - Listing Schema Registries...")
         try:
             for registry in regional_client.list_registries()["Registries"]:
@@ -123,7 +123,7 @@ class Schema(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_resource_policy__(self, regional_client):
+    def _get_resource_policy(self, regional_client):
         logger.info("EventBridge - Getting Registry Resource Policy...")
         try:
             for registry in self.registries.values():

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -14,10 +14,10 @@ class FMS(AWSService):
         self.policy_arn_template = f"arn:{self.audited_partition}:fms:{self.region}:{self.audited_account}:policy"
         self.fms_admin_account = True
         self.fms_policies = []
-        self.__list_policies__()
-        self.__list_compliance_status__()
+        self._list_policies()
+        self._list_compliance_status()
 
-    def __list_policies__(self):
+    def _list_policies(self):
         logger.info("FMS - Listing Policies...")
         try:
             list_policies_paginator = self.client.get_paginator("list_policies")
@@ -64,7 +64,7 @@ class FMS(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_compliance_status__(self):
+    def _list_compliance_status(self):
         logger.info("FMS - Listing Policies...")
         try:
             for fms_policy in self.fms_policies:

--- a/prowler/providers/aws/services/glacier/glacier_service.py
+++ b/prowler/providers/aws/services/glacier/glacier_service.py
@@ -15,11 +15,11 @@ class Glacier(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.vaults = {}
-        self.__threading_call__(self.__list_vaults__)
-        self.__threading_call__(self.__get_vault_access_policy__)
-        self.__list_tags_for_vault__()
+        self.__threading_call__(self._list_vaults)
+        self.__threading_call__(self._get_vault_access_policy)
+        self._list_tags_for_vault()
 
-    def __list_vaults__(self, regional_client):
+    def _list_vaults(self, regional_client):
         logger.info("Glacier - Listing Vaults...")
         try:
             list_vaults_paginator = regional_client.get_paginator("list_vaults")
@@ -44,7 +44,7 @@ class Glacier(AWSService):
                 f" {error}"
             )
 
-    def __get_vault_access_policy__(self, regional_client):
+    def _get_vault_access_policy(self, regional_client):
         logger.info("Glacier - Getting Vault Access Policy...")
         try:
             for vault in self.vaults.values():
@@ -66,7 +66,7 @@ class Glacier(AWSService):
                 f" {error}"
             )
 
-    def __list_tags_for_vault__(self):
+    def _list_tags_for_vault(self):
         logger.info("Glacier - List Tags...")
         try:
             for vault in self.vaults.values():

--- a/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
+++ b/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
@@ -17,9 +17,9 @@ class GlobalAccelerator(AWSService):
             # That is, for example, specify --region us-west-2 on AWS CLI commands.
             self.region = "us-west-2"
             self.client = self.session.client(self.service, self.region)
-            self.__list_accelerators__()
+            self._list_accelerators()
 
-    def __list_accelerators__(self):
+    def _list_accelerators(self):
         logger.info("GlobalAccelerator - Listing Accelerators...")
         try:
             list_accelerators_paginator = self.client.get_paginator("list_accelerators")

--- a/prowler/providers/aws/services/glue/glue_data_catalogs_connection_passwords_encryption_enabled/glue_data_catalogs_connection_passwords_encryption_enabled.py
+++ b/prowler/providers/aws/services/glue/glue_data_catalogs_connection_passwords_encryption_enabled/glue_data_catalogs_connection_passwords_encryption_enabled.py
@@ -10,7 +10,7 @@ class glue_data_catalogs_connection_passwords_encryption_enabled(Check):
             if encryption.tables or glue_client.provider.scan_unused_services:
                 report = Check_Report_AWS(self.metadata())
                 report.resource_id = glue_client.audited_account
-                report.resource_arn = glue_client.__get_data_catalog_arn_template__(
+                report.resource_arn = glue_client._get_data_catalog_arn_template(
                     encryption.region
                 )
                 report.region = encryption.region

--- a/prowler/providers/aws/services/glue/glue_data_catalogs_metadata_encryption_enabled/glue_data_catalogs_metadata_encryption_enabled.py
+++ b/prowler/providers/aws/services/glue/glue_data_catalogs_metadata_encryption_enabled/glue_data_catalogs_metadata_encryption_enabled.py
@@ -10,7 +10,7 @@ class glue_data_catalogs_metadata_encryption_enabled(Check):
             if encryption.tables or glue_client.provider.scan_unused_services:
                 report = Check_Report_AWS(self.metadata())
                 report.resource_id = glue_client.audited_account
-                report.resource_arn = glue_client.__get_data_catalog_arn_template__(
+                report.resource_arn = glue_client._get_data_catalog_arn_template(
                     encryption.region
                 )
                 report.region = encryption.region

--- a/prowler/providers/aws/services/glue/glue_service.py
+++ b/prowler/providers/aws/services/glue/glue_service.py
@@ -14,22 +14,22 @@ class Glue(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.connections = []
-        self.__threading_call__(self.__get_connections__)
+        self.__threading_call__(self._get_connections)
         self.tables = []
-        self.__threading_call__(self.__search_tables__)
+        self.__threading_call__(self._search_tables)
         self.catalog_encryption_settings = []
-        self.__threading_call__(self.__get_data_catalog_encryption_settings__)
+        self.__threading_call__(self._get_data_catalog_encryption_settings)
         self.dev_endpoints = []
-        self.__threading_call__(self.__get_dev_endpoints__)
+        self.__threading_call__(self._get_dev_endpoints)
         self.security_configs = []
-        self.__threading_call__(self.__get_security_configurations__)
+        self.__threading_call__(self._get_security_configurations)
         self.jobs = []
-        self.__threading_call__(self.__get_jobs__)
+        self.__threading_call__(self._get_jobs)
 
-    def __get_data_catalog_arn_template__(self, region):
+    def _get_data_catalog_arn_template(self, region):
         return f"arn:{self.audited_partition}:glue:{region}:{self.audited_account}:data-catalog"
 
-    def __get_connections__(self, regional_client):
+    def _get_connections(self, regional_client):
         logger.info("Glue - Getting connections...")
         try:
             get_connections_paginator = regional_client.get_paginator("get_connections")
@@ -53,7 +53,7 @@ class Glue(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_dev_endpoints__(self, regional_client):
+    def _get_dev_endpoints(self, regional_client):
         logger.info("Glue - Getting dev endpoints...")
         try:
             get_dev_endpoints_paginator = regional_client.get_paginator(
@@ -90,7 +90,7 @@ class Glue(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_jobs__(self, regional_client):
+    def _get_jobs(self, regional_client):
         logger.info("Glue - Getting jobs...")
         try:
             get_jobs_paginator = regional_client.get_paginator("get_jobs")
@@ -114,7 +114,7 @@ class Glue(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_security_configurations__(self, regional_client):
+    def _get_security_configurations(self, regional_client):
         logger.info("Glue - Getting security configs...")
         try:
             get_security_configurations_paginator = regional_client.get_paginator(
@@ -154,7 +154,7 @@ class Glue(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __search_tables__(self, regional_client):
+    def _search_tables(self, regional_client):
         logger.info("Glue - Search Tables...")
         try:
             for table in regional_client.search_tables()["TableList"]:
@@ -176,7 +176,7 @@ class Glue(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_data_catalog_encryption_settings__(self, regional_client):
+    def _get_data_catalog_encryption_settings(self, regional_client):
         logger.info("Glue - Catalog Encryption Settings...")
         try:
             settings = regional_client.get_data_catalog_encryption_settings()[

--- a/prowler/providers/aws/services/guardduty/guardduty_service.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_service.py
@@ -13,14 +13,14 @@ class GuardDuty(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.detectors = []
-        self.__threading_call__(self.__list_detectors__)
-        self.__get_detector__()
-        self.__list_findings__()
-        self.__list_members__()
-        self.__get_administrator_account__()
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_detectors)
+        self._get_detector()
+        self._list_findings()
+        self._list_members()
+        self._get_administrator_account()
+        self._list_tags_for_resource()
 
-    def __list_detectors__(self, regional_client):
+    def _list_detectors(self, regional_client):
         logger.info("GuardDuty - listing detectors...")
         try:
             detectors = False
@@ -51,7 +51,7 @@ class GuardDuty(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_detector__(self):
+    def _get_detector(self):
         logger.info("GuardDuty - getting detector info...")
         try:
             for detector in self.detectors:
@@ -75,7 +75,7 @@ class GuardDuty(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __get_administrator_account__(self):
+    def _get_administrator_account(self):
         logger.info("GuardDuty - getting administrator account...")
         try:
             for detector in self.detectors:
@@ -105,7 +105,7 @@ class GuardDuty(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_members__(self):
+    def _list_members(self):
         logger.info("GuardDuty - listing members...")
         try:
             for detector in self.detectors:
@@ -130,7 +130,7 @@ class GuardDuty(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_findings__(self):
+    def _list_findings(self):
         logger.info("GuardDuty - listing findings...")
         try:
             for detector in self.detectors:
@@ -164,7 +164,7 @@ class GuardDuty(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Guardduty - List Tags...")
         try:
             for detector in self.detectors:

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -57,50 +57,50 @@ class IAM(AWSService):
         self.mfa_arn_template = (
             f"arn:{self.audited_partition}:iam:{self.region}:{self.audited_account}:mfa"
         )
-        self.users = self.__get_users__()
-        self.roles = self.__get_roles__()
-        self.account_summary = self.__get_account_summary__()
-        self.virtual_mfa_devices = self.__list_virtual_mfa_devices__()
-        self.credential_report = self.__get_credential_report__()
-        self.groups = self.__get_groups__()
-        self.__get_group_users__()
-        self.__list_attached_group_policies__()
-        self.__list_attached_user_policies__()
-        self.__list_attached_role_policies__()
-        self.__list_mfa_devices__()
-        self.password_policy = self.__get_password_policy__()
+        self.users = self._get_users()
+        self.roles = self._get_roles()
+        self.account_summary = self._get_account_summary()
+        self.virtual_mfa_devices = self._list_virtual_mfa_devices()
+        self.credential_report = self._get_credential_report()
+        self.groups = self._get_groups()
+        self._get_group_users()
+        self._list_attached_group_policies()
+        self._list_attached_user_policies()
+        self._list_attached_role_policies()
+        self._list_mfa_devices()
+        self.password_policy = self._get_password_policy()
         support_policy_arn = (
             "arn:aws:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
         )
         self.entities_role_attached_to_support_policy = (
-            self.__list_entities_role_for_policy__(support_policy_arn)
+            self._list_entities_role_for_policy(support_policy_arn)
         )
         securityaudit_policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
         self.entities_role_attached_to_securityaudit_policy = (
-            self.__list_entities_role_for_policy__(securityaudit_policy_arn)
+            self._list_entities_role_for_policy(securityaudit_policy_arn)
         )
         # List both Customer (attached and unattached) and AWS Managed (only attached) policies
         self.policies = []
-        self.policies.extend(self.__list_policies__("AWS"))
-        self.policies.extend(self.__list_policies__("Local"))
-        self.__list_policies_version__(self.policies)
-        self.__list_inline_user_policies__()
-        self.__list_inline_group_policies__()
-        self.__list_inline_role_policies__()
-        self.saml_providers = self.__list_saml_providers__()
-        self.server_certificates = self.__list_server_certificates__()
-        self.__list_tags_for_resource__()
+        self.policies.extend(self._list_policies("AWS"))
+        self.policies.extend(self._list_policies("Local"))
+        self._list_policies_version(self.policies)
+        self._list_inline_user_policies()
+        self._list_inline_group_policies()
+        self._list_inline_role_policies()
+        self.saml_providers = self._list_saml_providers()
+        self.server_certificates = self._list_server_certificates()
+        self._list_tags_for_resource()
         self.access_keys_metadata = {}
-        self.__get_access_keys_metadata__()
+        self._get_access_keys_metadata()
         self.last_accessed_services = {}
-        self.__get_last_accessed_services__()
+        self._get_last_accessed_services()
         self.user_temporary_credentials_usage = {}
-        self.__get_user_temporary_credentials_usage__()
+        self._get_user_temporary_credentials_usage()
 
-    def __get_client__(self):
+    def _get_client(self):
         return self.client
 
-    def __get_roles__(self):
+    def _get_roles(self):
         logger.info("IAM - List Roles...")
         try:
             roles = []
@@ -135,7 +135,7 @@ class IAM(AWSService):
         finally:
             return roles
 
-    def __get_credential_report__(self):
+    def _get_credential_report(self):
         logger.info("IAM - Get Credential Report...")
         report_is_completed = False
         credential_list = []
@@ -168,7 +168,7 @@ class IAM(AWSService):
         finally:
             return credential_list
 
-    def __get_groups__(self):
+    def _get_groups(self):
         logger.info("IAM - Get Groups...")
         try:
             groups = []
@@ -187,7 +187,7 @@ class IAM(AWSService):
         finally:
             return groups
 
-    def __get_account_summary__(self):
+    def _get_account_summary(self):
         logger.info("IAM - Get Account Summary...")
         try:
             account_summary = self.client.get_account_summary()
@@ -199,7 +199,7 @@ class IAM(AWSService):
         finally:
             return account_summary
 
-    def __get_password_policy__(self):
+    def _get_password_policy(self):
         logger.info("IAM - Get Password Policy...")
         try:
             stored_password_policy = None
@@ -267,7 +267,7 @@ class IAM(AWSService):
         finally:
             return stored_password_policy
 
-    def __get_users__(self):
+    def _get_users(self):
         logger.info("IAM - List Users...")
         try:
             get_users_paginator = self.client.get_paginator("list_users")
@@ -304,7 +304,7 @@ class IAM(AWSService):
         finally:
             return users
 
-    def __list_virtual_mfa_devices__(self):
+    def _list_virtual_mfa_devices(self):
         logger.info("IAM - List Virtual MFA Devices...")
         try:
             mfa_devices = []
@@ -322,7 +322,7 @@ class IAM(AWSService):
         finally:
             return mfa_devices
 
-    def __list_attached_group_policies__(self):
+    def _list_attached_group_policies(self):
         logger.info("IAM - List Attached Group Policies...")
         try:
             for group in self.groups:
@@ -347,7 +347,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_group_users__(self):
+    def _get_group_users(self):
         logger.info("IAM - Get Group Users...")
         try:
             for group in self.groups:
@@ -373,7 +373,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_mfa_devices__(self):
+    def _list_mfa_devices(self):
         logger.info("IAM - List MFA Devices...")
         try:
             for user in self.users:
@@ -397,7 +397,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_attached_user_policies__(self):
+    def _list_attached_user_policies(self):
         logger.info("IAM - List Attached User Policies...")
         try:
             for user in self.users:
@@ -433,7 +433,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_attached_role_policies__(self):
+    def _list_attached_role_policies(self):
         logger.info("IAM - List Attached User Policies...")
         try:
             if self.roles:
@@ -470,7 +470,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_inline_user_policies__(self):
+    def _list_inline_user_policies(self):
         logger.info("IAM - List Inline User Policies...")
         for user in self.users:
             try:
@@ -528,7 +528,7 @@ class IAM(AWSService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __list_inline_group_policies__(self):
+    def _list_inline_group_policies(self):
         logger.info("IAM - List Inline Group Policies...")
         for group in self.groups:
             try:
@@ -588,7 +588,7 @@ class IAM(AWSService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __list_inline_role_policies__(self):
+    def _list_inline_role_policies(self):
         logger.info("IAM - List Inline Role Policies...")
         if self.roles:
             for role in self.roles:
@@ -651,7 +651,7 @@ class IAM(AWSService):
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
-    def __list_entities_role_for_policy__(self, policy_arn):
+    def _list_entities_role_for_policy(self, policy_arn):
         logger.info("IAM - List Entities Role For Policy...")
         try:
             roles = []
@@ -676,7 +676,7 @@ class IAM(AWSService):
         finally:
             return roles
 
-    def __list_policies__(self, scope):
+    def _list_policies(self, scope):
         logger.info("IAM - List Policies...")
         try:
             policies = []
@@ -707,7 +707,7 @@ class IAM(AWSService):
         finally:
             return policies
 
-    def __list_policies_version__(self, policies):
+    def _list_policies_version(self, policies):
         logger.info("IAM - List Policies Version...")
         try:
             for policy in policies:
@@ -731,7 +731,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_saml_providers__(self):
+    def _list_saml_providers(self):
         logger.info("IAM - List SAML Providers...")
         try:
             saml_providers = self.client.list_saml_providers()["SAMLProviderList"]
@@ -743,7 +743,7 @@ class IAM(AWSService):
         finally:
             return saml_providers
 
-    def __list_server_certificates__(self):
+    def _list_server_certificates(self):
         logger.info("IAM - List Server Certificates...")
         try:
             server_certificates = []
@@ -768,7 +768,7 @@ class IAM(AWSService):
         finally:
             return server_certificates
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("IAM - List Tags...")
         try:
             if self.roles:
@@ -838,7 +838,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_last_accessed_services__(self):
+    def _get_last_accessed_services(self):
         logger.info("IAM - Getting Last Accessed Services ...")
         try:
             for user in self.users:
@@ -876,7 +876,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_access_keys_metadata__(self):
+    def _get_access_keys_metadata(self):
         logger.info("IAM - Getting Access Keys Metadata ...")
         try:
             for user in self.users:
@@ -905,7 +905,7 @@ class IAM(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_user_temporary_credentials_usage__(self):
+    def _get_user_temporary_credentials_usage(self):
         logger.info("IAM - Getting User Temporary Credentials Usage ...")
         try:
             temporary_credentials_usage = False

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -10,10 +10,10 @@ class Inspector2(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.inspectors = []
-        self.__threading_call__(self.__batch_get_account_status__)
-        self.__threading_call__(self.__list_active_findings__, self.inspectors)
+        self.__threading_call__(self._batch_get_account_status)
+        self.__threading_call__(self._list_active_findings, self.inspectors)
 
-    def __batch_get_account_status__(self, regional_client):
+    def _batch_get_account_status(self, regional_client):
         # We use this function to check if inspector2 is enabled
         logger.info("Inspector2 - Getting account status...")
         try:
@@ -33,7 +33,7 @@ class Inspector2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_active_findings__(self, inspector):
+    def _list_active_findings(self, inspector):
         logger.info("Inspector2 - Listing active findings...")
         try:
             regional_client = self.regional_clients[inspector.region]

--- a/prowler/providers/aws/services/kafka/kafka_service.py
+++ b/prowler/providers/aws/services/kafka/kafka_service.py
@@ -10,11 +10,11 @@ class Kafka(AWSService):
         super().__init__(__class__.__name__, provider)
         self.account_arn_template = f"arn:{self.audited_partition}:kafka:{self.region}:{self.audited_account}:cluster"
         self.clusters = {}
-        self.__threading_call__(self.__list_clusters__)
+        self.__threading_call__(self._list_clusters)
         self.kafka_versions = []
-        self.__threading_call__(self.__list_kafka_versions__)
+        self.__threading_call__(self._list_kafka_versions)
 
-    def __list_clusters__(self, regional_client):
+    def _list_clusters(self, regional_client):
         try:
             cluster_paginator = regional_client.get_paginator("list_clusters")
 
@@ -70,7 +70,7 @@ class Kafka(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_kafka_versions__(self, regional_client):
+    def _list_kafka_versions(self, regional_client):
         try:
             kafka_versions_paginator = regional_client.get_paginator(
                 "list_kafka_versions"

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -14,14 +14,14 @@ class KMS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.keys = []
-        self.__threading_call__(self.__list_keys__)
+        self.__threading_call__(self._list_keys)
         if self.keys:
-            self.__describe_key__()
-            self.__get_key_rotation_status__()
-            self.__get_key_policy__()
-            self.__list_resource_tags__()
+            self._describe_key()
+            self._get_key_rotation_status()
+            self._get_key_policy()
+            self._list_resource_tags()
 
-    def __list_keys__(self, regional_client):
+    def _list_keys(self, regional_client):
         logger.info("KMS - Listing Keys...")
         try:
             list_keys_paginator = regional_client.get_paginator("list_keys")
@@ -42,7 +42,7 @@ class KMS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __describe_key__(self):
+    def _describe_key(self):
         logger.info("KMS - Describing Key...")
         try:
             for key in self.keys:
@@ -57,7 +57,7 @@ class KMS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __get_key_rotation_status__(self):
+    def _get_key_rotation_status(self):
         logger.info("KMS - Get Key Rotation Status...")
         try:
             for key in self.keys:
@@ -76,7 +76,7 @@ class KMS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __get_key_policy__(self):
+    def _get_key_policy(self):
         logger.info("KMS - Get Key Policy...")
         try:
             for key in self.keys:
@@ -94,7 +94,7 @@ class KMS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_resource_tags__(self):
+    def _list_resource_tags(self):
         logger.info("KMS - List Tags...")
         for key in self.keys:
             if (

--- a/prowler/providers/aws/services/lightsail/lightsail_service.py
+++ b/prowler/providers/aws/services/lightsail/lightsail_service.py
@@ -11,13 +11,13 @@ class Lightsail(AWSService):
     def __init__(self, provider):
         super().__init__(__class__.__name__, provider)
         self.instances = {}
-        self.__threading_call__(self.__get_instances__)
+        self.__threading_call__(self._get_instances)
         self.databases = {}
-        self.__threading_call__(self.__get_databases__)
+        self.__threading_call__(self._get_databases)
         self.static_ips = {}
-        self.__threading_call__(self.__get_static_ips__)
+        self.__threading_call__(self._get_static_ips)
 
-    def __get_instances__(self, regional_client):
+    def _get_instances(self, regional_client):
         logger.info("Lightsail - Getting instances...")
         try:
             instance_paginator = regional_client.get_paginator("get_instances")
@@ -87,7 +87,7 @@ class Lightsail(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_databases__(self, regional_client):
+    def _get_databases(self, regional_client):
         logger.info("Lightsail - Getting databases...")
         try:
             databases_paginator = regional_client.get_paginator(
@@ -125,7 +125,7 @@ class Lightsail(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_static_ips__(self, regional_client):
+    def _get_static_ips(self, regional_client):
         logger.info("Lightsail - Getting static IPs...")
         try:
             static_ips_paginator = regional_client.get_paginator("get_static_ips")

--- a/prowler/providers/aws/services/macie/macie_is_enabled/macie_is_enabled.py
+++ b/prowler/providers/aws/services/macie/macie_is_enabled/macie_is_enabled.py
@@ -9,9 +9,7 @@ class macie_is_enabled(Check):
         for session in macie_client.sessions:
             report = Check_Report_AWS(self.metadata())
             report.region = session.region
-            report.resource_arn = macie_client.__get_session_arn_template__(
-                session.region
-            )
+            report.resource_arn = macie_client._get_session_arn_template(session.region)
             report.resource_id = macie_client.audited_account
             if session.status == "ENABLED":
                 report.status = "PASS"

--- a/prowler/providers/aws/services/macie/macie_service.py
+++ b/prowler/providers/aws/services/macie/macie_service.py
@@ -10,12 +10,12 @@ class Macie(AWSService):
         # Call AWSService's __init__
         super().__init__("macie2", provider)
         self.sessions = []
-        self.__threading_call__(self.__get_macie_session__)
+        self.__threading_call__(self._get_macie_session)
 
-    def __get_session_arn_template__(self, region):
+    def _get_session_arn_template(self, region):
         return f"arn:{self.audited_partition}:macie:{region}:{self.audited_account}:session"
 
-    def __get_macie_session__(self, regional_client):
+    def _get_macie_session(self, regional_client):
         logger.info("Macie - Get Macie Session...")
         try:
             self.sessions.append(

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -11,10 +11,10 @@ class NetworkFirewall(AWSService):
         # Call AWSService's __init__
         super().__init__("network-firewall", provider)
         self.network_firewalls = []
-        self.__threading_call__(self.__list_firewalls__)
-        self.__describe_firewall__()
+        self.__threading_call__(self._list_firewalls)
+        self._describe_firewall()
 
-    def __list_firewalls__(self, regional_client):
+    def _list_firewalls(self, regional_client):
         logger.info("Network Firewall - Listing Network Firewalls...")
         try:
             list_network_firewalls_paginator = regional_client.get_paginator(
@@ -39,7 +39,7 @@ class NetworkFirewall(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_firewall__(self):
+    def _describe_firewall(self):
         logger.info("Network Firewall - Describe Network Firewalls...")
         try:
             for network_firewall in self.network_firewalls:

--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -14,12 +14,12 @@ class OpenSearchService(AWSService):
         # Call AWSService's __init__
         super().__init__("opensearch", provider)
         self.opensearch_domains = []
-        self.__threading_call__(self.__list_domain_names__)
-        self.__describe_domain_config__(self.regional_clients)
-        self.__describe_domain__(self.regional_clients)
-        self.__list_tags__()
+        self.__threading_call__(self._list_domain_names)
+        self._describe_domain_config(self.regional_clients)
+        self._describe_domain(self.regional_clients)
+        self._list_tags()
 
-    def __list_domain_names__(self, regional_client):
+    def _list_domain_names(self, regional_client):
         logger.info("OpenSearch - listing domain names...")
         try:
             domains = regional_client.list_domain_names()
@@ -40,7 +40,7 @@ class OpenSearchService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_domain_config__(self, regional_clients):
+    def _describe_domain_config(self, regional_clients):
         logger.info("OpenSearch - describing domain configurations...")
         try:
             for domain in self.opensearch_domains:
@@ -79,7 +79,7 @@ class OpenSearchService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_domain__(self, regional_clients):
+    def _describe_domain(self, regional_clients):
         logger.info("OpenSearch - describing domain configurations...")
         try:
             for domain in self.opensearch_domains:
@@ -132,7 +132,7 @@ class OpenSearchService(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags__(self):
+    def _list_tags(self):
         logger.info("OpenSearch - List Tags...")
         for domain in self.opensearch_domains:
             try:

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -24,9 +24,9 @@ class Organizations(AWSService):
         self.organizations = []
         self.policies = []
         self.delegated_administrators = []
-        self.__describe_organization__()
+        self._describe_organization()
 
-    def __describe_organization__(self):
+    def _describe_organization(self):
         logger.info("Organizations - Describe Organization...")
 
         try:
@@ -37,10 +37,10 @@ class Organizations(AWSService):
                 organization_id = organization_desc.get("Id")
                 organization_master_id = organization_desc.get("MasterAccountId")
                 # Fetch policies for organization:
-                organization_policies = self.__list_policies__()
+                organization_policies = self._list_policies()
                 # Fetch delegated administrators for organization:
                 organization_delegated_administrator = (
-                    self.__list_delegated_administrators__()
+                    self._list_delegated_administrators()
                 )
             except ClientError as error:
                 if (
@@ -90,7 +90,7 @@ class Organizations(AWSService):
             )
 
     # I'm using list_policies instead of list_policies_for_target, because the last one only returns "Attached directly" policies but not "Inherited from..." policies.
-    def __list_policies__(self):
+    def _list_policies(self):
         logger.info("Organizations - List policies...")
 
         try:
@@ -103,8 +103,8 @@ class Organizations(AWSService):
                 for page in list_policies_paginator.paginate(Filter=policy_type):
                     for policy in page["Policies"]:
                         policy_id = policy.get("Id")
-                        policy_content = self.__describe_policy__(policy_id)
-                        policy_targets = self.__list_targets_for_policy__(policy_id)
+                        policy_content = self._describe_policy(policy_id)
+                        policy_targets = self._list_targets_for_policy(policy_id)
                         self.policies.append(
                             Policy(
                                 arn=policy.get("Arn"),
@@ -128,7 +128,7 @@ class Organizations(AWSService):
         finally:
             return self.policies
 
-    def __describe_policy__(self, policy_id) -> dict:
+    def _describe_policy(self, policy_id) -> dict:
         logger.info("Organizations - Describe policy: %s ...", policy_id)
 
         # This operation can be called only from the organization’s management account or by a member account that is a delegated administrator for an Amazon Web Services service.
@@ -151,7 +151,7 @@ class Organizations(AWSService):
             )
             return {}
 
-    def __list_targets_for_policy__(self, policy_id) -> list:
+    def _list_targets_for_policy(self, policy_id) -> list:
         logger.info("Organizations - List Targets for policy: %s ...", policy_id)
 
         try:
@@ -169,7 +169,7 @@ class Organizations(AWSService):
             )
             return []
 
-    def __list_delegated_administrators__(self):
+    def _list_delegated_administrators(self):
         logger.info("Organizations - List Delegated Administrators")
 
         try:

--- a/prowler/providers/aws/services/rds/rds_instance_event_subscription_security_groups/rds_instance_event_subscription_security_groups.py
+++ b/prowler/providers/aws/services/rds/rds_instance_event_subscription_security_groups/rds_instance_event_subscription_security_groups.py
@@ -11,9 +11,7 @@ class rds_instance_event_subscription_security_groups(Check):
                 report.status = "FAIL"
                 report.status_extended = "RDS security group event categories of configuration change and failure are not subscribed."
                 report.resource_id = rds_client.audited_account
-                report.resource_arn = rds_client.__get_rds_arn_template__(
-                    db_event.region
-                )
+                report.resource_arn = rds_client._get_rds_arn_template(db_event.region)
                 report.region = db_event.region
                 if db_event.source_type == "db-security-group" and db_event.enabled:
                     if db_event.event_list == []:

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -21,26 +21,26 @@ class RDS(AWSService):
         self.db_cluster_parameters = {}
         self.db_cluster_snapshots = []
         self.db_event_subscriptions = []
-        self.__threading_call__(self.__describe_db_instances__)
-        self.__threading_call__(self.__describe_db_certificate__)
-        self.__threading_call__(self.__describe_db_parameters__)
-        self.__threading_call__(self.__describe_db_snapshots__)
-        self.__threading_call__(self.__describe_db_snapshot_attributes__)
-        self.__threading_call__(self.__describe_db_clusters__)
-        self.__threading_call__(self.__describe_db_cluster_parameters__)
-        self.__threading_call__(self.__describe_db_cluster_snapshots__)
-        self.__threading_call__(self.__describe_db_cluster_snapshot_attributes__)
-        self.__threading_call__(self.__describe_db_engine_versions__)
-        self.__threading_call__(self.__describe_db_event_subscriptions__)
+        self.__threading_call__(self._describe_db_instances)
+        self.__threading_call__(self._describe_db_certificate)
+        self.__threading_call__(self._describe_db_parameters)
+        self.__threading_call__(self._describe_db_snapshots)
+        self.__threading_call__(self._describe_db_snapshot_attributes)
+        self.__threading_call__(self._describe_db_clusters)
+        self.__threading_call__(self._describe_db_cluster_parameters)
+        self.__threading_call__(self._describe_db_cluster_snapshots)
+        self.__threading_call__(self._describe_db_cluster_snapshot_attributes)
+        self.__threading_call__(self._describe_db_engine_versions)
+        self.__threading_call__(self._describe_db_event_subscriptions)
 
-    def __get_rds_arn_template__(self, region):
+    def _get_rds_arn_template(self, region):
         return (
             f"arn:{self.audited_partition}:rds:{region}:{self.audited_account}:account"
             if region
             else f"arn:{self.audited_partition}:rds:{self.region}:{self.audited_account}:account"
         )
 
-    def __describe_db_instances__(self, regional_client):
+    def _describe_db_instances(self, regional_client):
         logger.info("RDS - Describe Instances...")
         try:
             describe_db_instances_paginator = regional_client.get_paginator(
@@ -106,7 +106,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_parameters__(self, regional_client):
+    def _describe_db_parameters(self, regional_client):
         logger.info("RDS - Describe DB Parameters...")
         try:
             for (
@@ -129,7 +129,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_certificate__(self, regional_client):
+    def _describe_db_certificate(self, regional_client):
         logger.info("RDS - Describe DB Certificate...")
         try:
             for instance in self.db_instances.values():
@@ -160,7 +160,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_snapshots__(self, regional_client):
+    def _describe_db_snapshots(self, regional_client):
         logger.info("RDS - Describe Snapshots...")
         try:
             describe_db_snapshots_paginator = regional_client.get_paginator(
@@ -188,7 +188,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_snapshot_attributes__(self, regional_client):
+    def _describe_db_snapshot_attributes(self, regional_client):
         logger.info("RDS - Describe Snapshot Attributes...")
         for snapshot in self.db_snapshots:
             try:
@@ -210,7 +210,7 @@ class RDS(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __describe_db_clusters__(self, regional_client):
+    def _describe_db_clusters(self, regional_client):
         logger.info("RDS - Describe Clusters...")
         try:
             describe_db_clusters_paginator = regional_client.get_paginator(
@@ -277,7 +277,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_cluster_parameters__(self, regional_client):
+    def _describe_db_cluster_parameters(self, regional_client):
         logger.info("RDS - Describe DB Cluster Parameters...")
         try:
             for cluster in self.db_clusters.values():
@@ -326,7 +326,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_cluster_snapshots__(self, regional_client):
+    def _describe_db_cluster_snapshots(self, regional_client):
         logger.info("RDS - Describe Cluster Snapshots...")
         try:
             describe_db_snapshots_paginator = regional_client.get_paginator(
@@ -357,7 +357,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_cluster_snapshot_attributes__(self, regional_client):
+    def _describe_db_cluster_snapshot_attributes(self, regional_client):
         logger.info("RDS - Describe Cluster Snapshot Attributes...")
         try:
             for snapshot in self.db_cluster_snapshots:
@@ -382,7 +382,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_engine_versions__(self, regional_client):
+    def _describe_db_engine_versions(self, regional_client):
         logger.info("RDS - Describe Engine Versions...")
         try:
             describe_db_engine_versions_paginator = regional_client.get_paginator(
@@ -412,7 +412,7 @@ class RDS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_db_event_subscriptions__(self, regional_client):
+    def _describe_db_event_subscriptions(self, regional_client):
         logger.info("RDS - Describe Event Subscriptions...")
         try:
             describe_event_subscriptions_paginator = regional_client.get_paginator(

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -13,11 +13,11 @@ class Redshift(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.clusters = []
-        self.__threading_call__(self.__describe_clusters__)
-        self.__describe_logging_status__(self.regional_clients)
-        self.__describe_cluster_snapshots__(self.regional_clients)
+        self.__threading_call__(self._describe_clusters)
+        self._describe_logging_status(self.regional_clients)
+        self._describe_cluster_snapshots(self.regional_clients)
 
-    def __describe_clusters__(self, regional_client):
+    def _describe_clusters(self, regional_client):
         logger.info("Redshift - describing clusters...")
         try:
             list_clusters_paginator = regional_client.get_paginator("describe_clusters")
@@ -53,7 +53,7 @@ class Redshift(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_logging_status__(self, regional_clients):
+    def _describe_logging_status(self, regional_clients):
         logger.info("Redshift - describing logging status...")
         try:
             for cluster in self.clusters:
@@ -74,7 +74,7 @@ class Redshift(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_cluster_snapshots__(self, regional_clients):
+    def _describe_cluster_snapshots(self, regional_clients):
         logger.info("Redshift - describing logging status...")
         try:
             for cluster in self.clusters:

--- a/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
+++ b/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
@@ -13,9 +13,9 @@ class ResourceExplorer2(AWSService):
         super().__init__("resource-explorer-2", provider)
         self.index_arn_template = f"arn:{self.audited_partition}:resource-explorer:{self.region}:{self.audited_account}:index"
         self.indexes = []
-        self.__threading_call__(self.__list_indexes__)
+        self.__threading_call__(self._list_indexes)
 
-    def __list_indexes__(self, regional_client):
+    def _list_indexes(self, regional_client):
         logger.info("ResourceExplorer - list indexes...")
         try:
             list_indexes_paginator = regional_client.get_paginator("list_indexes")

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -14,12 +14,12 @@ class Route53(AWSService):
         super().__init__(__class__.__name__, provider, global_service=True)
         self.hosted_zones = {}
         self.record_sets = []
-        self.__list_hosted_zones__()
-        self.__list_query_logging_configs__()
-        self.__list_tags_for_resource__()
-        self.__list_resource_record_sets__()
+        self._list_hosted_zones()
+        self._list_query_logging_configs()
+        self._list_tags_for_resource()
+        self._list_resource_record_sets()
 
-    def __list_hosted_zones__(self):
+    def _list_hosted_zones(self):
         logger.info("Route53 - Listing Hosting Zones...")
         try:
             list_hosted_zones_paginator = self.client.get_paginator("list_hosted_zones")
@@ -46,7 +46,7 @@ class Route53(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_resource_record_sets__(self):
+    def _list_resource_record_sets(self):
         logger.info("Route53 - Listing Hosting Zones...")
         try:
             list_resource_record_sets_paginator = self.client.get_paginator(
@@ -78,7 +78,7 @@ class Route53(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_query_logging_configs__(self):
+    def _list_query_logging_configs(self):
         logger.info("Route53 - Listing Query Logging Configs...")
         try:
             for hosted_zone in self.hosted_zones.values():
@@ -100,7 +100,7 @@ class Route53(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("Route53Domains - List Tags...")
         for hosted_zone in self.hosted_zones.values():
             try:
@@ -148,11 +148,11 @@ class Route53Domains(AWSService):
             # but you must specify the US East (N. Virginia) Region to create, update, or otherwise work with domains.
             self.region = "us-east-1"
             self.client = self.session.client(self.service, self.region)
-            self.__list_domains__()
-            self.__get_domain_detail__()
-            self.__list_tags_for_domain__()
+            self._list_domains()
+            self._get_domain_detail()
+            self._list_tags_for_domain()
 
-    def __list_domains__(self):
+    def _list_domains(self):
         logger.info("Route53Domains - Listing Domains...")
         try:
             list_domains_zones_paginator = self.client.get_paginator("list_domains")
@@ -169,7 +169,7 @@ class Route53Domains(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_domain_detail__(self):
+    def _get_domain_detail(self):
         logger.info("Route53Domains - Getting Domain Detail...")
         try:
             for domain in self.domains.values():
@@ -182,7 +182,7 @@ class Route53Domains(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_domain__(self):
+    def _list_tags_for_domain(self):
         logger.info("Route53Domains - List Tags...")
         for domain in self.domains.values():
             try:

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -16,15 +16,15 @@ class SageMaker(AWSService):
         self.sagemaker_notebook_instances = []
         self.sagemaker_models = []
         self.sagemaker_training_jobs = []
-        self.__threading_call__(self.__list_notebook_instances__)
-        self.__threading_call__(self.__list_models__)
-        self.__threading_call__(self.__list_training_jobs__)
-        self.__describe_model__(self.regional_clients)
-        self.__describe_notebook_instance__(self.regional_clients)
-        self.__describe_training_job__(self.regional_clients)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_notebook_instances)
+        self.__threading_call__(self._list_models)
+        self.__threading_call__(self._list_training_jobs)
+        self._describe_model(self.regional_clients)
+        self._describe_notebook_instance(self.regional_clients)
+        self._describe_training_job(self.regional_clients)
+        self._list_tags_for_resource()
 
-    def __list_notebook_instances__(self, regional_client):
+    def _list_notebook_instances(self, regional_client):
         logger.info("SageMaker - listing notebook instances...")
         try:
             list_notebook_instances_paginator = regional_client.get_paginator(
@@ -50,7 +50,7 @@ class SageMaker(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_models__(self, regional_client):
+    def _list_models(self, regional_client):
         logger.info("SageMaker - listing models...")
         try:
             list_models_paginator = regional_client.get_paginator("list_models")
@@ -71,7 +71,7 @@ class SageMaker(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_training_jobs__(self, regional_client):
+    def _list_training_jobs(self, regional_client):
         logger.info("SageMaker - listing training jobs...")
         try:
             list_training_jobs_paginator = regional_client.get_paginator(
@@ -96,7 +96,7 @@ class SageMaker(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_notebook_instance__(self, regional_clients):
+    def _describe_notebook_instance(self, regional_clients):
         logger.info("SageMaker - describing notebook instances...")
         try:
             for notebook_instance in self.sagemaker_notebook_instances:
@@ -135,7 +135,7 @@ class SageMaker(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_model__(self, regional_clients):
+    def _describe_model(self, regional_clients):
         logger.info("SageMaker - describing models...")
         try:
             for model in self.sagemaker_models:
@@ -153,7 +153,7 @@ class SageMaker(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_training_job__(self, regional_clients):
+    def _describe_training_job(self, regional_clients):
         logger.info("SageMaker - describing training jobs...")
         try:
             for training_job in self.sagemaker_training_jobs:
@@ -188,7 +188,7 @@ class SageMaker(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("SageMaker - List Tags...")
         try:
             for model in self.sagemaker_models:

--- a/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
+++ b/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
@@ -13,9 +13,9 @@ class SecretsManager(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.secrets = {}
-        self.__threading_call__(self.__list_secrets__)
+        self.__threading_call__(self._list_secrets)
 
-    def __list_secrets__(self, regional_client):
+    def _list_secrets(self, regional_client):
         logger.info("SecretsManager - Listing Secrets...")
         try:
             list_secrets_paginator = regional_client.get_paginator("list_secrets")

--- a/prowler/providers/aws/services/securityhub/securityhub_service.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_service.py
@@ -12,9 +12,9 @@ class SecurityHub(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.securityhubs = []
-        self.__threading_call__(self.__describe_hub__)
+        self.__threading_call__(self._describe_hub)
 
-    def __describe_hub__(self, regional_client):
+    def _describe_hub(self, regional_client):
         logger.info("SecurityHub - Describing Hub...")
         try:
             # Check if SecurityHub is active

--- a/prowler/providers/aws/services/shield/shield_service.py
+++ b/prowler/providers/aws/services/shield/shield_service.py
@@ -11,11 +11,11 @@ class Shield(AWSService):
         super().__init__(__class__.__name__, provider, global_service=True)
         self.protections = {}
         self.enabled = False
-        self.enabled = self.__get_subscription_state__()
+        self.enabled = self._get_subscription_state()
         if self.enabled:
-            self.__list_protections__()
+            self._list_protections()
 
-    def __get_subscription_state__(self):
+    def _get_subscription_state(self):
         logger.info("Shield - Getting Subscription State...")
         try:
             return (
@@ -28,7 +28,7 @@ class Shield(AWSService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_protections__(self):
+    def _list_protections(self):
         logger.info("Shield - Listing Protections...")
         try:
             list_protections_paginator = self.client.get_paginator("list_protections")

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -14,12 +14,12 @@ class SNS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.topics = []
-        self.__threading_call__(self.__list_topics__)
-        self.__get_topic_attributes__(self.regional_clients)
-        self.__list_tags_for_resource__()
-        self.__list_subscriptions_by_topic__()
+        self.__threading_call__(self._list_topics)
+        self._get_topic_attributes(self.regional_clients)
+        self._list_tags_for_resource()
+        self._list_subscriptions_by_topic()
 
-    def __list_topics__(self, regional_client):
+    def _list_topics(self, regional_client):
         logger.info("SNS - listing topics...")
         try:
             list_topics_paginator = regional_client.get_paginator("list_topics")
@@ -42,7 +42,7 @@ class SNS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_topic_attributes__(self, regional_clients):
+    def _get_topic_attributes(self, regional_clients):
         logger.info("SNS - getting topic attributes...")
         try:
             for topic in self.topics:
@@ -61,7 +61,7 @@ class SNS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("SNS - List Tags...")
         try:
             for topic in self.topics:
@@ -75,7 +75,7 @@ class SNS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_subscriptions_by_topic__(self):
+    def _list_subscriptions_by_topic(self):
         logger.info("SNS - Listing subscriptions by topic...")
         try:
             for topic in self.topics:

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -15,11 +15,11 @@ class SQS(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.queues = []
-        self.__threading_call__(self.__list_queues__)
-        self.__get_queue_attributes__()
-        self.__list_queue_tags__()
+        self.__threading_call__(self._list_queues)
+        self._get_queue_attributes()
+        self._list_queue_tags()
 
-    def __list_queues__(self, regional_client):
+    def _list_queues(self, regional_client):
         logger.info("SQS - describing queues...")
         try:
             list_queues_paginator = regional_client.get_paginator("list_queues")
@@ -49,7 +49,7 @@ class SQS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_queue_attributes__(self):
+    def _get_queue_attributes(self):
         try:
             logger.info("SQS - describing queue attributes...")
             for queue in self.queues:
@@ -94,7 +94,7 @@ class SQS(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_queue_tags__(self):
+    def _list_queue_tags(self):
         logger.info("SQS - List Tags...")
         try:
             for queue in self.queues:

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -19,13 +19,13 @@ class SSM(AWSService):
         self.documents = {}
         self.compliance_resources = {}
         self.managed_instances = {}
-        self.__threading_call__(self.__list_documents__)
-        self.__threading_call__(self.__get_document__)
-        self.__threading_call__(self.__describe_document_permission__)
-        self.__threading_call__(self.__list_resource_compliance_summaries__)
-        self.__threading_call__(self.__describe_instance_information__)
+        self.__threading_call__(self._list_documents)
+        self.__threading_call__(self._get_document)
+        self.__threading_call__(self._describe_document_permission)
+        self.__threading_call__(self._list_resource_compliance_summaries)
+        self.__threading_call__(self._describe_instance_information)
 
-    def __list_documents__(self, regional_client):
+    def _list_documents(self, regional_client):
         logger.info("SSM - Listing Documents...")
         try:
             # To retrieve only the documents owned by the account
@@ -62,7 +62,7 @@ class SSM(AWSService):
                 f" {error}"
             )
 
-    def __get_document__(self, regional_client):
+    def _get_document(self, regional_client):
         logger.info("SSM - Getting Document...")
         for document in self.documents.values():
             try:
@@ -88,7 +88,7 @@ class SSM(AWSService):
                     f" {error}"
                 )
 
-    def __describe_document_permission__(self, regional_client):
+    def _describe_document_permission(self, regional_client):
         logger.info("SSM - Describing Document Permission...")
         try:
             for document in self.documents.values():
@@ -107,7 +107,7 @@ class SSM(AWSService):
                 f" {error}"
             )
 
-    def __list_resource_compliance_summaries__(self, regional_client):
+    def _list_resource_compliance_summaries(self, regional_client):
         logger.info("SSM - List Resources Compliance Summaries...")
         try:
             list_resource_compliance_summaries_paginator = (
@@ -136,7 +136,7 @@ class SSM(AWSService):
                 f" {error}"
             )
 
-    def __describe_instance_information__(self, regional_client):
+    def _describe_instance_information(self, regional_client):
         logger.info("SSM - Describing Instance Information...")
         try:
             describe_instance_information_paginator = regional_client.get_paginator(

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -19,13 +19,13 @@ class SSMIncidents(AWSService):
         super().__init__("ssm-incidents", provider)
         self.replication_set_arn_template = f"arn:{self.audited_partition}:ssm-incidents:{self.region}:{self.audited_account}:replication-set"
         self.replication_set = []
-        self.__list_replication_sets__()
-        self.__get_replication_set__()
+        self._list_replication_sets()
+        self._get_replication_set()
         self.response_plans = []
-        self.__threading_call__(self.__list_response_plans__)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_response_plans)
+        self._list_tags_for_resource()
 
-    def __list_replication_sets__(self):
+    def _list_replication_sets(self):
         logger.info("SSMIncidents - Listing Replication Sets...")
         try:
             if self.regional_clients:
@@ -61,7 +61,7 @@ class SSMIncidents(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __get_replication_set__(self):
+    def _get_replication_set(self):
         logger.info("SSMIncidents - Getting Replication Sets...")
         try:
             if not self.replication_set:
@@ -100,7 +100,7 @@ class SSMIncidents(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_response_plans__(self, regional_client):
+    def _list_response_plans(self, regional_client):
         logger.info("SSMIncidents - Listing Response Plans...")
         try:
             list_response_plans_paginator = regional_client.get_paginator(
@@ -120,7 +120,7 @@ class SSMIncidents(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("SSMIncidents - List Tags...")
         try:
             for response_plan in self.response_plans:

--- a/prowler/providers/aws/services/storagegateway/storagegateway_service.py
+++ b/prowler/providers/aws/services/storagegateway/storagegateway_service.py
@@ -13,11 +13,11 @@ class StorageGateway(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.fileshares = []
-        self.__threading_call__(self.__list_file_shares__)
-        self.__threading_call__(self.__describe_nfs_file_shares__)
-        self.__threading_call__(self.__describe_smb_file_shares__)
+        self.__threading_call__(self._list_file_shares)
+        self.__threading_call__(self._describe_nfs_file_shares)
+        self.__threading_call__(self._describe_smb_file_shares)
 
-    def __list_file_shares__(self, regional_client):
+    def _list_file_shares(self, regional_client):
         try:
             list_file_share_paginator = regional_client.get_paginator(
                 "list_file_shares"
@@ -45,7 +45,7 @@ class StorageGateway(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_nfs_file_shares__(self, regional_client):
+    def _describe_nfs_file_shares(self, regional_client):
         logger.info("StorageGateway - Describe NFS FileShares...")
         try:
             for fileshare in self.fileshares:
@@ -64,7 +64,7 @@ class StorageGateway(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_smb_file_shares__(self, regional_client):
+    def _describe_smb_file_shares(self, regional_client):
         logger.info("StorageGateway - Describe SMB FileShares...")
         try:
             for fileshare in self.fileshares:

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -24,12 +24,12 @@ class TrustedAdvisor(AWSService):
                 support_region = "us-gov-west-1"
             self.client = self.session.client(self.service, region_name=support_region)
             self.client.region = support_region
-            self.__describe_services__()
+            self._describe_services()
             if getattr(self.premium_support, "enabled", False):
-                self.__describe_trusted_advisor_checks__()
-                self.__describe_trusted_advisor_check_result__()
+                self._describe_trusted_advisor_checks()
+                self._describe_trusted_advisor_check_result()
 
-    def __describe_trusted_advisor_checks__(self):
+    def _describe_trusted_advisor_checks(self):
         logger.info("TrustedAdvisor - Describing Checks...")
         try:
             for check in self.client.describe_trusted_advisor_checks(language="en").get(
@@ -62,7 +62,7 @@ class TrustedAdvisor(AWSService):
                 f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_trusted_advisor_check_result__(self):
+    def _describe_trusted_advisor_check_result(self):
         logger.info("TrustedAdvisor - Describing Check Result...")
         try:
             for check in self.checks:
@@ -86,7 +86,7 @@ class TrustedAdvisor(AWSService):
                 f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_services__(self):
+    def _describe_services(self):
         logger.info("Support - Describing Services...")
         try:
             self.client.describe_services()

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -21,18 +21,18 @@ class VPC(AWSService):
         self.vpc_peering_connections = []
         self.vpc_endpoints = []
         self.vpc_endpoint_services = []
-        self.__threading_call__(self.__describe_vpcs__)
-        self.__threading_call__(self.__describe_vpc_peering_connections__)
-        self.__threading_call__(self.__describe_vpc_endpoints__)
-        self.__threading_call__(self.__describe_vpc_endpoint_services__)
-        self.__describe_flow_logs__()
-        self.__describe_peering_route_tables__()
-        self.__describe_vpc_endpoint_service_permissions__()
+        self.__threading_call__(self._describe_vpcs)
+        self.__threading_call__(self._describe_vpc_peering_connections)
+        self.__threading_call__(self._describe_vpc_endpoints)
+        self.__threading_call__(self._describe_vpc_endpoint_services)
+        self._describe_flow_logs()
+        self._describe_peering_route_tables()
+        self._describe_vpc_endpoint_service_permissions()
         self.vpc_subnets = {}
-        self.__threading_call__(self.__describe_vpc_subnets__)
-        self.__describe_network_interfaces__()
+        self.__threading_call__(self._describe_vpc_subnets)
+        self._describe_network_interfaces()
 
-    def __describe_vpcs__(self, regional_client):
+    def _describe_vpcs(self, regional_client):
         logger.info("VPC - Describing VPCs...")
         try:
             describe_vpcs_paginator = regional_client.get_paginator("describe_vpcs")
@@ -65,7 +65,7 @@ class VPC(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_vpc_peering_connections__(self, regional_client):
+    def _describe_vpc_peering_connections(self, regional_client):
         logger.info("VPC - Describing VPC Peering Connections...")
         try:
             describe_vpc_peering_connections_paginator = regional_client.get_paginator(
@@ -104,7 +104,7 @@ class VPC(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_peering_route_tables__(self):
+    def _describe_peering_route_tables(self):
         logger.info("VPC - Describing Peering Route Tables...")
         try:
             for conn in self.vpc_peering_connections:
@@ -147,7 +147,7 @@ class VPC(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __describe_flow_logs__(self):
+    def _describe_flow_logs(self):
         logger.info("VPC - Describing flow logs...")
         try:
             for vpc in self.vpcs.values():
@@ -174,7 +174,7 @@ class VPC(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __describe_network_interfaces__(self):
+    def _describe_network_interfaces(self):
         logger.info("VPC - Describing flow logs...")
         try:
             for vpc in self.vpcs.values():
@@ -214,7 +214,7 @@ class VPC(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __describe_vpc_endpoints__(self, regional_client):
+    def _describe_vpc_endpoints(self, regional_client):
         logger.info("VPC - Describing VPC Endpoints...")
         try:
             describe_vpc_endpoints_paginator = regional_client.get_paginator(
@@ -252,7 +252,7 @@ class VPC(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_vpc_endpoint_services__(self, regional_client):
+    def _describe_vpc_endpoint_services(self, regional_client):
         logger.info("VPC - Describing VPC Endpoint Services...")
         try:
             describe_vpc_endpoint_services_paginator = regional_client.get_paginator(
@@ -285,7 +285,7 @@ class VPC(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_vpc_endpoint_service_permissions__(self):
+    def _describe_vpc_endpoint_service_permissions(self):
         logger.info("VPC - Describing VPC Endpoint service permissions...")
         try:
             for service in self.vpc_endpoint_services:
@@ -312,7 +312,7 @@ class VPC(AWSService):
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
-    def __describe_vpc_subnets__(self, regional_client):
+    def _describe_vpc_subnets(self, regional_client):
         logger.info("VPC - Describing VPC subnets...")
         try:
             describe_subnets_paginator = regional_client.get_paginator(

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -11,10 +11,10 @@ class WAF(AWSService):
         # Call AWSService's __init__
         super().__init__("waf-regional", provider)
         self.web_acls = []
-        self.__threading_call__(self.__list_web_acls__)
-        self.__threading_call__(self.__list_resources_for_web_acl__)
+        self.__threading_call__(self._list_web_acls)
+        self.__threading_call__(self._list_resources_for_web_acl)
 
-    def __list_web_acls__(self, regional_client):
+    def _list_web_acls(self, regional_client):
         logger.info("WAF - Listing Regional Web ACLs...")
         try:
             for waf in regional_client.list_web_acls()["WebACLs"]:
@@ -34,7 +34,7 @@ class WAF(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_resources_for_web_acl__(self, regional_client):
+    def _list_resources_for_web_acl(self, regional_client):
         logger.info("WAF - Describing resources...")
         try:
             for acl in self.web_acls:

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -12,11 +12,11 @@ class WAFv2(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.web_acls = []
-        self.__threading_call__(self.__list_web_acls__)
-        self.__threading_call__(self.__list_resources_for_web_acl__)
-        self.__threading_call__(self.__get_logging_configuration__)
+        self.__threading_call__(self._list_web_acls)
+        self.__threading_call__(self._list_resources_for_web_acl)
+        self.__threading_call__(self._get_logging_configuration)
 
-    def __list_web_acls__(self, regional_client):
+    def _list_web_acls(self, regional_client):
         logger.info("WAFv2 - Listing Regional Web ACLs...")
         try:
             for wafv2 in regional_client.list_web_acls(Scope="REGIONAL")["WebACLs"]:
@@ -38,7 +38,7 @@ class WAFv2(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_logging_configuration__(self, regional_client):
+    def _get_logging_configuration(self, regional_client):
         logger.info("WAFv2 - Get Logging Configuration...")
         for acl in self.web_acls:
             if acl.region == regional_client.region:
@@ -64,7 +64,7 @@ class WAFv2(AWSService):
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
-    def __list_resources_for_web_acl__(self, regional_client):
+    def _list_resources_for_web_acl(self, regional_client):
         logger.info("WAFv2 - Describing resources...")
         for acl in self.web_acls:
             if acl.region == regional_client.region:

--- a/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
+++ b/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
@@ -14,10 +14,10 @@ class WellArchitected(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.workloads = []
-        self.__threading_call__(self.__list_workloads__)
-        self.__list_tags_for_resource__()
+        self.__threading_call__(self._list_workloads)
+        self._list_tags_for_resource()
 
-    def __list_workloads__(self, regional_client):
+    def _list_workloads(self, regional_client):
         logger.info("WellArchitected - Listing Workloads...")
         try:
             for workload in regional_client.list_workloads()["WorkloadSummaries"]:
@@ -41,7 +41,7 @@ class WellArchitected(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_tags_for_resource__(self):
+    def _list_tags_for_resource(self):
         logger.info("WellArchitected - Listing Tags...")
         try:
             for workload in self.workloads:

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -13,10 +13,10 @@ class WorkSpaces(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.workspaces = []
-        self.__threading_call__(self.__describe_workspaces__)
-        self.__describe_tags__()
+        self.__threading_call__(self._describe_workspaces)
+        self._describe_tags()
 
-    def __describe_workspaces__(self, regional_client):
+    def _describe_workspaces(self, regional_client):
         logger.info("WorkSpaces - describing workspaces...")
         try:
             describe_workspaces_paginator = regional_client.get_paginator(
@@ -51,7 +51,7 @@ class WorkSpaces(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __describe_tags__(self):
+    def _describe_tags(self):
         logger.info("Workspaces - List Tags...")
         try:
             for workspace in self.workspaces:

--- a/prowler/providers/azure/services/aks/aks_service.py
+++ b/prowler/providers/azure/services/aks/aks_service.py
@@ -12,9 +12,9 @@ from prowler.providers.azure.lib.service.service import AzureService
 class AKS(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(ContainerServiceClient, provider)
-        self.clusters = self.__get_clusters__()
+        self.clusters = self._get_clusters()
 
-    def __get_clusters__(self):
+    def _get_clusters(self):
         logger.info("AKS - Getting clusters...")
         clusters = {}
 

--- a/prowler/providers/azure/services/app/app_service.py
+++ b/prowler/providers/azure/services/app/app_service.py
@@ -14,10 +14,10 @@ from prowler.providers.azure.services.monitor.monitor_service import DiagnosticS
 class App(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(WebSiteManagementClient, provider)
-        self.apps = self.__get_apps__()
-        self.functions = self.__get_functions__()
+        self.apps = self._get_apps()
+        self.functions = self._get_functions()
 
-    def __get_apps__(self):
+    def _get_apps(self):
         logger.info("App - Getting apps...")
         apps = {}
 
@@ -50,11 +50,11 @@ class App(AzureService):
                                         resource_group_name=app.resource_group,
                                         name=app.name,
                                     ),
-                                    client_cert_mode=self.__get_client_cert_mode__(
+                                    client_cert_mode=self._get_client_cert_mode(
                                         getattr(app, "client_cert_enabled", False),
                                         getattr(app, "client_cert_mode", "Ignore"),
                                     ),
-                                    monitor_diagnostic_settings=self.__get_app_monitor_settings__(
+                                    monitor_diagnostic_settings=self._get_app_monitor_settings(
                                         app.name, app.resource_group, subscription_name
                                     ),
                                     https_only=getattr(app, "https_only", False),
@@ -71,7 +71,7 @@ class App(AzureService):
 
         return apps
 
-    def __get_functions__(self):
+    def _get_functions(self):
         logger.info("Function - Getting functions...")
         functions = {}
 
@@ -138,9 +138,7 @@ class App(AzureService):
 
         return functions
 
-    def __get_client_cert_mode__(
-        self, client_cert_enabled: bool, client_cert_mode: str
-    ):
+    def _get_client_cert_mode(self, client_cert_enabled: bool, client_cert_mode: str):
         cert_mode = "Ignore"
         if not client_cert_enabled and client_cert_mode == "OptionalInteractiveUser":
             cert_mode = "Ignore"
@@ -155,7 +153,7 @@ class App(AzureService):
 
         return cert_mode
 
-    def __get_app_monitor_settings__(self, app_name, resource_group, subscription):
+    def _get_app_monitor_settings(self, app_name, resource_group, subscription):
         logger.info(f"App - Getting monitor diagnostics settings for {app_name}...")
         monitor_diagnostics_settings = []
         try:

--- a/prowler/providers/azure/services/appinsights/appinsights_service.py
+++ b/prowler/providers/azure/services/appinsights/appinsights_service.py
@@ -10,9 +10,9 @@ from prowler.providers.azure.lib.service.service import AzureService
 class AppInsights(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(ApplicationInsightsManagementClient, provider)
-        self.components = self.__get_components__()
+        self.components = self._get_components()
 
-    def __get_components__(self):
+    def _get_components(self):
         logger.info("AppInsights - Getting components...")
         components = {}
 

--- a/prowler/providers/azure/services/cosmosdb/cosmosdb_service.py
+++ b/prowler/providers/azure/services/cosmosdb/cosmosdb_service.py
@@ -11,9 +11,9 @@ from prowler.providers.azure.lib.service.service import AzureService
 class CosmosDB(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(CosmosDBManagementClient, provider)
-        self.accounts = self.__get_accounts__()
+        self.accounts = self._get_accounts()
 
-    def __get_accounts__(self):
+    def _get_accounts(self):
         logger.info("CosmosDB - Getting accounts...")
         accounts = {}
         for subscription, client in self.clients.items():

--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -19,14 +19,14 @@ class Defender(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(SecurityCenter, provider)
 
-        self.pricings = self.__get_pricings__()
-        self.auto_provisioning_settings = self.__get_auto_provisioning_settings__()
-        self.assessments = self.__get_assessments__()
-        self.settings = self.__get_settings__()
-        self.security_contacts = self.__get_security_contacts__()
-        self.iot_security_solutions = self.__get_iot_security_solutions__()
+        self.pricings = self._get_pricings()
+        self.auto_provisioning_settings = self._get_auto_provisioning_settings()
+        self.assessments = self._get_assessments()
+        self.settings = self._get_settings()
+        self.security_contacts = self._get_security_contacts()
+        self.iot_security_solutions = self._get_iot_security_solutions()
 
-    def __get_pricings__(self):
+    def _get_pricings(self):
         logger.info("Defender - Getting pricings...")
         pricings = {}
         for subscription_name, client in self.clients.items():
@@ -66,7 +66,7 @@ class Defender(AzureService):
                 )
         return pricings
 
-    def __get_auto_provisioning_settings__(self):
+    def _get_auto_provisioning_settings(self):
         logger.info("Defender - Getting auto provisioning settings...")
         auto_provisioning = {}
         for subscription_name, client in self.clients.items():
@@ -95,7 +95,7 @@ class Defender(AzureService):
                 )
         return auto_provisioning
 
-    def __get_assessments__(self):
+    def _get_assessments(self):
         logger.info("Defender - Getting assessments...")
         assessments = {}
         for subscription_name, client in self.clients.items():
@@ -120,7 +120,7 @@ class Defender(AzureService):
                 )
         return assessments
 
-    def __get_settings__(self):
+    def _get_settings(self):
         logger.info("Defender - Getting settings...")
         settings = {}
         for subscription_name, client in self.clients.items():
@@ -149,7 +149,7 @@ class Defender(AzureService):
                 )
         return settings
 
-    def __get_security_contacts__(self):
+    def _get_security_contacts(self):
         logger.info("Defender - Getting security contacts...")
         security_contacts = {}
         for subscription_name, client in self.clients.items():
@@ -195,7 +195,7 @@ class Defender(AzureService):
                 )
         return security_contacts
 
-    def __get_iot_security_solutions__(self):
+    def _get_iot_security_solutions(self):
         logger.info("Defender - Getting IoT Security Solutions...")
         iot_security_solutions = {}
         for subscription_name, client in self.clients.items():

--- a/prowler/providers/azure/services/entra/entra_service.py
+++ b/prowler/providers/azure/services/entra/entra_service.py
@@ -23,16 +23,16 @@ class Entra(AzureService):
         loop = get_event_loop()
 
         # Get users first alone because it is a dependency for other attributes
-        self.users = loop.run_until_complete(self.__get_users__())
+        self.users = loop.run_until_complete(self._get_users())
 
         attributes = loop.run_until_complete(
             gather(
-                self.__get_authorization_policy__(),
-                self.__get_group_settings__(),
-                self.__get_security_default__(),
-                self.__get_named_locations__(),
-                self.__get_directory_roles__(),
-                self.__get_conditional_access_policy__(),
+                self._get_authorization_policy(),
+                self._get_group_settings(),
+                self._get_security_default(),
+                self._get_named_locations(),
+                self._get_directory_roles(),
+                self._get_conditional_access_policy(),
             )
         )
 
@@ -43,7 +43,7 @@ class Entra(AzureService):
         self.directory_roles = attributes[4]
         self.conditional_access_policy = attributes[5]
 
-    async def __get_users__(self):
+    async def _get_users(self):
         logger.info("Entra - Getting users...")
         users = {}
         try:
@@ -79,7 +79,7 @@ class Entra(AzureService):
 
         return users
 
-    async def __get_authorization_policy__(self):
+    async def _get_authorization_policy(self):
         logger.info("Entra - Getting authorization policy...")
 
         authorization_policy = {}
@@ -115,7 +115,7 @@ class Entra(AzureService):
 
         return authorization_policy
 
-    async def __get_group_settings__(self):
+    async def _get_group_settings(self):
         logger.info("Entra - Getting group settings...")
         group_settings = {}
         try:
@@ -139,7 +139,7 @@ class Entra(AzureService):
 
         return group_settings
 
-    async def __get_security_default__(self):
+    async def _get_security_default(self):
         logger.info("Entra - Getting security default...")
         try:
             security_defaults = {}
@@ -163,7 +163,7 @@ class Entra(AzureService):
 
         return security_defaults
 
-    async def __get_named_locations__(self):
+    async def _get_named_locations(self):
         logger.info("Entra - Getting named locations...")
         named_locations = {}
         try:
@@ -194,7 +194,7 @@ class Entra(AzureService):
 
         return named_locations
 
-    async def __get_directory_roles__(self):
+    async def _get_directory_roles(self):
         logger.info("Entra - Getting directory roles...")
         directory_roles_with_members = {}
         try:
@@ -228,7 +228,7 @@ class Entra(AzureService):
             )
         return directory_roles_with_members
 
-    async def __get_conditional_access_policy__(self):
+    async def _get_conditional_access_policy(self):
         logger.info("Entra - Getting conditional access policy...")
         conditional_access_policy = {}
         try:

--- a/prowler/providers/azure/services/iam/iam_service.py
+++ b/prowler/providers/azure/services/iam/iam_service.py
@@ -12,10 +12,10 @@ from prowler.providers.azure.lib.service.service import AzureService
 class IAM(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(AuthorizationManagementClient, provider)
-        self.roles, self.custom_roles = self.__get_roles__()
-        self.role_assignments = self.__get_role_assignments__()
+        self.roles, self.custom_roles = self._get_roles()
+        self.role_assignments = self._get_role_assignments()
 
-    def __get_roles__(self):
+    def _get_roles(self):
         logger.info("IAM - Getting roles...")
         builtin_roles = {}
         custom_roles = {}
@@ -54,7 +54,7 @@ class IAM(AzureService):
                 )
         return builtin_roles, custom_roles
 
-    def __get_role_assignments__(self):
+    def _get_role_assignments(self):
         logger.info("IAM - Getting role assignments...")
         role_assignments = {}
         for subscription, client in self.clients.items():

--- a/prowler/providers/azure/services/keyvault/keyvault_service.py
+++ b/prowler/providers/azure/services/keyvault/keyvault_service.py
@@ -21,9 +21,9 @@ class KeyVault(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(KeyVaultManagementClient, provider)
         # TODO: review this credentials assignment
-        self.key_vaults = self.__get_key_vaults__(provider)
+        self.key_vaults = self._get_key_vaults(provider)
 
-    def __get_key_vaults__(self, provider):
+    def _get_key_vaults(self, provider):
         logger.info("KeyVault - Getting key_vaults...")
         key_vaults = {}
         for subscription, client in self.clients.items():
@@ -36,10 +36,10 @@ class KeyVault(AzureService):
                     keyvault_properties = client.vaults.get(
                         resource_group, keyvault_name
                     ).properties
-                    keys = self.__get_keys__(
+                    keys = self._get_keys(
                         subscription, resource_group, keyvault_name, provider
                     )
-                    secrets = self.__get_secrets__(
+                    secrets = self._get_secrets(
                         subscription, resource_group, keyvault_name
                     )
                     key_vaults[subscription].append(
@@ -51,7 +51,7 @@ class KeyVault(AzureService):
                             properties=keyvault_properties,
                             keys=keys,
                             secrets=secrets,
-                            monitor_diagnostic_settings=self.__get_vault_monitor_settings__(
+                            monitor_diagnostic_settings=self._get_vault_monitor_settings(
                                 keyvault_name, resource_group, subscription
                             ),
                         )
@@ -62,7 +62,7 @@ class KeyVault(AzureService):
                 )
         return key_vaults
 
-    def __get_keys__(self, subscription, resource_group, keyvault_name, provider):
+    def _get_keys(self, subscription, resource_group, keyvault_name, provider):
         logger.info(f"KeyVault - Getting keys for {keyvault_name}...")
         keys = []
         try:
@@ -103,7 +103,7 @@ class KeyVault(AzureService):
             )
         return keys
 
-    def __get_secrets__(self, subscription, resource_group, keyvault_name):
+    def _get_secrets(self, subscription, resource_group, keyvault_name):
         logger.info(f"KeyVault - Getting secrets for {keyvault_name}...")
         secrets = []
         try:
@@ -125,9 +125,7 @@ class KeyVault(AzureService):
             )
         return secrets
 
-    def __get_vault_monitor_settings__(
-        self, keyvault_name, resource_group, subscription
-    ):
+    def _get_vault_monitor_settings(self, keyvault_name, resource_group, subscription):
         logger.info(
             f"KeyVault - Getting monitor diagnostics settings for {keyvault_name}..."
         )

--- a/prowler/providers/azure/services/monitor/monitor_service.py
+++ b/prowler/providers/azure/services/monitor/monitor_service.py
@@ -13,10 +13,10 @@ class Monitor(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(MonitorManagementClient, provider)
 
-        self.diagnostics_settings = self.__get_diagnostics_settings__()
+        self.diagnostics_settings = self._get_diagnostics_settings()
         self.alert_rules = self.get_alert_rules()
 
-    def __get_diagnostics_settings__(self):
+    def _get_diagnostics_settings(self):
         logger.info("Monitor - Getting diagnostics settings...")
         diagnostics_settings_list = []
         diagnostics_settings = {}

--- a/prowler/providers/azure/services/mysql/mysql_service.py
+++ b/prowler/providers/azure/services/mysql/mysql_service.py
@@ -12,9 +12,9 @@ class MySQL(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(MySQLManagementClient, provider)
 
-        self.flexible_servers = self.__get_flexible_servers__()
+        self.flexible_servers = self._get_flexible_servers()
 
-    def __get_flexible_servers__(self):
+    def _get_flexible_servers(self):
         logger.info("MySQL - Getting servers...")
         servers = {}
         for subscription_name, client in self.clients.items():
@@ -28,7 +28,7 @@ class MySQL(AzureService):
                                 resource_id=server.id,
                                 location=server.location,
                                 version=server.version,
-                                configurations=self.__get_configurations__(
+                                configurations=self._get_configurations(
                                     client, server.id.split("/")[4], server.name
                                 ),
                             )
@@ -40,7 +40,7 @@ class MySQL(AzureService):
                 )
         return servers
 
-    def __get_configurations__(self, client, resource_group, server_name):
+    def _get_configurations(self, client, resource_group, server_name):
         logger.info(f"MySQL - Getting configurations from server {server_name} ...")
         configurations = {}
         try:

--- a/prowler/providers/azure/services/network/network_service.py
+++ b/prowler/providers/azure/services/network/network_service.py
@@ -10,12 +10,12 @@ from prowler.providers.azure.lib.service.service import AzureService
 class Network(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(NetworkManagementClient, provider)
-        self.security_groups = self.__get_security_groups__()
-        self.bastion_hosts = self.__get_bastion_hosts__()
-        self.network_watchers = self.__get_network_watchers__()
-        self.public_ip_addresses = self.__get_public_ip_addresses__()
+        self.security_groups = self._get_security_groups()
+        self.bastion_hosts = self._get_bastion_hosts()
+        self.network_watchers = self._get_network_watchers()
+        self.public_ip_addresses = self._get_public_ip_addresses()
 
-    def __get_security_groups__(self):
+    def _get_security_groups(self):
         logger.info("Network - Getting Network Security Groups...")
         security_groups = {}
         for subscription, client in self.clients.items():
@@ -38,7 +38,7 @@ class Network(AzureService):
                 )
         return security_groups
 
-    def __get_network_watchers__(self):
+    def _get_network_watchers(self):
         logger.info("Network - Getting Network Watchers...")
         network_watchers = {}
         for subscription, client in self.clients.items():
@@ -46,9 +46,7 @@ class Network(AzureService):
                 network_watchers.update({subscription: []})
                 network_watchers_list = client.network_watchers.list_all()
                 for network_watcher in network_watchers_list:
-                    flow_logs = self.__get_flow_logs__(
-                        subscription, network_watcher.name
-                    )
+                    flow_logs = self._get_flow_logs(subscription, network_watcher.name)
                     network_watchers[subscription].append(
                         NetworkWatcher(
                             id=network_watcher.id,
@@ -64,14 +62,14 @@ class Network(AzureService):
                 )
         return network_watchers
 
-    def __get_flow_logs__(self, subscription, network_watcher_name):
+    def _get_flow_logs(self, subscription, network_watcher_name):
         logger.info("Network - Getting Flow Logs...")
         client = self.clients[subscription]
         resource_group = "NetworkWatcherRG"
         flow_logs = client.flow_logs.list(resource_group, network_watcher_name)
         return flow_logs
 
-    def __get_bastion_hosts__(self):
+    def _get_bastion_hosts(self):
         logger.info("Network - Getting Bastion Hosts...")
         bastion_hosts = {}
         for subscription, client in self.clients.items():
@@ -93,7 +91,7 @@ class Network(AzureService):
                 )
         return bastion_hosts
 
-    def __get_public_ip_addresses__(self):
+    def _get_public_ip_addresses(self):
         logger.info("Network - Getting Public IP Addresses...")
         public_ip_addresses = {}
         for subscription, client in self.clients.items():

--- a/prowler/providers/azure/services/policy/policy_service.py
+++ b/prowler/providers/azure/services/policy/policy_service.py
@@ -11,9 +11,9 @@ from prowler.providers.azure.lib.service.service import AzureService
 class Policy(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(PolicyClient, provider)
-        self.policy_assigments = self.__get_policy_assigments__()
+        self.policy_assigments = self._get_policy_assigments()
 
-    def __get_policy_assigments__(self):
+    def _get_policy_assigments(self):
         logger.info("Policy - Getting policy assigments...")
         policy_assigments = {}
 

--- a/prowler/providers/azure/services/postgresql/postgresql_service.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_service.py
@@ -10,9 +10,9 @@ from prowler.providers.azure.lib.service.service import AzureService
 class PostgreSQL(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(PostgreSQLManagementClient, provider)
-        self.flexible_servers = self.__get_flexible_servers__()
+        self.flexible_servers = self._get_flexible_servers()
 
-    def __get_flexible_servers__(self):
+    def _get_flexible_servers(self):
         logger.info("PostgreSQL - Getting PostgreSQL servers...")
         flexible_servers = {}
         for subscription, client in self.clients.items():
@@ -20,29 +20,29 @@ class PostgreSQL(AzureService):
                 flexible_servers.update({subscription: []})
                 flexible_servers_list = client.servers.list()
                 for postgresql_server in flexible_servers_list:
-                    resource_group = self.__get_resource_group__(postgresql_server.id)
-                    require_secure_transport = self.__get_require_secure_transport__(
+                    resource_group = self._get_resource_group(postgresql_server.id)
+                    require_secure_transport = self._get_require_secure_transport(
                         subscription, resource_group, postgresql_server.name
                     )
-                    log_checkpoints = self.__get_log_checkpoints__(
+                    log_checkpoints = self._get_log_checkpoints(
                         subscription, resource_group, postgresql_server.name
                     )
-                    log_disconnections = self.__get_log_disconnections__(
+                    log_disconnections = self._get_log_disconnections(
                         subscription, resource_group, postgresql_server.name
                     )
-                    log_connections = self.__get_log_connections__(
+                    log_connections = self._get_log_connections(
                         subscription, resource_group, postgresql_server.name
                     )
-                    connection_throttling = self.__get_connection_throttling__(
+                    connection_throttling = self._get_connection_throttling(
                         subscription, resource_group, postgresql_server.name
                     )
-                    log_retention_days = self.__get_log_retention_days__(
+                    log_retention_days = self._get_log_retention_days(
                         subscription, resource_group, postgresql_server.name
                     )
-                    firewall = self.__get_firewall__(
+                    firewall = self._get_firewall(
                         subscription, resource_group, postgresql_server.name
                     )
-                    location = self.__get_location__(
+                    location = self._get_location(
                         subscription, resource_group, postgresql_server.name
                     )
                     flexible_servers[subscription].append(
@@ -66,11 +66,11 @@ class PostgreSQL(AzureService):
                 )
         return flexible_servers
 
-    def __get_resource_group__(self, id):
+    def _get_resource_group(self, id):
         resource_group = id.split("/")[4]
         return resource_group
 
-    def __get_require_secure_transport__(
+    def _get_require_secure_transport(
         self, subscription, resouce_group_name, server_name
     ):
         client = self.clients[subscription]
@@ -79,42 +79,40 @@ class PostgreSQL(AzureService):
         )
         return require_secure_transport.value.upper()
 
-    def __get_log_checkpoints__(self, subscription, resouce_group_name, server_name):
+    def _get_log_checkpoints(self, subscription, resouce_group_name, server_name):
         client = self.clients[subscription]
         log_checkpoints = client.configurations.get(
             resouce_group_name, server_name, "log_checkpoints"
         )
         return log_checkpoints.value.upper()
 
-    def __get_log_connections__(self, subscription, resouce_group_name, server_name):
+    def _get_log_connections(self, subscription, resouce_group_name, server_name):
         client = self.clients[subscription]
         log_connections = client.configurations.get(
             resouce_group_name, server_name, "log_connections"
         )
         return log_connections.value.upper()
 
-    def __get_log_disconnections__(self, subscription, resouce_group_name, server_name):
+    def _get_log_disconnections(self, subscription, resouce_group_name, server_name):
         client = self.clients[subscription]
         log_disconnections = client.configurations.get(
             resouce_group_name, server_name, "log_disconnections"
         )
         return log_disconnections.value.upper()
 
-    def __get_location__(self, subscription, resouce_group_name, server_name):
+    def _get_location(self, subscription, resouce_group_name, server_name):
         client = self.clients[subscription]
         location = client.servers.get(resouce_group_name, server_name).location
         return location
 
-    def __get_connection_throttling__(
-        self, subscription, resouce_group_name, server_name
-    ):
+    def _get_connection_throttling(self, subscription, resouce_group_name, server_name):
         client = self.clients[subscription]
         connection_throttling = client.configurations.get(
             resouce_group_name, server_name, "connection_throttle.enable"
         )
         return connection_throttling.value.upper()
 
-    def __get_log_retention_days__(self, subscription, resouce_group_name, server_name):
+    def _get_log_retention_days(self, subscription, resouce_group_name, server_name):
         client = self.clients[subscription]
         try:
             log_retention_days = client.configurations.get(
@@ -125,7 +123,7 @@ class PostgreSQL(AzureService):
             log_retention_days = None
         return log_retention_days
 
-    def __get_firewall__(self, subscription, resource_group, server_name):
+    def _get_firewall(self, subscription, resource_group, server_name):
         client = self.clients[subscription]
         firewall = client.firewall_rules.list_by_server(resource_group, server_name)
         firewall_list = []

--- a/prowler/providers/azure/services/sqlserver/sqlserver_service.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_service.py
@@ -20,9 +20,9 @@ from prowler.providers.azure.lib.service.service import AzureService
 class SQLServer(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(SqlManagementClient, provider)
-        self.sql_servers = self.__get_sql_servers__()
+        self.sql_servers = self._get_sql_servers()
 
-    def __get_sql_servers__(self):
+    def _get_sql_servers(self):
         logger.info("SQL Server - Getting SQL servers...")
         sql_servers = {}
         for subscription, client in self.clients.items():
@@ -30,25 +30,23 @@ class SQLServer(AzureService):
                 sql_servers.update({subscription: []})
                 sql_servers_list = client.servers.list()
                 for sql_server in sql_servers_list:
-                    resource_group = self.__get_resource_group__(sql_server.id)
-                    auditing_policies = self.__get_server_blob_auditing_policies__(
+                    resource_group = self._get_resource_group(sql_server.id)
+                    auditing_policies = self._get_server_blob_auditing_policies(
                         subscription, resource_group, sql_server.name
                     )
-                    firewall_rules = self.__get_firewall_rules__(
+                    firewall_rules = self._get_firewall_rules(
                         subscription, resource_group, sql_server.name
                     )
-                    encryption_protector = self.__get_enctyption_protectors__(
+                    encryption_protector = self._get_enctyption_protectors(
                         subscription, resource_group, sql_server.name
                     )
-                    vulnerability_assessment = self.__get_vulnerability_assesments__(
+                    vulnerability_assessment = self._get_vulnerability_assesments(
                         subscription, resource_group, sql_server.name
                     )
-                    security_alert_policies = (
-                        self.__get_server_security_alert_policies__(
-                            subscription, resource_group, sql_server.name
-                        )
+                    security_alert_policies = self._get_server_security_alert_policies(
+                        subscription, resource_group, sql_server.name
                     )
-                    location = self.__get_location__(
+                    location = self._get_location(
                         subscription, resource_group, sql_server.name
                     )
 
@@ -62,7 +60,7 @@ class SQLServer(AzureService):
                             auditing_policies=auditing_policies,
                             firewall_rules=firewall_rules,
                             encryption_protector=encryption_protector,
-                            databases=self.__get_databases__(
+                            databases=self._get_databases(
                                 subscription, resource_group, sql_server.name
                             ),
                             vulnerability_assessment=vulnerability_assessment,
@@ -76,11 +74,11 @@ class SQLServer(AzureService):
                 )
         return sql_servers
 
-    def __get_resource_group__(self, id):
+    def _get_resource_group(self, id):
         resource_group = id.split("/")[4]
         return resource_group
 
-    def __get_transparent_data_encryption__(
+    def _get_transparent_data_encryption(
         self, subscription, resource_group, server_name, database_name
     ):
         client = self.clients[subscription]
@@ -92,7 +90,7 @@ class SQLServer(AzureService):
         )
         return tde_encrypted
 
-    def __get_enctyption_protectors__(self, subscription, resource_group, server_name):
+    def _get_enctyption_protectors(self, subscription, resource_group, server_name):
         client = self.clients[subscription]
         encryption_protectors = client.encryption_protectors.get(
             resource_group_name=resource_group,
@@ -101,7 +99,7 @@ class SQLServer(AzureService):
         )
         return encryption_protectors
 
-    def __get_databases__(self, subscription, resource_group, server_name):
+    def _get_databases(self, subscription, resource_group, server_name):
         logger.info("SQL Server - Getting server databases...")
         databases = []
         try:
@@ -111,7 +109,7 @@ class SQLServer(AzureService):
                 server_name=server_name,
             )
             for database in databases_server:
-                tde_encrypted = self.__get_transparent_data_encryption__(
+                tde_encrypted = self._get_transparent_data_encryption(
                     subscription, resource_group, server_name, database.name
                 )
                 databases.append(
@@ -130,9 +128,7 @@ class SQLServer(AzureService):
             )
         return databases
 
-    def __get_vulnerability_assesments__(
-        self, subscription, resource_group, server_name
-    ):
+    def _get_vulnerability_assesments(self, subscription, resource_group, server_name):
         client = self.clients[subscription]
         vulnerability_assessment = client.server_vulnerability_assessments.get(
             resource_group_name=resource_group,
@@ -141,7 +137,7 @@ class SQLServer(AzureService):
         )
         return vulnerability_assessment
 
-    def __get_server_blob_auditing_policies__(
+    def _get_server_blob_auditing_policies(
         self, subscription, resource_group, server_name
     ):
         client = self.clients[subscription]
@@ -151,14 +147,14 @@ class SQLServer(AzureService):
         )
         return auditing_policies
 
-    def __get_firewall_rules__(self, subscription, resource_group, server_name):
+    def _get_firewall_rules(self, subscription, resource_group, server_name):
         client = self.clients[subscription]
         firewall_rules = client.firewall_rules.list_by_server(
             resource_group_name=resource_group, server_name=server_name
         )
         return firewall_rules
 
-    def __get_server_security_alert_policies__(
+    def _get_server_security_alert_policies(
         self, subscription, resource_group, server_name
     ):
         client = self.clients[subscription]
@@ -169,7 +165,7 @@ class SQLServer(AzureService):
         )
         return security_alert_policies
 
-    def __get_location__(self, subscription, resouce_group_name, server_name):
+    def _get_location(self, subscription, resouce_group_name, server_name):
         client = self.clients[subscription]
         location = client.servers.get(resouce_group_name, server_name).location
 

--- a/prowler/providers/azure/services/storage/storage_service.py
+++ b/prowler/providers/azure/services/storage/storage_service.py
@@ -16,10 +16,10 @@ from prowler.providers.azure.lib.service.service import AzureService
 class Storage(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(StorageManagementClient, provider)
-        self.storage_accounts = self.__get_storage_accounts__()
-        self.__get_blob_properties__()
+        self.storage_accounts = self._get_storage_accounts()
+        self._get_blob_properties()
 
-    def __get_storage_accounts__(self):
+    def _get_storage_accounts(self):
         logger.info("Storage - Getting storage accounts...")
         storage_accounts = {}
         for subscription, client in self.clients.items():
@@ -60,7 +60,7 @@ class Storage(AzureService):
                 )
         return storage_accounts
 
-    def __get_blob_properties__(self):
+    def _get_blob_properties(self):
         logger.info("Storage - Getting blob properties...")
         try:
             for subscription, accounts in self.storage_accounts.items():

--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -12,10 +12,10 @@ from prowler.providers.azure.lib.service.service import AzureService
 class VirtualMachines(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(ComputeManagementClient, provider)
-        self.virtual_machines = self.__get_virtual_machines__()
-        self.disks = self.__get_disks__()
+        self.virtual_machines = self._get_virtual_machines()
+        self.disks = self._get_disks()
 
-    def __get_virtual_machines__(self):
+    def _get_virtual_machines(self):
         logger.info("VirtualMachines - Getting virtual machines...")
         virtual_machines = {}
 
@@ -43,7 +43,7 @@ class VirtualMachines(AzureService):
 
         return virtual_machines
 
-    def __get_disks__(self):
+    def _get_disks(self):
         logger.info("VirtualMachines - Getting disks...")
         disks = {}
 

--- a/prowler/providers/gcp/lib/service/service.py
+++ b/prowler/providers/gcp/lib/service/service.py
@@ -33,7 +33,7 @@ class GCPService:
         self.audit_config = provider.audit_config
         self.fixer_config = provider.fixer_config
 
-    def __get_client__(self):
+    def _get_client(self):
         return self.client
 
     def __threading_call__(self, call, iterator):

--- a/prowler/providers/gcp/services/apikeys/apikeys_service.py
+++ b/prowler/providers/gcp/services/apikeys/apikeys_service.py
@@ -11,9 +11,9 @@ class APIKeys(GCPService):
         super().__init__(__class__.__name__, provider, api_version="v2")
 
         self.keys = []
-        self.__get_keys__()
+        self._get_keys()
 
-    def __get_keys__(self):
+    def _get_keys(self):
         for project_id in self.project_ids:
             try:
                 request = (

--- a/prowler/providers/gcp/services/bigquery/bigquery_service.py
+++ b/prowler/providers/gcp/services/bigquery/bigquery_service.py
@@ -12,10 +12,10 @@ class BigQuery(GCPService):
 
         self.datasets = []
         self.tables = []
-        self.__get_datasets__()
-        self.__get_tables__()
+        self._get_datasets()
+        self._get_tables()
 
-    def __get_datasets__(self):
+    def _get_datasets(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.datasets().list(projectId=project_id)
@@ -59,7 +59,7 @@ class BigQuery(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_tables__(self):
+    def _get_tables(self):
         for dataset in self.datasets:
             try:
                 request = self.client.tables().list(

--- a/prowler/providers/gcp/services/cloudresourcemanager/cloudresourcemanager_service.py
+++ b/prowler/providers/gcp/services/cloudresourcemanager/cloudresourcemanager_service.py
@@ -13,10 +13,10 @@ class CloudResourceManager(GCPService):
         self.bindings = []
         self.projects = []
         self.organizations = []
-        self.__get_iam_policy__()
-        self.__get_organizations__()
+        self._get_iam_policy()
+        self._get_organizations()
 
-    def __get_iam_policy__(self):
+    def _get_iam_policy(self):
         for project_id in self.project_ids:
             try:
                 policy = (
@@ -41,7 +41,7 @@ class CloudResourceManager(GCPService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_organizations__(self):
+    def _get_organizations(self):
         try:
             response = self.client.organizations().search().execute()
             for org in response.get("organizations", []):

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_service.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_service.py
@@ -10,9 +10,9 @@ class CloudSQL(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__("sqladmin", provider)
         self.instances = []
-        self.__get_instances__()
+        self._get_instances()
 
-    def __get_instances__(self):
+    def _get_instances(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.instances().list(project=project_id)

--- a/prowler/providers/gcp/services/cloudstorage/cloudstorage_service.py
+++ b/prowler/providers/gcp/services/cloudstorage/cloudstorage_service.py
@@ -12,9 +12,9 @@ class CloudStorage(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__("storage", provider)
         self.buckets = []
-        self.__get_buckets__()
+        self._get_buckets()
 
-    def __get_buckets__(self):
+    def _get_buckets(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.buckets().list(project=project_id)

--- a/prowler/providers/gcp/services/compute/compute_service.py
+++ b/prowler/providers/gcp/services/compute/compute_service.py
@@ -18,18 +18,18 @@ class Compute(GCPService):
         self.firewalls = []
         self.projects = []
         self.load_balancers = []
-        self.__get_url_maps__()
-        self.__describe_backend_service__()
-        self.__get_regions__()
-        self.__get_projects__()
-        self.__get_zones__()
-        self.__threading_call__(self.__get_instances__, self.zones)
-        self.__get_networks__()
-        self.__threading_call__(self.__get_subnetworks__, self.regions)
-        self.__get_firewalls__()
-        self.__threading_call__(self.__get_addresses__, self.regions)
+        self._get_url_maps()
+        self._describe_backend_service()
+        self._get_regions()
+        self._get_projects()
+        self._get_zones()
+        self.__threading_call__(self._get_instances, self.zones)
+        self._get_networks()
+        self.__threading_call__(self._get_subnetworks, self.regions)
+        self._get_firewalls()
+        self.__threading_call__(self._get_addresses, self.regions)
 
-    def __get_regions__(self):
+    def _get_regions(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.regions().list(project=project_id)
@@ -47,7 +47,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_zones__(self):
+    def _get_zones(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.zones().list(project=project_id)
@@ -65,7 +65,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_projects__(self):
+    def _get_projects(self):
         for project_id in self.project_ids:
             try:
                 enable_oslogin = False
@@ -81,7 +81,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_instances__(self, zone):
+    def _get_instances(self, zone):
         for project_id in self.project_ids:
             try:
                 request = self.client.instances().list(project=project_id, zone=zone)
@@ -139,7 +139,7 @@ class Compute(GCPService):
                     f"{zone} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_networks__(self):
+    def _get_networks(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.networks().list(project=project_id)
@@ -170,7 +170,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_subnetworks__(self, region):
+    def _get_subnetworks(self, region):
         for project_id in self.project_ids:
             try:
                 request = self.client.subnetworks().list(
@@ -200,7 +200,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_addresses__(self, region):
+    def _get_addresses(self, region):
         for project_id in self.project_ids:
             try:
                 request = self.client.addresses().list(
@@ -230,7 +230,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_firewalls__(self):
+    def _get_firewalls(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.firewalls().list(project=project_id)
@@ -257,7 +257,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_url_maps__(self):
+    def _get_url_maps(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.urlMaps().list(project=project_id)
@@ -281,7 +281,7 @@ class Compute(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __describe_backend_service__(self):
+    def _describe_backend_service(self):
         for balancer in self.load_balancers:
             try:
                 response = (

--- a/prowler/providers/gcp/services/dataproc/dataproc_service.py
+++ b/prowler/providers/gcp/services/dataproc/dataproc_service.py
@@ -12,9 +12,9 @@ class Dataproc(GCPService):
         super().__init__(__class__.__name__, provider)
         self.regions = compute_client.regions
         self.clusters = []
-        self.__threading_call__(self.__get_clusters__, self.regions)
+        self.__threading_call__(self._get_clusters, self.regions)
 
-    def __get_clusters__(self, region):
+    def _get_clusters(self, region):
         for project_id in self.project_ids:
             try:
                 request = (

--- a/prowler/providers/gcp/services/dns/dns_service.py
+++ b/prowler/providers/gcp/services/dns/dns_service.py
@@ -10,11 +10,11 @@ class DNS(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__(__class__.__name__, provider)
         self.managed_zones = []
-        self.__get_managed_zones__()
+        self._get_managed_zones()
         self.policies = []
-        self.__get_policies__()
+        self._get_policies()
 
-    def __get_managed_zones__(self):
+    def _get_managed_zones(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.managedZones().list(project=project_id)
@@ -41,7 +41,7 @@ class DNS(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_policies__(self):
+    def _get_policies(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.policies().list(project=project_id)

--- a/prowler/providers/gcp/services/gke/gke_service.py
+++ b/prowler/providers/gcp/services/gke/gke_service.py
@@ -10,11 +10,11 @@ class GKE(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__("container", provider, api_version="v1beta1")
         self.locations = []
-        self.__get_locations__()
+        self._get_locations()
         self.clusters = {}
-        self.__threading_call__(self.__get_clusters__, self.locations)
+        self.__threading_call__(self._get_clusters, self.locations)
 
-    def __get_locations__(self):
+    def _get_locations(self):
         for project_id in self.project_ids:
             try:
                 request = (
@@ -34,7 +34,7 @@ class GKE(GCPService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_clusters__(self, location):
+    def _get_clusters(self, location):
         try:
             request = (
                 self.client.projects()

--- a/prowler/providers/gcp/services/iam/iam_service.py
+++ b/prowler/providers/gcp/services/iam/iam_service.py
@@ -15,10 +15,10 @@ class IAM(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__(__class__.__name__, provider)
         self.service_accounts = []
-        self.__get_service_accounts__()
-        self.__get_service_accounts_keys__()
+        self._get_service_accounts()
+        self._get_service_accounts_keys()
 
-    def __get_service_accounts__(self):
+    def _get_service_accounts(self):
         for project_id in self.project_ids:
             try:
                 request = (
@@ -49,7 +49,7 @@ class IAM(GCPService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_service_accounts_keys__(self):
+    def _get_service_accounts_keys(self):
         try:
             for sa in self.service_accounts:
                 request = (
@@ -107,9 +107,9 @@ class AccessApproval(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__(__class__.__name__, provider)
         self.settings = {}
-        self.__get_settings__()
+        self._get_settings()
 
-    def __get_settings__(self):
+    def _get_settings(self):
         for project_id in self.project_ids:
             try:
                 response = (
@@ -138,9 +138,9 @@ class EssentialContacts(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__(__class__.__name__, provider)
         self.organizations = []
-        self.__get_contacts__()
+        self._get_contacts()
 
-    def __get_contacts__(self):
+    def _get_contacts(self):
         for org in cloudresourcemanager_client.organizations:
             try:
                 contacts = False

--- a/prowler/providers/gcp/services/kms/kms_service.py
+++ b/prowler/providers/gcp/services/kms/kms_service.py
@@ -14,12 +14,12 @@ class KMS(GCPService):
         self.locations = []
         self.key_rings = []
         self.crypto_keys = []
-        self.__get_locations__()
-        self.__threading_call__(self.__get_key_rings__, self.locations)
-        self.__get_crypto_keys__()
-        self.__get_crypto_keys_iam_policy__()
+        self._get_locations()
+        self.__threading_call__(self._get_key_rings, self.locations)
+        self._get_crypto_keys()
+        self._get_crypto_keys_iam_policy()
 
-    def __get_locations__(self):
+    def _get_locations(self):
         for project_id in self.project_ids:
             try:
                 request = (
@@ -45,7 +45,7 @@ class KMS(GCPService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_key_rings__(self, location):
+    def _get_key_rings(self, location):
         try:
             request = (
                 self.client.projects().locations().keyRings().list(parent=location.name)
@@ -72,7 +72,7 @@ class KMS(GCPService):
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __get_crypto_keys__(self):
+    def _get_crypto_keys(self):
         for ring in self.key_rings:
             try:
                 request = (
@@ -110,7 +110,7 @@ class KMS(GCPService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_crypto_keys_iam_policy__(self):
+    def _get_crypto_keys_iam_policy(self):
         for key in self.crypto_keys:
             try:
                 request = (

--- a/prowler/providers/gcp/services/logging/logging_service.py
+++ b/prowler/providers/gcp/services/logging/logging_service.py
@@ -11,10 +11,10 @@ class Logging(GCPService):
         super().__init__(__class__.__name__, provider, api_version="v2")
         self.sinks = []
         self.metrics = []
-        self.__get_sinks__()
-        self.__get_metrics__()
+        self._get_sinks()
+        self._get_metrics()
 
-    def __get_sinks__(self):
+    def _get_sinks(self):
         for project_id in self.project_ids:
             try:
                 request = self.client.sinks().list(parent=f"projects/{project_id}")
@@ -39,7 +39,7 @@ class Logging(GCPService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
-    def __get_metrics__(self):
+    def _get_metrics(self):
         for project_id in self.project_ids:
             try:
                 request = (

--- a/prowler/providers/gcp/services/monitoring/monitoring_service.py
+++ b/prowler/providers/gcp/services/monitoring/monitoring_service.py
@@ -10,9 +10,9 @@ class Monitoring(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__(__class__.__name__, provider, api_version="v3")
         self.alert_policies = []
-        self.__get_alert_policies__()
+        self._get_alert_policies()
 
-    def __get_alert_policies__(self):
+    def _get_alert_policies(self):
         for project_id in self.project_ids:
             try:
                 request = (

--- a/prowler/providers/gcp/services/serviceusage/serviceusage_service.py
+++ b/prowler/providers/gcp/services/serviceusage/serviceusage_service.py
@@ -10,9 +10,9 @@ class ServiceUsage(GCPService):
     def __init__(self, provider: GcpProvider):
         super().__init__(__class__.__name__, provider)
         self.active_services = {}
-        self.__get_active_services__()
+        self._get_active_services()
 
-    def __get_active_services__(self):
+    def _get_active_services(self):
         for project_id in self.project_ids:
             self.active_services[project_id] = []
             try:

--- a/prowler/providers/kubernetes/services/apiserver/apiserver_service.py
+++ b/prowler/providers/kubernetes/services/apiserver/apiserver_service.py
@@ -10,9 +10,9 @@ class APIServer(KubernetesService):
         super().__init__(provider)
         self.client = core_client
 
-        self.apiserver_pods = self.__get_apiserver_pods__()
+        self.apiserver_pods = self._get_apiserver_pods()
 
-    def __get_apiserver_pods__(self):
+    def _get_apiserver_pods(self):
         try:
             apiserver_pods = []
             for pod in self.client.pods.values():

--- a/prowler/providers/kubernetes/services/controllermanager/controllermanager_service.py
+++ b/prowler/providers/kubernetes/services/controllermanager/controllermanager_service.py
@@ -10,9 +10,9 @@ class ControllerManager(KubernetesService):
         super().__init__(provider)
         self.client = core_client
 
-        self.controllermanager_pods = self.__get_controllermanager_pods__()
+        self.controllermanager_pods = self._get_controllermanager_pods()
 
-    def __get_controllermanager_pods__(self):
+    def _get_controllermanager_pods(self):
         try:
             controllermanager_pods = []
             for pod in self.client.pods.values():

--- a/prowler/providers/kubernetes/services/core/core_service.py
+++ b/prowler/providers/kubernetes/services/core/core_service.py
@@ -18,14 +18,14 @@ class Core(KubernetesService):
         self.client = client.CoreV1Api(self.api_client)
         self.namespaces = provider.namespaces
         self.pods = {}
-        self.__get_pods__()
+        self._get_pods()
         self.config_maps = {}
-        self.__list_config_maps__()
+        self._list_config_maps()
         self.nodes = {}
-        self.__list_nodes__()
-        self.__in_worker_node__()
+        self._list_nodes()
+        self._in_worker_node()
 
-    def __get_pods__(self):
+    def _get_pods(self):
         try:
             for namespace in self.namespaces:
                 pods = self.client.list_namespaced_pod(namespace)
@@ -87,7 +87,7 @@ class Core(KubernetesService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_config_maps__(self):
+    def _list_config_maps(self):
         try:
             response = self.client.list_config_map_for_all_namespaces()
             for cm in response.items:
@@ -104,7 +104,7 @@ class Core(KubernetesService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __list_nodes__(self):
+    def _list_nodes(self):
         try:
             response = self.client.list_node()
             for node in response.items:
@@ -131,7 +131,7 @@ class Core(KubernetesService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def __in_worker_node__(self):
+    def _in_worker_node(self):
         try:
             hostname = socket.gethostname()
             for node in self.nodes.values():

--- a/prowler/providers/kubernetes/services/etcd/etcd_service.py
+++ b/prowler/providers/kubernetes/services/etcd/etcd_service.py
@@ -10,9 +10,9 @@ class Etcd(KubernetesService):
         super().__init__(provider)
         self.client = core_client
 
-        self.etcd_pods = self.__get_etcd_pods__()
+        self.etcd_pods = self._get_etcd_pods()
 
-    def __get_etcd_pods__(self):
+    def _get_etcd_pods(self):
         try:
             etcd_pods = []
             for pod in self.client.pods.values():

--- a/prowler/providers/kubernetes/services/kubelet/kubelet_service.py
+++ b/prowler/providers/kubernetes/services/kubelet/kubelet_service.py
@@ -12,9 +12,9 @@ class Kubelet(KubernetesService):
         super().__init__(provider)
         self.client = core_client
 
-        self.kubelet_config_maps = self.__get_kubelet_config_maps__()
+        self.kubelet_config_maps = self._get_kubelet_config_maps()
 
-    def __get_kubelet_config_maps__(self):
+    def _get_kubelet_config_maps(self):
         try:
             kubelet_config_maps = []
             for cm in self.client.config_maps.values():

--- a/prowler/providers/kubernetes/services/rbac/rbac_service.py
+++ b/prowler/providers/kubernetes/services/rbac/rbac_service.py
@@ -14,12 +14,12 @@ class Rbac(KubernetesService):
         super().__init__(provider)
         self.client = client.RbacAuthorizationV1Api()
 
-        self.cluster_role_bindings = self.__list_cluster_role_bindings__()
-        self.role_bindings = self.__list_role_bindings__()
-        self.cluster_roles = self.__list_cluster_roles__()
-        self.roles = self.__list_roles__()
+        self.cluster_role_bindings = self._list_cluster_role_bindings()
+        self.role_bindings = self._list_role_bindings()
+        self.cluster_roles = self._list_cluster_roles()
+        self.roles = self._list_roles()
 
-    def __list_cluster_role_bindings__(self):
+    def _list_cluster_role_bindings(self):
         try:
             bindings = {}
             for binding in self.client.list_cluster_role_binding().items:
@@ -53,7 +53,7 @@ class Rbac(KubernetesService):
             )
             return {}
 
-    def __list_role_bindings__(self):
+    def _list_role_bindings(self):
         try:
             role_bindings = {}
             for binding in self.client.list_role_binding_for_all_namespaces().items:
@@ -82,7 +82,7 @@ class Rbac(KubernetesService):
             )
             return {}
 
-    def __list_roles__(self):
+    def _list_roles(self):
         try:
             roles = {}
             for role in self.client.list_role_for_all_namespaces().items:
@@ -107,7 +107,7 @@ class Rbac(KubernetesService):
             )
             return {}
 
-    def __list_cluster_roles__(self):
+    def _list_cluster_roles(self):
         try:
             cluster_roles = {}
             for role in self.client.list_cluster_role().items:

--- a/prowler/providers/kubernetes/services/scheduler/scheduler_service.py
+++ b/prowler/providers/kubernetes/services/scheduler/scheduler_service.py
@@ -10,9 +10,9 @@ class Scheduler(KubernetesService):
         super().__init__(provider)
         self.client = core_client
 
-        self.scheduler_pods = self.__get_scheduler_pods__()
+        self.scheduler_pods = self._get_scheduler_pods()
 
-    def __get_scheduler_pods__(self):
+    def _get_scheduler_pods(self):
         try:
             scheduler_pods = []
             for pod in self.client.pods.values():

--- a/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
+++ b/tests/providers/aws/services/accessanalyzer/accessanalyzer_service_test.py
@@ -70,7 +70,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_AccessAnalyzer_Service:
     # Test AccessAnalyzer Client
-    def test__get_client__(self):
+    def test_get_client(self):
         access_analyzer = AccessAnalyzer(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
         )
@@ -93,7 +93,7 @@ class Test_AccessAnalyzer_Service:
         )
         assert access_analyzer.service == "accessanalyzer"
 
-    def test__list_analyzers__(self):
+    def test_list_analyzers(self):
         access_analyzer = AccessAnalyzer(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
         )
@@ -105,7 +105,7 @@ class Test_AccessAnalyzer_Service:
         assert access_analyzer.analyzers[0].type == "ACCOUNT"
         assert access_analyzer.analyzers[0].region == AWS_REGION_EU_WEST_1
 
-    def test__list_findings__(self):
+    def test_list_findings(self):
         access_analyzer = AccessAnalyzer(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
         )

--- a/tests/providers/aws/services/apigateway/apigateway_service_test.py
+++ b/tests/providers/aws/services/apigateway/apigateway_service_test.py
@@ -45,7 +45,7 @@ class Test_APIGateway_Service:
 
     # Test APIGateway Get Rest APIs
     @mock_aws
-    def test__get_rest_apis__(self):
+    def test_get_rest_apis(self):
         # Generate APIGateway Client
         apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
@@ -61,7 +61,7 @@ class Test_APIGateway_Service:
 
     # Test APIGateway Get Authorizers
     @mock_aws
-    def test__get_authorizers__(self):
+    def test_get_authorizers(self):
         # Generate APIGateway Client
         apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API
@@ -81,7 +81,7 @@ class Test_APIGateway_Service:
 
     # Test APIGateway Get Rest API
     @mock_aws
-    def test__get_rest_api__(self):
+    def test_get_rest_api(self):
         # Generate APIGateway Client
         apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create private APIGateway Rest API
@@ -98,7 +98,7 @@ class Test_APIGateway_Service:
 
     # Test APIGateway Get Stages
     @mock_aws
-    def test__get_stages__(self):
+    def test_get_stages(self):
         # Generate APIGateway Client
         apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
         # Create APIGateway Rest API and a deployment stage
@@ -147,9 +147,9 @@ class Test_APIGateway_Service:
         apigateway = APIGateway(aws_provider)
         assert apigateway.rest_apis[0].stages[0].logging is True
 
-    # Test APIGateway __get_resources__
+    # Test APIGateway _get_resources
     @mock_aws
-    def test__get_resources__(self):
+    def test_get_resources(self):
         apigateway_client = client("apigateway", region_name=AWS_REGION_US_EAST_1)
 
         rest_api = apigateway_client.create_rest_api(

--- a/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
+++ b/tests/providers/aws/services/apigatewayv2/apigatewayv2_service_test.py
@@ -76,7 +76,7 @@ class Test_ApiGatewayV2_Service:
 
     # Test ApiGatewayV2 Get APIs
     @mock_aws
-    def test__get_apis__(self):
+    def test_get_apis(self):
         # Generate ApiGatewayV2 Client
         apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 API
@@ -91,7 +91,7 @@ class Test_ApiGatewayV2_Service:
 
     # Test ApiGatewayV2 Get Authorizers
     @mock_aws
-    def test__get_authorizers__(self):
+    def test_get_authorizers(self):
         # Generate ApiGatewayV2 Client
         apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 Rest API
@@ -111,7 +111,7 @@ class Test_ApiGatewayV2_Service:
 
     # Test ApiGatewayV2 Get Stages
     @mock_aws
-    def test__get_stages__(self):
+    def test_get_stages(self):
         # Generate ApiGatewayV2 Client
         apigatewayv2_client = client("apigatewayv2", region_name=AWS_REGION_US_EAST_1)
         # Create ApiGatewayV2 Rest API and a deployment stage

--- a/tests/providers/aws/services/appstream/appstream_service_test.py
+++ b/tests/providers/aws/services/appstream/appstream_service_test.py
@@ -67,7 +67,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_AppStream_Service:
     # Test AppStream Client
-    def test__get_client__(self):
+    def test_get_client(self):
         appstream = AppStream(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert appstream.regional_clients[AWS_REGION].__class__.__name__ == "AppStream"
 
@@ -81,7 +81,7 @@ class Test_AppStream_Service:
         appstream = AppStream(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert appstream.service == "appstream"
 
-    def test__describe_fleets__(self):
+    def test_describe_fleets(self):
         # Set partition for the service
         appstream = AppStream(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert len(appstream.fleets) == 2
@@ -108,7 +108,7 @@ class Test_AppStream_Service:
         assert appstream.fleets[1].enable_default_internet_access is True
         assert appstream.fleets[1].region == AWS_REGION
 
-    def test__list_tags_for_resource__(self):
+    def test_list_tags_for_resource(self):
         # Set partition for the service
         appstream = AppStream(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert len(appstream.fleets) == 2

--- a/tests/providers/aws/services/athena/athena_service_test.py
+++ b/tests/providers/aws/services/athena/athena_service_test.py
@@ -52,7 +52,7 @@ def mock_generate_regional_clients(provider, service):
 class Test_Athena_Service:
     # Test Athena Get Workgrups
     @mock_aws
-    def test__get_workgroups__not_encrypted(self):
+    def test_get_workgroupsnot_encrypted(self):
         default_workgroup_name = "primary"
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         workgroup_arn = f"arn:{aws_provider.identity.partition}:athena:{AWS_REGION_EU_WEST_1}:{aws_provider.identity.account}:workgroup/{default_workgroup_name}"
@@ -76,7 +76,7 @@ class Test_Athena_Service:
     # We mock the get_work_group to return an encrypted workgroup
     @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     @mock_aws
-    def test__get_workgroups__encrypted(self):
+    def test_get_workgroupsencrypted(self):
         default_workgroup_name = "primary"
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 

--- a/tests/providers/aws/services/autoscaling/autoscaling_service_test.py
+++ b/tests/providers/aws/services/autoscaling/autoscaling_service_test.py
@@ -48,7 +48,7 @@ class Test_AutoScaling_Service:
 
     # Test AutoScaling Get APIs
     @mock_aws
-    def test__describe_launch_configurations__(self):
+    def test_describe_launch_configurations(self):
         # Generate AutoScaling Client
         autoscaling_client = client("autoscaling", region_name=AWS_REGION_US_EAST_1)
         # Create AutoScaling API
@@ -84,7 +84,7 @@ class Test_AutoScaling_Service:
 
     # Test Describe Auto Scaling Groups
     @mock_aws
-    def test__describe_auto_scaling_groups__(self):
+    def test_describe_auto_scaling_groups(self):
         # Generate AutoScaling Client
         autoscaling_client = client("autoscaling", region_name=AWS_REGION_US_EAST_1)
         autoscaling_client.create_launch_configuration(

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
@@ -47,13 +47,13 @@ def get_lambda_code_with_secrets(code):
     )
 
 
-def mock__get_function_code__with_secrets():
+def mock_get_function_codewith_secrets():
     yield create_lambda_function(), get_lambda_code_with_secrets(
         LAMBDA_FUNCTION_CODE_WITH_SECRETS
     )
 
 
-def mock__get_function_code__without_secrets():
+def mock_get_function_codewithout_secrets():
     yield create_lambda_function(), get_lambda_code_with_secrets(
         LAMBDA_FUNCTION_CODE_WITHOUT_SECRETS
     )
@@ -84,7 +84,7 @@ class Test_awslambda_function_no_secrets_in_code:
     def test_function_code_with_secrets(self):
         lambda_client = mock.MagicMock
         lambda_client.functions = {LAMBDA_FUNCTION_ARN: create_lambda_function()}
-        lambda_client.__get_function_code__ = mock__get_function_code__with_secrets
+        lambda_client._get_function_code = mock_get_function_codewith_secrets
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=set_mocked_aws_provider(),
@@ -115,7 +115,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client = mock.MagicMock
         lambda_client.functions = {LAMBDA_FUNCTION_ARN: create_lambda_function()}
 
-        lambda_client.__get_function_code__ = mock__get_function_code__without_secrets
+        lambda_client._get_function_code = mock_get_function_codewithout_secrets
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/aws/services/awslambda/awslambda_service_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_service_test.py
@@ -68,7 +68,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_Lambda_Service:
     # Test Lambda Client
-    def test__get_client__(self):
+    def test_get_client(self):
         awslambda = Lambda(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert (
             awslambda.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
@@ -86,7 +86,7 @@ class Test_Lambda_Service:
         assert awslambda.service == "lambda"
 
     @mock_aws
-    def test__list_functions__(self):
+    def test_list_functions(self):
         # Create IAM Lambda Role
         iam_client = client("iam", region_name=AWS_REGION_EU_WEST_1)
         iam_role = iam_client.create_role(
@@ -237,7 +237,7 @@ class Test_Lambda_Service:
 
             # Lambda Code
             with tempfile.TemporaryDirectory() as tmp_dir_name:
-                for function, function_code in awslambda.__get_function_code__():
+                for function, function_code in awslambda._get_function_code():
                     if function.arn == lambda_arn_1 or function.arn == lambda_arn_2:
                         assert search(
                             f"s3://awslambda-{function.region}-tasks.s3-{function.region}.amazonaws.com",

--- a/tests/providers/aws/services/backup/backup_service_test.py
+++ b/tests/providers/aws/services/backup/backup_service_test.py
@@ -73,7 +73,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_Backup_Service:
     # Test Backup Client
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         backup = Backup(aws_provider)
         assert (
@@ -93,7 +93,7 @@ class Test_Backup_Service:
         assert access_analyzer.service == "backup"
 
     # Test Backup List Backup Vaults
-    def test__list_backup_vaults__(self):
+    def test_list_backup_vaults(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         backup = Backup(aws_provider)
         assert len(backup.backup_vaults) == 1
@@ -107,7 +107,7 @@ class Test_Backup_Service:
         assert backup.backup_vaults[0].max_retention_days == 2
 
     # Test Backup List Backup Plans
-    def test__list_backup_plans__(self):
+    def test_list_backup_plans(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         backup = Backup(aws_provider)
         assert len(backup.backup_plans) == 1
@@ -120,7 +120,7 @@ class Test_Backup_Service:
         assert backup.backup_plans[0].advanced_settings == []
 
     # Test Backup List Report Plans
-    def test__list_backup_report_plans__(self):
+    def test_list_backup_report_plans(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         backup = Backup(aws_provider)
         assert len(backup.backup_report_plans) == 1

--- a/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_service_test.py
@@ -136,7 +136,7 @@ def mock_generate_regional_clients(provider, service):
 class Test_CloudFormation_Service:
     # Test CloudFormation Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         cloudformation = CloudFormation(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
         assert (
             cloudformation.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
@@ -159,7 +159,7 @@ class Test_CloudFormation_Service:
         assert cloudformation.session.__class__.__name__ == "Session"
 
     @mock_aws
-    def test__describe_stacks__(self):
+    def test_describe_stacks(self):
         cloudformation_client = boto3.client(
             "cloudformation", region_name=AWS_REGION_EU_WEST_1
         )

--- a/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
@@ -149,7 +149,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 class Test_CloudFront_Service:
     # Test CloudFront Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         cloudfront = CloudFront(set_mocked_aws_provider())
         assert cloudfront.client.__class__.__name__ == "CloudFront"
 
@@ -166,13 +166,13 @@ class Test_CloudFront_Service:
         assert cloudfront.service == "cloudfront"
 
     @mock_aws
-    def test__list_distributions__zero(self):
+    def test_list_distributionszero(self):
         cloudfront = CloudFront(set_mocked_aws_provider())
 
         assert len(cloudfront.distributions) == 0
 
     @mock_aws
-    def test__list_distributions__complete(self):
+    def test_list_distributionscomplete(self):
         cloudfront_client = client("cloudfront")
         config = example_distribution_config("ref")
         response = cloudfront_client.create_distribution(DistributionConfig=config)

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_service_test.py
@@ -294,7 +294,7 @@ class Test_Cloudtrail_Service:
                     assert trail.data_events[0].is_advanced
 
     @mock_aws
-    def test__lookup_events__(self):
+    def test_lookup_events(self):
         cloudtrail_client_us_east_1 = client(
             "cloudtrail", region_name=AWS_REGION_US_EAST_1
         )
@@ -316,7 +316,7 @@ class Test_Cloudtrail_Service:
         assert len(cloudtrail.trails) == len(aws_provider.identity.audited_regions)
 
     @mock_aws
-    def test__list_tags_for_resource__(self):
+    def test_list_tags_for_resource(self):
         tag = "test-tag"
         cloudtrail_client_us_east_1 = client(
             "cloudtrail", region_name=AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration_test.py
@@ -9,7 +9,7 @@ from tests.providers.aws.utils import (
 )
 
 
-def mock__get_trail_arn_template__(region=None, *_) -> str:
+def mock_get_trail_arn_template(region=None, *_) -> str:
     if region:
         return f"arn:aws:cloudtrail:{region}:{AWS_ACCOUNT_NUMBER}:trail"
     else:
@@ -32,8 +32,8 @@ class Test_cloudtrail_threat_detection_enumeration:
     def test_no_trails(self):
         cloudtrail_client = mock.MagicMock()
         cloudtrail_client.trails = {}
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
         cloudtrail_client.audited_account = AWS_ACCOUNT_NUMBER
         cloudtrail_client.region = AWS_REGION_US_EAST_1
 
@@ -83,8 +83,8 @@ class Test_cloudtrail_threat_detection_enumeration:
             "threat_detection_enumeration_minutes": THREAT_DETECTION_MINUTES,
         }
 
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -132,8 +132,8 @@ class Test_cloudtrail_threat_detection_enumeration:
             "threat_detection_enumeration_minutes": THREAT_DETECTION_MINUTES,
         }
 
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -182,8 +182,8 @@ class Test_cloudtrail_threat_detection_enumeration:
             "threat_detection_enumeration_minutes": THREAT_DETECTION_MINUTES,
         }
 
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_threat_detection_privilege_escalation/cloudtrail_threat_detection_privilege_escalation_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_threat_detection_privilege_escalation/cloudtrail_threat_detection_privilege_escalation_test.py
@@ -9,7 +9,7 @@ from tests.providers.aws.utils import (
 )
 
 
-def mock__get_trail_arn_template__(region=None, *_) -> str:
+def mock_get_trail_arn_template(region=None, *_) -> str:
     if region:
         return f"arn:aws:cloudtrail:{region}:{AWS_ACCOUNT_NUMBER}:trail"
     else:
@@ -32,8 +32,8 @@ class Test_cloudtrail_threat_detection_privilege_escalation:
     def test_no_trails(self):
         cloudtrail_client = mock.MagicMock()
         cloudtrail_client.trails = {}
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
         cloudtrail_client.audited_account = AWS_ACCOUNT_NUMBER
         cloudtrail_client.region = AWS_REGION_US_EAST_1
 
@@ -81,8 +81,8 @@ class Test_cloudtrail_threat_detection_privilege_escalation:
             "threat_detection_privilege_escalation_minutes": 1440,
         }
 
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -131,8 +131,8 @@ class Test_cloudtrail_threat_detection_privilege_escalation:
             "threat_detection_privilege_escalation_minutes": 1440,
         }
 
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -181,8 +181,8 @@ class Test_cloudtrail_threat_detection_privilege_escalation:
             "threat_detection_privilege_escalation_minutes": 1440,
         }
 
-        cloudtrail_client.__lookup_events__ = mock__get_lookup_events__
-        cloudtrail_client.__get_trail_arn_template__ = mock__get_trail_arn_template__
+        cloudtrail_client._lookup_events = mock__get_lookup_events__
+        cloudtrail_client._get_trail_arn_template = mock_get_trail_arn_template
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -580,7 +580,7 @@ class Test_cloudwatch_changes_to_network_acls_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_changes_to_network_gateways_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_changes_to_network_route_tables_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_changes_to_vpcs_alarm_configured:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled_test.py
@@ -24,7 +24,7 @@ class Test_cloudwatch_cross_account_sharing_disabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -71,7 +71,7 @@ class Test_cloudwatch_cross_account_sharing_disabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -112,7 +112,7 @@ class Test_cloudwatch_cross_account_sharing_disabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_kms_encryption_enabled/cloudwatch_log_group_kms_encryption_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_kms_encryption_enabled/cloudwatch_log_group_kms_encryption_enabled_test.py
@@ -22,7 +22,7 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -64,7 +64,7 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -110,7 +110,7 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -151,7 +151,7 @@ class Test_cloudwatch_log_group_kms_encryption_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_no_secrets_in_logs/cloudwatch_log_group_no_secrets_in_logs_test.py
@@ -24,7 +24,7 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -74,7 +74,7 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -127,7 +127,7 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -167,7 +167,7 @@ class Test_cloudwatch_log_group_no_secrets_in_logs:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_retention_policy_specific_days_enabled/cloudwatch_log_group_retention_policy_specific_days_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_retention_policy_specific_days_enabled/cloudwatch_log_group_retention_policy_specific_days_enabled_test.py
@@ -24,7 +24,7 @@ class Test_cloudwatch_log_group_retention_policy_specific_days_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -66,7 +66,7 @@ class Test_cloudwatch_log_group_retention_policy_specific_days_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -120,7 +120,7 @@ class Test_cloudwatch_log_group_retention_policy_specific_days_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -174,7 +174,7 @@ class Test_cloudwatch_log_group_retention_policy_specific_days_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -228,7 +228,7 @@ class Test_cloudwatch_log_group_retention_policy_specific_days_enabled:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -95,7 +95,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -166,7 +166,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -249,7 +249,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -344,7 +344,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -439,7 +439,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -534,7 +534,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -594,7 +594,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -95,7 +95,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -166,7 +166,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -249,7 +249,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -344,7 +344,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -439,7 +439,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -534,7 +534,7 @@ class Test_cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_c
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_log_metric_filter_authentication_failures:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_log_metric_filter_aws_organizations_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk/cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -95,7 +95,7 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -166,7 +166,7 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -249,7 +249,7 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -344,7 +344,7 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -439,7 +439,7 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -534,7 +534,7 @@ class Test_cloudwatch_log_metric_filter_disable_or_scheduled_deletion_of_kms_cmk
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_log_metric_filter_for_s3_bucket_policy_changes:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_root_usage:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_log_metric_filter_root_usage:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_log_metric_filter_root_usage:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_log_metric_filter_root_usage:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_log_metric_filter_root_usage:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_log_metric_filter_root_usage:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_log_metric_filter_root_usage:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -94,7 +94,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -164,7 +164,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -246,7 +246,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -339,7 +339,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -432,7 +432,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -525,7 +525,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_log_metric_filter_sign_in_without_mfa:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls_test.py
@@ -30,7 +30,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -93,7 +93,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -162,7 +162,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -243,7 +243,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -336,7 +336,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -429,7 +429,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,
@@ -522,7 +522,7 @@ class Test_cloudwatch_log_metric_filter_unauthorized_api_calls:
 
         aws_provider.audit_metadata = Audit_Metadata(
             services_scanned=0,
-            # We need to set this check to call __describe_log_groups__
+            # We need to set this check to call _describe_log_groups
             expected_checks=["cloudwatch_log_group_no_secrets_in_logs"],
             completed_checks=0,
             audit_progress=0,

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_service_test.py
@@ -97,7 +97,7 @@ class Test_CloudWatch_Service:
 
     # Test CloudWatch Alarms
     @mock_aws
-    def test__describe_alarms__(self):
+    def test_describe_alarms(self):
         # CloudWatch client for this test class
         cw_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
         cw_client.put_metric_alarm(
@@ -136,7 +136,7 @@ class Test_CloudWatch_Service:
 
     # Test Logs Filters
     @mock_aws
-    def test__describe_metric_filters__(self):
+    def test_describe_metric_filters(self):
         # Logs client for this test class
         logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         logs_client.put_metric_filter(
@@ -164,7 +164,7 @@ class Test_CloudWatch_Service:
 
     # Test Logs Filters
     @mock_aws
-    def test__describe_log_groups__(self):
+    def test_describe_log_groups(self):
         # Logs client for this test class
         logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         logs_client.create_log_group(
@@ -194,7 +194,7 @@ class Test_CloudWatch_Service:
         ]
 
     @mock_aws
-    def test__describe_log_groups__never_expire(self):
+    def test_describe_log_groupsnever_expire(self):
         # Logs client for this test class
         logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
         logs_client.create_log_group(

--- a/tests/providers/aws/services/codeartifact/codeartifact_service_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_service_test.py
@@ -102,7 +102,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_CodeArtifact_Service:
     # Test CodeArtifact Client
-    def test__get_client__(self):
+    def test_get_client(self):
         codeartifact = CodeArtifact(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
         )
@@ -125,7 +125,7 @@ class Test_CodeArtifact_Service:
         )
         assert codeartifact.service == "codeartifact"
 
-    def test__list_repositories__(self):
+    def test_list_repositories(self):
         # Set partition for the service
         codeartifact = CodeArtifact(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])

--- a/tests/providers/aws/services/config/config_service_test.py
+++ b/tests/providers/aws/services/config/config_service_test.py
@@ -54,7 +54,7 @@ class Test_Config_Service:
 
     # Test Config Get Rest APIs
     @mock_aws
-    def test__describe_configuration_recorder_status__(self):
+    def test_describe_configuration_recorder_status(self):
         # Generate Config Client
         config_client = client("config", region_name=AWS_REGION_US_EAST_1)
         # Create Config Recorder and start it

--- a/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
+++ b/tests/providers/aws/services/directoryservice/directoryservice_service_test.py
@@ -120,7 +120,7 @@ def mock_generate_regional_clients(provider, service):
 class Test_DirectoryService_Service:
     # Test DirectoryService Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         directoryservice = DirectoryService(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
         )
@@ -146,13 +146,13 @@ class Test_DirectoryService_Service:
         assert directoryservice.service == "ds"
 
     @mock_aws
-    def test__describe_directories__(self):
+    def test_describe_directories(self):
         # Set partition for the service
         directoryservice = DirectoryService(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
         )
 
-        # __describe_directories__
+        # _describe_directories
         assert directoryservice.directories["d-12345a1b2"].id == "d-12345a1b2"
         assert (
             directoryservice.directories["d-12345a1b2"].arn
@@ -180,7 +180,7 @@ class Test_DirectoryService_Service:
             == RadiusStatus.Creating
         )
 
-        # __list_log_subscriptions__
+        # _list_log_subscriptions
         assert len(directoryservice.directories["d-12345a1b2"].log_subscriptions) == 1
         assert (
             directoryservice.directories["d-12345a1b2"]
@@ -192,7 +192,7 @@ class Test_DirectoryService_Service:
             0
         ].created_date_time == datetime(2022, 1, 1)
 
-        # __describe_event_topics__
+        # _describe_event_topics
         assert len(directoryservice.directories["d-12345a1b2"].event_topics) == 1
         assert (
             directoryservice.directories["d-12345a1b2"].event_topics[0].topic_name
@@ -210,7 +210,7 @@ class Test_DirectoryService_Service:
             0
         ].created_date_time == datetime(2022, 1, 1)
 
-        # __list_certificates__
+        # _list_certificates
         assert len(directoryservice.directories["d-12345a1b2"].certificates) == 1
         assert (
             directoryservice.directories["d-12345a1b2"].certificates[0].id
@@ -232,7 +232,7 @@ class Test_DirectoryService_Service:
             == CertificateType.ClientLDAPS
         )
 
-        # __get_snapshot_limits__
+        # _get_snapshot_limits
         assert directoryservice.directories["d-12345a1b2"].snapshots_limits
         assert (
             directoryservice.directories[

--- a/tests/providers/aws/services/dlm/dlm_ebs_snapshot_lifecycle_policy_exists/dlm_ebs_snapshot_lifecycle_policy_exists_test.py
+++ b/tests/providers/aws/services/dlm/dlm_ebs_snapshot_lifecycle_policy_exists/dlm_ebs_snapshot_lifecycle_policy_exists_test.py
@@ -88,7 +88,7 @@ class Test_dlm_ebs_snapshot_lifecycle_policy_exists:
             }
         }
         dlm_client.lifecycle_policy_arn_template = f"arn:{dlm_client.audited_partition}:dlm:{dlm_client.region}:{dlm_client.audited_account}:policy"
-        dlm_client.__get_lifecycle_policy_arn_template__ = mock.MagicMock(
+        dlm_client._get_lifecycle_policy_arn_template = mock.MagicMock(
             return_value=dlm_client.lifecycle_policy_arn_template
         )
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])

--- a/tests/providers/aws/services/drs/drs_job_exist/drs_job_exist_test.py
+++ b/tests/providers/aws/services/drs/drs_job_exist/drs_job_exist_test.py
@@ -31,7 +31,7 @@ class Test_drs_job_exist:
             )
         ]
         drs_client.recovery_job_arn_template = f"arn:{drs_client.audited_partition}:drs:{drs_client.region}:{drs_client.audited_account}:recovery-job"
-        drs_client.__get_recovery_job_arn_template__ = mock.MagicMock(
+        drs_client._get_recovery_job_arn_template = mock.MagicMock(
             return_value=drs_client.recovery_job_arn_template
         )
         with mock.patch(
@@ -74,7 +74,7 @@ class Test_drs_job_exist:
             )
         ]
         drs_client.recovery_job_arn_template = f"arn:{drs_client.audited_partition}:drs:{drs_client.region}:{drs_client.audited_account}:recovery-job"
-        drs_client.__get_recovery_job_arn_template__ = mock.MagicMock(
+        drs_client._get_recovery_job_arn_template = mock.MagicMock(
             return_value=drs_client.recovery_job_arn_template
         )
         with mock.patch(
@@ -118,7 +118,7 @@ class Test_drs_job_exist:
             )
         ]
         drs_client.recovery_job_arn_template = f"arn:{drs_client.audited_partition}:drs:{drs_client.region}:{drs_client.audited_account}:recovery-job"
-        drs_client.__get_recovery_job_arn_template__ = mock.MagicMock(
+        drs_client._get_recovery_job_arn_template = mock.MagicMock(
             return_value=drs_client.recovery_job_arn_template
         )
         with mock.patch(
@@ -160,7 +160,7 @@ class Test_drs_job_exist:
             )
         ]
         drs_client.recovery_job_arn_template = f"arn:{drs_client.audited_partition}:drs:{drs_client.region}:{drs_client.audited_account}:recovery-job"
-        drs_client.__get_recovery_job_arn_template__ = mock.MagicMock(
+        drs_client._get_recovery_job_arn_template = mock.MagicMock(
             return_value=drs_client.recovery_job_arn_template
         )
         with mock.patch(

--- a/tests/providers/aws/services/drs/drs_service_test.py
+++ b/tests/providers/aws/services/drs/drs_service_test.py
@@ -53,7 +53,7 @@ def mock_generate_regional_clients(provider, service):
     new=mock_generate_regional_clients,
 )
 class Test_DRS_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider()
         drs = DRS(aws_provider)
         assert drs.regional_clients[AWS_REGION_US_EAST_1].__class__.__name__ == "drs"
@@ -63,7 +63,7 @@ class Test_DRS_Service:
         drs = DRS(aws_provider)
         assert drs.service == "drs"
 
-    def test__describe_jobs__(self):
+    def test_describe_jobs(self):
         aws_provider = set_mocked_aws_provider()
         drs = DRS(aws_provider)
         assert len(drs.drs_services) == 1

--- a/tests/providers/aws/services/dynamodb/dynamodb_service_test.py
+++ b/tests/providers/aws/services/dynamodb/dynamodb_service_test.py
@@ -45,7 +45,7 @@ class Test_DynamoDB_Service:
 
     # Test DynamoDB List Tables
     @mock_aws
-    def test__list_tables__(self):
+    def test_list_tables(self):
         # Generate DynamoDB Client
         dynamodb_client = client("dynamodb", region_name=AWS_REGION_US_EAST_1)
         # Create DynamoDB Tables
@@ -84,7 +84,7 @@ class Test_DynamoDB_Service:
 
     # Test DynamoDB Describe Table
     @mock_aws
-    def test__describe_table__(self):
+    def test_describe_table(self):
         # Generate DynamoDB Client
         dynamodb_client = client("dynamodb", region_name=AWS_REGION_US_EAST_1)
         # Create DynamoDB Table
@@ -116,7 +116,7 @@ class Test_DynamoDB_Service:
 
     # Test DynamoDB Describe Continuous Backups
     @mock_aws
-    def test__describe_continuous_backups__(self):
+    def test_describe_continuous_backups(self):
         # Generate DynamoDB Client
         dynamodb_client = client("dynamodb", region_name=AWS_REGION_US_EAST_1)
         # Create DynamoDB Table
@@ -147,7 +147,7 @@ class Test_DynamoDB_Service:
 
     # Test DAX Describe Clusters
     @mock_aws
-    def test__describe_clusters__(self):
+    def test_describe_clusters(self):
         # Generate DAX Client
         dax_client = client("dax", region_name=AWS_REGION_US_EAST_1)
         # Create DAX Clusters

--- a/tests/providers/aws/services/ec2/ec2_service_test.py
+++ b/tests/providers/aws/services/ec2/ec2_service_test.py
@@ -89,7 +89,7 @@ class Test_EC2_Service:
     # Test EC2 Describe Instances
     @mock_aws
     @freeze_time(MOCK_DATETIME)
-    def test__describe_instances__(self):
+    def test_describe_instances(self):
         # Generate EC2 Client
         ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
@@ -134,7 +134,7 @@ class Test_EC2_Service:
 
     # Test EC2 Describe Security Groups
     @mock_aws
-    def test__describe_security_groups__(self):
+    def test_describe_security_groups(self):
         # Generate EC2 Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create EC2 Security Group
@@ -203,7 +203,7 @@ class Test_EC2_Service:
 
     # Test EC2 Describe Nacls
     @mock_aws
-    def test__describe_network_acls__(self):
+    def test_describe_network_acls(self):
         # Generate EC2 Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
@@ -241,7 +241,7 @@ class Test_EC2_Service:
 
     # Test EC2 Describe Snapshots
     @mock_aws
-    def test__describe_snapshots__(self):
+    def test_describe_snapshots(self):
         # Generate EC2 Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
@@ -326,7 +326,7 @@ class Test_EC2_Service:
 
     # Test EC2 Instance User Data
     @mock_aws
-    def test__get_instance_user_data__(self):
+    def test_get_instance_user_data(self):
         user_data = "This is some user_data"
         ec2 = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2.create_instances(
@@ -362,7 +362,7 @@ class Test_EC2_Service:
                 assert result.status
 
     # Test EC2 get_snapshot_block_public_access_state
-    def test__get_snapshot_block_public_access_state__(self):
+    def test_get_snapshot_block_public_access_state(self):
         from prowler.providers.aws.services.ec2.ec2_service import (
             EbsSnapshotBlockPublicAccess,
         )
@@ -388,9 +388,9 @@ class Test_EC2_Service:
                 == "block-all-sharing"
             )
 
-    # Test EC2 __get_resources_for_regions__
+    # Test EC2 _get_resources_for_regions
     @mock_aws
-    def test__get_resources_for_regions__(self):
+    def test_get_resources_for_regions(self):
         # Generate EC2 Client
         ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
@@ -436,9 +436,9 @@ class Test_EC2_Service:
         assert ec2.attributes_for_regions[AWS_REGION_US_EAST_1]["has_instances"]
         assert ec2.attributes_for_regions[AWS_REGION_US_EAST_1]["has_volumes"]
 
-    # Test __get_instance_metadata_defaults__
+    # Test _get_instance_metadata_defaults
     @mock_aws
-    def test__get_instance_metadata_defaults__(self):
+    def test_get_instance_metadata_defaults(self):
         from prowler.providers.aws.services.ec2.ec2_service import (
             InstanceMetadataDefaults,
         )
@@ -494,7 +494,7 @@ class Test_EC2_Service:
 
     # Test EC2 Describe Network Interfaces
     @mock_aws
-    def test__describe_network_interfaces__(self):
+    def test_describe_network_interfaces(self):
         # Generate EC2 Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
@@ -549,7 +549,7 @@ class Test_EC2_Service:
 
     # Test EC2 Describe Images
     @mock_aws
-    def test__describe_images__(self):
+    def test_describe_images(self):
         # Generate EC2 Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_US_EAST_1)
@@ -601,7 +601,7 @@ class Test_EC2_Service:
 
     # Test EC2 Describe Volumes
     @mock_aws
-    def test__describe_volumes__(self):
+    def test_describe_volumes(self):
         # Generate EC2 Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create Volume
@@ -676,7 +676,7 @@ class Test_EC2_Service:
 
     # Test EC2 Describe Launch Templates
     @mock_aws
-    def test__get_launch_template_versions__(self):
+    def test_get_launch_template_versions(self):
         # Generate EC2 Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
 

--- a/tests/providers/aws/services/ecs/ecs_service_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_test.py
@@ -41,7 +41,7 @@ class Test_ECS_Service:
 
     # Test list ECS task definitions
     @mock_aws
-    def test__list_task_definitions__(self):
+    def test_list_task_definitions(self):
         ecs_client = client("ecs", region_name=AWS_REGION_EU_WEST_1)
 
         definition = dict(

--- a/tests/providers/aws/services/efs/efs_service_test.py
+++ b/tests/providers/aws/services/efs/efs_service_test.py
@@ -68,7 +68,7 @@ class Test_EFS:
 
     @mock_aws
     # Test EFS describe file systems
-    def test__describe_file_systems__(self):
+    def test_describe_file_systems(self):
         efs_client = client("efs", AWS_REGION_EU_WEST_1)
         efs = efs_client.create_file_system(
             CreationToken=creation_token,
@@ -87,7 +87,7 @@ class Test_EFS:
 
     @mock_aws
     # Test EFS describe file systems
-    def test__describe_file_system_policies__(self):
+    def test_describe_file_system_policies(self):
         efs_client = client("efs", AWS_REGION_EU_WEST_1)
         efs = efs_client.create_file_system(
             CreationToken=creation_token, Encrypted=True

--- a/tests/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled_test.py
+++ b/tests/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled_test.py
@@ -18,7 +18,7 @@ class Test_emr_cluster_account_public_block_enabled:
         emr_client.region = AWS_REGION_EU_WEST_1
         emr_client.audited_partition = "aws"
         emr_client.cluster_arn_template = f"arn:{emr_client.audited_partition}:elasticmapreduce:{emr_client.region}:{emr_client.audited_account}:cluster"
-        emr_client.__get_cluster_arn_template__ = mock.MagicMock(
+        emr_client._get_cluster_arn_template = mock.MagicMock(
             return_value=emr_client.cluster_arn_template
         )
         with mock.patch(
@@ -53,7 +53,7 @@ class Test_emr_cluster_account_public_block_enabled:
         emr_client.region = AWS_REGION_EU_WEST_1
         emr_client.audited_partition = "aws"
         emr_client.cluster_arn_template = f"arn:{emr_client.audited_partition}:elasticmapreduce:{emr_client.region}:{emr_client.audited_account}:cluster"
-        emr_client.__get_cluster_arn_template__ = mock.MagicMock(
+        emr_client._get_cluster_arn_template = mock.MagicMock(
             return_value=emr_client.cluster_arn_template
         )
         with mock.patch(

--- a/tests/providers/aws/services/emr/emr_service_test.py
+++ b/tests/providers/aws/services/emr/emr_service_test.py
@@ -52,7 +52,7 @@ def mock_generate_regional_clients(provider, service):
 class Test_EMR_Service:
     # Test EMR Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         emr = EMR(set_mocked_aws_provider())
         assert emr.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__ == "EMR"
 
@@ -68,9 +68,9 @@ class Test_EMR_Service:
         emr = EMR(set_mocked_aws_provider())
         assert emr.service == "emr"
 
-    # Test __list_clusters__ and __describe_cluster__
+    # Test _list_clusters and _describe_cluster
     @mock_aws
-    def test__list_clusters__(self):
+    def test_list_clusters(self):
         # Create EMR Cluster
         emr_client = client("emr", region_name=AWS_REGION_EU_WEST_1)
         cluster_name = "test-cluster"
@@ -114,7 +114,7 @@ class Test_EMR_Service:
         ]
 
     @mock_aws
-    def test__get_block_public_access_configuration__(self):
+    def test_get_block_public_access_configuration(self):
         emr = EMR(set_mocked_aws_provider())
 
         assert len(emr.block_public_access_configuration) == 1

--- a/tests/providers/aws/services/eventbridge/eventbridge_service_test.py
+++ b/tests/providers/aws/services/eventbridge/eventbridge_service_test.py
@@ -109,7 +109,7 @@ class Test_EventBridge_Service:
 
     # Test EventBridge Buses
     @mock_aws
-    def test__list_event_buses__(self):
+    def test_list_event_buses(self):
         # EventBridge client for this test class
         events_client = client("events", region_name=AWS_REGION_US_EAST_1)
         events_client.create_event_bus(Name="test")
@@ -149,7 +149,7 @@ class Test_EventBridge_Service:
                 assert bus.tags == [{"Key": "key-1", "Value": "value-1"}]
 
     # Test Schema Registries
-    def test__list_policies__(self):
+    def test_list_policies(self):
         aws_provider = set_mocked_aws_provider()
         schema = Schema(aws_provider)
         assert len(schema.registries) == 1

--- a/tests/providers/aws/services/fms/fms_service_test.py
+++ b/tests/providers/aws/services/fms/fms_service_test.py
@@ -61,7 +61,7 @@ def mock_make_api_call(self, operation_name, kwargs):
 # Patch every AWS call using Boto3
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
 class Test_FMS_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider()
         fms = FMS(aws_provider)
         assert fms.client.__class__.__name__ == "FMS"
@@ -71,7 +71,7 @@ class Test_FMS_Service:
         fms = FMS(aws_provider)
         assert fms.service == "fms"
 
-    def test__list_policies__(self):
+    def test_list_policies(self):
         aws_provider = set_mocked_aws_provider()
         fms = FMS(aws_provider)
         assert len(fms.fms_policies) == 1
@@ -87,7 +87,7 @@ class Test_FMS_Service:
             == DELETE_UNUSED_MANAGED_RESOURCES
         )
 
-    def test__list_compliance_status__(self):
+    def test_list_compliance_status(self):
         aws_provider = set_mocked_aws_provider()
         fms = FMS(aws_provider)
         assert len(fms.fms_policies) == 1

--- a/tests/providers/aws/services/glacier/glacier_service_test.py
+++ b/tests/providers/aws/services/glacier/glacier_service_test.py
@@ -78,7 +78,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_Glacier_Service:
     # Test Glacier Client
-    def test__get_client__(self):
+    def test_get_client(self):
         glacier = Glacier(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
         )
@@ -101,7 +101,7 @@ class Test_Glacier_Service:
         )
         assert glacier.service == "glacier"
 
-    def test__list_vaults__(self):
+    def test_list_vaults(self):
         # Set partition for the service
         glacier = Glacier(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])
@@ -117,7 +117,7 @@ class Test_Glacier_Service:
         assert glacier.vaults[TEST_VAULT_ARN].region == AWS_REGION_EU_WEST_1
         assert glacier.vaults[TEST_VAULT_ARN].tags == [{"test": "test"}]
 
-    def test__get_vault_access_policy__(self):
+    def test_get_vault_access_policy(self):
         # Set partition for the service
         glacier = Glacier(
             set_mocked_aws_provider([AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1])

--- a/tests/providers/aws/services/globalaccelerator/globalaccelerator_service_test.py
+++ b/tests/providers/aws/services/globalaccelerator/globalaccelerator_service_test.py
@@ -71,7 +71,7 @@ class Test_GlobalAccelerator_Service:
         globalaccelerator = GlobalAccelerator(aws_provider)
         assert globalaccelerator.session.__class__.__name__ == "Session"
 
-    def test__list_accelerators__(self):
+    def test_list_accelerators(self):
         # GlobalAccelerator client for this test class
         aws_provider = set_mocked_aws_provider()
         globalaccelerator = GlobalAccelerator(aws_provider)

--- a/tests/providers/aws/services/glue/glue_data_catalogs_connection_passwords_encryption_enabled/glue_data_catalogs_connection_passwords_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_data_catalogs_connection_passwords_encryption_enabled/glue_data_catalogs_connection_passwords_encryption_enabled_test.py
@@ -46,7 +46,7 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
         glue_client.audited_partition = AWS_COMMERCIAL_PARTITION
         glue_client.region = AWS_REGION_US_EAST_1
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
         with mock.patch(
@@ -88,7 +88,7 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
         glue_client.audited_partition = AWS_COMMERCIAL_PARTITION
         glue_client.region = AWS_REGION_US_EAST_1
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
         glue_client.provider._scan_unused_services = False
@@ -123,7 +123,7 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
         glue_client.region = AWS_REGION_US_EAST_1
         glue_client.audited_account = AWS_ACCOUNT_NUMBER
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
         glue_client.provider._scan_unused_services = False
@@ -165,7 +165,7 @@ class Test_glue_data_catalogs_connection_passwords_encryption_enabled:
         glue_client.region = AWS_REGION_US_EAST_1
         glue_client.audited_account = AWS_ACCOUNT_NUMBER
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
 

--- a/tests/providers/aws/services/glue/glue_data_catalogs_metadata_encryption_enabled/glue_data_catalogs_metadata_encryption_enabled_test.py
+++ b/tests/providers/aws/services/glue/glue_data_catalogs_metadata_encryption_enabled/glue_data_catalogs_metadata_encryption_enabled_test.py
@@ -47,7 +47,7 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
         glue_client.audited_account = AWS_ACCOUNT_NUMBER
         glue_client.audited_partition = AWS_COMMERCIAL_PARTITION
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
         with mock.patch(
@@ -90,7 +90,7 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
         glue_client.audited_account = AWS_ACCOUNT_NUMBER
         glue_client.audited_partition = AWS_COMMERCIAL_PARTITION
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
         with mock.patch(
@@ -125,7 +125,7 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
         glue_client.audited_account = AWS_ACCOUNT_NUMBER
         glue_client.audited_partition = AWS_COMMERCIAL_PARTITION
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
         with mock.patch(
@@ -167,7 +167,7 @@ class Test_glue_data_catalogs_metadata_encryption_enabled:
         glue_client.audited_account = AWS_ACCOUNT_NUMBER
         glue_client.audited_partition = AWS_COMMERCIAL_PARTITION
         glue_client.data_catalog_arn_template = f"arn:{glue_client.audited_partition}:glue:{glue_client.region}:{glue_client.audited_account}:data-catalog"
-        glue_client.__get_data_catalog_arn_template__ = mock.MagicMock(
+        glue_client._get_data_catalog_arn_template = mock.MagicMock(
             return_value=glue_client.data_catalog_arn_template
         )
         with mock.patch(

--- a/tests/providers/aws/services/glue/glue_service_test.py
+++ b/tests/providers/aws/services/glue/glue_service_test.py
@@ -154,7 +154,7 @@ class Test_Glue_Service:
 
     # Test Glue Search Tables
     @mock_aws
-    def test__search_tables__(self):
+    def test_search_tables(self):
         aws_provider = set_mocked_aws_provider()
         glue = Glue(aws_provider)
         assert len(glue.tables) == 1
@@ -165,7 +165,7 @@ class Test_Glue_Service:
 
     # Test Glue Get Connections
     @mock_aws
-    def test__get_connections__(self):
+    def test_get_connections(self):
         aws_provider = set_mocked_aws_provider()
         glue = Glue(aws_provider)
         assert len(glue.connections) == 1
@@ -182,7 +182,7 @@ class Test_Glue_Service:
 
     # Test Glue Get Catalog Encryption
     @mock_aws
-    def test__get_data_catalog_encryption_settings__(self):
+    def test_get_data_catalog_encryption_settings(self):
         aws_provider = set_mocked_aws_provider()
         glue = Glue(aws_provider)
         assert len(glue.catalog_encryption_settings) == 1
@@ -194,7 +194,7 @@ class Test_Glue_Service:
 
     # Test Glue Get Dev Endpoints
     @mock_aws
-    def test__get_dev_endpoints__(self):
+    def test_get_dev_endpoints(self):
         aws_provider = set_mocked_aws_provider()
         glue = Glue(aws_provider)
         assert len(glue.dev_endpoints) == 1
@@ -204,7 +204,7 @@ class Test_Glue_Service:
 
     # Test Glue Get Security Configs
     @mock_aws
-    def test__get_security_configurations__(self):
+    def test_get_security_configurations(self):
         aws_provider = set_mocked_aws_provider()
         glue = Glue(aws_provider)
         assert len(glue.security_configs) == 1
@@ -216,7 +216,7 @@ class Test_Glue_Service:
 
     # Test Glue Get Security Configs
     @mock_aws
-    def test__get_jobs__(self):
+    def test_get_jobs(self):
         aws_provider = set_mocked_aws_provider()
         glue = Glue(aws_provider)
         assert len(glue.jobs) == 1

--- a/tests/providers/aws/services/guardduty/guardduty_service_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_service_test.py
@@ -85,7 +85,7 @@ class Test_GuardDuty_Service:
 
     @mock_aws
     # Test GuardDuty session
-    def test__list_detectors__(self):
+    def test_list_detectors(self):
         guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True, Tags={"test": "test"})
 
@@ -107,7 +107,7 @@ class Test_GuardDuty_Service:
 
     @mock_aws
     # Test GuardDuty session
-    def test__get_detector__(self):
+    def test_get_detector(self):
         guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 
@@ -129,7 +129,7 @@ class Test_GuardDuty_Service:
 
     @mock_aws
     # Test GuardDuty session
-    def test__list_findings__(self):
+    def test_list_findings(self):
         guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 
@@ -150,7 +150,7 @@ class Test_GuardDuty_Service:
         assert guardduty.detectors[0].tags == [{"test": "test"}]
 
     @mock_aws
-    def test__list_members__(self):
+    def test_list_members(self):
         guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 
@@ -172,7 +172,7 @@ class Test_GuardDuty_Service:
 
     @mock_aws
     # Test GuardDuty session
-    def test__get_administrator_account__(self):
+    def test_get_administrator_account(self):
         guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(Enable=True)
 

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -82,7 +82,7 @@ class Test_IAM_Service:
 
     # Test IAM Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         # IAM client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         iam = IAM(aws_provider)
@@ -99,7 +99,7 @@ class Test_IAM_Service:
     # Test IAM Get Credential Report
     @freeze_time(TEST_DATETIME)
     @mock_aws
-    def test__get_credential_report__(self):
+    def test_get_credential_report(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Create IAM User
@@ -265,7 +265,7 @@ class Test_IAM_Service:
 
     # Test IAM Get Roles
     @mock_aws
-    def test__get_roles__(self):
+    def test_get_roles(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Create 2 IAM Roles
@@ -320,7 +320,7 @@ class Test_IAM_Service:
 
     # Test IAM Get Groups
     @mock_aws
-    def test__get_groups__(self):
+    def test_get_groups(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Create 2 IAM Groups
@@ -338,7 +338,7 @@ class Test_IAM_Service:
 
     # Test IAM Get Users
     @mock_aws
-    def test__get_users__(self):
+    def test_get_users(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Create 2 IAM Users
@@ -368,7 +368,7 @@ class Test_IAM_Service:
 
     # Test IAM Get Account Summary
     @mock_aws
-    def test__get_account_summary__(self):
+    def test_get_account_summary(self):
         # Generate IAM Client
         iam_client = client("iam")
         account_summary = iam_client.get_account_summary()["SummaryMap"]
@@ -381,7 +381,7 @@ class Test_IAM_Service:
 
     # Test IAM Get Password Policy
     @mock_aws
-    def test__get_password_policy__(self):
+    def test_get_password_policy(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Update Password Policy
@@ -484,7 +484,7 @@ class Test_IAM_Service:
 
     # Test IAM List Virtual MFA Device
     @mock_aws
-    def test__list_virtual_mfa_devices__(self):
+    def test_list_virtual_mfa_devices(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Generate IAM user
@@ -517,7 +517,7 @@ class Test_IAM_Service:
 
     # Test IAM Get Group Users
     @mock_aws
-    def test__get_group_users__(self):
+    def test_get_group_users(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Generate IAM user
@@ -543,7 +543,7 @@ class Test_IAM_Service:
 
     # Test IAM List Attached Group Policies
     @mock_aws
-    def test__list_attached_group_policies__(self):
+    def test_list_attached_group_policies(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Generate IAM user
@@ -592,7 +592,7 @@ class Test_IAM_Service:
 
     # Test IAM List Attached Role Policies
     @mock_aws(config={"iam": {"load_aws_managed_policies": True}})
-    def test__list_attached_role_policies__(self):
+    def test_list_attached_role_policies(self):
         iam = client("iam")
         role_name = "test"
         assume_role_policy_document = {
@@ -719,7 +719,7 @@ class Test_IAM_Service:
         )
 
     @mock_aws
-    def test___list_policies__(self):
+    def test__list_policies(self):
         iam_client = client("iam")
         policy_name = "policy1"
         policy_document = {
@@ -748,7 +748,7 @@ class Test_IAM_Service:
         assert custom_policies == 1
 
     @mock_aws
-    def test__list_policies_version__(self):
+    def test_list_policies_version(self):
         iam_client = client("iam")
         policy_name = "policy2"
         policy_document = {
@@ -775,7 +775,7 @@ class Test_IAM_Service:
 
     # Test IAM List SAML Providers
     @mock_aws
-    def test__list_saml_providers__(self):
+    def test_list_saml_providers(self):
         iam_client = client("iam")
         xml_template = r"""<EntityDescriptor
     xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
@@ -819,7 +819,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
 
     # Test IAM User Inline Policy
     @mock_aws
-    def test__list_inline_user_policies__(self):
+    def test_list_inline_user_policies(self):
         # IAM Client
         iam_client = client("iam")
         # Create IAM User
@@ -862,7 +862,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
 
     # Test IAM Group Inline Policy
     @mock_aws
-    def test__list_inline_group_policies__(self):
+    def test_list_inline_group_policies(self):
         # IAM Client
         iam_client = client("iam")
         # Create IAM Group
@@ -904,7 +904,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
 
     # Test IAM Role Inline Policy
     @mock_aws
-    def test__list_inline_role_policies__(self):
+    def test_list_inline_role_policies(self):
         # IAM Client
         iam_client = client("iam")
         # Create IAM Role
@@ -950,7 +950,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
 
     # Test IAM List Attached Group Policies
     @mock_aws
-    def test__get_user_temporary_credentials_usage__(self):
+    def test_get_user_temporary_credentials_usage(self):
         # Generate IAM Client
         iam_client = client("iam")
         # Generate IAM user

--- a/tests/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials_test.py
+++ b/tests/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials_test.py
@@ -18,10 +18,10 @@ class Test_iam_user_with_temporary_credentials:
 
         # Generate temporary credentials usage
         iam_client.user_temporary_credentials_usage = {}
-        iam_client.__get_user_temporary_credentials_usage__ = (
-            IAM.__get_user_temporary_credentials_usage__
+        iam_client._get_user_temporary_credentials_usage = (
+            IAM._get_user_temporary_credentials_usage
         )
-        iam_client.__get_user_temporary_credentials_usage__(iam_client)
+        iam_client._get_user_temporary_credentials_usage(iam_client)
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_service.IAM",
@@ -47,10 +47,10 @@ class Test_iam_user_with_temporary_credentials:
 
         # Generate temporary credentials usage
         iam_client.user_temporary_credentials_usage = {}
-        iam_client.__get_user_temporary_credentials_usage__ = (
-            IAM.__get_user_temporary_credentials_usage__
+        iam_client._get_user_temporary_credentials_usage = (
+            IAM._get_user_temporary_credentials_usage
         )
-        iam_client.__get_user_temporary_credentials_usage__(iam_client)
+        iam_client._get_user_temporary_credentials_usage(iam_client)
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_service.IAM",
@@ -84,10 +84,10 @@ class Test_iam_user_with_temporary_credentials:
 
         # Generate temporary credentials usage
         iam_client.user_temporary_credentials_usage = {}
-        iam_client.__get_user_temporary_credentials_usage__ = (
-            IAM.__get_user_temporary_credentials_usage__
+        iam_client._get_user_temporary_credentials_usage = (
+            IAM._get_user_temporary_credentials_usage
         )
-        iam_client.__get_user_temporary_credentials_usage__(iam_client)
+        iam_client._get_user_temporary_credentials_usage(iam_client)
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_service.IAM",
@@ -121,10 +121,10 @@ class Test_iam_user_with_temporary_credentials:
 
         # Generate temporary credentials usage
         iam_client.user_temporary_credentials_usage = {}
-        iam_client.__get_user_temporary_credentials_usage__ = (
-            IAM.__get_user_temporary_credentials_usage__
+        iam_client._get_user_temporary_credentials_usage = (
+            IAM._get_user_temporary_credentials_usage
         )
-        iam_client.__get_user_temporary_credentials_usage__(iam_client)
+        iam_client._get_user_temporary_credentials_usage(iam_client)
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_service.IAM",
@@ -160,10 +160,10 @@ class Test_iam_user_with_temporary_credentials:
 
         # Generate temporary credentials usage
         iam_client.user_temporary_credentials_usage = {}
-        iam_client.__get_user_temporary_credentials_usage__ = (
-            IAM.__get_user_temporary_credentials_usage__
+        iam_client._get_user_temporary_credentials_usage = (
+            IAM._get_user_temporary_credentials_usage
         )
-        iam_client.__get_user_temporary_credentials_usage__(iam_client)
+        iam_client._get_user_temporary_credentials_usage(iam_client)
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_service.IAM",
@@ -199,10 +199,10 @@ class Test_iam_user_with_temporary_credentials:
 
         # Generate temporary credentials usage
         iam_client.user_temporary_credentials_usage = {}
-        iam_client.__get_user_temporary_credentials_usage__ = (
-            IAM.__get_user_temporary_credentials_usage__
+        iam_client._get_user_temporary_credentials_usage = (
+            IAM._get_user_temporary_credentials_usage
         )
-        iam_client.__get_user_temporary_credentials_usage__(iam_client)
+        iam_client._get_user_temporary_credentials_usage(iam_client)
 
         with mock.patch(
             "prowler.providers.aws.services.iam.iam_service.IAM",

--- a/tests/providers/aws/services/inspector2/inspector2_service_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_service_test.py
@@ -84,7 +84,7 @@ def mock_generate_regional_clients(provider, service):
     new=mock_generate_regional_clients,
 )
 class Test_Inspector2_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2 = Inspector2(aws_provider)
         assert (
@@ -97,7 +97,7 @@ class Test_Inspector2_Service:
         inspector2 = Inspector2(aws_provider)
         assert inspector2.service == "inspector2"
 
-    def test__batch_get_account_status__(self):
+    def test_batch_get_account_status(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2 = Inspector2(aws_provider)
         assert len(inspector2.inspectors) == 1
@@ -105,7 +105,7 @@ class Test_Inspector2_Service:
         assert inspector2.inspectors[0].region == AWS_REGION_EU_WEST_1
         assert inspector2.inspectors[0].status == "ENABLED"
 
-    def test__list_active_findings__(self):
+    def test_list_active_findings(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         inspector2 = Inspector2(aws_provider)
         assert inspector2.inspectors[0].active_findings

--- a/tests/providers/aws/services/kms/kms_service_test.py
+++ b/tests/providers/aws/services/kms/kms_service_test.py
@@ -48,7 +48,7 @@ class Test_ACM_Service:
 
     # Test KMS List Keys
     @mock_aws
-    def test__list_keys__(self):
+    def test_list_keys(self):
         # Generate KMS Client
         kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Create KMS keys
@@ -63,7 +63,7 @@ class Test_ACM_Service:
 
     # Test KMS Describe Keys
     @mock_aws
-    def test__describe_key__(self):
+    def test_describe_key(self):
         # Generate KMS Client
         kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Create KMS keys
@@ -86,7 +86,7 @@ class Test_ACM_Service:
 
     # Test KMS Get rotation status
     @mock_aws
-    def test__get_key_rotation_status__(self):
+    def test_get_key_rotation_status(self):
         # Generate KMS Client
         kms_client = client("kms", region_name=AWS_REGION_US_EAST_1)
         # Create KMS keys
@@ -104,7 +104,7 @@ class Test_ACM_Service:
 
     # Test KMS Key policy
     @mock_aws
-    def test__get_key_policy__(self):
+    def test_get_key_policy(self):
         public_policy = json.dumps(
             {
                 "Version": "2012-10-17",

--- a/tests/providers/aws/services/macie/macie_is_enabled/macie_is_enabled_test.py
+++ b/tests/providers/aws/services/macie/macie_is_enabled/macie_is_enabled_test.py
@@ -32,7 +32,7 @@ class Test_macie_is_enabled:
             )
         ]
         macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
-        macie_client.__get_session_arn_template__ = mock.MagicMock(
+        macie_client._get_session_arn_template = mock.MagicMock(
             return_value=macie_client.session_arn_template
         )
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -84,7 +84,7 @@ class Test_macie_is_enabled:
             )
         ]
         macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
-        macie_client.__get_session_arn_template__ = mock.MagicMock(
+        macie_client._get_session_arn_template = mock.MagicMock(
             return_value=macie_client.session_arn_template
         )
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -130,7 +130,7 @@ class Test_macie_is_enabled:
         macie_client.audited_partition = "aws"
         macie_client.region = AWS_REGION_EU_WEST_1
         macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
-        macie_client.__get_session_arn_template__ = mock.MagicMock(
+        macie_client._get_session_arn_template = mock.MagicMock(
             return_value=macie_client.session_arn_template
         )
         macie_client.sessions = [
@@ -189,7 +189,7 @@ class Test_macie_is_enabled:
             )
         ]
         macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
-        macie_client.__get_session_arn_template__ = mock.MagicMock(
+        macie_client._get_session_arn_template = mock.MagicMock(
             return_value=macie_client.session_arn_template
         )
         macie_client.provider._scan_unused_services = False
@@ -243,7 +243,7 @@ class Test_macie_is_enabled:
         ]
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
-        macie_client.__get_session_arn_template__ = mock.MagicMock(
+        macie_client._get_session_arn_template = mock.MagicMock(
             return_value=macie_client.session_arn_template
         )
         with mock.patch(

--- a/tests/providers/aws/services/macie/macie_service_test.py
+++ b/tests/providers/aws/services/macie/macie_service_test.py
@@ -45,7 +45,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_Macie_Service:
     # Test Macie Client
-    def test__get_client__(self):
+    def test_get_client(self):
         macie = Macie(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
         assert (
             macie.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__ == "Macie2"
@@ -61,7 +61,7 @@ class Test_Macie_Service:
         macie = Macie(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
         assert macie.service == "macie2"
 
-    def test__get_macie_session__(self):
+    def test_get_macie_session(self):
         # Set partition for the service
         macie = Macie(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
         macie.sessions = [

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
@@ -63,7 +63,7 @@ def mock_generate_regional_clients(provider, service):
     new=mock_generate_regional_clients,
 )
 class Test_NetworkFirewall_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         networkfirewall = NetworkFirewall(aws_provider)
         assert (
@@ -76,7 +76,7 @@ class Test_NetworkFirewall_Service:
         networkfirewall = NetworkFirewall(aws_provider)
         assert networkfirewall.service == "network-firewall"
 
-    def test__list_firewalls__(self):
+    def test_list_firewalls(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         networkfirewall = NetworkFirewall(aws_provider)
         assert len(networkfirewall.network_firewalls) == 1
@@ -84,7 +84,7 @@ class Test_NetworkFirewall_Service:
         assert networkfirewall.network_firewalls[0].region == AWS_REGION_US_EAST_1
         assert networkfirewall.network_firewalls[0].name == FIREWALL_NAME
 
-    def test__describe_firewall__(self):
+    def test_describe_firewall(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         networkfirewall = NetworkFirewall(aws_provider)
         assert len(networkfirewall.network_firewalls) == 1

--- a/tests/providers/aws/services/opensearch/opensearch_service_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_test.py
@@ -128,7 +128,7 @@ class Test_OpenSearchService_Service:
         assert opensearch.session.__class__.__name__ == "Session"
 
     # Test OpenSearchService list domains names
-    def test__list_domain_names__(self):
+    def test_list_domain_names(self):
         aws_provider = set_mocked_aws_provider([])
         opensearch = OpenSearchService(aws_provider)
         assert len(opensearch.opensearch_domains) == 1
@@ -136,7 +136,7 @@ class Test_OpenSearchService_Service:
         assert opensearch.opensearch_domains[0].region == AWS_REGION_EU_WEST_1
 
     # Test OpenSearchService describ domain config
-    def test__describe_domain_config__(self):
+    def test_describe_domain_config(self):
         aws_provider = set_mocked_aws_provider([])
         opensearch = OpenSearchService(aws_provider)
         assert len(opensearch.opensearch_domains) == 1
@@ -151,7 +151,7 @@ class Test_OpenSearchService_Service:
         assert opensearch.opensearch_domains[0].logging[2].enabled
 
     # Test OpenSearchService describ domain
-    def test__describe_domain__(self):
+    def test_describe_domain(self):
         aws_provider = set_mocked_aws_provider([])
         opensearch = OpenSearchService(aws_provider)
         assert len(opensearch.opensearch_domains) == 1

--- a/tests/providers/aws/services/organizations/organizations_service_test.py
+++ b/tests/providers/aws/services/organizations/organizations_service_test.py
@@ -21,7 +21,7 @@ class Test_Organizations_Service:
         assert organizations.service == "organizations"
 
     @mock_aws
-    def test__describe_organization__(self):
+    def test_describe_organization(self):
         # Create Organization
         conn = client("organizations", region_name=AWS_REGION_EU_WEST_1)
         response = conn.create_organization()
@@ -42,7 +42,7 @@ class Test_Organizations_Service:
         assert organizations.organizations[0].delegated_administrators == []
 
     @mock_aws
-    def test__list_policies__(self):
+    def test_list_policies(self):
         # Create Policy
         conn = client("organizations", region_name=AWS_REGION_EU_WEST_1)
         conn.create_organization()

--- a/tests/providers/aws/services/rds/rds_service_test.py
+++ b/tests/providers/aws/services/rds/rds_service_test.py
@@ -69,7 +69,7 @@ class Test_RDS_Service:
 
     # Test RDS Describe DB Instances
     @mock_aws
-    def test__describe_db_instances__(self):
+    def test_describe_db_instances(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
@@ -123,7 +123,7 @@ class Test_RDS_Service:
         assert db_instance.copy_tags_to_snapshot
 
     @mock_aws
-    def test__describe_db_parameters__(self):
+    def test_describe_db_parameters(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_parameter_group(
             DBParameterGroupName="test",
@@ -161,7 +161,7 @@ class Test_RDS_Service:
                 assert parameter["ParameterValue"] == "1"
 
     @mock_aws
-    def test__describe_db_certificate__(self):
+    def test_describe_db_certificate(self):
         rds_client = mock.MagicMock
         rds_client.db_instances = {
             "arn:aws:rds:us-east-1:123456789012:db:db-master-1": DBInstance(
@@ -226,7 +226,7 @@ class Test_RDS_Service:
 
     # Test RDS Describe DB Snapshots
     @mock_aws
-    def test__describe_db_snapshots__(self):
+    def test_describe_db_snapshots(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-primary-1",
@@ -250,7 +250,7 @@ class Test_RDS_Service:
 
     # Test RDS Describe DB Clusters
     @mock_aws
-    def test__describe_db_clusters__(self):
+    def test_describe_db_clusters(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         cluster_id = "db-master-1"
         conn.create_db_cluster_parameter_group(
@@ -309,7 +309,7 @@ class Test_RDS_Service:
 
     # Test RDS Describe DB Cluster Snapshots
     @mock_aws
-    def test__describe_db_cluster_snapshots__(self):
+    def test_describe_db_cluster_snapshots(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-primary-1",
@@ -366,7 +366,7 @@ class Test_RDS_Service:
 
     # Test RDS engine version
     @mock_aws
-    def test__describe_db_engine_versions__(self):
+    def test_describe_db_engine_versions(self):
         # RDS client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         rds = RDS(aws_provider)

--- a/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
+++ b/tests/providers/aws/services/resourceexplorer2/resourceexplorer2_service_test.py
@@ -41,7 +41,7 @@ def mock_generate_regional_clients(provider, service):
     new=mock_generate_regional_clients,
 )
 class Test_ResourceExplorer2_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         resourceeplorer2 = ResourceExplorer2(aws_provider)
         assert (
@@ -54,7 +54,7 @@ class Test_ResourceExplorer2_Service:
         resourceeplorer2 = ResourceExplorer2(aws_provider)
         assert resourceeplorer2.service == "resource-explorer-2"
 
-    def test__list_indexes__(self):
+    def test_list_indexes(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         resourceeplorer2 = ResourceExplorer2(aws_provider)
         assert len(resourceeplorer2.indexes) == 1

--- a/tests/providers/aws/services/route53/route53_service_test.py
+++ b/tests/providers/aws/services/route53/route53_service_test.py
@@ -34,7 +34,7 @@ class Test_Route53_Service:
 
     # Test Route53 Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         route53 = Route53(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert route53.client.__class__.__name__ == "Route53"
 
@@ -51,7 +51,7 @@ class Test_Route53_Service:
         assert route53.service == "route53"
 
     @mock_aws
-    def test__list_hosted_zones__private_with_logging(self):
+    def test_list_hosted_zonesprivate_with_logging(self):
         # Create Hosted Zone
         r53_client = client("route53", region_name=AWS_REGION_US_EAST_1)
         hosted_zone_name = "testdns.aws.com."
@@ -95,7 +95,7 @@ class Test_Route53_Service:
         ]
 
     @mock_aws
-    def test__list_hosted_zones__public_with_logging(self):
+    def test_list_hosted_zonespublic_with_logging(self):
         # Create Hosted Zone
         r53_client = client("route53", region_name=AWS_REGION_US_EAST_1)
         hosted_zone_name = "testdns.aws.com."
@@ -136,7 +136,7 @@ class Test_Route53_Service:
         assert route53.hosted_zones[hosted_zone_id].region == AWS_REGION_US_EAST_1
 
     @mock_aws
-    def test__list_hosted_zones__private_without_logging(self):
+    def test_list_hosted_zonesprivate_without_logging(self):
         # Create Hosted Zone
         r53_client = client("route53", region_name=AWS_REGION_US_EAST_1)
         hosted_zone_name = "testdns.aws.com."
@@ -163,7 +163,7 @@ class Test_Route53_Service:
         assert route53.hosted_zones[hosted_zone_id].region == AWS_REGION_US_EAST_1
 
     @mock_aws
-    def test__list_hosted_zones__public_without_logging(self):
+    def test_list_hosted_zonespublic_without_logging(self):
         # Create Hosted Zone
         r53_client = client("route53", region_name=AWS_REGION_US_EAST_1)
         hosted_zone_name = "testdns.aws.com."
@@ -191,7 +191,7 @@ class Test_Route53_Service:
         assert route53.hosted_zones[hosted_zone_id].region == AWS_REGION_US_EAST_1
 
     @mock_aws
-    def test__list_resource_record_sets__(self):
+    def test_list_resource_record_sets(self):
         # Create Hosted Zone
         r53_client = client("route53", region_name=AWS_REGION_US_EAST_1)
         zone = r53_client.create_hosted_zone(

--- a/tests/providers/aws/services/route53/route53domains_service_test.py
+++ b/tests/providers/aws/services/route53/route53domains_service_test.py
@@ -68,7 +68,7 @@ def mock_make_api_call(self, operation_name, kwarg):
 class Test_Route53_Service:
 
     # Test Route53Domains Client
-    def test__get_client__(self):
+    def test_get_client(self):
         route53domains = Route53Domains(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert route53domains.client.__class__.__name__ == "Route53Domains"
 
@@ -82,7 +82,7 @@ class Test_Route53_Service:
         route53domains = Route53Domains(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert route53domains.service == "route53domains"
 
-    def test__list_domains__(self):
+    def test_list_domains(self):
         route53domains = Route53Domains(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         domain_name = "test.domain.com"
         assert len(route53domains.domains)

--- a/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
+++ b/tests/providers/aws/services/secretsmanager/secretsmanager_service_test.py
@@ -28,7 +28,7 @@ def mock_generate_regional_clients(provider, service):
 class Test_SecretsManager_Service:
     # Test SecretsManager Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         secretsmanager = SecretsManager(aws_provider)
         assert (
@@ -51,7 +51,7 @@ class Test_SecretsManager_Service:
         assert secretsmanager.service == "secretsmanager"
 
     @mock_aws
-    def test__list_secrets__(self):
+    def test_list_secrets(self):
         secretsmanager_client = client(
             "secretsmanager", region_name=AWS_REGION_EU_WEST_1
         )

--- a/tests/providers/aws/services/securityhub/securityhub_service_test.py
+++ b/tests/providers/aws/services/securityhub/securityhub_service_test.py
@@ -57,7 +57,7 @@ def mock_generate_regional_clients(provider, service):
 )
 class Test_SecurityHub_Service:
     # Test SecurityHub Client
-    def test__get_client__(self):
+    def test_get_client(self):
         security_hub = SecurityHub(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
         assert (
             security_hub.regional_clients[AWS_REGION_EU_WEST_1].__class__.__name__
@@ -69,7 +69,7 @@ class Test_SecurityHub_Service:
         security_hub = SecurityHub(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
         assert security_hub.session.__class__.__name__ == "Session"
 
-    def test__describe_hub__(self):
+    def test_describe_hub(self):
         # Set partition for the service
         securityhub = SecurityHub(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
         assert len(securityhub.securityhubs) == 1

--- a/tests/providers/aws/services/shield/shield_service_test.py
+++ b/tests/providers/aws/services/shield/shield_service_test.py
@@ -54,13 +54,13 @@ class Test_Shield_Service:
         shield = Shield(aws_provider)
         assert shield.session.__class__.__name__ == "Session"
 
-    def test__get_subscription_state__(self):
+    def test_get_subscription_state(self):
         # Shield client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         shield = Shield(aws_provider)
         assert shield.enabled
 
-    def test__list_protections__(self):
+    def test_list_protections(self):
         # Shield client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         shield = Shield(aws_provider)

--- a/tests/providers/aws/services/sns/sns_service_test.py
+++ b/tests/providers/aws/services/sns/sns_service_test.py
@@ -72,7 +72,7 @@ class Test_SNS_Service:
 
     @mock_aws
     # Test SNS session
-    def test__list_topics__(self):
+    def test_list_topics(self):
         sns_client = client("sns", region_name=AWS_REGION_EU_WEST_1)
         sns_client.create_topic(
             Name=topic_name,
@@ -97,7 +97,7 @@ class Test_SNS_Service:
 
     @mock_aws
     # Test SNS session
-    def test__get_topic_attributes__(self):
+    def test_get_topic_attributes(self):
         sns_client = client("sns", region_name=AWS_REGION_EU_WEST_1)
         sns_client.create_topic(Name=topic_name)
 
@@ -114,7 +114,7 @@ class Test_SNS_Service:
         assert sns.topics[0].kms_master_key_id == kms_key_id
 
     @mock_aws
-    def test__list_subscriptions_by_topic__(self):
+    def test_list_subscriptions_by_topic(self):
         sns_client = client("sns", region_name=AWS_REGION_EU_WEST_1)
         topic_response = sns_client.create_topic(Name=topic_name)
         topic_arn = topic_response["TopicArn"]

--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -74,7 +74,7 @@ class Test_SQS_Service:
 
     @mock_aws
     # Test SQS list queues
-    def test__list_queues__(self):
+    def test_list_queues(self):
         sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
         queue = sqs_client.create_queue(QueueName=test_queue, tags={"test": "test"})
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -92,7 +92,7 @@ class Test_SQS_Service:
     # so this test currently always fails
     # @mock_aws
     # # Test SQS list queues for over 1000 queues
-    # def test__list_queues__pagination_over_a_thousand(self):
+    # def test_list_queuespagination_over_a_thousand(self):
     #     sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
     #     for i in range(0,1050):
     #         sqs_client.create_queue(QueueName=f"{test_queue}-{i}", tags={"test": "test"})
@@ -102,7 +102,7 @@ class Test_SQS_Service:
 
     @mock_aws
     # Test SQS list queues
-    def test__get_queue_attributes__(self):
+    def test_get_queue_attributes(self):
         sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
         queue = sqs_client.create_queue(
             QueueName=test_queue,

--- a/tests/providers/aws/services/ssm/ssm_service_test.py
+++ b/tests/providers/aws/services/ssm/ssm_service_test.py
@@ -135,7 +135,7 @@ mainSteps:
 class Test_SSM_Service:
     # Test SSM Client
     @mock_aws
-    def test__get_client__(self):
+    def test_get_client(self):
         ssm = SSM(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         assert ssm.regional_clients[AWS_REGION_US_EAST_1].__class__.__name__ == "SSM"
 
@@ -152,7 +152,7 @@ class Test_SSM_Service:
         assert ssm.service == "ssm"
 
     @mock_aws
-    def test__list_documents__(self):
+    def test_list_documents(self):
         # Create SSM Document
         ssm_client = client("ssm", region_name=AWS_REGION_US_EAST_1)
         ssm_document_name = "test-document"
@@ -189,7 +189,7 @@ class Test_SSM_Service:
         assert ssm.documents[document_arn].account_owners == [AWS_ACCOUNT_NUMBER]
 
     @mock_aws
-    def test__list_resource_compliance_summaries__(self):
+    def test_list_resource_compliance_summaries(self):
         ssm = SSM(set_mocked_aws_provider([AWS_REGION_US_EAST_1]))
         instance_id = "i-1234567890abcdef0"
         assert len(ssm.compliance_resources) == 1

--- a/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
+++ b/tests/providers/aws/services/ssmincidents/ssmincidents_service_test.py
@@ -66,7 +66,7 @@ def mock_generate_regional_clients(provider, service):
     new=mock_generate_regional_clients,
 )
 class Test_SSMIncidents_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         ssmincidents = SSMIncidents(aws_provider)
         assert (
@@ -79,12 +79,12 @@ class Test_SSMIncidents_Service:
         ssmincidents = SSMIncidents(aws_provider)
         assert ssmincidents.service == "ssm-incidents"
 
-    def test__list_replication_sets__(self):
+    def test_list_replication_sets(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         ssmincidents = SSMIncidents(aws_provider)
         assert len(ssmincidents.replication_set) == 1
 
-    def test__get_replication_set__(self):
+    def test_get_replication_set(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         ssmincidents = SSMIncidents(aws_provider)
         assert ssmincidents.replication_set[0].arn == REPLICATION_SET_ARN
@@ -94,7 +94,7 @@ class Test_SSMIncidents_Service:
             assert region.status == "ACTIVE"
             assert region.sse_kms_id == "DefaultKey"
 
-    def test__list_response_plans__(self):
+    def test_list_response_plans(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         ssmincidents = SSMIncidents(aws_provider)
         assert len(ssmincidents.response_plans) == 1
@@ -103,7 +103,7 @@ class Test_SSMIncidents_Service:
         assert ssmincidents.response_plans[0].region == AWS_REGION_US_EAST_1
         assert ssmincidents.response_plans[0].tags == {"tag_test": "tag_value"}
 
-    def test__list_tags_for_resource__(self):
+    def test_list_tags_for_resource(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         ssmincidents = SSMIncidents(aws_provider)
         assert len(ssmincidents.response_plans) == 1

--- a/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
+++ b/tests/providers/aws/services/trustedadvisor/trustedadvisor_service_test.py
@@ -55,7 +55,7 @@ class Test_TrustedAdvisor_Service:
 
     @mock_aws
     # Test TrustedAdvisor session
-    def test__describe_trusted_advisor_checks__(self):
+    def test_describe_trusted_advisor_checks(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         trustedadvisor = TrustedAdvisor(aws_provider)
         assert trustedadvisor.premium_support.enabled

--- a/tests/providers/aws/services/vpc/vpc_service_test.py
+++ b/tests/providers/aws/services/vpc/vpc_service_test.py
@@ -65,7 +65,7 @@ class Test_VPC_Service:
 
     # Test VPC Describe VPCs
     @mock_aws
-    def test__describe_vpcs__(self):
+    def test_describe_vpcs(self):
         # Generate VPC Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC
@@ -98,7 +98,7 @@ class Test_VPC_Service:
 
     # Test VPC Describe Flow Logs
     @mock_aws
-    def test__describe_flow_logs__(self):
+    def test_describe_flow_logs(self):
         # Generate VPC Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         new_vpc = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]
@@ -127,7 +127,7 @@ class Test_VPC_Service:
 
     # Test VPC Describe VPC Peering connections
     @mock_aws
-    def test__describe_vpc_peering_connections__(self):
+    def test_describe_vpc_peering_connections(self):
         # Generate VPC Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPCs peers
@@ -211,7 +211,7 @@ class Test_VPC_Service:
 
     # Test VPC Describe VPC Endpoints
     @mock_aws
-    def test__describe_vpc_endpoints__(self):
+    def test_describe_vpc_endpoints(self):
         # Generate VPC Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC endpoint
@@ -259,7 +259,7 @@ class Test_VPC_Service:
 
     # Test VPC Describe VPC Endpoint Services
     @mock_aws
-    def test__describe_vpc_endpoint_services__(self):
+    def test_describe_vpc_endpoint_services(self):
         # Generate VPC Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         elbv2_client = client("elbv2", region_name=AWS_REGION_US_EAST_1)
@@ -314,7 +314,7 @@ class Test_VPC_Service:
 
     # Test VPC Describe VPC Subnets
     @mock_aws
-    def test__describe_vpc_subnets__(self):
+    def test_describe_vpc_subnets(self):
         # Generate VPC Client
         ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
         # Create VPC

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -66,7 +66,7 @@ class Test_WAF_Service:
         assert waf.session.__class__.__name__ == "Session"
 
     # Test WAF Describe Web ACLs
-    def test__list_web_acls__(self):
+    def test_list_web_acls(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
@@ -76,7 +76,7 @@ class Test_WAF_Service:
         assert waf.web_acls[0].id == "my-web-acl-id"
 
     # Test WAF Describe Web ACLs Resources
-    def test__list_resources_for_web_acl__(self):
+    def test_list_resources_for_web_acl(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)

--- a/tests/providers/aws/services/wafv2/wafv2_service_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_service_test.py
@@ -33,7 +33,7 @@ class Test_WAFv2_Service:
 
     # Test WAFv2 Describe Web ACLs
     @mock_aws
-    def test__list_web_acls__(self):
+    def test_list_web_acls(self):
         wafv2 = client("wafv2", region_name=AWS_REGION_EU_WEST_1)
         waf = wafv2.create_web_acl(
             Scope="REGIONAL",
@@ -56,7 +56,7 @@ class Test_WAFv2_Service:
 
     # Test WAFv2 Describe Web ACLs Resources
     @mock_aws
-    def test__list_resources_for_web_acl__(self):
+    def test_list_resources_for_web_acl(self):
         wafv2 = client("wafv2", region_name=AWS_REGION_EU_WEST_1)
         conn = client("elbv2", region_name=AWS_REGION_EU_WEST_1)
         ec2 = resource("ec2", region_name=AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/wellarchitected/wellarchitected_service_test.py
+++ b/tests/providers/aws/services/wellarchitected/wellarchitected_service_test.py
@@ -74,7 +74,7 @@ class Test_WellArchitected_Service:
         assert wellarchitected.session.__class__.__name__ == "Session"
 
     # Test WellArchitected list workloads
-    def test__list_workloads__(self):
+    def test_list_workloads(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         wellarchitected = WellArchitected(aws_provider)
         assert len(wellarchitected.workloads) == 1

--- a/tests/providers/aws/services/workspaces/workspaces_service_test.py
+++ b/tests/providers/aws/services/workspaces/workspaces_service_test.py
@@ -66,7 +66,7 @@ class Test_WorkSpaces_Service:
         assert workspaces.session.__class__.__name__ == "Session"
 
     # Test WorkSpaces describe workspaces
-    def test__describe_workspaces__(self):
+    def test_describe_workspaces(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         workspaces = WorkSpaces(aws_provider)
         assert len(workspaces.workspaces) == 1

--- a/tests/providers/azure/services/aks/aks_service_test.py
+++ b/tests/providers/azure/services/aks/aks_service_test.py
@@ -24,11 +24,11 @@ def mock_aks_get_clusters(_):
 
 
 @patch(
-    "prowler.providers.azure.services.aks.aks_service.AKS.__get_clusters__",
+    "prowler.providers.azure.services.aks.aks_service.AKS._get_clusters",
     new=mock_aks_get_clusters,
 )
 class Test_AppInsights_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         aks = AKS(set_mocked_azure_provider())
         assert (
             aks.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
@@ -39,7 +39,7 @@ class Test_AppInsights_Service:
         aks = AKS(set_mocked_azure_provider())
         assert aks.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_components__(self):
+    def test_get_components(self):
         aks = AKS(set_mocked_azure_provider())
         assert len(aks.clusters) == 1
         assert (

--- a/tests/providers/azure/services/app/app_service_test.py
+++ b/tests/providers/azure/services/app/app_service_test.py
@@ -59,7 +59,7 @@ from tests.providers.azure.azure_fixtures import (
 
 
 # @patch(
-#     "prowler.providers.azure.services.app.app_service.App.__get_apps__",
+#     "prowler.providers.azure.services.app.app_service.App._get_apps",
 #     new=mock_app_get_apps,
 # )
 class Test_App_Service:

--- a/tests/providers/azure/services/appinsights/appinsights_service_test.py
+++ b/tests/providers/azure/services/appinsights/appinsights_service_test.py
@@ -24,11 +24,11 @@ def mock_appinsights_get_components(_):
 
 
 @patch(
-    "prowler.providers.azure.services.appinsights.appinsights_service.AppInsights.__get_components__",
+    "prowler.providers.azure.services.appinsights.appinsights_service.AppInsights._get_components",
     new=mock_appinsights_get_components,
 )
 class Test_AppInsights_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         app_insights = AppInsights(set_mocked_azure_provider())
         assert (
             app_insights.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
@@ -39,7 +39,7 @@ class Test_AppInsights_Service:
         app_insights = AppInsights(set_mocked_azure_provider())
         assert app_insights.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_components__(self):
+    def test_get_components(self):
         appinsights = AppInsights(set_mocked_azure_provider())
         assert len(appinsights.components) == 1
         assert (

--- a/tests/providers/azure/services/cosmosdb/cosmosdb_service_test.py
+++ b/tests/providers/azure/services/cosmosdb/cosmosdb_service_test.py
@@ -25,18 +25,18 @@ def mock_cosmosdb_get_accounts(_):
 
 
 @patch(
-    "prowler.providers.azure.services.cosmosdb.cosmosdb_service.CosmosDB.__get_accounts__",
+    "prowler.providers.azure.services.cosmosdb.cosmosdb_service.CosmosDB._get_accounts",
     new=mock_cosmosdb_get_accounts,
 )
 class Test_CosmosDB_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         account = CosmosDB(set_mocked_azure_provider())
         assert (
             account.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
             == "CosmosDBManagementClient"
         )
 
-    def test__get_accounts__(self):
+    def test_get_accounts(self):
         account = CosmosDB(set_mocked_azure_provider())
         assert (
             account.accounts[AZURE_SUBSCRIPTION_ID][0].__class__.__name__ == "Account"

--- a/tests/providers/azure/services/defender/defender_service_test.py
+++ b/tests/providers/azure/services/defender/defender_service_test.py
@@ -95,31 +95,31 @@ def mock_defender_get_iot_security_solutions(_):
 
 
 @patch(
-    "prowler.providers.azure.services.defender.defender_service.Defender.__get_pricings__",
+    "prowler.providers.azure.services.defender.defender_service.Defender._get_pricings",
     new=mock_defender_get_pricings,
 )
 @patch(
-    "prowler.providers.azure.services.defender.defender_service.Defender.__get_auto_provisioning_settings__",
+    "prowler.providers.azure.services.defender.defender_service.Defender._get_auto_provisioning_settings",
     new=mock_defender_get_auto_provisioning_settings,
 )
 @patch(
-    "prowler.providers.azure.services.defender.defender_service.Defender.__get_assessments__",
+    "prowler.providers.azure.services.defender.defender_service.Defender._get_assessments",
     new=mock_defender_get_assessments,
 )
 @patch(
-    "prowler.providers.azure.services.defender.defender_service.Defender.__get_settings__",
+    "prowler.providers.azure.services.defender.defender_service.Defender._get_settings",
     new=mock_defender_get_settings,
 )
 @patch(
-    "prowler.providers.azure.services.defender.defender_service.Defender.__get_security_contacts__",
+    "prowler.providers.azure.services.defender.defender_service.Defender._get_security_contacts",
     new=mock_defender_get_security_contacts,
 )
 @patch(
-    "prowler.providers.azure.services.defender.defender_service.Defender.__get_iot_security_solutions__",
+    "prowler.providers.azure.services.defender.defender_service.Defender._get_iot_security_solutions",
     new=mock_defender_get_iot_security_solutions,
 )
 class Test_Defender_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         defender = Defender(set_mocked_azure_provider())
         assert (
             defender.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
@@ -131,7 +131,7 @@ class Test_Defender_Service:
         defender = Defender(set_mocked_azure_provider())
         assert defender.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_pricings__(self):
+    def test_get_pricings(self):
         defender = Defender(set_mocked_azure_provider())
         assert len(defender.pricings) == 1
         assert (
@@ -147,7 +147,7 @@ class Test_Defender_Service:
         ].free_trial_remaining_time == timedelta(days=1)
         assert defender.pricings[AZURE_SUBSCRIPTION_ID]["Standard"].extensions == {}
 
-    def test__get_auto_provisioning_settings__(self):
+    def test_get_auto_provisioning_settings(self):
         defender = Defender(set_mocked_azure_provider())
         assert len(defender.auto_provisioning_settings) == 1
         assert (
@@ -175,7 +175,7 @@ class Test_Defender_Service:
             == "On"
         )
 
-    def test__get_assessments__(self):
+    def test_get_assessments(self):
         defender = Defender(set_mocked_azure_provider())
         assert len(defender.assessments) == 1
         assert (
@@ -190,7 +190,7 @@ class Test_Defender_Service:
             defender.assessments[AZURE_SUBSCRIPTION_ID]["default"].status == "Healthy"
         )
 
-    def test__get_settings__(self):
+    def test_get_settings(self):
         defender = Defender(set_mocked_azure_provider())
         assert len(defender.settings) == 1
         assert (
@@ -207,7 +207,7 @@ class Test_Defender_Service:
         )
         assert defender.settings[AZURE_SUBSCRIPTION_ID]["MCAS"].enabled
 
-    def test__get_security_contacts__(self):
+    def test_get_security_contacts(self):
         defender = Defender(set_mocked_azure_provider())
         assert len(defender.security_contacts) == 1
         assert (
@@ -244,7 +244,7 @@ class Test_Defender_Service:
             == "On"
         )
 
-    def test__get_iot_security_solutions__(self):
+    def test_get_iot_security_solutions(self):
         defender = Defender(set_mocked_azure_provider())
         assert len(defender.iot_security_solutions) == 1
         assert (

--- a/tests/providers/azure/services/entra/entra_service_test.py
+++ b/tests/providers/azure/services/entra/entra_service_test.py
@@ -99,35 +99,35 @@ async def mock_entra_get_conditional_access_policy(_):
 
 
 @patch(
-    "prowler.providers.azure.services.entra.entra_service.Entra.__get_users__",
+    "prowler.providers.azure.services.entra.entra_service.Entra._get_users",
     new=mock_entra_get_users,
 )
 @patch(
-    "prowler.providers.azure.services.entra.entra_service.Entra.__get_authorization_policy__",
+    "prowler.providers.azure.services.entra.entra_service.Entra._get_authorization_policy",
     new=mock_entra_get_authorization_policy,
 )
 @patch(
-    "prowler.providers.azure.services.entra.entra_service.Entra.__get_group_settings__",
+    "prowler.providers.azure.services.entra.entra_service.Entra._get_group_settings",
     new=mock_entra_get_group_settings,
 )
 @patch(
-    "prowler.providers.azure.services.entra.entra_service.Entra.__get_security_default__",
+    "prowler.providers.azure.services.entra.entra_service.Entra._get_security_default",
     new=mock_entra_get_security_default,
 )
 @patch(
-    "prowler.providers.azure.services.entra.entra_service.Entra.__get_named_locations__",
+    "prowler.providers.azure.services.entra.entra_service.Entra._get_named_locations",
     new=mock_entra_get_named_locations,
 )
 @patch(
-    "prowler.providers.azure.services.entra.entra_service.Entra.__get_directory_roles__",
+    "prowler.providers.azure.services.entra.entra_service.Entra._get_directory_roles",
     new=mock_entra_get_directory_roles,
 )
 @patch(
-    "prowler.providers.azure.services.entra.entra_service.Entra.__get_conditional_access_policy__",
+    "prowler.providers.azure.services.entra.entra_service.Entra._get_conditional_access_policy",
     new=mock_entra_get_conditional_access_policy,
 )
 class Test_Entra_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         entra_client = Entra(
             set_mocked_azure_provider(identity=AzureIdentityInfo(tenant_domain=DOMAIN))
         )
@@ -137,7 +137,7 @@ class Test_Entra_Service:
         entra_client = Entra(set_mocked_azure_provider())
         assert entra_client.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_users__(self):
+    def test_get_users(self):
         entra_client = Entra(set_mocked_azure_provider())
         assert len(entra_client.users) == 1
         assert entra_client.users[DOMAIN]["user-1@tenant1.es"].id == "id-1"
@@ -147,7 +147,7 @@ class Test_Entra_Service:
             == 0
         )
 
-    def test__get_authorization_policy__(self):
+    def test_get_authorization_policy(self):
         entra_client = Entra(set_mocked_azure_provider())
         assert entra_client.authorization_policy[DOMAIN].id == "id-1"
         assert entra_client.authorization_policy[DOMAIN].name == "Name 1"
@@ -156,7 +156,7 @@ class Test_Entra_Service:
             DOMAIN
         ].default_user_role_permissions
 
-    def test__get_group_settings__(self):
+    def test_get_group_settings(self):
         entra_client = Entra(set_mocked_azure_provider())
         assert entra_client.group_settings[DOMAIN]["id-1"].name == "Test"
         assert (
@@ -165,13 +165,13 @@ class Test_Entra_Service:
         )
         assert len(entra_client.group_settings[DOMAIN]["id-1"].settings) == 0
 
-    def test__get_security_default__(self):
+    def test_get_security_default(self):
         entra_client = Entra(set_mocked_azure_provider())
         assert entra_client.security_default[DOMAIN].id == "id-security-default"
         assert entra_client.security_default[DOMAIN].name == "Test"
         assert entra_client.security_default[DOMAIN].is_enabled
 
-    def test__get_named_locations__(self):
+    def test_get_named_locations(self):
         entra_client = Entra(set_mocked_azure_provider())
         assert entra_client.named_locations[DOMAIN]["id-1"].name == "Test"
         assert (
@@ -179,7 +179,7 @@ class Test_Entra_Service:
         )
         assert not entra_client.named_locations[DOMAIN]["id-1"].is_trusted
 
-    def test__get_directory_roles__(self):
+    def test_get_directory_roles(self):
         entra_client = Entra(set_mocked_azure_provider())
         assert (
             entra_client.directory_roles[DOMAIN]["GlobalAdministrator"].id
@@ -190,7 +190,7 @@ class Test_Entra_Service:
             == 0
         )
 
-    def test__get_conditional_access_policy__(self):
+    def test_get_conditional_access_policy(self):
         entra_client = Entra(set_mocked_azure_provider())
         assert len(entra_client.conditional_access_policy) == 1
         assert len(entra_client.conditional_access_policy[DOMAIN]) == 1

--- a/tests/providers/azure/services/keyvault/keyvault_service_test.py
+++ b/tests/providers/azure/services/keyvault/keyvault_service_test.py
@@ -61,7 +61,7 @@ from tests.providers.azure.azure_fixtures import (
 
 
 # @patch(
-#     "prowler.providers.azure.services.keyvault.keyvault_service.KeyVault.__get_key_vaults__",
+#     "prowler.providers.azure.services.keyvault.keyvault_service.KeyVault._get_key_vaults",
 #     new=mock_keyvault_get_key_vaults,
 # )
 class Test_keyvault_service:

--- a/tests/providers/azure/services/monitor/monitor_service_test.py
+++ b/tests/providers/azure/services/monitor/monitor_service_test.py
@@ -40,11 +40,11 @@ def mock_monitor_get_diagnostics_settings(_):
 
 
 @patch(
-    "prowler.providers.azure.services.monitor.monitor_service.Monitor.__get_diagnostics_settings__",
+    "prowler.providers.azure.services.monitor.monitor_service.Monitor._get_diagnostics_settings",
     new=mock_monitor_get_diagnostics_settings,
 )
 class Test_Monitor_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         monitor = Monitor(set_mocked_azure_provider())
         assert (
             monitor.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__

--- a/tests/providers/azure/services/mysql/mysql_service_test.py
+++ b/tests/providers/azure/services/mysql/mysql_service_test.py
@@ -41,15 +41,15 @@ def mock_mysql_get_configurations(_):
 
 
 @patch(
-    "prowler.providers.azure.services.mysql.mysql_service.MySQL.__get_flexible_servers__",
+    "prowler.providers.azure.services.mysql.mysql_service.MySQL._get_flexible_servers",
     new=mock_mysql_get_servers,
 )
 @patch(
-    "prowler.providers.azure.services.mysql.mysql_service.MySQL.__get_configurations__",
+    "prowler.providers.azure.services.mysql.mysql_service.MySQL._get_configurations",
     new=mock_mysql_get_configurations,
 )
 class Test_MySQL_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         mysql = MySQL(set_mocked_azure_provider())
         assert (
             mysql.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
@@ -60,7 +60,7 @@ class Test_MySQL_Service:
         mysql = MySQL(set_mocked_azure_provider())
         assert mysql.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_flexible_servers__(self):
+    def test_get_flexible_servers(self):
         mysql = MySQL(set_mocked_azure_provider())
         assert len(mysql.flexible_servers) == 1
         assert (
@@ -96,9 +96,9 @@ class Test_MySQL_Service:
             == "value"
         )
 
-    def test__get_configurations__(self):
+    def test_get_configurations(self):
         mysql = MySQL(set_mocked_azure_provider())
-        configurations = mysql.__get_configurations__()
+        configurations = mysql._get_configurations()
 
         assert len(configurations) == 1
         assert configurations["test"].resource_id == "/subscriptions/resource_id"

--- a/tests/providers/azure/services/network/network_service_test.py
+++ b/tests/providers/azure/services/network/network_service_test.py
@@ -67,30 +67,30 @@ def mock_network_get_public_ip_addresses(_):
 
 
 @patch(
-    "prowler.providers.azure.services.network.network_service.Network.__get_security_groups__",
+    "prowler.providers.azure.services.network.network_service.Network._get_security_groups",
     new=mock_network_get_security_groups,
 )
 @patch(
-    "prowler.providers.azure.services.network.network_service.Network.__get_bastion_hosts__",
+    "prowler.providers.azure.services.network.network_service.Network._get_bastion_hosts",
     new=mock_network_get_bastion_hosts,
 )
 @patch(
-    "prowler.providers.azure.services.network.network_service.Network.__get_network_watchers__",
+    "prowler.providers.azure.services.network.network_service.Network._get_network_watchers",
     new=mock_network_get_network_watchers,
 )
 @patch(
-    "prowler.providers.azure.services.network.network_service.Network.__get_public_ip_addresses__",
+    "prowler.providers.azure.services.network.network_service.Network._get_public_ip_addresses",
     new=mock_network_get_public_ip_addresses,
 )
 class Test_Network_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         network = Network(set_mocked_azure_provider())
         assert (
             network.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
             == "NetworkManagementClient"
         )
 
-    def test__get_security_groups__(self):
+    def test_get_security_groups(self):
         network = Network(set_mocked_azure_provider())
         assert (
             network.security_groups[AZURE_SUBSCRIPTION_ID][0].__class__.__name__
@@ -101,7 +101,7 @@ class Test_Network_Service:
         assert network.security_groups[AZURE_SUBSCRIPTION_ID][0].location == "location"
         assert network.security_groups[AZURE_SUBSCRIPTION_ID][0].security_rules == []
 
-    def test__get_network_watchers__(self):
+    def test_get_network_watchers(self):
         network = Network(set_mocked_azure_provider())
         assert (
             network.network_watchers[AZURE_SUBSCRIPTION_ID][0].__class__.__name__
@@ -114,7 +114,7 @@ class Test_Network_Service:
             FlowLog(enabled=True, retention_policy=90)
         ]
 
-    def __get_flow_logs__(self):
+    def _get_flow_logs(self):
         network = Network(set_mocked_azure_provider())
         nw_name = "name"
         assert (
@@ -137,7 +137,7 @@ class Test_Network_Service:
             == 90
         )
 
-    def __get_bastion_hosts__(self):
+    def _get_bastion_hosts(self):
         network = Network(set_mocked_azure_provider())
         assert (
             network.bastion_hosts[AZURE_SUBSCRIPTION_ID][0].__class__.__name__
@@ -147,7 +147,7 @@ class Test_Network_Service:
         assert network.bastion_hosts[AZURE_SUBSCRIPTION_ID][0].name == "name"
         assert network.bastion_hosts[AZURE_SUBSCRIPTION_ID][0].location == "location"
 
-    def __get_public_ip_addresses__(self):
+    def _get_public_ip_addresses(self):
         network = Network(set_mocked_azure_provider())
         assert (
             network.public_ip_addresses[AZURE_SUBSCRIPTION_ID][0].__class__.__name__

--- a/tests/providers/azure/services/policy/policy_service_test.py
+++ b/tests/providers/azure/services/policy/policy_service_test.py
@@ -19,11 +19,11 @@ def mock_policy_assigments(_):
 
 
 @patch(
-    "prowler.providers.azure.services.policy.policy_service.Policy.__get_policy_assigments__",
+    "prowler.providers.azure.services.policy.policy_service.Policy._get_policy_assigments",
     new=mock_policy_assigments,
 )
 class Test_Policy_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         policy = Policy(set_mocked_azure_provider())
         assert (
             policy.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__ == "PolicyClient"
@@ -33,7 +33,7 @@ class Test_Policy_Service:
         policy = Policy(set_mocked_azure_provider())
         assert policy.subscriptions.__class__.__name__ == "dict"
 
-    def test__get_policy_assigments__(self):
+    def test_get_policy_assigments(self):
         policy = Policy(set_mocked_azure_provider())
         assert policy.policy_assigments.__class__.__name__ == "dict"
         assert (

--- a/tests/providers/azure/services/postgresql/postgresql_service_test.py
+++ b/tests/providers/azure/services/postgresql/postgresql_service_test.py
@@ -38,18 +38,18 @@ def mock_sqlserver_get_postgresql_flexible_servers(_):
 
 
 @patch(
-    "prowler.providers.azure.services.postgresql.postgresql_service.PostgreSQL.__get_flexible_servers__",
+    "prowler.providers.azure.services.postgresql.postgresql_service.PostgreSQL._get_flexible_servers",
     new=mock_sqlserver_get_postgresql_flexible_servers,
 )
 class Test_SqlServer_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         postgresql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgresql.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
             == "PostgreSQLManagementClient"
         )
 
-    def test__get_sql_servers__(self):
+    def test_get_sql_servers(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][0].__class__.__name__
@@ -65,12 +65,12 @@ class Test_SqlServer_Service:
             == "resource_group"
         )
 
-    def test__get_resource_group__(self):
+    def test_get_resource_group(self):
         id = "/subscriptions/subscription/resourceGroups/resource_group/providers/Microsoft.DBforPostgreSQL/flexibleServers/server"
         postgresql = PostgreSQL(set_mocked_azure_provider())
-        assert postgresql.__get_resource_group__(id) == "resource_group"
+        assert postgresql._get_resource_group(id) == "resource_group"
 
-    def test__get_require_secure_transport__(self):
+    def test_get_require_secure_transport(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][
@@ -79,40 +79,40 @@ class Test_SqlServer_Service:
             == "ON"
         )
 
-    def test__get_log_checkpoints__(self):
+    def test_get_log_checkpoints(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][0].log_checkpoints == "ON"
         )
 
-    def test__get_log_connections__(self):
+    def test_get_log_connections(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][0].log_connections == "ON"
         )
 
-    def test__get_log_disconnections__(self):
+    def test_get_log_disconnections(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][0].log_disconnections
             == "ON"
         )
 
-    def test__get_connection_throttling__(self):
+    def test_get_connection_throttling(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][0].connection_throttling
             == "ON"
         )
 
-    def test__get_log_retention_days__(self):
+    def test_get_log_retention_days(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][0].log_retention_days
             == "3"
         )
 
-    def test__get_firewall__(self):
+    def test_get_firewall(self):
         postgesql = PostgreSQL(set_mocked_azure_provider())
         assert (
             postgesql.flexible_servers[AZURE_SUBSCRIPTION_ID][0]

--- a/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_service_test.py
@@ -54,18 +54,18 @@ def mock_sqlserver_get_sql_servers(_):
 
 
 @patch(
-    "prowler.providers.azure.services.sqlserver.sqlserver_service.SQLServer.__get_sql_servers__",
+    "prowler.providers.azure.services.sqlserver.sqlserver_service.SQLServer._get_sql_servers",
     new=mock_sqlserver_get_sql_servers,
 )
 class Test_SqlServer_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         sql_server = SQLServer(set_mocked_azure_provider())
         assert (
             sql_server.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
             == "SqlManagementClient"
         )
 
-    def test__get_sql_servers__(self):
+    def test_get_sql_servers(self):
         database = Database(
             id="id",
             name="name",
@@ -117,7 +117,7 @@ class Test_SqlServer_Service:
             == "ServerVulnerabilityAssessment"
         )
 
-    def test__get_databases__(self):
+    def test_get_databases(self):
         sql_server = SQLServer(set_mocked_azure_provider())
         assert (
             sql_server.sql_servers[AZURE_SUBSCRIPTION_ID][0]
@@ -147,7 +147,7 @@ class Test_SqlServer_Service:
             == "TransparentDataEncryption"
         )
 
-    def test__get_transparent_data_encryption__(self):
+    def test_get_transparent_data_encryption(self):
         sql_server = SQLServer(set_mocked_azure_provider())
         assert (
             sql_server.sql_servers[AZURE_SUBSCRIPTION_ID][0]
@@ -177,10 +177,10 @@ class Test_SqlServer_Service:
             == "AzureKeyVault"
         )
 
-    def test__get_resource_group__(self):
+    def test_get_resource_group(self):
         id = "/subscriptions/subscription_id/resourceGroups/resource_group/providers/Microsoft.Sql/servers/sql_server"
         sql_server = SQLServer(set_mocked_azure_provider())
-        assert sql_server.__get_resource_group__(id) == "resource_group"
+        assert sql_server._get_resource_group(id) == "resource_group"
 
     def test__get_vulnerability_assessment__(self):
         sql_server = SQLServer(set_mocked_azure_provider())
@@ -198,7 +198,7 @@ class Test_SqlServer_Service:
             == storage_container_path
         )
 
-    def test__get_server_blob_auditing_policies__(self):
+    def test_get_server_blob_auditing_policies(self):
         sql_server = SQLServer(set_mocked_azure_provider())
         auditing_policies = ServerBlobAuditingPolicy(state="Disabled")
         assert (
@@ -212,7 +212,7 @@ class Test_SqlServer_Service:
             == auditing_policies
         )
 
-    def test__get_firewall_rules__(self):
+    def test_get_firewall_rules(self):
         sql_server = SQLServer(set_mocked_azure_provider())
         firewall_rules = FirewallRule(name="name")
         assert (
@@ -226,7 +226,7 @@ class Test_SqlServer_Service:
             == firewall_rules
         )
 
-    def test__get_server_security_alert_policies__(self):
+    def test_get_server_security_alert_policies(self):
         sql_server = SQLServer(set_mocked_azure_provider())
         security_alert_policies = ServerSecurityAlertPolicy(state="Disabled")
         assert (

--- a/tests/providers/azure/services/storage/storage_service_test.py
+++ b/tests/providers/azure/services/storage/storage_service_test.py
@@ -41,18 +41,18 @@ def mock_storage_get_storage_accounts(_):
 
 
 @patch(
-    "prowler.providers.azure.services.storage.storage_service.Storage.__get_storage_accounts__",
+    "prowler.providers.azure.services.storage.storage_service.Storage._get_storage_accounts",
     new=mock_storage_get_storage_accounts,
 )
 class Test_Storage_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         storage = Storage(set_mocked_azure_provider())
         assert (
             storage.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__
             == "StorageManagementClient"
         )
 
-    def test__get_storage_accounts__(self):
+    def test_get_storage_accounts(self):
         storage = Storage(set_mocked_azure_provider())
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].__class__.__name__
@@ -111,7 +111,7 @@ class Test_Storage_Service:
             container_delete_retention_policy=None,
         )
 
-    def test__get_blob_properties__(self):
+    def test_get_blob_properties(self):
         storage = Storage(set_mocked_azure_provider())
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][

--- a/tests/providers/azure/services/vm/vm_service_test.py
+++ b/tests/providers/azure/services/vm/vm_service_test.py
@@ -55,15 +55,15 @@ def mock_vm_get_disks(_):
 
 
 @patch(
-    "prowler.providers.azure.services.vm.vm_service.VirtualMachines.__get_virtual_machines__",
+    "prowler.providers.azure.services.vm.vm_service.VirtualMachines._get_virtual_machines",
     new=mock_vm_get_virtual_machines,
 )
 @patch(
-    "prowler.providers.azure.services.vm.vm_service.VirtualMachines.__get_disks__",
+    "prowler.providers.azure.services.vm.vm_service.VirtualMachines._get_disks",
     new=mock_vm_get_disks,
 )
 class Test_AppInsights_Service:
-    def test__get_client__(self):
+    def test_get_client(self):
         app_insights = VirtualMachines(set_mocked_azure_provider())
         assert (
             app_insights.clients[AZURE_SUBSCRIPTION_ID].__class__.__name__


### PR DESCRIPTION
### Context

Now we were using incorrect format to naming methods for services. To indicate internal use for methods is better to use `_*`.

[Ref](https://peps.python.org/pep-0008/#descriptive-naming-styles)

### Description

Changes all methods from services form all providers defined in the same class. Not having in count father methods.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
