### PR TITLE
chore(ssm): add trusted accounts variable to ssm check

### DIFF
--- a/docs/tutorials/configuration_file.md
+++ b/docs/tutorials/configuration_file.md
@@ -157,6 +157,7 @@ aws:
     ]
 
   # AWS VPC Configuration (vpc_endpoint_connections_trust_boundaries, vpc_endpoint_services_allowed_principals_trust_boundaries)
+  # AWS SSM Configuration (aws.ssm_documents_set_as_public)
   # Single account environment: No action required. The AWS account number will be automatically added by the checks.
   # Multi account environment: Any additional trusted account number should be added as a space separated list, e.g.
   # trusted_account_ids : ["123456789012", "098765432109", "678901234567"]

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -58,6 +58,7 @@ aws:
     ]
 
   # AWS VPC Configuration (vpc_endpoint_connections_trust_boundaries, vpc_endpoint_services_allowed_principals_trust_boundaries)
+  # AWS SSM Configuration (aws.ssm_documents_set_as_public)
   # Single account environment: No action required. The AWS account number will be automatically added by the checks.
   # Multi account environment: Any additional trusted account number should be added as a space separated list, e.g.
   # trusted_account_ids : ["123456789012", "098765432109", "678901234567"]

--- a/prowler/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public.py
+++ b/prowler/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public.py
@@ -11,12 +11,25 @@ class ssm_documents_set_as_public(Check):
             report.resource_arn = document.arn
             report.resource_id = document.name
             report.resource_tags = document.tags
-            if document.account_owners:
-                report.status = "FAIL"
-                report.status_extended = f"SSM Document {document.name} is public."
-            else:
+            trusted_account_ids = ssm_client.audit_config.get("trusted_account_ids", [])
+            if ssm_client.audited_account not in trusted_account_ids:
+                trusted_account_ids.append(ssm_client.audited_account)
+            if not document.account_owners or document.account_owners == [
+                ssm_client.audited_account
+            ]:
                 report.status = "PASS"
                 report.status_extended = f"SSM Document {document.name} is not public."
+            elif document.account_owners == ["all"]:
+                report.status = "FAIL"
+                report.status_extended = f"SSM Document {document.name} is public."
+            elif all(owner in trusted_account_ids for owner in document.account_owners):
+                report.status = "PASS"
+                report.status_extended = f"SSM Document {document.name} is shared to trusted AWS accounts: {", ".join(document.account_owners)}."
+            elif not all(
+                owner in trusted_account_ids for owner in document.account_owners
+            ):
+                report.status = "FAIL"
+                report.status_extended = f"SSM Document {document.name} is shared to non-trusted AWS accounts: {", ".join(document.account_owners)}."
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public.py
+++ b/prowler/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public.py
@@ -24,12 +24,12 @@ class ssm_documents_set_as_public(Check):
                 report.status_extended = f"SSM Document {document.name} is public."
             elif all(owner in trusted_account_ids for owner in document.account_owners):
                 report.status = "PASS"
-                report.status_extended = f"SSM Document {document.name} is shared to trusted AWS accounts: {", ".join(document.account_owners)}."
+                report.status_extended = f"SSM Document {document.name} is shared to trusted AWS accounts: {', '.join(document.account_owners)}."
             elif not all(
                 owner in trusted_account_ids for owner in document.account_owners
             ):
                 report.status = "FAIL"
-                report.status_extended = f"SSM Document {document.name} is shared to non-trusted AWS accounts: {", ".join(document.account_owners)}."
+                report.status_extended = f"SSM Document {document.name} is shared to non-trusted AWS accounts: {', '.join(document.account_owners)}."
 
             findings.append(report)
 

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -93,7 +93,7 @@ config_aws = {
         8080,
         8088,
     ],
-    "trusted_account_ids": ["580944000508"],
+    "trusted_account_ids": [],
     "log_group_retention_days": 365,
     "max_idle_disconnect_timeout_in_seconds": 600,
     "max_disconnect_timeout_in_seconds": 300,

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -93,7 +93,7 @@ config_aws = {
         8080,
         8088,
     ],
