### PR TITLE
fix(security-groups): remove RFC1918 from ec2_securitygroup_allow_wide_open_public_ipv4

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "ec2_securitygroup_allow_wide_open_public_ipv4",
-  "CheckTitle": "Ensure no security groups allow ingress and egress from public ip addresses.",
+  "CheckTitle": "Ensure no security groups allow ingress and egress from wide-open IP address with a mask between 0 and 24.",
   "CheckType": [
     "Infrastructure Security"
   ],
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "high",
   "ResourceType": "AwsEc2SecurityGroup",
-  "Description": "Ensure no security groups allow ingress and egress from public ip addresses.",
+  "Description": "Ensure no security groups allow ingress and egress from ide-open IP address with a mask between 0 and 24.",
   "Risk": "If Security groups are not properly configured the attack surface is increased.",
   "RelatedUrl": "",
   "Remediation": {

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "ec2_securitygroup_allow_wide_open_public_ipv4",
-  "CheckTitle": "Ensure no security groups allow ingress and egress from wide-open non-RFC1918 address.",
+  "CheckTitle": "Ensure no security groups allow ingress and egress from public ip addresses.",
   "CheckType": [
     "Infrastructure Security"
   ],
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "high",
   "ResourceType": "AwsEc2SecurityGroup",
-  "Description": "Ensure no security groups allow ingress and egress from wide-open non-RFC1918 address.",
+  "Description": "Ensure no security groups allow ingress and egress from public ip addresses.",
   "Risk": "If Security groups are not properly configured the attack surface is increased.",
   "RelatedUrl": "",
   "Remediation": {

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.py
@@ -28,7 +28,7 @@ class ec2_securitygroup_allow_wide_open_public_ipv4(Check):
                 for ingress_rule in security_group.ingress_rules:
                     for ipv4 in ingress_rule["IpRanges"]:
                         ip = ipaddress.ip_network(ipv4["CidrIp"])
-                        # Check if IP is public according to RFC1918 and if 0 < prefixlen < 24
+                        # Check if IP is public if 0 < prefixlen < 24
                         if (
                             ip.is_global
                             and ip.prefixlen < cidr_treshold
@@ -42,7 +42,7 @@ class ec2_securitygroup_allow_wide_open_public_ipv4(Check):
                 for egress_rule in security_group.egress_rules:
                     for ipv4 in egress_rule["IpRanges"]:
                         ip = ipaddress.ip_network(ipv4["CidrIp"])
-                        # Check if IP is public according to RFC1918 and if 0 < prefixlen < 24
+                        # Check if IP is public if 0 < prefixlen < 24
                         if (
                             ip.is_global
                             and ip.prefixlen < cidr_treshold


### PR DESCRIPTION
### Context

#4936

### Description

This check only ensures that netmask from IP are between 0 and 24, both not included. Updated the metadata and comments from check.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
