### PR TITLE
refactor(provider): move audit and fixer config inside the provider

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -13,12 +13,7 @@ from colorama import Fore, Style
 from pytz import utc
 from tzlocal import get_localzone
 
-from prowler.config.config import (
-    aws_services_json_file,
-    get_default_mute_file_path,
-    load_and_validate_config_file,
-    load_and_validate_fixer_config_file,
-)
+from prowler.config.config import aws_services_json_file, get_default_mute_file_path
 from prowler.lib.check.utils import list_modules, recover_checks_from_service
 from prowler.lib.logger import logger
 from prowler.lib.utils.utils import open_file, parse_json_file, print_boxes
@@ -91,8 +86,8 @@ class AwsProvider(Provider):
         scan_unused_services: bool = None,
         resource_tags: list[str] = [],
         resource_arn: list[str] = [],
-        config_file: str = None,
-        fixer_config: str = None,
+        audit_config: dict = {},
+        fixer_config: dict = {},
     ):
         """
         Initializes the AWS provider.
@@ -110,8 +105,8 @@ class AwsProvider(Provider):
             - scan_unused_services: A boolean indicating whether to scan unused services.
             - resource_tags: A list of tags to filter the resources to audit.
             - resource_arn: A list of ARNs of the resources to audit.
-            - config_file: The path to the configuration file.
-            - fixer_config: The path to the fixer configuration
+            - audit_config: The audit configuration.
+            - fixer_config: The fixer configuration.
 
         Raises:
             - ArgumentTypeError: If the input MFA ARN is invalid.
@@ -270,16 +265,10 @@ class AwsProvider(Provider):
         # Set ignore unused services
         self._scan_unused_services = scan_unused_services
 
-        # TODO: move this to the providers, pending for AWS, GCP, AZURE and K8s
         # Audit Config
-        self._audit_config = {}
-        if config_file:
-            self._audit_config = load_and_validate_config_file(self._type, config_file)
-        self._fixer_config = {}
-        if fixer_config:
-            self._fixer_config = load_and_validate_fixer_config_file(
-                self._type, fixer_config
-            )
+        self._audit_config = audit_config
+        # Fixer Config
+        self._fixer_config = fixer_config
 
     @property
     def identity(self):

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -10,10 +10,7 @@ from azure.mgmt.subscription import SubscriptionClient
 from colorama import Fore, Style
 from msgraph import GraphServiceClient
 
-from prowler.config.config import (
-    get_default_mute_file_path,
-    load_and_validate_config_file,
-)
+from prowler.config.config import get_default_mute_file_path
 from prowler.lib.logger import logger
 from prowler.lib.utils.utils import print_boxes
 from prowler.providers.azure.exceptions.exceptions import (
@@ -98,9 +95,32 @@ class AzureProvider(Provider):
         tenant_id: str = None,
         region: str = "AzureCloud",
         subscription_ids: list = [],
-        config_file: str = None,
-        fixer_config: str = None,
+        audit_config: dict = {},
+        fixer_config: dict = {},
     ):
+        """
+        Initializes the Azure provider.
+
+        Args:
+            az_cli_auth (bool): Flag indicating whether to use Azure CLI authentication.
+            sp_env_auth (bool): Flag indicating whether to use Service Principal environment authentication.
+            browser_auth (bool): Flag indicating whether to use interactive browser authentication.
+            managed_identity_auth (bool): Flag indicating whether to use managed identity authentication.
+            tenant_id (str): The Azure Active Directory tenant ID.
+            region (str): The Azure region.
+            subscription_ids (list): List of subscription IDs.
+            audit_config (dict): The audit configuration for the Azure provider.
+            fixer_config (dict): The fixer configuration.
+
+        Returns:
+            None
+
+        Raises:
+            AzureArgumentTypeValidationError: If there is an error in the argument type validation.
+            AzureSetUpRegionConfigError: If there is an error in setting up the region configuration.
+            AzureDefaultAzureCredentialError: If there is an error in retrieving the Azure credentials.
+            AzureInteractiveBrowserCredentialError: If there is an error in retrieving the Azure credentials using browser authentication.
+        """
         logger.info("Setting Azure provider ...")
 
         logger.info("Checking if any credentials mode is set ...")
@@ -135,10 +155,10 @@ class AzureProvider(Provider):
         # TODO: should we keep this here or within the identity?
         self._locations = self.get_locations(self.session)
 
-        # TODO: move this to the providers, pending for AWS, GCP, AZURE and K8s
         # Audit Config
-        self._audit_config = load_and_validate_config_file(self._type, config_file)
-        self._fixer_config = load_and_validate_config_file(self._type, fixer_config)
+        self._audit_config = audit_config
+        # Fixer Config
+        self._fixer_config = fixer_config
 
     @property
     def identity(self):

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from importlib import import_module
 from typing import Any, Optional
 
+from prowler.config.config import load_and_validate_config_file
 from prowler.lib.logger import logger
 from prowler.lib.mutelist.mutelist import Mutelist
 
@@ -178,6 +179,12 @@ class Provider(ABC):
             provider_class = getattr(
                 import_module(provider_class_path), provider_class_name
             )
+            audit_config = load_and_validate_config_file(
+                arguments.provider, arguments.config_file
+            )
+            fixer_config = load_and_validate_config_file(
+                arguments.provider, arguments.fixer_config
+            )
 
             if not isinstance(Provider._global, provider_class):
                 if "aws" in provider_class_name.lower():
@@ -194,8 +201,8 @@ class Provider(ABC):
                         arguments.scan_unused_services,
                         arguments.resource_tag,
                         arguments.resource_arn,
-                        arguments.config_file,
-                        arguments.fixer_config,
+                        audit_config,
+                        fixer_config,
                     )
                 elif "azure" in provider_class_name.lower():
                     global_provider = provider_class(
@@ -206,8 +213,8 @@ class Provider(ABC):
                         arguments.tenant_id,
                         arguments.azure_region,
                         arguments.subscription_id,
-                        arguments.config_file,
-                        arguments.fixer_config,
+                        audit_config,
+                        fixer_config,
                     )
                 elif "gcp" in provider_class_name.lower():
                     global_provider = provider_class(
@@ -216,16 +223,16 @@ class Provider(ABC):
                         arguments.credentials_file,
                         arguments.impersonate_service_account,
                         arguments.list_project_id,
-                        arguments.config_file,
-                        arguments.fixer_config,
+                        audit_config,
+                        fixer_config,
                     )
                 elif "kubernetes" in provider_class_name.lower():
                     global_provider = provider_class(
                         arguments.kubeconfig_file,
                         arguments.context,
                         arguments.namespace,
-                        arguments.config_file,
-                        arguments.fixer_config,
+                        audit_config,
+                        fixer_config,
                     )
 
             Provider._global = global_provider

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -9,10 +9,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 
-from prowler.config.config import (
-    get_default_mute_file_path,
-    load_and_validate_config_file,
-)
+from prowler.config.config import get_default_mute_file_path
 from prowler.lib.logger import logger
 from prowler.lib.utils.utils import print_boxes
 from prowler.providers.common.models import Audit_Metadata, Connection
@@ -53,8 +50,8 @@ class GcpProvider(Provider):
         credentials_file: str = None,
         impersonate_service_account: str = None,
         list_project_ids: bool = False,
-        config_file: str = None,
-        fixer_config: str = None,
+        audit_config: dict = {},
+        fixer_config: dict = {},
     ):
         """
         GCP Provider constructor
