### PR TITLE
feat(aws): Add new check to ensure Aurora MySQL DB Clusters publish audit logs to CloudWatch logs

### DIFF
--- a/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.metadata.json
@@ -1,14 +1,14 @@
 {
   "Provider": "aws",
   "CheckID": "rds_cluster_integration_cloudwatch_logs",
-  "CheckTitle": "Check if RDS Aurora MySQL cluster is integrated with CloudWatch Logs.",
+  "CheckTitle": "Check if RDS cluster is integrated with CloudWatch Logs.",
   "CheckType": [],
   "ServiceName": "rds",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
   "Severity": "medium",
   "ResourceType": "AwsRdsDbCluster",
-  "Description": "Check if RDS Aurora MySQL cluster is integrated with CloudWatch Logs.",
+  "Description": "Check if RDS cluster is integrated with CloudWatch Logs. The types valid are Aurora MySQL, Aurora PostgreSQL, MySQL, PostgreSQL.",
   "Risk": "If logs are not enabled, monitoring of service use and threat analysis is not possible.",
   "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html",
   "Remediation": {

--- a/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_cluster_integration_cloudwatch_logs",
+  "CheckTitle": "Check if RDS Aurora MySQL cluster is integrated with CloudWatch Logs.",
+  "CheckType": [],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
+  "Severity": "medium",
+  "ResourceType": "AwsRdsDbCluster",
+  "Description": "Check if RDS Aurora MySQL cluster is integrated with CloudWatch Logs.",
+  "Risk": "If logs are not enabled, monitoring of service use and threat analysis is not possible.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_LogAccess.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws rds modify-db-cluster --db-cluster-identifier <db_cluster_id> --cloudwatch-logs-export-configuration {'EnableLogTypes':['audit',error','general','slowquery']} --apply-immediately",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-34",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Use CloudWatch Logs to perform real-time analysis of the log data. Create alarms and view metrics.",
+      "Url": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/publishing_cloudwatchlogs.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
@@ -5,8 +5,9 @@ from prowler.providers.aws.services.rds.rds_client import rds_client
 class rds_cluster_integration_cloudwatch_logs(Check):
     def execute(self):
         findings = []
+        valid_engines = ["aurora-mysql", "aurora-postgresql", "mysql", "postgres"]
         for db_cluster_arn, db_cluster in rds_client.db_clusters.items():
-            if db_cluster.engine == "aurora-mysql":
+            if db_cluster.engine in valid_engines:
                 report = Check_Report_AWS(self.metadata())
                 report.region = db_cluster.region
                 report.resource_id = db_cluster.id
@@ -14,10 +15,10 @@ class rds_cluster_integration_cloudwatch_logs(Check):
                 report.resource_tags = db_cluster.tags
                 if db_cluster.cloudwatch_logs:
                     report.status = "PASS"
-                    report.status_extended = f"Aurora MySQL Cluster {db_cluster.id} is shipping {', '.join(db_cluster.cloudwatch_logs)} logs to CloudWatch Logs."
+                    report.status_extended = f"RDS Cluster {db_cluster.id} is shipping {', '.join(db_cluster.cloudwatch_logs)} logs to CloudWatch Logs."
                 else:
                     report.status = "FAIL"
-                    report.status_extended = f"Aurora MySQL Cluster {db_cluster.id} does not have CloudWatch Logs enabled."
+                    report.status_extended = f"RDS Cluster {db_cluster.id} does not have CloudWatch Logs enabled."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
@@ -14,7 +14,7 @@ class rds_cluster_integration_cloudwatch_logs(Check):
                 report.resource_tags = db_cluster.tags
                 if db_cluster.cloudwatch_logs:
                     report.status = "PASS"
-                    report.status_extended = f"Aurora MySQL Cluster {db_cluster.id} is shipping {' '.join(db_cluster.cloudwatch_logs)} to CloudWatch Logs."
+                    report.status_extended = f"Aurora MySQL Cluster {db_cluster.id} is shipping {', '.join(db_cluster.cloudwatch_logs)} logs to CloudWatch Logs."
                 else:
                     report.status = "FAIL"
                     report.status_extended = f"Aurora MySQL Cluster {db_cluster.id} does not have CloudWatch Logs enabled."

--- a/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
@@ -1,0 +1,24 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_aurora_mysql_integration_cloudwatch_logs(Check):
+    def execute(self):
+        findings = []
+        for db_cluster_arn, db_cluster in rds_client.db_clusters.items():
+            if db_cluster.engine == "aurora-mysql":
+                report = Check_Report_AWS(self.metadata())
+                report.region = db_cluster.region
+                report.resource_id = db_cluster.id
+                report.resource_arn = db_cluster_arn
+                report.resource_tags = db_cluster.tags
+                if db_cluster.cloudwatch_logs:
+                    report.status = "PASS"
+                    report.status_extended = f"Aurora MySQL Cluster {db_cluster.id} is shipping {' '.join(db_cluster.cloudwatch_logs)} to CloudWatch Logs."
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = f"Aurora MySQL Cluster {db_cluster.id} does not have CloudWatch Logs enabled."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs.py
@@ -2,7 +2,7 @@ from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.rds.rds_client import rds_client
 
 
-class rds_aurora_mysql_integration_cloudwatch_logs(Check):
+class rds_cluster_integration_cloudwatch_logs(Check):
     def execute(self):
         findings = []
         for db_cluster_arn, db_cluster in rds_client.db_clusters.items():

--- a/prowler/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs.py
+++ b/prowler/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs.py
@@ -13,7 +13,7 @@ class rds_instance_integration_cloudwatch_logs(Check):
             report.resource_tags = db_instance.tags
             if db_instance.cloudwatch_logs:
                 report.status = "PASS"
-                report.status_extended = f"RDS Instance {db_instance.id} is shipping {' '.join(db_instance.cloudwatch_logs)} to CloudWatch Logs."
+                report.status_extended = f"RDS Instance {db_instance.id} is shipping {', '.join(db_instance.cloudwatch_logs)} logs to CloudWatch Logs."
             else:
                 report.status = "FAIL"
                 report.status_extended = f"RDS Instance {db_instance.id} does not have CloudWatch Logs enabled."

--- a/tests/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs_test.py
@@ -119,7 +119,7 @@ class Test_rds_cluster_integration_cloudwatch_logs:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "Aurora MySQL Cluster aurora-cluster-1 does not have CloudWatch Logs enabled."
+                    == "RDS Cluster aurora-cluster-1 does not have CloudWatch Logs enabled."
                 )
                 assert result[0].resource_id == "aurora-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -164,7 +164,7 @@ class Test_rds_cluster_integration_cloudwatch_logs:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "Aurora MySQL Cluster aurora-cluster-1 is shipping audit, error logs to CloudWatch Logs."
+                    == "RDS Cluster aurora-cluster-1 is shipping audit, error logs to CloudWatch Logs."
                 )
                 assert result[0].resource_id == "aurora-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs_test.py
