### PR TITLE
feat(aws) add region for GuardDuty checks

### DIFF
--- a/prowler/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed.py
@@ -13,9 +13,7 @@ class guardduty_centrally_managed(Check):
                 report.resource_arn = detector.arn
                 report.resource_tags = detector.tags
                 report.status = "FAIL"
-                report.status_extended = (
-                    f"GuardDuty detector {detector.id} in region {detector.region} is not centrally managed."
-                )
+                report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} is not centrally managed."
                 if detector.administrator_account:
                     report.status = "PASS"
                     report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} is centrally managed by account {detector.administrator_account}."

--- a/prowler/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed.py
@@ -14,14 +14,14 @@ class guardduty_centrally_managed(Check):
                 report.resource_tags = detector.tags
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"GuardDuty detector {detector.id} is not centrally managed."
+                    f"GuardDuty detector {detector.id} in region {detector.region} is not centrally managed."
                 )
                 if detector.administrator_account:
                     report.status = "PASS"
-                    report.status_extended = f"GuardDuty detector {detector.id} is centrally managed by account {detector.administrator_account}."
+                    report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} is centrally managed by account {detector.administrator_account}."
                 elif detector.member_accounts:
                     report.status = "PASS"
-                    report.status_extended = f"GuardDuty detector {detector.id} is administrator account with {len(detector.member_accounts)} member accounts."
+                    report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} is administrator account with {len(detector.member_accounts)} member accounts."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
@@ -12,20 +12,20 @@ class guardduty_is_enabled(Check):
             report.resource_arn = detector.arn
             report.resource_tags = detector.tags
             report.status = "PASS"
-            report.status_extended = f"GuardDuty detector {detector.id} enabled."
+            report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} enabled."
 
             if not detector.enabled_in_account:
                 report.status = "FAIL"
-                report.status_extended = "GuardDuty is not enabled."
+                report.status_extended = f"GuardDuty is not enabled in region {detector.region}."
             elif detector.status is None:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"GuardDuty detector {detector.id} not configured."
+                    f"GuardDuty detector {detector.id} in region {detector.region} not configured."
                 )
             elif not detector.status:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"GuardDuty detector {detector.id} configured but suspended."
+                    f"GuardDuty detector {detector.id} in region {detector.region} configured but suspended."
                 )
 
             if report.status == "FAIL" and (

--- a/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled.py
@@ -12,21 +12,21 @@ class guardduty_is_enabled(Check):
             report.resource_arn = detector.arn
             report.resource_tags = detector.tags
             report.status = "PASS"
-            report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} enabled."
+            report.status_extended = (
+                f"GuardDuty detector {detector.id} in region {detector.region} enabled."
+            )
 
             if not detector.enabled_in_account:
                 report.status = "FAIL"
-                report.status_extended = f"GuardDuty is not enabled in region {detector.region}."
+                report.status_extended = (
+                    f"GuardDuty is not enabled in region {detector.region}."
+                )
             elif detector.status is None:
                 report.status = "FAIL"
-                report.status_extended = (
-                    f"GuardDuty detector {detector.id} in region {detector.region} not configured."
-                )
+                report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} not configured."
             elif not detector.status:
                 report.status = "FAIL"
-                report.status_extended = (
-                    f"GuardDuty detector {detector.id} in region {detector.region} configured but suspended."
-                )
+                report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} configured but suspended."
 
             if report.status == "FAIL" and (
                 guardduty_client.audit_config.get("mute_non_default_regions", False)

--- a/prowler/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_no_high_severity_findings/guardduty_no_high_severity_findings.py
@@ -13,10 +13,10 @@ class guardduty_no_high_severity_findings(Check):
                 report.resource_arn = detector.arn
                 report.resource_tags = detector.tags
                 report.status = "PASS"
-                report.status_extended = f"GuardDuty detector {detector.id} does not have high severity findings."
+                report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} does not have high severity findings."
                 if len(detector.findings) > 0:
                     report.status = "FAIL"
-                    report.status_extended = f"GuardDuty detector {detector.id} has {str(len(detector.findings))} high severity findings."
+                    report.status_extended = f"GuardDuty detector {detector.id} in region {detector.region} has {str(len(detector.findings))} high severity findings."
 
                 findings.append(report)
 

--- a/tests/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_centrally_managed/guardduty_centrally_managed_test.py
@@ -53,7 +53,7 @@ class Test_guardduty_centrally_managed:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {DETECTOR_ID} is not centrally managed."
+                == f"GuardDuty detector {DETECTOR_ID} in region {AWS_REGION_EU_WEST_1} is not centrally managed."
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].region == AWS_REGION_EU_WEST_1
@@ -113,7 +113,7 @@ class Test_guardduty_centrally_managed:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {DETECTOR_ID} is centrally managed by account {AWS_ACCOUNT_NUMBER_ADMIN}."
+                == f"GuardDuty detector {DETECTOR_ID} in region {AWS_REGION_EU_WEST_1} is centrally managed by account {AWS_ACCOUNT_NUMBER_ADMIN}."
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].region == AWS_REGION_EU_WEST_1
@@ -148,7 +148,7 @@ class Test_guardduty_centrally_managed:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {DETECTOR_ID} is administrator account with 1 member accounts."
+                == f"GuardDuty detector {DETECTOR_ID} in region {AWS_REGION_EU_WEST_1} is administrator account with 1 member accounts."
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
@@ -38,7 +38,10 @@ class Test_guardduty_is_enabled:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].status_extended == f"GuardDuty is not enabled in region {AWS_REGION_EU_WEST_1}."
+            assert (
+                result[0].status_extended
+                == f"GuardDuty is not enabled in region {AWS_REGION_EU_WEST_1}."
+            )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_test.py
@@ -38,7 +38,7 @@ class Test_guardduty_is_enabled:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].status_extended == "GuardDuty is not enabled."
+            assert result[0].status_extended == f"GuardDuty is not enabled in region {AWS_REGION_EU_WEST_1}."
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_EU_WEST_1
@@ -68,7 +68,7 @@ class Test_guardduty_is_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {DETECTOR_ID} enabled."
+                == f"GuardDuty detector {DETECTOR_ID} in region {AWS_REGION_EU_WEST_1} enabled."
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
@@ -100,7 +100,7 @@ class Test_guardduty_is_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {DETECTOR_ID} configured but suspended."
+                == f"GuardDuty detector {DETECTOR_ID} in region {AWS_REGION_EU_WEST_1} configured but suspended."
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
@@ -131,7 +131,7 @@ class Test_guardduty_is_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {DETECTOR_ID} not configured."
+                == f"GuardDuty detector {DETECTOR_ID} in region {AWS_REGION_EU_WEST_1} not configured."
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN
@@ -164,7 +164,7 @@ class Test_guardduty_is_enabled:
             assert result[0].muted
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {DETECTOR_ID} not configured."
+                == f"GuardDuty detector {DETECTOR_ID} in region {AWS_REGION_EU_WEST_1} not configured."
             )
             assert result[0].resource_id == DETECTOR_ID
             assert result[0].resource_arn == DETECTOR_ARN


### PR DESCRIPTION
### Context

Until this PR, the prowler reports of GuardDuty checks did not contain the region of the GuardDuty detector. This made it quite difficult to find the right place to verify and mitigate the reported risks.

### Description

This PR adds to the prowler report the region of the analyzed GuardDuty detector.

### Checklist

- Are there new checks included in this PR? **No**
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