@@ -65,8 +62,8 @@ class GcpProvider(Provider):
             credentials_file: str
             impersonate_service_account: str
             list_project_ids: bool
-            config_file: str
-            fixer_config: str
+            audit_config: dict
+            fixer_config: dict
         """
         logger.info("Instantiating GCP Provider ...")
         self._impersonated_service_account = impersonate_service_account
@@ -136,8 +133,8 @@ class GcpProvider(Provider):
 
         # TODO: move this to the providers, pending for AWS, GCP, AZURE and K8s
         # Audit Config
-        self._audit_config = load_and_validate_config_file(self._type, config_file)
-        self._fixer_config = load_and_validate_config_file(self._type, fixer_config)
+        self._audit_config = audit_config
+        self._fixer_config = fixer_config
 
     @property
     def identity(self):

--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -6,10 +6,7 @@ from kubernetes.config.config_exception import ConfigException
 from requests.exceptions import Timeout
 
 from kubernetes import client, config
-from prowler.config.config import (
-    get_default_mute_file_path,
-    load_and_validate_config_file,
-)
+from prowler.config.config import get_default_mute_file_path
 from prowler.lib.logger import logger
 from prowler.lib.utils.utils import print_boxes
 from prowler.providers.common.models import Audit_Metadata, Connection
@@ -45,8 +42,8 @@ class KubernetesProvider(Provider):
         kubeconfig_file: str = None,
         context: str = None,
         namespace: list = None,
-        config_file: str = None,
-        fixer_config: str = None,
+        audit_config: dict = {},
+        fixer_config: dict = {},
     ):
         """
         Initializes the KubernetesProvider instance.
@@ -54,8 +51,8 @@ class KubernetesProvider(Provider):
             kubeconfig_file (str): Path to the kubeconfig file.
             context (str): Context name.
             namespace (list): List of namespaces.
