### PR TITLE
refactor(parser): remove --only-logs option

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -119,7 +119,7 @@ def prowler():
         args.output_formats.extend(get_available_compliance_frameworks(provider))
 
     # Set Logger configuration
-    set_logging_config(args.log_level, args.log_file, args.only_logs)
+    set_logging_config(args.log_level, args.log_file)
 
     if args.list_services:
         print_services(list_services(provider))
@@ -194,8 +194,7 @@ def prowler():
     global_provider = Provider.get_global_provider()
 
     # Print Provider Credentials
-    if not args.only_logs:
-        global_provider.print_credentials()
+    global_provider.print_credentials()
 
     # Import custom checks from folder
     if checks_folder:
@@ -616,37 +615,36 @@ def prowler():
                 )
 
     # Display summary table
-    if not args.only_logs:
-        display_summary_table(
-            findings,
-            global_provider,
-            global_provider.output_options,
-        )
-        # Only display compliance table if there are findings (not all MANUAL) and it is a default execution
-        if (
-            findings and not all(finding.status == "MANUAL" for finding in findings)
-        ) and default_execution:
-            compliance_overview = False
-            if not compliance_framework:
-                compliance_framework = get_available_compliance_frameworks(provider)
-                if (
-                    compliance_framework
-                ):  # If there are compliance frameworks, print compliance overview
-                    compliance_overview = True
-            for compliance in sorted(compliance_framework):
-                # Display compliance table
-                display_compliance_table(
-                    findings,
-                    bulk_checks_metadata,
-                    compliance,
-                    global_provider.output_options.output_filename,
-                    global_provider.output_options.output_directory,
-                    compliance_overview,
-                )
-            if compliance_overview:
-                print(
-                    f"\nDetailed compliance results are in {Fore.YELLOW}{global_provider.output_options.output_directory}/compliance/{Style.RESET_ALL}\n"
-                )
+    display_summary_table(
+        findings,
+        global_provider,
+        global_provider.output_options,
+    )
+    # Only display compliance table if there are findings (not all MANUAL) and it is a default execution
+    if (
+        findings and not all(finding.status == "MANUAL" for finding in findings)
+    ) and default_execution:
+        compliance_overview = False
+        if not compliance_framework:
+            compliance_framework = get_available_compliance_frameworks(provider)
+            if (
+                compliance_framework
+            ):  # If there are compliance frameworks, print compliance overview
+                compliance_overview = True
+        for compliance in sorted(compliance_framework):
+            # Display compliance table
+            display_compliance_table(
+                findings,
+                bulk_checks_metadata,
+                compliance,
+                global_provider.output_options.output_filename,
+                global_provider.output_options.output_directory,
+                compliance_overview,
+            )
+        if compliance_overview:
+            print(
+                f"\nDetailed compliance results are in {Fore.YELLOW}{global_provider.output_options.output_directory}/compliance/{Style.RESET_ALL}\n"
+            )
 
     # If custom checks were passed, remove the modules
     if checks_folder:

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -112,7 +112,7 @@ Detailed documentation at https://docs.prowler.com
             )
 
         # Only Logging Configuration
-        if args.provider != "dashboard" and (args.only_logs or args.list_checks_json):
+        if args.provider != "dashboard" and args.list_checks_json:
             args.no_banner = True
 
         # Extra validation for provider arguments
@@ -200,11 +200,6 @@ Detailed documentation at https://docs.prowler.com
             "--log-file",
             nargs="?",
             help="Set log file name",
-        )
-        common_logging_parser.add_argument(
-            "--only-logs",
-            action="store_true",
-            help="Print only Prowler logs by the stdout. This option sets --no-banner.",
         )
 
     def __init_exclude_checks_parser__(self):

--- a/prowler/lib/logger.py
+++ b/prowler/lib/logger.py
@@ -11,7 +11,13 @@ logging_levels = {
 }
 
 
