### PR TITLE
refactor(azure): remove validate_arguments for CLI

### DIFF
--- a/prowler/providers/azure/lib/arguments/arguments.py
+++ b/prowler/providers/azure/lib/arguments/arguments.py
@@ -80,6 +80,11 @@ def validate_arguments(args: Namespace) -> tuple[bool, str]:
     Returns:
         tuple[bool, str]: A tuple containing a boolean indicating if the arguments are valid and a string with an error message if the arguments are invalid
     """
+    # If has any listing argument set, it's valid
+    if any(
+        attr for attr in dir(args) if attr.startswith("list") and getattr(args, attr)
+    ):
+        return (True, "")
     if not args.browser_auth and args.tenant_id:
         return (
             False,

--- a/prowler/providers/azure/lib/arguments/arguments.py
+++ b/prowler/providers/azure/lib/arguments/arguments.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentTypeError, Namespace
+from argparse import ArgumentTypeError
 
 
 def init_parser(self):
@@ -68,42 +68,3 @@ def validate_azure_region(region):
             f"Region {region} not allowed, allowed regions are {' '.join(regions_allowed)}"
         )
     return region
-
-
-def validate_arguments(args: Namespace) -> tuple[bool, str]:
-    """
-    Validates the authentication arguments for the Azure provider.
-
-    Args:
-        args (Namespace): The parsed arguments from the Azure provider.
-
-    Returns:
-        tuple[bool, str]: A tuple containing a boolean indicating if the arguments are valid and a string with an error message if the arguments are invalid
-    """
-    # If has any listing argument set, it's valid
-    if any(
-        attr for attr in dir(args) if attr.startswith("list") and getattr(args, attr)
-    ):
-        return (True, "")
-    if not args.browser_auth and args.tenant_id:
-        return (
-            False,
-            "Azure Tenant ID (--tenant-id) is required for browser authentication mode",
-        )
-    elif (
-        not args.az_cli_auth
-        and not args.sp_env_auth
-        and not args.browser_auth
-        and not args.managed_identity_auth
-    ):
-        return (
-            False,
-            "Azure provider requires at least one authentication method set: [--az-cli-auth | --sp-env-auth | --browser-auth | --managed-identity-auth]",
-        )
-    elif args.browser_auth and not args.tenant_id:
-        return (
-            False,
-            "Azure Tenant ID (--tenant-id) is required for browser authentication mode",
-        )
-
-    return (True, "")

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -238,11 +238,8 @@ class Test_Parser:
 
     def test_root_parser_azure_provider(self):
         command = [prowler_command, "azure"]
-        # Expecting a SystemExit exception
-        with pytest.raises(SystemExit) as wrapped_exit:
-            _ = self.parser.parse(command)
-        assert wrapped_exit.type == SystemExit
-        assert wrapped_exit.value.code == 2
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "azure"
 
     def test_root_parser_gcp_provider(self):
         command = [prowler_command, "gcp"]
@@ -1110,22 +1107,18 @@ class Test_Parser:
 
     def test_parser_azure_auth_browser(self):
         argument = "--browser-auth"
-        # Expected to raise an error
         command = [prowler_command, "azure", argument]
-        with pytest.raises(SystemExit) as wrapped_exit:
-            _ = self.parser.parse(command)
-        assert wrapped_exit.type == SystemExit
-        assert wrapped_exit.value.code == 2
+        parser = self.parser.parse(command)
+        assert parser.provider == "azure"
+        assert parser.browser_auth
 
     def test_parser_azure_tenant_id(self):
         argument = "--tenant-id"
         tenant_id = "test-tenant-id"
         command = [prowler_command, "azure", argument, tenant_id]
-        # Expected to raise an error
-        with pytest.raises(SystemExit) as wrapped_exit:
-            _ = self.parser.parse(command)
-        assert wrapped_exit.type == SystemExit
-        assert wrapped_exit.value.code == 2
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "azure"
+        assert parsed.tenant_id == tenant_id
 
     def test_parser_azure_auth_az_cli(self):
         argument = "--az-cli-auth"


### PR DESCRIPTION
### Description

Validate_arguments method inside azure specific parser was not valid since listing flags and others were not allowed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
