### PR TITLE
refactor(cloudfront): replace origins dictionary with custom Origin class

### DIFF
--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols/cloudfront_distributions_using_deprecated_ssl_protocols.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols/cloudfront_distributions_using_deprecated_ssl_protocols.py
@@ -21,10 +21,8 @@ class cloudfront_distributions_using_deprecated_ssl_protocols(Check):
 
             bad_ssl_protocol = False
             for origin in distribution.origins:
-                if "CustomOriginConfig" in origin:
-                    for ssl_protocol in origin["CustomOriginConfig"][
-                        "OriginSslProtocols"
-                    ]["Items"]:
+                if origin.origin_ssl_protocols:
+                    for ssl_protocol in origin.origin_ssl_protocols:
                         if ssl_protocol in (
                             OriginsSSLProtocols.SSLv3.value,
                             OriginsSSLProtocols.TLSv1.value,
@@ -32,6 +30,7 @@ class cloudfront_distributions_using_deprecated_ssl_protocols(Check):
                         ):
                             bad_ssl_protocol = True
                             break
+
                 if bad_ssl_protocol:
                     report.status = "FAIL"
                     report.status_extended = f"CloudFront Distribution {distribution.id} is using a deprecated SSL protocol."

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -31,14 +31,7 @@ class CloudFront(AWSService):
                             distribution_id = item["Id"]
                             distribution_arn = item["ARN"]
                             origins = []
-                            ssl_protocols = []
                             for origin in item.get("Origins", {}).get("Items", []):
-                                for protocol in (
-                                    origin.get("CustomOriginConfig", {})
-                                    .get("OriginSslProtocols", {})
-                                    .get("Items", [])
-                                ):
-                                    ssl_protocols.append(protocol)
                                 origins.append(
                                     Origin(
                                         id=origin["Id"],
@@ -46,7 +39,11 @@ class CloudFront(AWSService):
                                         origin_protocol_policy=origin.get(
                                             "CustomOriginConfig", {}
                                         ).get("OriginProtocolPolicy", ""),
-                                        origin_ssl_protocols=ssl_protocols,
+                                        origin_ssl_protocols=origin.get(
+                                            "CustomOriginConfig", {}
+                                        )
+                                        .get("OriginSslProtocols", {})
+                                        .get("Items", []),
                                     )
                                 )
                             distribution = Distribution(

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols/cloudfront_distributions_using_deprecated_ssl_protocols_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_using_deprecated_ssl_protocols/cloudfront_distributions_using_deprecated_ssl_protocols_test.py
@@ -1,6 +1,9 @@
 from unittest import mock
 
-from prowler.providers.aws.services.cloudfront.cloudfront_service import Distribution
+from prowler.providers.aws.services.cloudfront.cloudfront_service import (
+    Distribution,
+    Origin,
+)
 from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER
 
 DISTRIBUTION_ID = "E27LVI50CSW06W"
@@ -36,41 +39,12 @@ class Test_cloudfront_distributions_using_deprecated_ssl_protocols:
                 id=DISTRIBUTION_ID,
                 region=REGION,
                 origins=[
-                    {
-                        "Id": "string",
-                        "DomainName": "string",
-                        "OriginPath": "string",
-                        "CustomHeaders": {
-                            "Quantity": 123,
-                            "Items": [
-                                {
-                                    "HeaderName": "string",
-                                    "HeaderValue": "string",
-                                },
-                            ],
-                        },
-                        "S3OriginConfig": {"OriginAccessIdentity": "string"},
-                        "CustomOriginConfig": {
-                            "HTTPPort": 123,
-                            "HTTPSPort": 123,
-                            "OriginProtocolPolicy": "https-only",
-                            "OriginSslProtocols": {
-                                "Quantity": 123,
-                                "Items": [
-                                    "SSLv3",
-                                ],
-                            },
-                            "OriginReadTimeout": 123,
-                            "OriginKeepaliveTimeout": 123,
-                        },
-                        "ConnectionAttempts": 123,
-                        "ConnectionTimeout": 123,
-                        "OriginShield": {
-                            "Enabled": False,
-                            "OriginShieldRegion": "string",
-                        },
-                        "OriginAccessControlId": "string",
-                    },
+                    Origin(
+                        id="string",
+                        domain_name="string",
+                        origin_protocol_policy="https-only",
+                        origin_ssl_protocols=["SSLv3"],
+                    )
                 ],
             )
         }
@@ -106,42 +80,15 @@ class Test_cloudfront_distributions_using_deprecated_ssl_protocols:
                 id=DISTRIBUTION_ID,
                 region=REGION,
                 origins=[
-                    {
-                        "Id": "string",
-                        "DomainName": "string",
-                        "OriginPath": "string",
-                        "CustomHeaders": {
-                            "Quantity": 123,
-                            "Items": [
-                                {
-                                    "HeaderName": "string",
-                                    "HeaderValue": "string",
-                                },
-                            ],
-                        },
-                        "S3OriginConfig": {"OriginAccessIdentity": "string"},
-                        "CustomOriginConfig": {
-                            "HTTPPort": 123,
-                            "HTTPSPort": 123,
-                            "OriginProtocolPolicy": "https-only",
-                            "OriginSslProtocols": {
-                                "Quantity": 123,
-                                "Items": [
-                                    "SSLv3",
-                                    "TLSv1.2",
-                                ],
-                            },
-                            "OriginReadTimeout": 123,
-                            "OriginKeepaliveTimeout": 123,
-                        },
-                        "ConnectionAttempts": 123,
-                        "ConnectionTimeout": 123,
-                        "OriginShield": {
-                            "Enabled": False,
-                            "OriginShieldRegion": "string",
-                        },
-                        "OriginAccessControlId": "string",
-                    },
+                    Origin(
+                        id="string",
+                        domain_name="string",
+                        origin_protocol_policy="https-only",
+                        origin_ssl_protocols=[
+                            "SSLv3",
+                            "TLSv1.2",
+                        ],
+                    )
                 ],
             )
         }