-    "trusted_account_ids": [],
+    "trusted_account_ids": ["580944000508"],
     "log_group_retention_days": 365,
     "max_idle_disconnect_timeout_in_seconds": 600,
     "max_disconnect_timeout_in_seconds": 300,

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -62,7 +62,7 @@ aws:
   # Single account environment: No action required. The AWS account number will be automatically added by the checks.
   # Multi account environment: Any additional trusted account number should be added as a space separated list, e.g.
   # trusted_account_ids : ["123456789012", "098765432109", "678901234567"]
-  trusted_account_ids: ["580944000508"]
+  trusted_account_ids: []
 
   # AWS Cloudwatch Configuration
   # aws.cloudwatch_log_group_retention_policy_specific_days_enabled --> by default is 365 days

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -58,10 +58,11 @@ aws:
     ]
 
   # AWS VPC Configuration (vpc_endpoint_connections_trust_boundaries, vpc_endpoint_services_allowed_principals_trust_boundaries)
+  # AWS SSM Configuration (aws.ssm_documents_set_as_public)
   # Single account environment: No action required. The AWS account number will be automatically added by the checks.
   # Multi account environment: Any additional trusted account number should be added as a space separated list, e.g.
   # trusted_account_ids : ["123456789012", "098765432109", "678901234567"]
-  trusted_account_ids: []
+  trusted_account_ids: ["580944000508"]
 
   # AWS Cloudwatch Configuration
   # aws.cloudwatch_log_group_retention_policy_specific_days_enabled --> by default is 365 days

--- a/tests/config/fixtures/config_old.yaml
+++ b/tests/config/fixtures/config_old.yaml
@@ -19,6 +19,7 @@ ec2_allowed_instance_owners:
   ]
 
 # AWS VPC Configuration (vpc_endpoint_connections_trust_boundaries, vpc_endpoint_services_allowed_principals_trust_boundaries)
+# AWS SSM Configuration (aws.ssm_documents_set_as_public)
 # Single account environment: No action required. The AWS account number will be automatically added by the checks.
 # Multi account environment: Any additional trusted account number should be added as a space separated list, e.g.
 # trusted_account_ids : ["123456789012", "098765432109", "678901234567"]

--- a/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
+++ b/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
@@ -22,7 +22,7 @@ class Test_ssm_documents_set_as_public:
 
             assert len(result) == 0
 
-    def test_document_public(self):
+    def test_document_public_account_owners(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"
         document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
@@ -56,6 +56,41 @@ class Test_ssm_documents_set_as_public:
             assert (
                 result[0].status_extended
                 == f"SSM Document {document_name} is shared to non-trusted AWS accounts: 111111111111, 111111222222."
+            )
+
+    def test_document_public_all_account_owners(self):
+        ssm_client = mock.MagicMock
+        document_name = "test-document"
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
+        ssm_client.documents = {
+            document_name: Document(
+                arn=document_arn,
+                name=document_name,
+                region=AWS_REGION_US_EAST_1,
+                content="",
+                account_owners=["all"],
+            )
+        }
+        with mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ssm.ssm_documents_set_as_public.ssm_documents_set_as_public import (
+                ssm_documents_set_as_public,
+            )
+
+            check = ssm_documents_set_as_public()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == document_name
+            assert result[0].resource_arn == document_arn
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended == f"SSM Document {document_name} is public."
             )
 
     def test_document_public_to_other_trusted_AWS_accounts(self):

--- a/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
+++ b/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
@@ -57,6 +57,81 @@ class Test_ssm_documents_set_as_public:
                 result[0].status_extended == f"SSM Document {document_name} is public."
             )
 