-def set_logging_config(log_level: str, log_file: str = None, only_logs: bool = False):
+def set_logging_config(log_level: str, log_file: str = None):
+    """
+    Set the logging configuration for the application
+    Args:
+        log_level (str): Log level
+        log_file (str): Log file path
+    """
     # Logs formatter
     stream_formatter = logging.Formatter(
         "\n%(asctime)s [File: %(filename)s:%(lineno)d] \t[Module: %(module)s]\t %(levelname)s: %(message)s"
@@ -23,12 +29,9 @@ def set_logging_config(log_level: str, log_file: str = None, only_logs: bool = F
     # Where to put logs
     logging_handlers = []
 
-    # Include stdout by default, if only_logs is set the log format is JSON
+    # Include stdout by default for local development
     stream_handler = logging.StreamHandler()
-    if only_logs:
-        stream_handler.setFormatter(log_file_formatter)
-    else:
-        stream_handler.setFormatter(stream_formatter)
+    stream_handler.setFormatter(stream_formatter)
     logging_handlers.append(stream_handler)
 
     # Log to file configuration

--- a/prowler/providers/common/models.py
+++ b/prowler/providers/common/models.py
@@ -24,7 +24,6 @@ class ProviderOutputOptions:
     bulk_checks_metadata: dict
     verbose: str
     output_filename: str
-    only_logs: bool
     unix_timestamp: bool
 
     def __init__(self, arguments, bulk_checks_metadata):
@@ -33,7 +32,6 @@ class ProviderOutputOptions:
         self.output_directory = arguments.output_directory
         self.verbose = arguments.verbose
         self.bulk_checks_metadata = bulk_checks_metadata
-        self.only_logs = arguments.only_logs
         self.unix_timestamp = arguments.unix_timestamp
         self.shodan_api_key = arguments.shodan
         self.fixer = getattr(arguments, "fixer", None)

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -891,27 +891,6 @@ class TestCheck:
                 == f"\nCheck ID: {check.CheckID} - {Fore.MAGENTA}{check.ServiceName}{Fore.YELLOW} [{check.Severity}]{Style.RESET_ALL}\n"
             )
 
-    def test_run_check_exception_only_logs(self, caplog):
-        caplog.set_level(ERROR)
-
-        findings = []
-        check = Mock()
-        check.CheckID = "test-check"
-        check.ServiceName = "test-service"
-        check.Severity = "test-severity"
-        error = Exception()
-        check.execute = Mock(side_effect=error)
-
-        with patch("prowler.lib.check.check.execute", return_value=findings):
-            assert run_check(check, only_logs=True) == findings
-            assert caplog.record_tuples == [
-                (
-                    "root",
-                    ERROR,
-                    f"{check.CheckID} -- {error.__class__.__name__}[{traceback.extract_tb(error.__traceback__)[-1].lineno}]: {error}",
-                )
-            ]
-
     def test_run_check_exception(self, caplog, capsys):
         caplog.set_level(ERROR)
 

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -56,7 +56,6 @@ class Test_Parser:
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
         assert not parsed.log_file
-        assert not parsed.only_logs
         assert not parsed.check
         assert not parsed.checks_file
         assert not parsed.checks_folder
@@ -104,7 +103,6 @@ class Test_Parser:
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
         assert not parsed.log_file
-        assert not parsed.only_logs
         assert not parsed.check
         assert not parsed.checks_file
         assert not parsed.checks_folder
@@ -144,7 +142,6 @@ class Test_Parser:
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
         assert not parsed.log_file
-        assert not parsed.only_logs
         assert not parsed.check
         assert not parsed.checks_file
         assert not parsed.checks_folder
@@ -179,7 +176,6 @@ class Test_Parser:
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
         assert not parsed.log_file
-        assert not parsed.only_logs
         assert not parsed.check
         assert not parsed.checks_file
         assert not parsed.checks_folder
@@ -364,12 +360,6 @@ class Test_Parser:
         command = [prowler_command, "--unix-timestamp"]
         parsed = self.parser.parse(command)
         assert parsed.unix_timestamp
-
-    def test_logging_parser_only_logs_set(self):
-        command = [prowler_command, "--only-logs"]
-        parsed = self.parser.parse(command)
-        assert parsed.only_logs
-        assert parsed.no_banner
 
     def test_logging_parser_log_level_default(self):
         log_level = "CRITICAL"

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1048,7 +1048,6 @@ aws:
         arguments.verbose = True
         arguments.security_hub = True
         arguments.shodan = "test-api-key"
-        arguments.only_logs = False
         arguments.unix_timestamp = False
         arguments.send_sh_only_fails = True
 
@@ -1097,7 +1096,6 @@ aws:
         arguments.output_filename = "output_test_filename"
         arguments.security_hub = True
         arguments.shodan = "test-api-key"
-        arguments.only_logs = False
         arguments.unix_timestamp = False
         arguments.send_sh_only_fails = True
 

--- a/tests/providers/aws/utils.py
+++ b/tests/providers/aws/utils.py
@@ -168,7 +168,6 @@ def set_default_provider_arguments(
     arguments.output_formats = []
     arguments.output_directory = ""
     arguments.verbose = False
-    arguments.only_logs = False
     arguments.unix_timestamp = False
     arguments.shodan = None
     arguments.security_hub = False

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -225,7 +225,6 @@ class TestAzureProvider:
         output_directory = arguments.output_directory
         arguments.status = []
         arguments.verbose = True
-        arguments.only_logs = False
         arguments.unix_timestamp = False
         arguments.shodan = "test-api-key"
 

--- a/tests/providers/gcp/gcp_provider_test.py
+++ b/tests/providers/gcp/gcp_provider_test.py
@@ -87,7 +87,6 @@ class TestGCPProvider:
         arguments.output_formats = ["csv"]
         arguments.output_directory = "output_test_directory"
         arguments.verbose = True
-        arguments.only_logs = False
         arguments.unix_timestamp = False
         arguments.shodan = "test-api-key"
 
@@ -180,7 +179,6 @@ class TestGCPProvider:
         arguments.output_formats = ["csv"]
         arguments.output_directory = "output_test_directory"
         arguments.verbose = True
-        arguments.only_logs = False
         arguments.unix_timestamp = False
         arguments.shodan = "test-api-key"
 

--- a/tests/providers/kubernetes/kubernetes_provider_test.py
+++ b/tests/providers/kubernetes/kubernetes_provider_test.py
@@ -49,7 +49,6 @@ class TestKubernetesProvider:
             arguments = Namespace()
             arguments.kubeconfig_file = "dummy_path"
             arguments.context = None
-            arguments.only_logs = False
             arguments.namespace = None
             audit_config = load_and_validate_config_file(
                 "kubernetes", default_config_file_path
@@ -84,7 +83,6 @@ class TestKubernetesProvider:
         arguments = Namespace()
         arguments.kubeconfig_file = "dummy_path"
         arguments.context = None
-        arguments.only_logs = False
         arguments.namespace = None
         arguments.config_file = default_config_file_path
         arguments.fixer_config = default_fixer_config_file_path
@@ -93,7 +91,6 @@ class TestKubernetesProvider:
         arguments.output_directory = "output_test_directory"
         arguments.verbose = True
         arguments.output_filename = "output_test_filename"
-        arguments.only_logs = False
         arguments.unix_timestamp = False
         arguments.shodan = "test-api-key"
 


### PR DESCRIPTION
### Description

This PR remove the option to use `--only-logs` during execution.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
