### PR TITLE
docs(check): change where extract ResourceTypes

### DIFF
--- a/docs/developer-guide/checks.md
+++ b/docs/developer-guide/checks.md
@@ -272,7 +272,7 @@ Each Prowler check has metadata associated which is stored at the same level of 
   # Severity holds the check's severity, always in lowercase (critical, high, medium, low or informational)
   "Severity": "critical",
   # ResourceType only for AWS, holds the type from here
-  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html
+  # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Types_ResourceDetails.html
   "ResourceType": "Other",
   # Description holds the title of the check, for now is the same as CheckTitle
   "Description": "Ensure there are no EC2 AMIs set as Public.",


### PR DESCRIPTION
### Context

Change the current CloudFormation link reference in metadata.

### Description

Changed link in [docs](https://docs.prowler.com/projects/prowler-open-source/en/latest/developer-guide/checks/#check-metadata)

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