@@ -177,42 +124,15 @@ class Test_cloudfront_distributions_using_deprecated_ssl_protocols:
                 id=DISTRIBUTION_ID,
                 region=REGION,
                 origins=[
-                    {
-                        "Id": "string",
-                        "DomainName": "string",
-                        "OriginPath": "string",
-                        "CustomHeaders": {
-                            "Quantity": 123,
-                            "Items": [
-                                {
-                                    "HeaderName": "string",
-                                    "HeaderValue": "string",
-                                },
-                            ],
-                        },
-                        "S3OriginConfig": {"OriginAccessIdentity": "string"},
-                        "CustomOriginConfig": {
-                            "HTTPPort": 123,
-                            "HTTPSPort": 123,
-                            "OriginProtocolPolicy": "https-only",
-                            "OriginSslProtocols": {
-                                "Quantity": 123,
-                                "Items": [
-                                    "SSLv3",
-                                    "TLSv1.1",
-                                ],
-                            },
-                            "OriginReadTimeout": 123,
-                            "OriginKeepaliveTimeout": 123,
-                        },
-                        "ConnectionAttempts": 123,
-                        "ConnectionTimeout": 123,
-                        "OriginShield": {
-                            "Enabled": False,
-                            "OriginShieldRegion": "string",
-                        },
-                        "OriginAccessControlId": "string",
-                    },
+                    Origin(
+                        id="string",
+                        domain_name="string",
+                        origin_protocol_policy="https-only",
+                        origin_ssl_protocols=[
+                            "SSLv3",
+                            "TLSv1.1",
+                        ],
+                    )
                 ],
             )
         }
@@ -248,39 +168,14 @@ class Test_cloudfront_distributions_using_deprecated_ssl_protocols:
                 id=DISTRIBUTION_ID,
                 region=REGION,
                 origins=[
-                    {
-                        "Id": "string",
-                        "DomainName": "string",
-                        "OriginPath": "string",
-                        "CustomHeaders": {
-                            "Quantity": 123,
-                            "Items": [
-                                {
-                                    "HeaderName": "string",
-                                    "HeaderValue": "string",
-                                },
-                            ],
-                        },
-                        "S3OriginConfig": {"OriginAccessIdentity": "string"},
-                        "CustomOriginConfig": {
-                            "HTTPPort": 123,
-                            "HTTPSPort": 123,
-                            "OriginProtocolPolicy": "https-only",
-                            "OriginSslProtocols": {
-                                "Quantity": 123,
-                                "Items": ["TLSv1.2"],
-                            },
-                            "OriginReadTimeout": 123,
-                            "OriginKeepaliveTimeout": 123,
-                        },
-                        "ConnectionAttempts": 123,
-                        "ConnectionTimeout": 123,
-                        "OriginShield": {
-                            "Enabled": False,
-                            "OriginShieldRegion": "string",
-                        },
-                        "OriginAccessControlId": "string",
-                    },
+                    Origin(
+                        id="string",
+                        domain_name="string",
+                        origin_protocol_policy="https-only",
+                        origin_ssl_protocols=[
+                            "TLSv1.2",
+                        ],
+                    )
                 ],
             )
         }

--- a/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_service_test.py
@@ -196,12 +196,11 @@ class Test_CloudFront_Service:
         assert (
             cloudfront.distributions[cloudfront_distribution_id].logging_enabled is True
         )
-        assert (
-            cloudfront.distributions[cloudfront_distribution_id].origins
-            == cloudfront_client.get_distribution(Id=cloudfront_distribution_id)[
-                "Distribution"
-            ]["DistributionConfig"]["Origins"]["Items"]
-        )
+        for origin in cloudfront.distributions[cloudfront_distribution_id].origins:
+            assert origin.id == "origin1"
+            assert origin.domain_name == "asdf.s3.us-east-1.amazonaws.com"
+            assert origin.origin_protocol_policy == ""
+            assert origin.origin_ssl_protocols == []
         assert (
             cloudfront.distributions[cloudfront_distribution_id].geo_restriction_type
             == GeoRestrictionType.blacklist


### PR DESCRIPTION
### Context

This pull request introduces a significant refactor in how `CloudFront` origin data is stored and managed. Previously, origins were represented as dictionaries, which led to less structured code and potential difficulties in data manipulation and validation. 

### Description

The new implementation replaces these dictionaries with a custom `Origin` class, which provides a more structured and object-oriented approach to handling origin data.

### Checklist

- Are there new checks included in this PR? No.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
