### PR TITLE
fix(gcp): add default project for org level checks

### DIFF
--- a/prowler/providers/gcp/lib/service/service.py
+++ b/prowler/providers/gcp/lib/service/service.py
@@ -30,6 +30,7 @@ class GCPService:
         )
         # Only project ids that have their API enabled will be scanned
         self.project_ids = self.__is_api_active__(provider.project_ids)
+        self.default_project_id = provider.default_project_id
         self.audit_config = provider.audit_config
         self.fixer_config = provider.fixer_config
 

--- a/prowler/providers/gcp/services/iam/iam_organization_essential_contacts_configured/iam_organization_essential_contacts_configured.py
+++ b/prowler/providers/gcp/services/iam/iam_organization_essential_contacts_configured/iam_organization_essential_contacts_configured.py
@@ -9,7 +9,7 @@ class iam_organization_essential_contacts_configured(Check):
         findings = []
         for org in essentialcontacts_client.organizations:
             report = Check_Report_GCP(self.metadata())
-            report.project_id = org.id
+            report.project_id = essentialcontacts_client.default_project_id
             report.resource_id = org.id
             report.resource_name = org.name
             report.location = essentialcontacts_client.region

--- a/tests/providers/gcp/gcp_fixtures.py
+++ b/tests/providers/gcp/gcp_fixtures.py
@@ -12,13 +12,14 @@ GCP_US_CENTER1_LOCATION = "us-central1"
 
 
 def set_mocked_gcp_provider(
-    project_ids: list[str] = [], profile: str = ""
+    project_ids: list[str] = [GCP_PROJECT_ID], profile: str = ""
 ) -> GcpProvider:
     provider = MagicMock()
     provider.type = "gcp"
     provider.session = MagicMock()
     provider.session._service_account_email = "test@test.com"
     provider.project_ids = project_ids
+    provider.default_project_id = GCP_PROJECT_ID
     provider.identity = GCPIdentityInfo(
         profile=profile,
     )

--- a/tests/providers/gcp/gcp_provider_test.py
+++ b/tests/providers/gcp/gcp_provider_test.py
@@ -45,7 +45,7 @@ class TestGCPProvider:
 
         with patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.setup_session",
-            return_value=None,
+            return_value=(None, None),
         ), patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.get_projects",
             return_value=projects,
@@ -108,7 +108,7 @@ class TestGCPProvider:
         )
         with patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.setup_session",
-            return_value=None,
+            return_value=(None, None),
         ), patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.get_projects",
             return_value=projects,
@@ -201,7 +201,7 @@ class TestGCPProvider:
         )
         with patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.setup_session",
-            return_value=None,
+            return_value=(None, None),
         ), patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.get_projects",
             return_value=projects,

--- a/tests/providers/gcp/gcp_provider_test.py
+++ b/tests/providers/gcp/gcp_provider_test.py
@@ -45,7 +45,7 @@ class TestGCPProvider:
 
         with patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.setup_session",
-            return_value=(None, None),
+            return_value=(None, "test-project"),
         ), patch(
             "prowler.providers.gcp.gcp_provider.GcpProvider.get_projects",
             return_value=projects,
@@ -68,6 +68,7 @@ class TestGCPProvider:
             assert gcp_provider.session is None
             assert gcp_provider.project_ids == ["test-project"]
             assert gcp_provider.projects == projects
+            assert gcp_provider.default_project_id == "test-project"
             assert gcp_provider.identity == GCPIdentityInfo(profile="default")
             assert gcp_provider.audit_config == {"shodan_api_key": None}
 

--- a/tests/providers/gcp/services/iam/iam_organization_essential_contacts_configured/iam_organization_essential_contacts_configured_test.py
+++ b/tests/providers/gcp/services/iam/iam_organization_essential_contacts_configured/iam_organization_essential_contacts_configured_test.py
@@ -40,6 +40,7 @@ class Test_iam_organization_essential_contacts_configured:
             essentialcontacts_client.organizations = [
                 Organization(id="test_id", name="test", contacts=True)
             ]
+            essentialcontacts_client.default_project_id = "test_id"
             from prowler.providers.gcp.services.iam.iam_organization_essential_contacts_configured.iam_organization_essential_contacts_configured import (
                 iam_organization_essential_contacts_configured,
             )
@@ -73,6 +74,7 @@ class Test_iam_organization_essential_contacts_configured:
             essentialcontacts_client.organizations = [
                 Organization(id="test_id", name="test", contacts=False)
             ]
+            essentialcontacts_client.default_project_id = "test_id"
 
             from prowler.providers.gcp.services.iam.iam_organization_essential_contacts_configured.iam_organization_essential_contacts_configured import (
                 iam_organization_essential_contacts_configured,


### PR DESCRIPTION
### Description

To avoid a KeyError in `finding.py` in the following line:
```
provider.projects[check_output.project_id]
```
We need to always add a Project ID in the `project_id` attribute of the checks, therefore, for Organization level checks, I created the `default_project_id` variable containing the GCP default project ID associated to the GCP credentials that Prowler is using.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