@@ -146,7 +146,7 @@ class Test_rds_cluster_integration_cloudwatch_logs:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "Aurora MySQL Cluster aurora-cluster-1 is shipping audit error to CloudWatch Logs."
+                    == "Aurora MySQL Cluster aurora-cluster-1 is shipping audit, error logs to CloudWatch Logs."
                 )
                 assert result[0].resource_id == "aurora-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_integration_cloudwatch_logs/rds_cluster_integration_cloudwatch_logs_test.py
@@ -1,0 +1,157 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_rds_cluster_integration_cloudwatch_logs:
+    @mock_aws
+    def test_rds_no_clusters(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs import (
+                    rds_cluster_integration_cloudwatch_logs,
+                )
+
+                check = rds_cluster_integration_cloudwatch_logs()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_rds_no_aurora_cluster(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="cluster-1",
+            Engine="mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password",
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs import (
+                    rds_cluster_integration_cloudwatch_logs,
+                )
+
+                check = rds_cluster_integration_cloudwatch_logs()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_rds_cluster_no_logs(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="aurora-cluster-1",
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password",
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs import (
+                    rds_cluster_integration_cloudwatch_logs,
+                )
+
+                check = rds_cluster_integration_cloudwatch_logs()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "Aurora MySQL Cluster aurora-cluster-1 does not have CloudWatch Logs enabled."
+                )
+                assert result[0].resource_id == "aurora-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:aurora-cluster-1"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_rds_cluster_with_logs(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="aurora-cluster-1",
+            Engine="aurora-mysql",
+            MasterUsername="admin",
+            MasterUserPassword="password",
+            EnableCloudwatchLogsExports=["audit", "error"],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_cluster_integration_cloudwatch_logs.rds_cluster_integration_cloudwatch_logs import (
+                    rds_cluster_integration_cloudwatch_logs,
+                )
+
+                check = rds_cluster_integration_cloudwatch_logs()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "Aurora MySQL Cluster aurora-cluster-1 is shipping audit error to CloudWatch Logs."
+                )
+                assert result[0].resource_id == "aurora-cluster-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:aurora-cluster-1"
+                )
+                assert result[0].resource_tags == []

--- a/tests/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_integration_cloudwatch_logs/rds_instance_integration_cloudwatch_logs_test.py
@@ -135,7 +135,7 @@ class Test_rds_instance_integration_cloudwatch_logs:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-1 is shipping audit error to CloudWatch Logs."
+                    == "RDS Instance db-master-1 is shipping audit, error logs to CloudWatch Logs."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

This new check verifies that Amazon Aurora MySQL DB clusters are configured to publish audit logs to Amazon CloudWatch Logs. Audit logs are vital for tracking database activity such as login attempts, data modifications, and schema changes. Configuring audit logs to publish to CloudWatch enables real-time analysis, durable storage of logs, and the creation of alarms and metrics for enhanced monitoring and compliance.

I have done this new check following the SH implementation, but there is an option of doing it as it’s done for instances, the option done is mirroring the existing AWS Security Hub control, focusing only on Aurora MySQL clusters, which have specific and robust support for audit log exports.
The other option would be doing as the [RDS.9](https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-9) control but for clusters, the problem here is that some clusters needs plugins to publish audit and they are not as complete as the Aurora MySQL ones.

So, in conclusion, I've done this check only for the Aurora MySQL clusters but the option of changing it is available and I’ll be open to listen any suggestion.

### Description

Added new `rds_cluster_integration_cloudwatch_logs` check with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
