### PR TITLE
fix(audit): solve resources audit

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -225,7 +225,7 @@ def prowler():
     # it is time to check what Prowler's checks are going to be executed
     checks_from_resources = global_provider.get_checks_to_execute_by_audit_resources()
     # Intersect checks from resources with checks to execute so we only run the checks that apply to the resources with the specified ARNs or tags
-    if args.resource_arn or args.resource_tag:
+    if getattr(args, "resource_arn", None) or getattr(args, "resource_tag", None):
         checks_to_execute = checks_to_execute.intersection(checks_from_resources)
 
     # Sort final check list


### PR DESCRIPTION
### Description

Check if the argument for auditing specific resources exits, to avoid this error:
 
```
Traceback (most recent call last):
  File "/Users/user/Documents/prowler-repos/prowler/./prowler.py", line 7, in <module>
    sys.exit(prowler())
             ^^^^^^^^^
  File "/Users/user/Documents/prowler-repos/prowler/prowler/__main__.py", line 228, in prowler
    if args.resource_arn or args.resource_tag:
       ^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'resource_arn'
```
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
