### PR TITLE
fix(rds): Modify RDS Event Notification Subscriptions for Security Groups Events check

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_event_subscription_security_groups/rds_instance_event_subscription_security_groups.py
+++ b/prowler/providers/aws/services/rds/rds_instance_event_subscription_security_groups/rds_instance_event_subscription_security_groups.py
@@ -14,7 +14,10 @@ class rds_instance_event_subscription_security_groups(Check):
                 report.resource_arn = rds_client._get_rds_arn_template(db_event.region)
                 report.region = db_event.region
                 if db_event.source_type == "db-security-group" and db_event.enabled:
-                    if db_event.event_list == []:
+                    if db_event.event_list == [] or set(db_event.event_list) == {
+                        "failure",
+                        "configuration change",
+                    }:
                         report.resource_id = db_event.id
                         report.resource_arn = db_event.arn
                         report.status = "PASS"

--- a/tests/providers/aws/services/rds/rds_instance_event_subscription_security_groups/rds_instance_event_subscription_security_groups_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_event_subscription_security_groups/rds_instance_event_subscription_security_groups_test.py
@@ -349,3 +349,63 @@ class Test_rds_instance__no_event_subscriptions:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == AWS_ACCOUNT_NUMBER
                 assert result[0].resource_arn == RDS_ACCOUNT_ARN
+
+    @mock_aws
+    def test_rds_security_event_subscription_both_enabled(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_parameter_group(
+            DBParameterGroupName="test",
+            DBParameterGroupFamily="default.aurora-postgresql14",
+            Description="test parameter group",
+        )
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="aurora-postgres",
+            DBInstanceClass="db.m1.small",
+            DBParameterGroupName="test",
+            DBClusterIdentifier="db-cluster-1",
+        )
+        conn.create_event_subscription(
+            SubscriptionName="TestSub",
+            SnsTopicArn=f"arn:aws:sns:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:test",
+            SourceType="db-security-group",
+            EventCategories=["configuration change", "failure"],
+            Enabled=True,
+            Tags=[
+                {"Key": "test", "Value": "testing"},
+            ],
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_event_subscription_security_groups.rds_instance_event_subscription_security_groups.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.rds.rds_instance_event_subscription_security_groups.rds_instance_event_subscription_security_groups import (
+                    rds_instance_event_subscription_security_groups,
+                )
+
+                check = rds_instance_event_subscription_security_groups()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS security group events are subscribed."
+                )
+                assert result[0].resource_id == "TestSub"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:es:TestSub"
+                )


### PR DESCRIPTION
### Context


This check verifies if event notification subscriptions are enabled for Security Groups events, but it only passes if all parameters are selected. It's true that 'configuration change' and 'failure' are the only options available; however, if you select just these two instead of all, the check fails. To address this, I'll modify the check to pass if these specific parameters are selected, even if not all are chosen.

Fix #4927 

### Description

Modified `rds_instance_event_subscription_security_groups` check and added a unit test to verify it.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