-            config_file (str): Path to the configuration file.
-            fixer_config (str): Path to the fixer configuration file
+            audit_config (dict): Audit configuration.
+            fixer_config (dict): Fixer configuration.
         """
 
         logger.info("Instantiating Kubernetes Provider ...")
@@ -78,10 +75,10 @@ class KubernetesProvider(Provider):
             cluster=self._session.context["context"]["cluster"],
         )
 
-        # TODO: move this to the providers, pending for AWS, GCP, AZURE and K8s
         # Audit Config
-        self._audit_config = load_and_validate_config_file(self._type, config_file)
-        self._fixer_config = load_and_validate_config_file(self._type, fixer_config)
+        self._audit_config = audit_config
+        # Fixer Config
+        self._fixer_config = fixer_config
 
     @property
     def type(self):

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -18,6 +18,7 @@ from moto import mock_aws
 from pytest import raises
 from tzlocal import get_localzone
 
+from prowler.config.config import load_and_validate_config_file
 from prowler.providers.aws.aws_provider import (
     AwsProvider,
     get_aws_available_regions,
@@ -587,8 +588,9 @@ aws:
         config_file_input.write(bytes(config, encoding="raw_unicode_escape"))
         config_file_input.close()
         config_file_input = config_file_input.name
+        audit_config = load_and_validate_config_file("aws", config_file_input)
         aws_provider = AwsProvider(
-            config_file=config_file_input,
+            audit_config=audit_config,
         )
 
         os.remove(config_file_input)

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -13,6 +13,7 @@ from mock import MagicMock
 from prowler.config.config import (
     default_config_file_path,
     default_fixer_config_file_path,
+    load_and_validate_config_file,
 )
 from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.exceptions.exceptions import (
@@ -39,8 +40,10 @@ class TestAzureProvider:
         browser_auth = None
         managed_identity_auth = None
 
-        config_file = default_config_file_path
-        fixer_config = default_fixer_config_file_path
+        audit_config = load_and_validate_config_file("azure", default_config_file_path)
+        fixer_config = load_and_validate_config_file(
+            "azure", default_fixer_config_file_path
+        )
         azure_region = "AzureCloud"
 
         with patch(
@@ -58,8 +61,8 @@ class TestAzureProvider:
                 tenant_id,
                 azure_region,
                 subscription_id,
-                config_file,
-                fixer_config,
+                audit_config=audit_config,
+                fixer_config=fixer_config,
             )
 
             assert azure_provider.region_config == AzureRegionConfig(

--- a/tests/providers/gcp/gcp_provider_test.py
+++ b/tests/providers/gcp/gcp_provider_test.py
@@ -8,6 +8,7 @@ from mock import MagicMock, patch
 from prowler.config.config import (
     default_config_file_path,
     default_fixer_config_file_path,
+    load_and_validate_config_file,
 )
 from prowler.providers.gcp.gcp_provider import GcpProvider
 from prowler.providers.gcp.models import GCPIdentityInfo, GCPOutputOptions, GCPProject
@@ -21,8 +22,10 @@ class TestGCPProvider:
         list_project_id = False
         credentials_file = ""
         impersonate_service_account = ""
-        config_file = default_config_file_path
-        fixer_config = default_fixer_config_file_path
+        audit_config = load_and_validate_config_file("gcp", default_config_file_path)
+        fixer_config = load_and_validate_config_file(
+            "gcp", default_fixer_config_file_path
+        )
 
         projects = {
             "test-project": GCPProject(
@@ -59,8 +62,8 @@ class TestGCPProvider:
                 credentials_file,
                 impersonate_service_account,
                 list_project_id,
-                config_file,
-                fixer_config,
+                audit_config=audit_config,
+                fixer_config=fixer_config,
             )
             assert gcp_provider.session is None
             assert gcp_provider.project_ids == ["test-project"]

--- a/tests/providers/kubernetes/kubernetes_provider_test.py
+++ b/tests/providers/kubernetes/kubernetes_provider_test.py
@@ -6,6 +6,7 @@ from kubernetes import client
 from prowler.config.config import (
     default_config_file_path,
     default_fixer_config_file_path,
+    load_and_validate_config_file,
 )
 from prowler.providers.kubernetes.kubernetes_provider import KubernetesProvider
 from prowler.providers.kubernetes.models import (
@@ -50,16 +51,20 @@ class TestKubernetesProvider:
             arguments.context = None
             arguments.only_logs = False
             arguments.namespace = None
-            arguments.config_file = default_config_file_path
-            arguments.fixer_config = default_fixer_config_file_path
+            audit_config = load_and_validate_config_file(
+                "kubernetes", default_config_file_path
+            )
+            fixer_config = load_and_validate_config_file(
+                "kubernetes", default_fixer_config_file_path
+            )
 
             # Instantiate the KubernetesProvider with mocked arguments
             kubernetes_provider = KubernetesProvider(
                 arguments.kubeconfig_file,
                 arguments.context,
                 arguments.namespace,
-                arguments.config_file,
-                arguments.fixer_config,
+                audit_config=audit_config,
+                fixer_config=fixer_config,
             )
             assert isinstance(kubernetes_provider.session, KubernetesSession)
             assert kubernetes_provider.session.api_client is not None


### PR DESCRIPTION
### Description

Audit and fixer config were parsed from a file inside the provider. This PR makes the needed changes to pass the audit and fixer config directly inside the provider.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