+    def test_document_public_to_other_trusted_AWS_accounts(self):
+        ssm_client = mock.MagicMock
+        document_name = "test-document"
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
+        ssm_client.documents = {
+            document_name: Document(
+                arn=document_arn,
+                name=document_name,
+                region=AWS_REGION_US_EAST_1,
+                content="",
+                account_owners=["111111111111", "111111222222"],
+            )
+        }
+        ssm_client.audit_config = {
+            "trusted_account_ids": ["111111111111", "111111222222"]
+        }
+        with mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ssm.ssm_documents_set_as_public.ssm_documents_set_as_public import (
+                ssm_documents_set_as_public,
+            )
+
+            check = ssm_documents_set_as_public()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == document_name
+            assert result[0].resource_arn == document_arn
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SSM Document {document_name} is shared to trusted AWS accounts: 111111111111, 111111222222."
+            )
+
+    def test_document_public_to_self_account(self):
+        ssm_client = mock.MagicMock
+        document_name = "test-document"
+        document_arn = f"arn:aws:ssm:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:document/{document_name}"
+        ssm_client.audited_account = AWS_ACCOUNT_NUMBER
+        ssm_client.documents = {
+            document_name: Document(
+                arn=document_arn,
+                name=document_name,
+                region=AWS_REGION_US_EAST_1,
+                content="",
+                account_owners=[AWS_ACCOUNT_NUMBER],
+            )
+        }
+        with mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.ssm.ssm_documents_set_as_public.ssm_documents_set_as_public import (
+                ssm_documents_set_as_public,
+            )
+
+            check = ssm_documents_set_as_public()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == document_name
+            assert result[0].resource_arn == document_arn
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SSM Document {document_name} is not public."
+            )
+
     def test_document_not_public(self):
         ssm_client = mock.MagicMock
         document_name = "test-document"

--- a/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
+++ b/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
@@ -69,11 +69,11 @@ class Test_ssm_documents_set_as_public:
                 name=document_name,
                 region=AWS_REGION_US_EAST_1,
                 content="",
-                account_owners=["111111111111", "111111222222"],
+                account_owners=["111111111333", "111111222444"],
             )
         }
         ssm_client.audit_config = {
-            "trusted_account_ids": ["111111111111", "111111222222"]
+            "trusted_account_ids": ["111111111333", "111111222444"]
         }
         with mock.patch(
             "prowler.providers.aws.services.ssm.ssm_service.SSM",
@@ -94,7 +94,7 @@ class Test_ssm_documents_set_as_public:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"SSM Document {document_name} is shared to trusted AWS accounts: 111111111111, 111111222222."
+                == f"SSM Document {document_name} is shared to trusted AWS accounts: 111111111333, 111111222444."
             )
 
     def test_document_public_to_self_account(self):

--- a/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
+++ b/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
@@ -53,7 +53,6 @@ class Test_ssm_documents_set_as_public:
             assert result[0].resource_id == document_name
             assert result[0].resource_arn == document_arn
             assert result[0].status == "FAIL"
-            print(result[0].status_extended)
             assert (
                 result[0].status_extended
                 == f"SSM Document {document_name} is shared to non-trusted AWS accounts: 111111111111, 111111222222."

--- a/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
+++ b/tests/providers/aws/services/ssm/ssm_documents_set_as_public/ssm_documents_set_as_public_test.py
@@ -53,8 +53,10 @@ class Test_ssm_documents_set_as_public:
             assert result[0].resource_id == document_name
             assert result[0].resource_arn == document_arn
             assert result[0].status == "FAIL"
+            print(result[0].status_extended)
             assert (
-                result[0].status_extended == f"SSM Document {document_name} is public."
+                result[0].status_extended
+                == f"SSM Document {document_name} is shared to non-trusted AWS accounts: 111111111111, 111111222222."
             )
 
     def test_document_public_to_other_trusted_AWS_accounts(self):


### PR DESCRIPTION
### Description

Add the possibility of setting trusted AWS accounts for the check `ssm_documents_set_as_public` so Prowler gives only a FAIL when it is public or shared with a non-trusted account.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
