### PR TITLE
docs(dev-guide): refer poetry docs for installation

### DIFF
--- a/docs/developer-guide/introduction.md
+++ b/docs/developer-guide/introduction.md
@@ -14,10 +14,8 @@ Once that is satisfied go ahead and clone your forked repo:
 git clone https://github.com/<your-github-user>/prowler
 cd prowler
 ```
-For isolation and avoid conflicts with other environments, we recommend usage of `poetry`:
-```
-pip install poetry
-```
+For isolation and to avoid conflicts with other environments, we recommend using `poetry`, a Python dependency management tool. You can install it by following the instructions [here] (https://python-poetry.org/docs/).
+
 Then install all dependencies including the ones for developers:
 ```
 poetry install --with dev


### PR DESCRIPTION
### Context

Poetry installation was not correct as they recommend using `pipx` instead `pip`. Now refer to poetry docs to install it.

### Description

Change poetry install paragraph in DeveloperGuide/Introduction.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
