### PR TITLE
feat(slack): add more information about critical findings

### DIFF
--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -103,6 +103,14 @@ def extract_findings_statistics(findings: list) -> dict:
     all_fails_are_muted = True
     critical_severity_pass = 0
     critical_severity_fail = 0
+    high_severity_pass = 0
+    high_severity_fail = 0
+    medium_severity_pass = 0
+    medium_severity_fail = 0
+    low_severity_pass = 0
+    low_severity_fail = 0
+    informational_severity_pass = 0
+    informational_severity_fail = 0
 
     for finding in findings:
         # Save the resource_id
@@ -111,6 +119,14 @@ def extract_findings_statistics(findings: list) -> dict:
         if finding.status == "PASS":
             if finding.check_metadata.Severity == "critical":
                 critical_severity_pass += 1
+            if finding.check_metadata.Severity == "high":
+                high_severity_pass += 1
+            if finding.check_metadata.Severity == "medium":
+                medium_severity_pass += 1
+            if finding.check_metadata.Severity == "low":
+                low_severity_pass += 1
+            if finding.check_metadata.Severity == "informational":
+                informational_severity_pass += 1
             total_pass += 1
             findings_count += 1
             if finding.muted is True:
@@ -119,6 +135,14 @@ def extract_findings_statistics(findings: list) -> dict:
         if finding.status == "FAIL":
             if finding.check_metadata.Severity == "critical":
                 critical_severity_fail += 1
+            if finding.check_metadata.Severity == "high":
+                high_severity_fail += 1
+            if finding.check_metadata.Severity == "medium":
+                medium_severity_fail += 1
+            if finding.check_metadata.Severity == "low":
+                low_severity_fail += 1
+            if finding.check_metadata.Severity == "informational":
+                informational_severity_fail += 1
             total_fail += 1
             findings_count += 1
             if finding.muted is True:
@@ -134,6 +158,14 @@ def extract_findings_statistics(findings: list) -> dict:
     stats["findings_count"] = findings_count
     stats["total_critical_severity_fail"] = critical_severity_fail
     stats["total_critical_severity_pass"] = critical_severity_pass
+    stats["total_high_severity_fail"] = high_severity_fail
+    stats["total_high_severity_pass"] = high_severity_pass
+    stats["total_medium_severity_fail"] = medium_severity_fail
+    stats["total_medium_severity_pass"] = medium_severity_pass
+    stats["total_low_severity_fail"] = medium_severity_fail
+    stats["total_low_severity_pass"] = medium_severity_pass
+    stats["total_informational_severity_fail"] = informational_severity_fail
+    stats["total_informational_severity_pass"] = informational_severity_pass
     stats["all_fails_are_muted"] = all_fails_are_muted
 
     return stats

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -82,9 +82,14 @@ def extract_findings_statistics(findings: list) -> dict:
     extract_findings_statistics takes a list of findings and returns the following dict with the aggregated statistics
     {
         "total_pass": 0,
+        "total_muted_fail": 0,
         "total_fail": 0,
+        "total_muted_fail": 0,
         "resources_count": 0,
         "findings_count": 0,
+        "critical_failed_findings": [],
+        "critical_passed_findings": []
+        "all_fails_are_muted": False
     }
     """
     logger.info("Extracting audit statistics...")
@@ -96,18 +101,24 @@ def extract_findings_statistics(findings: list) -> dict:
     resources = set()
     findings_count = 0
     all_fails_are_muted = True
+    critical_pass_findings = []
+    critical_fail_findings = []
 
     for finding in findings:
         # Save the resource_id
         resources.add(finding.resource_id)
 
         if finding.status == "PASS":
+            if finding.check_metadata.Severity == "critical":
+                critical_pass_findings.append(finding.check_metadata.CheckTitle)
             total_pass += 1
             findings_count += 1
             if finding.muted is True:
                 muted_pass += 1
 
         if finding.status == "FAIL":
+            if finding.check_metadata.Severity == "critical":
+                critical_fail_findings.append(finding.check_metadata.CheckTitle)
             total_fail += 1
             findings_count += 1
             if finding.muted is True:
@@ -121,6 +132,8 @@ def extract_findings_statistics(findings: list) -> dict:
     stats["total_muted_fail"] = muted_fail
     stats["resources_count"] = len(resources)
     stats["findings_count"] = findings_count
+    stats["critical_failed_findings"] = critical_fail_findings
+    stats["critical_passed_findings"] = critical_pass_findings
     stats["all_fails_are_muted"] = all_fails_are_muted
 
     return stats

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -82,7 +82,7 @@ def extract_findings_statistics(findings: list) -> dict:
     extract_findings_statistics takes a list of findings and returns the following dict with the aggregated statistics
     {
         "total_pass": 0,
-        "total_muted_fail": 0,
+        "total_muted_pass": 0,
         "total_fail": 0,
         "total_muted_fail": 0,
         "resources_count": 0,
@@ -101,8 +101,8 @@ def extract_findings_statistics(findings: list) -> dict:
     resources = set()
     findings_count = 0
     all_fails_are_muted = True
-    critical_pass_findings = []
-    critical_fail_findings = []
+    critical_severity_pass = 0
+    critical_severity_fail = 0
 
     for finding in findings:
         # Save the resource_id
@@ -110,7 +110,7 @@ def extract_findings_statistics(findings: list) -> dict:
 
         if finding.status == "PASS":
             if finding.check_metadata.Severity == "critical":
-                critical_pass_findings.append(finding.check_metadata.CheckTitle)
+                critical_severity_pass += 1
             total_pass += 1
             findings_count += 1
             if finding.muted is True:
@@ -118,7 +118,7 @@ def extract_findings_statistics(findings: list) -> dict:
 
         if finding.status == "FAIL":
             if finding.check_metadata.Severity == "critical":
-                critical_fail_findings.append(finding.check_metadata.CheckTitle)
+                critical_severity_fail += 1
             total_fail += 1
             findings_count += 1
             if finding.muted is True:
@@ -132,8 +132,8 @@ def extract_findings_statistics(findings: list) -> dict:
     stats["total_muted_fail"] = muted_fail
     stats["resources_count"] = len(resources)
     stats["findings_count"] = findings_count
-    stats["critical_failed_findings"] = critical_fail_findings
-    stats["critical_passed_findings"] = critical_pass_findings
+    stats["total_critical_severity_fail"] = critical_severity_fail
+    stats["total_critical_severity_pass"] = critical_severity_pass
     stats["all_fails_are_muted"] = all_fails_are_muted
 
     return stats

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -109,8 +109,6 @@ def extract_findings_statistics(findings: list) -> dict:
     medium_severity_fail = 0
     low_severity_pass = 0
     low_severity_fail = 0
-    informational_severity_pass = 0
-    informational_severity_fail = 0
 
     for finding in findings:
         # Save the resource_id
@@ -125,8 +123,6 @@ def extract_findings_statistics(findings: list) -> dict:
                 medium_severity_pass += 1
             if finding.check_metadata.Severity == "low":
                 low_severity_pass += 1
-            if finding.check_metadata.Severity == "informational":
-                informational_severity_pass += 1
             total_pass += 1
             findings_count += 1
             if finding.muted is True:
@@ -141,8 +137,6 @@ def extract_findings_statistics(findings: list) -> dict:
                 medium_severity_fail += 1
             if finding.check_metadata.Severity == "low":
                 low_severity_fail += 1
-            if finding.check_metadata.Severity == "informational":
-                informational_severity_fail += 1
             total_fail += 1
             findings_count += 1
             if finding.muted is True:
@@ -164,8 +158,6 @@ def extract_findings_statistics(findings: list) -> dict:
     stats["total_medium_severity_pass"] = medium_severity_pass
     stats["total_low_severity_fail"] = medium_severity_fail
     stats["total_low_severity_pass"] = medium_severity_pass
-    stats["total_informational_severity_fail"] = informational_severity_fail
-    stats["total_informational_severity_pass"] = informational_severity_pass
     stats["all_fails_are_muted"] = all_fails_are_muted
 
     return stats

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -155,14 +155,6 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nInformational:\n"
-                        + f"• {stats['total_informational_severity_pass']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
                         "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                     },
                 },
@@ -194,14 +186,6 @@ class Slack:
                     "text": {
                         "type": "mrkdwn",
                         "text": "\nLow:\n" + f"• {stats['total_low_severity_fail']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nInformational:\n"
-                        + f"• {stats['total_informational_severity_fail']}",
                     },
                 },
                 {

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -150,7 +150,13 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                        "text": f"\nCritical Failed Findings:\n"
+                        + "\n".join(
+                            [
+                                f"• {finding}"
+                                for finding in stats["critical_failed_findings"]
+                            ]
+                        ),
                     },
                 },
                 {"type": "divider"},
@@ -158,7 +164,13 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                        "text": f"\nCritical Passed Findings:\n"
+                        + "\n".join(
+                            [
+                                f"• {finding}"
+                                for finding in stats["critical_passed_findings"]
+                            ]
+                        ),
                     },
                 },
                 {"type": "divider"},

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -126,14 +126,14 @@ class Slack:
                     "text": {
                         "type": "mrkdwn",
                         "text": "\nCritical:\n"
-                        + f"• {stats["total_critical_severity_pass"]}",
+                        + f"• {stats['total_critical_severity_pass']}",
                     },
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nHigh:\n" + f"• {stats["total_high_severity_pass"]}",
+                        "text": "\nHigh:\n" + f"• {stats['total_high_severity_pass']}",
                     },
                 },
                 {
@@ -141,14 +141,14 @@ class Slack:
                     "text": {
                         "type": "mrkdwn",
                         "text": "\nMedium:\n"
-                        + f"• {stats["total_medium_severity_pass"]}",
+                        + f"• {stats['total_medium_severity_pass']}",
                     },
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nLow:\n" + f"• {stats["total_low_severity_pass"]}",
+                        "text": "\nLow:\n" + f"• {stats['total_low_severity_pass']}",
                     },
                 },
                 {
@@ -156,7 +156,7 @@ class Slack:
                     "text": {
                         "type": "mrkdwn",
                         "text": "\nInformational:\n"
-                        + f"• {stats["total_informational_severity_pass"]}",
+                        + f"• {stats['total_informational_severity_pass']}",
                     },
                 },
                 {
@@ -171,14 +171,14 @@ class Slack:
                     "text": {
                         "type": "mrkdwn",
                         "text": "\nCritical:\n"
-                        + f"• {stats["total_critical_severity_fail"]}",
+                        + f"• {stats['total_critical_severity_fail']}",
                     },
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nHigh:\n" + f"• {stats["total_high_severity_fail"]}",
+                        "text": "\nHigh:\n" + f"• {stats['total_high_severity_fail']}",
                     },
                 },
                 {
@@ -186,14 +186,14 @@ class Slack:
                     "text": {
                         "type": "mrkdwn",
                         "text": "\nMedium:\n"
-                        + f"• {stats["total_medium_severity_fail"]}",
+                        + f"• {stats['total_medium_severity_fail']}",
                     },
                 },
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nLow:\n" + f"• {stats["total_low_severity_fail"]}",
+                        "text": "\nLow:\n" + f"• {stats['total_low_severity_fail']}",
                     },
                 },
                 {
@@ -201,7 +201,7 @@ class Slack:
                     "text": {
                         "type": "mrkdwn",
                         "text": "\nInformational:\n"
-                        + f"• {stats["total_informational_severity_fail"]}",
+                        + f"• {stats['total_informational_severity_fail']}",
                     },
                 },
                 {

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -133,6 +133,38 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
+                        "text": "\nHigh:\n"
+                        + f"• {stats["total_high_severity_pass"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nMedium:\n"
+                        + f"• {stats["total_medium_severity_pass"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nLow:\n"
+                        + f"• {stats["total_low_severity_pass"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nInformational:\n"
+                        + f"• {stats["total_informational_severity_pass"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
                         "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                     },
                 },
@@ -142,6 +174,38 @@ class Slack:
                         "type": "mrkdwn",
                         "text": "\nCritical:\n"
                         + f"• {stats["total_critical_severity_fail"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nHigh:\n"
+                        + f"• {stats["total_high_severity_fail"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nMedium:\n"
+                        + f"• {stats["total_medium_severity_fail"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nLow:\n"
+                        + f"• {stats["total_low_severity_fail"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nInformational:\n"
+                        + f"• {stats["total_informational_severity_fail"]}",
                     },
                 },
                 {

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -125,7 +125,23 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
+                        "text": "\nCritical:\n"
+                        + f"• {stats["total_critical_severity_pass"]}",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
                         "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "\nCritical:\n"
+                        + f"• {stats["total_critical_severity_fail"]}",
                     },
                 },
                 {
@@ -144,34 +160,6 @@ class Slack:
                             "text": f"Used parameters: `prowler {args}`",
                         }
                     ],
-                },
-                {"type": "divider"},
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nCritical Failed Findings:\n"
-                        + "\n".join(
-                            [
-                                f"• {finding}"
-                                for finding in stats["critical_failed_findings"]
-                            ]
-                        ),
-                    },
-                },
-                {"type": "divider"},
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nCritical Passed Findings:\n"
-                        + "\n".join(
-                            [
-                                f"• {finding}"
-                                for finding in stats["critical_passed_findings"]
-                            ]
-                        ),
-                    },
                 },
                 {"type": "divider"},
                 {

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -133,8 +133,7 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nHigh:\n"
-                        + f"• {stats["total_high_severity_pass"]}",
+                        "text": "\nHigh:\n" + f"• {stats["total_high_severity_pass"]}",
                     },
                 },
                 {
@@ -149,8 +148,7 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nLow:\n"
-                        + f"• {stats["total_low_severity_pass"]}",
+                        "text": "\nLow:\n" + f"• {stats["total_low_severity_pass"]}",
                     },
                 },
                 {
@@ -180,8 +178,7 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nHigh:\n"
-                        + f"• {stats["total_high_severity_fail"]}",
+                        "text": "\nHigh:\n" + f"• {stats["total_high_severity_fail"]}",
                     },
                 },
                 {
@@ -196,8 +193,7 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nLow:\n"
-                        + f"• {stats["total_low_severity_fail"]}",
+                        "text": "\nLow:\n" + f"• {stats["total_low_severity_fail"]}",
                     },
                 },
                 {

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -125,30 +125,13 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nCritical:\n"
-                        + f"• {stats['total_critical_severity_pass']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nHigh:\n" + f"• {stats['total_high_severity_pass']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nMedium:\n"
-                        + f"• {stats['total_medium_severity_pass']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nLow:\n" + f"• {stats['total_low_severity_pass']}",
+                        "text": (
+                            "*Severities:*\n"
+                            f"• *Critical:* {stats['total_critical_severity_pass']} "
+                            f"• *High:* {stats['total_high_severity_pass']} "
+                            f"• *Medium:* {stats['total_medium_severity_pass']} "
+                            f"• *Low:* {stats['total_low_severity_pass']}"
+                        ),
                     },
                 },
                 {
@@ -162,30 +145,13 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": "\nCritical:\n"
-                        + f"• {stats['total_critical_severity_fail']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nHigh:\n" + f"• {stats['total_high_severity_fail']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nMedium:\n"
-                        + f"• {stats['total_medium_severity_fail']}",
-                    },
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "\nLow:\n" + f"• {stats['total_low_severity_fail']}",
+                        "text": (
+                            "*Severities:*\n"
+                            f"• *Critical:* {stats['total_critical_severity_fail']} "
+                            f"• *High:* {stats['total_high_severity_fail']} "
+                            f"• *Medium:* {stats['total_medium_severity_fail']} "
+                            f"• *Low:* {stats['total_low_severity_fail']}"
+                        ),
                     },
                 },
                 {

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -148,6 +148,22 @@ class Slack:
                 {"type": "divider"},
                 {
                     "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                    },
+                },
+                {"type": "divider"},
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                    },
+                },
+                {"type": "divider"},
+                {
+                    "type": "section",
                     "text": {"type": "mrkdwn", "text": "Join our Slack Community!"},
                     "accessory": {
                         "type": "button",

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -150,7 +150,7 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"\nCritical Failed Findings:\n"
+                        "text": "\nCritical Failed Findings:\n"
                         + "\n".join(
                             [
                                 f"• {finding}"
@@ -164,7 +164,7 @@ class Slack:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"\nCritical Passed Findings:\n"
+                        "text": "\nCritical Passed Findings:\n"
                         + "\n".join(
                             [
                                 f"• {finding}"

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -331,15 +331,15 @@ class TestOutputs:
         finding_1.muted = True
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = (
-            "rds_instance_certificate_expiration"
-        )
+        finding_1.check_metadata.CheckTitle = "rds_instance_certificate_expiration"
         finding_2 = mock.MagicMock()
         finding_2.status = "FAIL"
         finding_2.muted = False
         finding_2.resource_id = "test_resource_1"
         finding_2.check_metadata.Severity = "critical"
-        finding_2.check_metadata.CheckTitle = "autoscaling_find_secrets_ec2_launch_configuration"
+        finding_2.check_metadata.CheckTitle = (
+            "autoscaling_find_secrets_ec2_launch_configuration"
+        )
         findings = [finding_1, finding_2]
 
         stats = extract_findings_statistics(findings)
@@ -350,7 +350,7 @@ class TestOutputs:
         assert stats["resources_count"] == 1
         assert stats["critical_failed_findings"] == [
             "rds_instance_certificate_expiration",
-            "autoscaling_find_secrets_ec2_launch_configuration"
+            "autoscaling_find_secrets_ec2_launch_configuration",
         ]
         assert stats["critical_passed_findings"] == []
         assert stats["findings_count"] == 2
@@ -391,9 +391,7 @@ class TestOutputs:
         finding_1.status = "PASS"
         finding_1.muted = True
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = (
-            "rds_instance_certificate_expiration"
-        )
+        finding_1.check_metadata.CheckTitle = "rds_instance_certificate_expiration"
         finding_1.resource_id = "test_resource_1"
         findings = [finding_1]
 

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -315,34 +315,26 @@ class TestOutputs:
         finding_1.status = "FAIL"
         finding_1.muted = True
         finding_1.resource_id = "test_resource_1"
-        finding_1.check_metadata.Severity = "high"
-        finding_1.check_metadata.CheckTitle = "acm_certificates_expiration_check"
+        finding_1.check_metadata.Severity = "medium"
+        finding_1.check_metadata.CheckID = "glue_etl_jobs_amazon_s3_encryption_enabled"
         finding_2 = mock.MagicMock()
         finding_2.status = "FAIL"
         finding_2.muted = True
         finding_2.resource_id = "test_resource_2"
-        finding_2.check_metadata.Severity = "medium"
-        finding_2.check_metadata.CheckTitle = (
-            "glue_etl_jobs_amazon_s3_encryption_enabled"
-        )
-        finding_3 = mock.MagicMock()
-        finding_3.status = "FAIL"
-        finding_3.muted = True
-        finding_3.resource_id = "test_resource_3"
-        finding_3.check_metadata.Severity = "low"
-        finding_3.check_metadata.CheckTitle = "lightsail_static_ip_unused"
-        findings = [finding_1, finding_2, finding_3]
+        finding_2.check_metadata.Severity = "low"
+        finding_2.check_metadata.CheckID = "lightsail_static_ip_unused"
+        findings = [finding_1, finding_2]
 
         stats = extract_findings_statistics(findings)
         assert stats["total_pass"] == 0
-        assert stats["total_fail"] == 3
+        assert stats["total_fail"] == 2
         assert stats["total_muted_pass"] == 0
-        assert stats["total_muted_fail"] == 3
-        assert stats["resources_count"] == 3
-        assert stats["findings_count"] == 3
+        assert stats["total_muted_fail"] == 2
+        assert stats["resources_count"] == 2
+        assert stats["findings_count"] == 2
         assert stats["total_critical_severity_fail"] == 0
         assert stats["total_critical_severity_pass"] == 0
-        assert stats["total_high_severity_fail"] == 1
+        assert stats["total_high_severity_fail"] == 0
         assert stats["total_high_severity_pass"] == 0
         assert stats["total_medium_severity_fail"] == 1
         assert stats["total_medium_severity_pass"] == 0
@@ -356,13 +348,13 @@ class TestOutputs:
         finding_1.muted = True
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = "rds_instance_certificate_expiration"
+        finding_1.check_metadata.CheckID = "rds_instance_certificate_expiration"
         finding_2 = mock.MagicMock()
         finding_2.status = "FAIL"
         finding_2.muted = False
         finding_2.resource_id = "test_resource_1"
         finding_2.check_metadata.Severity = "critical"
-        finding_2.check_metadata.CheckTitle = (
+        finding_2.check_metadata.CheckID = (
             "autoscaling_find_secrets_ec2_launch_configuration"
         )
         findings = [finding_1, finding_2]
@@ -390,7 +382,7 @@ class TestOutputs:
         finding_1.muted = True
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = (
+        finding_1.check_metadata.CheckID = (
             "autoscaling_find_secrets_ec2_launch_configuration"
         )
 
@@ -399,7 +391,7 @@ class TestOutputs:
         finding_2.muted = False
         finding_2.resource_id = "test_resource_1"
         finding_2.check_metadata.Severity = "high"
-        finding_2.check_metadata.CheckTitle = "acm_certificates_expiration_check"
+        finding_2.check_metadata.CheckID = "acm_certificates_expiration_check"
         findings = [finding_1, finding_2]
 
         stats = extract_findings_statistics(findings)
@@ -423,7 +415,7 @@ class TestOutputs:
         finding_1.status = "PASS"
         finding_1.muted = True
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = "rds_instance_certificate_expiration"
+        finding_1.check_metadata.CheckID = "rds_instance_certificate_expiration"
         finding_1.resource_id = "test_resource_1"
         findings = [finding_1]
 

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -332,14 +332,14 @@ class TestOutputs:
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "critical"
         finding_1.check_metadata.CheckTitle = (
-            "cloudfront_distributions_custom_ssl_certificate"
+            "rds_instance_certificate_expiration"
         )
         finding_2 = mock.MagicMock()
         finding_2.status = "FAIL"
         finding_2.muted = False
         finding_2.resource_id = "test_resource_1"
         finding_2.check_metadata.Severity = "critical"
-        finding_2.check_metadata.CheckTitle = "acm_certificates_expiration_check"
+        finding_2.check_metadata.CheckTitle = "autoscaling_find_secrets_ec2_launch_configuration"
         findings = [finding_1, finding_2]
 
         stats = extract_findings_statistics(findings)
@@ -349,8 +349,8 @@ class TestOutputs:
         assert stats["total_muted_fail"] == 1
         assert stats["resources_count"] == 1
         assert stats["critical_failed_findings"] == [
-            "cloudfront_distributions_custom_ssl_certificate",
-            "acm_certificates_expiration_check",
+            "rds_instance_certificate_expiration",
+            "autoscaling_find_secrets_ec2_launch_configuration"
         ]
         assert stats["critical_passed_findings"] == []
         assert stats["findings_count"] == 2
@@ -363,7 +363,7 @@ class TestOutputs:
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "critical"
         finding_1.check_metadata.CheckTitle = (
-            "cloudfront_distributions_custom_ssl_certificate"
+            "autoscaling_find_secrets_ec2_launch_configuration"
         )
 
         finding_2 = mock.MagicMock()
@@ -382,7 +382,7 @@ class TestOutputs:
         assert stats["resources_count"] == 1
         assert stats["critical_failed_findings"] == []
         assert stats["critical_passed_findings"] == [
-            "cloudfront_distributions_custom_ssl_certificate"
+            "autoscaling_find_secrets_ec2_launch_configuration"
         ]
         assert stats["findings_count"] == 2
 
@@ -392,7 +392,7 @@ class TestOutputs:
         finding_1.muted = True
         finding_1.check_metadata.Severity = "critical"
         finding_1.check_metadata.CheckTitle = (
-            "cloudfront_distributions_custom_ssl_certificate"
+            "rds_instance_certificate_expiration"
         )
         finding_1.resource_id = "test_resource_1"
         findings = [finding_1]
@@ -405,7 +405,7 @@ class TestOutputs:
         assert stats["resources_count"] == 1
         assert stats["critical_failed_findings"] == []
         assert stats["critical_passed_findings"] == [
-            "cloudfront_distributions_custom_ssl_certificate"
+            "rds_instance_certificate_expiration"
         ]
         assert stats["findings_count"] == 1
 

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -300,8 +300,8 @@ class TestOutputs:
         assert stats["total_fail"] == 0
         assert stats["total_muted_pass"] == 0
         assert stats["total_muted_fail"] == 0
-        assert stats["critical_failed_findings"] == []
-        assert stats["critical_passed_findings"] == []
+        assert stats["total_critical_severity_fail"] == 0
+        assert stats["total_critical_severity_pass"] == 0
         assert stats["resources_count"] == 0
         assert stats["findings_count"] == 0
 
@@ -321,8 +321,8 @@ class TestOutputs:
         assert stats["total_muted_fail"] == 1
         assert stats["resources_count"] == 1
         assert stats["findings_count"] == 1
-        assert stats["critical_failed_findings"] == []
-        assert stats["critical_passed_findings"] == []
+        assert stats["total_critical_severity_fail"] == 0
+        assert stats["total_critical_severity_pass"] == 0
         assert stats["all_fails_are_muted"]
 
     def test_extract_findings_statistics_all_fail_are_not_muted(self):
@@ -348,11 +348,8 @@ class TestOutputs:
         assert stats["total_muted_pass"] == 0
         assert stats["total_muted_fail"] == 1
         assert stats["resources_count"] == 1
-        assert stats["critical_failed_findings"] == [
-            "rds_instance_certificate_expiration",
-            "autoscaling_find_secrets_ec2_launch_configuration",
-        ]
-        assert stats["critical_passed_findings"] == []
+        assert stats["total_critical_severity_fail"] == 2
+        assert stats["total_critical_severity_pass"] == 0
         assert stats["findings_count"] == 2
         assert not stats["all_fails_are_muted"]
 
@@ -380,10 +377,8 @@ class TestOutputs:
         assert stats["total_muted_pass"] == 1
         assert stats["total_muted_fail"] == 0
         assert stats["resources_count"] == 1
-        assert stats["critical_failed_findings"] == []
-        assert stats["critical_passed_findings"] == [
-            "autoscaling_find_secrets_ec2_launch_configuration"
-        ]
+        assert stats["total_critical_severity_fail"] == 0
+        assert stats["total_critical_severity_pass"] == 1
         assert stats["findings_count"] == 2
 
     def test_extract_findings_statistics_all_passes_are_muted(self):
@@ -401,10 +396,8 @@ class TestOutputs:
         assert stats["total_muted_pass"] == 1
         assert stats["total_muted_fail"] == 0
         assert stats["resources_count"] == 1
-        assert stats["critical_failed_findings"] == []
-        assert stats["critical_passed_findings"] == [
-            "rds_instance_certificate_expiration"
-        ]
+        assert stats["total_critical_severity_fail"] == 0
+        assert stats["total_critical_severity_pass"] == 1
         assert stats["findings_count"] == 1
 
     def test_report_with_aws_provider_not_muted_pass(self):

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -244,7 +244,6 @@ class TestOutputs:
         finding_1 = mock.MagicMock()
         finding_1.status = "PASS"
         finding_1.resource_id = "test_resource_1"
-        finding_1.check
         finding_2 = mock.MagicMock()
         finding_2.status = "FAIL"
         finding_2.resource_id = "test_resource_2"
@@ -308,8 +307,6 @@ class TestOutputs:
         assert stats["total_medium_severity_pass"] == 0
         assert stats["total_low_severity_fail"] == 0
         assert stats["total_low_severity_pass"] == 0
-        assert stats["total_informational_severity_fail"] == 0
-        assert stats["total_informational_severity_pass"] == 0
         assert stats["resources_count"] == 0
         assert stats["findings_count"] == 0
 
@@ -320,25 +317,37 @@ class TestOutputs:
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "high"
         finding_1.check_metadata.CheckTitle = "acm_certificates_expiration_check"
-        findings = [finding_1]
+        finding_2 = mock.MagicMock()
+        finding_2.status = "FAIL"
+        finding_2.muted = True
+        finding_2.resource_id = "test_resource_2"
+        finding_2.check_metadata.Severity = "medium"
+        finding_2.check_metadata.CheckTitle = (
+            "glue_etl_jobs_amazon_s3_encryption_enabled"
+        )
+        finding_3 = mock.MagicMock()
+        finding_3.status = "FAIL"
+        finding_3.muted = True
+        finding_3.resource_id = "test_resource_3"
+        finding_3.check_metadata.Severity = "low"
+        finding_3.check_metadata.CheckTitle = "lightsail_static_ip_unused"
+        findings = [finding_1, finding_2, finding_3]
 
         stats = extract_findings_statistics(findings)
         assert stats["total_pass"] == 0
-        assert stats["total_fail"] == 1
+        assert stats["total_fail"] == 3
         assert stats["total_muted_pass"] == 0
-        assert stats["total_muted_fail"] == 1
-        assert stats["resources_count"] == 1
-        assert stats["findings_count"] == 1
+        assert stats["total_muted_fail"] == 3
+        assert stats["resources_count"] == 3
+        assert stats["findings_count"] == 3
         assert stats["total_critical_severity_fail"] == 0
         assert stats["total_critical_severity_pass"] == 0
         assert stats["total_high_severity_fail"] == 1
         assert stats["total_high_severity_pass"] == 0
-        assert stats["total_medium_severity_fail"] == 0
+        assert stats["total_medium_severity_fail"] == 1
         assert stats["total_medium_severity_pass"] == 0
-        assert stats["total_low_severity_fail"] == 0
+        assert stats["total_low_severity_fail"] == 1
         assert stats["total_low_severity_pass"] == 0
-        assert stats["total_informational_severity_fail"] == 0
-        assert stats["total_informational_severity_pass"] == 0
         assert stats["all_fails_are_muted"]
 
     def test_extract_findings_statistics_all_fail_are_not_muted(self):
@@ -372,8 +381,6 @@ class TestOutputs:
         assert stats["total_medium_severity_pass"] == 0
         assert stats["total_low_severity_fail"] == 0
         assert stats["total_low_severity_pass"] == 0
-        assert stats["total_informational_severity_fail"] == 0
-        assert stats["total_informational_severity_pass"] == 0
         assert stats["findings_count"] == 2
         assert not stats["all_fails_are_muted"]
 
@@ -409,8 +416,6 @@ class TestOutputs:
         assert stats["total_medium_severity_pass"] == 0
         assert stats["total_low_severity_fail"] == 0
         assert stats["total_low_severity_pass"] == 0
-        assert stats["total_informational_severity_fail"] == 0
-        assert stats["total_informational_severity_pass"] == 0
         assert stats["findings_count"] == 2
 
     def test_extract_findings_statistics_all_passes_are_muted(self):
@@ -436,8 +441,6 @@ class TestOutputs:
         assert stats["total_medium_severity_pass"] == 0
         assert stats["total_low_severity_fail"] == 0
         assert stats["total_low_severity_pass"] == 0
-        assert stats["total_informational_severity_fail"] == 0
-        assert stats["total_informational_severity_pass"] == 0
         assert stats["findings_count"] == 1
 
     def test_report_with_aws_provider_not_muted_pass(self):

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -302,6 +302,14 @@ class TestOutputs:
         assert stats["total_muted_fail"] == 0
         assert stats["total_critical_severity_fail"] == 0
         assert stats["total_critical_severity_pass"] == 0
+        assert stats["total_high_severity_fail"] == 0
+        assert stats["total_high_severity_pass"] == 0
+        assert stats["total_medium_severity_fail"] == 0
+        assert stats["total_medium_severity_pass"] == 0
+        assert stats["total_low_severity_fail"] == 0
+        assert stats["total_low_severity_pass"] == 0
+        assert stats["total_informational_severity_fail"] == 0
+        assert stats["total_informational_severity_pass"] == 0
         assert stats["resources_count"] == 0
         assert stats["findings_count"] == 0
 
@@ -323,6 +331,14 @@ class TestOutputs:
         assert stats["findings_count"] == 1
         assert stats["total_critical_severity_fail"] == 0
         assert stats["total_critical_severity_pass"] == 0
+        assert stats["total_high_severity_fail"] == 1
+        assert stats["total_high_severity_pass"] == 0
+        assert stats["total_medium_severity_fail"] == 0
+        assert stats["total_medium_severity_pass"] == 0
+        assert stats["total_low_severity_fail"] == 0
+        assert stats["total_low_severity_pass"] == 0
+        assert stats["total_informational_severity_fail"] == 0
+        assert stats["total_informational_severity_pass"] == 0
         assert stats["all_fails_are_muted"]
 
     def test_extract_findings_statistics_all_fail_are_not_muted(self):
@@ -350,6 +366,14 @@ class TestOutputs:
         assert stats["resources_count"] == 1
         assert stats["total_critical_severity_fail"] == 2
         assert stats["total_critical_severity_pass"] == 0
+        assert stats["total_high_severity_fail"] == 0
+        assert stats["total_high_severity_pass"] == 0
+        assert stats["total_medium_severity_fail"] == 0
+        assert stats["total_medium_severity_pass"] == 0
+        assert stats["total_low_severity_fail"] == 0
+        assert stats["total_low_severity_pass"] == 0
+        assert stats["total_informational_severity_fail"] == 0
+        assert stats["total_informational_severity_pass"] == 0
         assert stats["findings_count"] == 2
         assert not stats["all_fails_are_muted"]
 
@@ -379,6 +403,14 @@ class TestOutputs:
         assert stats["resources_count"] == 1
         assert stats["total_critical_severity_fail"] == 0
         assert stats["total_critical_severity_pass"] == 1
+        assert stats["total_high_severity_fail"] == 0
+        assert stats["total_high_severity_pass"] == 1
+        assert stats["total_medium_severity_fail"] == 0
+        assert stats["total_medium_severity_pass"] == 0
+        assert stats["total_low_severity_fail"] == 0
+        assert stats["total_low_severity_pass"] == 0
+        assert stats["total_informational_severity_fail"] == 0
+        assert stats["total_informational_severity_pass"] == 0
         assert stats["findings_count"] == 2
 
     def test_extract_findings_statistics_all_passes_are_muted(self):
@@ -398,6 +430,14 @@ class TestOutputs:
         assert stats["resources_count"] == 1
         assert stats["total_critical_severity_fail"] == 0
         assert stats["total_critical_severity_pass"] == 1
+        assert stats["total_high_severity_fail"] == 0
+        assert stats["total_high_severity_pass"] == 0
+        assert stats["total_medium_severity_fail"] == 0
+        assert stats["total_medium_severity_pass"] == 0
+        assert stats["total_low_severity_fail"] == 0
+        assert stats["total_low_severity_pass"] == 0
+        assert stats["total_informational_severity_fail"] == 0
+        assert stats["total_informational_severity_pass"] == 0
         assert stats["findings_count"] == 1
 
     def test_report_with_aws_provider_not_muted_pass(self):

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -331,7 +331,9 @@ class TestOutputs:
         finding_1.muted = True
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = "cloudfront_distributions_custom_ssl_certificate"
+        finding_1.check_metadata.CheckTitle = (
+            "cloudfront_distributions_custom_ssl_certificate"
+        )
         finding_2 = mock.MagicMock()
         finding_2.status = "FAIL"
         finding_2.muted = False
@@ -346,7 +348,10 @@ class TestOutputs:
         assert stats["total_muted_pass"] == 0
         assert stats["total_muted_fail"] == 1
         assert stats["resources_count"] == 1
-        assert stats["critical_failed_findings"] == ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
+        assert stats["critical_failed_findings"] == [
+            "cloudfront_distributions_custom_ssl_certificate",
+            "acm_certificates_expiration_check",
+        ]
         assert stats["critical_passed_findings"] == []
         assert stats["findings_count"] == 2
         assert not stats["all_fails_are_muted"]
@@ -357,7 +362,9 @@ class TestOutputs:
         finding_1.muted = True
         finding_1.resource_id = "test_resource_1"
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = "cloudfront_distributions_custom_ssl_certificate"
+        finding_1.check_metadata.CheckTitle = (
+            "cloudfront_distributions_custom_ssl_certificate"
+        )
 
         finding_2 = mock.MagicMock()
         finding_2.status = "PASS"
@@ -374,7 +381,9 @@ class TestOutputs:
         assert stats["total_muted_fail"] == 0
         assert stats["resources_count"] == 1
         assert stats["critical_failed_findings"] == []
-        assert stats["critical_passed_findings"] == ["cloudfront_distributions_custom_ssl_certificate"]
+        assert stats["critical_passed_findings"] == [
+            "cloudfront_distributions_custom_ssl_certificate"
+        ]
         assert stats["findings_count"] == 2
 
     def test_extract_findings_statistics_all_passes_are_muted(self):
@@ -382,7 +391,9 @@ class TestOutputs:
         finding_1.status = "PASS"
         finding_1.muted = True
         finding_1.check_metadata.Severity = "critical"
-        finding_1.check_metadata.CheckTitle = "cloudfront_distributions_custom_ssl_certificate"
+        finding_1.check_metadata.CheckTitle = (
+            "cloudfront_distributions_custom_ssl_certificate"
+        )
         finding_1.resource_id = "test_resource_1"
         findings = [finding_1]
 
@@ -393,7 +404,9 @@ class TestOutputs:
         assert stats["total_muted_fail"] == 0
         assert stats["resources_count"] == 1
         assert stats["critical_failed_findings"] == []
-        assert stats["critical_passed_findings"] == ["cloudfront_distributions_custom_ssl_certificate"]
+        assert stats["critical_passed_findings"] == [
+            "cloudfront_distributions_custom_ssl_certificate"
+        ]
         assert stats["findings_count"] == 1
 
     def test_report_with_aws_provider_not_muted_pass(self):

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -127,32 +127,28 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nHigh:\n"
-                    + "• 1",
+                    "text": "\nHigh:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nMedium:\n"
-                    + "• 1",
+                    "text": "\nMedium:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n"
-                    + "• 3",
+                    "text": "\nLow:\n" + "• 3",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n"
-                    + "• 3",
+                    "text": "\nInformational:\n" + "• 3",
                 },
             },
             {
@@ -173,32 +169,28 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nHigh:\n"
-                    + "• 1",
+                    "text": "\nHigh:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nMedium:\n"
-                    + "• 2",
+                    "text": "\nMedium:\n" + "• 2",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n"
-                    + "• 5",
+                    "text": "\nLow:\n" + "• 5",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n"
-                    + "• 1",
+                    "text": "\nInformational:\n" + "• 1",
                 },
             },
             {
@@ -310,32 +302,28 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nHigh:\n"
-                    + "• 1",
+                    "text": "\nHigh:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nMedium:\n"
-                    + "• 1",
+                    "text": "\nMedium:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n"
-                    + "• 3",
+                    "text": "\nLow:\n" + "• 3",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n"
-                    + "• 3",
+                    "text": "\nInformational:\n" + "• 3",
                 },
             },
             {
@@ -356,32 +344,28 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nHigh:\n"
-                    + "• 1",
+                    "text": "\nHigh:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nMedium:\n"
-                    + "• 2",
+                    "text": "\nMedium:\n" + "• 2",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n"
-                    + "• 5",
+                    "text": "\nLow:\n" + "• 5",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n"
-                    + "• 1",
+                    "text": "\nInformational:\n" + "• 1",
                 },
             },
             {
@@ -491,32 +475,28 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nHigh:\n"
-                    + "• 1",
+                    "text": "\nHigh:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nMedium:\n"
-                    + "• 1",
+                    "text": "\nMedium:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n"
-                    + "• 3",
+                    "text": "\nLow:\n" + "• 3",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n"
-                    + "• 3",
+                    "text": "\nInformational:\n" + "• 3",
                 },
             },
             {
@@ -537,32 +517,28 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nHigh:\n"
-                    + "• 1",
+                    "text": "\nHigh:\n" + "• 1",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nMedium:\n"
-                    + "• 2",
+                    "text": "\nMedium:\n" + "• 2",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n"
-                    + "• 5",
+                    "text": "\nLow:\n" + "• 5",
                 },
             },
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n"
-                    + "• 1",
+                    "text": "\nInformational:\n" + "• 1",
                 },
             },
             {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -143,7 +143,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Failed Findings:\n"
+                    "text": "\nCritical Failed Findings:\n"
                     + "\n".join(
                         [
                             f"• {finding}"
@@ -157,7 +157,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Passed Findings:\n"
+                    "text": "\nCritical Passed Findings:\n"
                     + "\n".join(
                         [
                             f"• {finding}"
@@ -275,7 +275,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Failed Findings:\n"
+                    "text": "\nCritical Failed Findings:\n"
                     + "\n".join(
                         [
                             f"• {finding}"
@@ -289,7 +289,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Passed Findings:\n"
+                    "text": "\nCritical Passed Findings:\n"
                     + "\n".join(
                         [
                             f"• {finding}"
@@ -405,7 +405,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Failed Findings:\n"
+                    "text": "\nCritical Failed Findings:\n"
                     + "\n".join(
                         [
                             f"• {finding}"
@@ -419,7 +419,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Passed Findings:\n"
+                    "text": "\nCritical Passed Findings:\n"
                     + "\n".join(
                         [
                             f"• {finding}"

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -116,28 +116,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nHigh:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nMedium:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 3",
+                    "text": (
+                        "*Severities:*\n"
+                        "• *Critical:* 2 "
+                        "• *High:* 1 "
+                        "• *Medium:* 1 "
+                        "• *Low:* 3"
+                    ),
                 },
             },
             {
@@ -151,28 +136,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n" + "• 4",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nHigh:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nMedium:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 2",
+                    "text": (
+                        "*Severities:*\n"
+                        "• *Critical:* 4 "
+                        "• *High:* 1 "
+                        "• *Medium:* 2 "
+                        "• *Low:* 2"
+                    ),
                 },
             },
             {
@@ -275,28 +245,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nHigh:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nMedium:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 3",
+                    "text": (
+                        "*Severities:*\n"
+                        "• *Critical:* 2 "
+                        "• *High:* 1 "
+                        "• *Medium:* 1 "
+                        "• *Low:* 3"
+                    ),
                 },
             },
             {
@@ -310,28 +265,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n" + "• 4",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nHigh:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nMedium:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 2",
+                    "text": (
+                        "*Severities:*\n"
+                        "• *Critical:* 4 "
+                        "• *High:* 1 "
+                        "• *Medium:* 2 "
+                        "• *Low:* 2"
+                    ),
                 },
             },
             {
@@ -432,28 +372,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nHigh:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nMedium:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 3",
+                    "text": (
+                        "*Severities:*\n"
+                        "• *Critical:* 2 "
+                        "• *High:* 1 "
+                        "• *Medium:* 1 "
+                        "• *Low:* 3"
+                    ),
                 },
             },
             {
@@ -467,28 +392,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n" + "• 4",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nHigh:\n" + "• 1",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nMedium:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 2",
+                    "text": (
+                        "*Severities:*\n"
+                        "• *Critical:* 4 "
+                        "• *High:* 1 "
+                        "• *Medium:* 2 "
+                        "• *Low:* 2"
+                    ),
                 },
             },
             {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -51,16 +51,16 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats["total_critical_severity_pass"] = 2
+        stats["total_critical_severity_pass"] = 4
         stats["total_critical_severity_fail"] = 4
         stats["total_high_severity_fail"] = 1
         stats["total_high_severity_pass"] = 1
         stats["total_medium_severity_fail"] = 2
         stats["total_medium_severity_pass"] = 1
-        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_fail"] = 3
         stats["total_low_severity_pass"] = 3
         stats["total_informational_severity_fail"] = 1
-        stats["total_informational_severity_pass"] = 3
+        stats["total_informational_severity_pass"] = 1
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -86,7 +86,7 @@ class TestSlackIntegration:
         stats["total_high_severity_pass"] = 1
         stats["total_medium_severity_fail"] = 2
         stats["total_medium_severity_pass"] = 1
-        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_fail"] = 2
         stats["total_low_severity_pass"] = 3
         stats["total_informational_severity_fail"] = 1
         stats["total_informational_severity_pass"] = 3
@@ -183,7 +183,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 5",
+                    "text": "\nLow:\n" + "• 2",
                 },
             },
             {
@@ -247,7 +247,7 @@ class TestSlackIntegration:
         ]
 
     def test_create_message_blocks_azure(self):
-        aws_provider = set_mocked_aws_provider()
+        aws_provider = set_mocked_azure_provider()
         slack = Slack(SLACK_TOKEN, SLACK_CHANNEL, aws_provider)
         args = "--slack"
         stats = {}
@@ -259,7 +259,7 @@ class TestSlackIntegration:
         stats["total_high_severity_pass"] = 1
         stats["total_medium_severity_fail"] = 2
         stats["total_medium_severity_pass"] = 1
-        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_fail"] = 2
         stats["total_low_severity_pass"] = 3
         stats["total_informational_severity_fail"] = 1
         stats["total_informational_severity_pass"] = 3
@@ -358,7 +358,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 5",
+                    "text": "\nLow:\n" + "• 2",
                 },
             },
             {
@@ -422,7 +422,7 @@ class TestSlackIntegration:
         ]
 
     def test_create_message_blocks_gcp(self):
-        aws_provider = set_mocked_aws_provider()
+        aws_provider = set_mocked_gcp_provider()
         slack = Slack(SLACK_TOKEN, SLACK_CHANNEL, aws_provider)
         args = "--slack"
         stats = {}
@@ -434,7 +434,7 @@ class TestSlackIntegration:
         stats["total_high_severity_pass"] = 1
         stats["total_medium_severity_fail"] = 2
         stats["total_medium_severity_pass"] = 1
-        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_fail"] = 2
         stats["total_low_severity_pass"] = 3
         stats["total_informational_severity_fail"] = 1
         stats["total_informational_severity_pass"] = 3
@@ -531,7 +531,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nLow:\n" + "• 5",
+                    "text": "\nLow:\n" + "• 2",
                 },
             },
             {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -59,8 +59,6 @@ class TestSlackIntegration:
         stats["total_medium_severity_pass"] = 1
         stats["total_low_severity_fail"] = 3
         stats["total_low_severity_pass"] = 3
-        stats["total_informational_severity_fail"] = 1
-        stats["total_informational_severity_pass"] = 1
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -88,8 +86,6 @@ class TestSlackIntegration:
         stats["total_medium_severity_pass"] = 1
         stats["total_low_severity_fail"] = 2
         stats["total_low_severity_pass"] = 3
-        stats["total_informational_severity_fail"] = 1
-        stats["total_informational_severity_pass"] = 3
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -148,13 +144,6 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n" + "• 3",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                 },
             },
@@ -184,13 +173,6 @@ class TestSlackIntegration:
                 "text": {
                     "type": "mrkdwn",
                     "text": "\nLow:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nInformational:\n" + "• 1",
                 },
             },
             {
@@ -261,8 +243,6 @@ class TestSlackIntegration:
         stats["total_medium_severity_pass"] = 1
         stats["total_low_severity_fail"] = 2
         stats["total_low_severity_pass"] = 3
-        stats["total_informational_severity_fail"] = 1
-        stats["total_informational_severity_pass"] = 3
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -323,13 +303,6 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n" + "• 3",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                 },
             },
@@ -359,13 +332,6 @@ class TestSlackIntegration:
                 "text": {
                     "type": "mrkdwn",
                     "text": "\nLow:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nInformational:\n" + "• 1",
                 },
             },
             {
@@ -436,8 +402,6 @@ class TestSlackIntegration:
         stats["total_medium_severity_pass"] = 1
         stats["total_low_severity_fail"] = 2
         stats["total_low_severity_pass"] = 3
-        stats["total_informational_severity_fail"] = 1
-        stats["total_informational_severity_pass"] = 3
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -496,13 +460,6 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nInformational:\n" + "• 3",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                 },
             },
@@ -532,13 +489,6 @@ class TestSlackIntegration:
                 "text": {
                     "type": "mrkdwn",
                     "text": "\nLow:\n" + "• 2",
-                },
-            },
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nInformational:\n" + "• 1",
                 },
             },
             {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -51,15 +51,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats["critical_failed_findings"] = [
-            "ec2_instance_account_imdsv2_enabled",
-            "ec2_ebs_snapshot_account_block_public_access",
-            "ec2_ebs_default_encryption",
-        ]
-        stats["critical_passed_findings"] = [
-            "cloudfront_distributions_custom_ssl_certificate",
-            "acm_certificates_expiration_check",
-        ]
+        stats["total_critical_severity_pass"] = 2
+        stats["total_critical_severity_fail"] = 4
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -79,15 +72,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats["critical_failed_findings"] = [
-            "ec2_instance_account_imdsv2_enabled",
-            "ec2_ebs_snapshot_account_block_public_access",
-            "ec2_ebs_default_encryption",
-        ]
-        stats["critical_passed_findings"] = [
-            "cloudfront_distributions_custom_ssl_certificate",
-            "acm_certificates_expiration_check",
-        ]
+        stats["total_critical_severity_pass"] = 2
+        stats["total_critical_severity_fail"] = 4
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -118,7 +104,23 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
+                    "text": "\nCritical:\n"
+                    + f"• 2",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nCritical:\n"
+                    + f"• 4",
                 },
             },
             {
@@ -137,34 +139,6 @@ class TestSlackIntegration:
                         "text": f"Used parameters: `prowler {args}`",
                     }
                 ],
-            },
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nCritical Failed Findings:\n"
-                    + "\n".join(
-                        [
-                            f"• {finding}"
-                            for finding in stats["critical_failed_findings"]
-                        ]
-                    ),
-                },
-            },
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nCritical Passed Findings:\n"
-                    + "\n".join(
-                        [
-                            f"• {finding}"
-                            for finding in stats["critical_passed_findings"]
-                        ]
-                    ),
-                },
             },
             {"type": "divider"},
             {
@@ -209,15 +183,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats["critical_failed_findings"] = [
-            "ec2_instance_account_imdsv2_enabled",
-            "ec2_ebs_snapshot_account_block_public_access",
-            "ec2_ebs_default_encryption",
-        ]
-        stats["critical_passed_findings"] = [
-            "cloudfront_distributions_custom_ssl_certificate",
-            "acm_certificates_expiration_check",
-        ]
+        stats["total_critical_severity_pass"] = 2
+        stats["total_critical_severity_fail"] = 4
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -250,7 +217,23 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
+                    "text": "\nCritical:\n"
+                    + f"• 2",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nCritical:\n"
+                    + f"• 4",
                 },
             },
             {
@@ -269,34 +252,6 @@ class TestSlackIntegration:
                         "text": f"Used parameters: `prowler {args}`",
                     }
                 ],
-            },
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nCritical Failed Findings:\n"
-                    + "\n".join(
-                        [
-                            f"• {finding}"
-                            for finding in stats["critical_failed_findings"]
-                        ]
-                    ),
-                },
-            },
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nCritical Passed Findings:\n"
-                    + "\n".join(
-                        [
-                            f"• {finding}"
-                            for finding in stats["critical_passed_findings"]
-                        ]
-                    ),
-                },
             },
             {"type": "divider"},
             {
@@ -341,15 +296,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats["critical_failed_findings"] = [
-            "ec2_instance_account_imdsv2_enabled",
-            "ec2_ebs_snapshot_account_block_public_access",
-            "ec2_ebs_default_encryption",
-        ]
-        stats["critical_passed_findings"] = [
-            "cloudfront_distributions_custom_ssl_certificate",
-            "acm_certificates_expiration_check",
-        ]
+        stats["total_critical_severity_pass"] = 2
+        stats["total_critical_severity_fail"] = 4
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -380,7 +328,23 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
+                    "text": "\nCritical:\n"
+                    + f"• 2",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nCritical:\n"
+                    + f"• 4",
                 },
             },
             {
@@ -399,34 +363,6 @@ class TestSlackIntegration:
                         "text": f"Used parameters: `prowler {args}`",
                     }
                 ],
-            },
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nCritical Failed Findings:\n"
-                    + "\n".join(
-                        [
-                            f"• {finding}"
-                            for finding in stats["critical_failed_findings"]
-                        ]
-                    ),
-                },
-            },
-            {"type": "divider"},
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": "\nCritical Passed Findings:\n"
-                    + "\n".join(
-                        [
-                            f"• {finding}"
-                            for finding in stats["critical_passed_findings"]
-                        ]
-                    ),
-                },
             },
             {"type": "divider"},
             {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -104,8 +104,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n"
-                    + f"• 2",
+                    "text": "\nCritical:\n" + "• 2",
                 },
             },
             {
@@ -119,8 +118,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n"
-                    + f"• 4",
+                    "text": "\nCritical:\n" + "• 4",
                 },
             },
             {
@@ -217,8 +215,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n"
-                    + f"• 2",
+                    "text": "\nCritical:\n" + "• 2",
                 },
             },
             {
@@ -232,8 +229,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n"
-                    + f"• 4",
+                    "text": "\nCritical:\n" + "• 4",
                 },
             },
             {
@@ -328,8 +324,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n"
-                    + f"• 2",
+                    "text": "\nCritical:\n" + "• 2",
                 },
             },
             {
@@ -343,8 +338,7 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "\nCritical:\n"
-                    + f"• 4",
+                    "text": "\nCritical:\n" + "• 4",
                 },
             },
             {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -51,8 +51,15 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
-        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
+        stats["critical_failed_findings"] = [
+            "ec2_instance_account_imdsv2_enabled",
+            "ec2_ebs_snapshot_account_block_public_access",
+            "ec2_ebs_default_encryption",
+        ]
+        stats["critical_passed_findings"] = [
+            "cloudfront_distributions_custom_ssl_certificate",
+            "acm_certificates_expiration_check",
+        ]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -72,8 +79,15 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
-        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
+        stats["critical_failed_findings"] = [
+            "ec2_instance_account_imdsv2_enabled",
+            "ec2_ebs_snapshot_account_block_public_access",
+            "ec2_ebs_default_encryption",
+        ]
+        stats["critical_passed_findings"] = [
+            "cloudfront_distributions_custom_ssl_certificate",
+            "acm_certificates_expiration_check",
+        ]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -129,7 +143,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                    "text": f"\nCritical Failed Findings:\n"
+                    + "\n".join(
+                        [
+                            f"• {finding}"
+                            for finding in stats["critical_failed_findings"]
+                        ]
+                    ),
                 },
             },
             {"type": "divider"},
@@ -137,7 +157,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                    "text": f"\nCritical Passed Findings:\n"
+                    + "\n".join(
+                        [
+                            f"• {finding}"
+                            for finding in stats["critical_passed_findings"]
+                        ]
+                    ),
                 },
             },
             {"type": "divider"},
@@ -183,8 +209,15 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
-        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
+        stats["critical_failed_findings"] = [
+            "ec2_instance_account_imdsv2_enabled",
+            "ec2_ebs_snapshot_account_block_public_access",
+            "ec2_ebs_default_encryption",
+        ]
+        stats["critical_passed_findings"] = [
+            "cloudfront_distributions_custom_ssl_certificate",
+            "acm_certificates_expiration_check",
+        ]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -242,7 +275,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                    "text": f"\nCritical Failed Findings:\n"
+                    + "\n".join(
+                        [
+                            f"• {finding}"
+                            for finding in stats["critical_failed_findings"]
+                        ]
+                    ),
                 },
             },
             {"type": "divider"},
@@ -250,7 +289,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                    "text": f"\nCritical Passed Findings:\n"
+                    + "\n".join(
+                        [
+                            f"• {finding}"
+                            for finding in stats["critical_passed_findings"]
+                        ]
+                    ),
                 },
             },
             {"type": "divider"},
@@ -296,8 +341,15 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
-        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
-        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
+        stats["critical_failed_findings"] = [
+            "ec2_instance_account_imdsv2_enabled",
+            "ec2_ebs_snapshot_account_block_public_access",
+            "ec2_ebs_default_encryption",
+        ]
+        stats["critical_passed_findings"] = [
+            "cloudfront_distributions_custom_ssl_certificate",
+            "acm_certificates_expiration_check",
+        ]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -353,7 +405,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                    "text": f"\nCritical Failed Findings:\n"
+                    + "\n".join(
+                        [
+                            f"• {finding}"
+                            for finding in stats["critical_failed_findings"]
+                        ]
+                    ),
                 },
             },
             {"type": "divider"},
@@ -361,7 +419,13 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                    "text": f"\nCritical Passed Findings:\n"
+                    + "\n".join(
+                        [
+                            f"• {finding}"
+                            for finding in stats["critical_passed_findings"]
+                        ]
+                    ),
                 },
             },
             {"type": "divider"},

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -51,6 +51,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
+        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
+        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -70,6 +72,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
+        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
+        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -123,6 +127,22 @@ class TestSlackIntegration:
             {"type": "divider"},
             {
                 "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
                 "text": {"type": "mrkdwn", "text": "Join our Slack Community!"},
                 "accessory": {
                     "type": "button",
@@ -163,6 +183,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
+        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
+        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -218,6 +240,22 @@ class TestSlackIntegration:
             {"type": "divider"},
             {
                 "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
                 "text": {"type": "mrkdwn", "text": "Join our Slack Community!"},
                 "accessory": {
                     "type": "button",
@@ -258,6 +296,8 @@ class TestSlackIntegration:
         stats = {}
         stats["total_pass"] = 12
         stats["total_fail"] = 10
+        stats['critical_failed_findings'] = ["ec2_instance_account_imdsv2_enabled", "ec2_ebs_snapshot_account_block_public_access", "ec2_ebs_default_encryption"]
+        stats['critical_passed_findings'] = ["cloudfront_distributions_custom_ssl_certificate", "acm_certificates_expiration_check"]
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -307,6 +347,22 @@ class TestSlackIntegration:
                         "text": f"Used parameters: `prowler {args}`",
                     }
                 ],
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\nCritical Failed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_failed_findings']]),
+                },
+            },
+            {"type": "divider"},
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"\nCritical Passed Findings:\n" + "\n".join([f"• {finding}" for finding in stats['critical_passed_findings']]),
+                },
             },
             {"type": "divider"},
             {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -53,6 +53,14 @@ class TestSlackIntegration:
         stats["total_fail"] = 10
         stats["total_critical_severity_pass"] = 2
         stats["total_critical_severity_fail"] = 4
+        stats["total_high_severity_fail"] = 1
+        stats["total_high_severity_pass"] = 1
+        stats["total_medium_severity_fail"] = 2
+        stats["total_medium_severity_pass"] = 1
+        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_pass"] = 3
+        stats["total_informational_severity_fail"] = 1
+        stats["total_informational_severity_pass"] = 3
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -74,6 +82,14 @@ class TestSlackIntegration:
         stats["total_fail"] = 10
         stats["total_critical_severity_pass"] = 2
         stats["total_critical_severity_fail"] = 4
+        stats["total_high_severity_fail"] = 1
+        stats["total_high_severity_pass"] = 1
+        stats["total_medium_severity_fail"] = 2
+        stats["total_medium_severity_pass"] = 1
+        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_pass"] = 3
+        stats["total_informational_severity_fail"] = 1
+        stats["total_informational_severity_pass"] = 3
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -111,6 +127,38 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
+                    "text": "\nHigh:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nMedium:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nLow:\n"
+                    + "• 3",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nInformational:\n"
+                    + "• 3",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                 },
             },
@@ -119,6 +167,38 @@ class TestSlackIntegration:
                 "text": {
                     "type": "mrkdwn",
                     "text": "\nCritical:\n" + "• 4",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nHigh:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nMedium:\n"
+                    + "• 2",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nLow:\n"
+                    + "• 5",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nInformational:\n"
+                    + "• 1",
                 },
             },
             {
@@ -183,6 +263,14 @@ class TestSlackIntegration:
         stats["total_fail"] = 10
         stats["total_critical_severity_pass"] = 2
         stats["total_critical_severity_fail"] = 4
+        stats["total_high_severity_fail"] = 1
+        stats["total_high_severity_pass"] = 1
+        stats["total_medium_severity_fail"] = 2
+        stats["total_medium_severity_pass"] = 1
+        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_pass"] = 3
+        stats["total_informational_severity_fail"] = 1
+        stats["total_informational_severity_pass"] = 3
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -222,6 +310,38 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
+                    "text": "\nHigh:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nMedium:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nLow:\n"
+                    + "• 3",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nInformational:\n"
+                    + "• 3",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                 },
             },
@@ -230,6 +350,38 @@ class TestSlackIntegration:
                 "text": {
                     "type": "mrkdwn",
                     "text": "\nCritical:\n" + "• 4",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nHigh:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nMedium:\n"
+                    + "• 2",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nLow:\n"
+                    + "• 5",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nInformational:\n"
+                    + "• 1",
                 },
             },
             {
@@ -294,6 +446,14 @@ class TestSlackIntegration:
         stats["total_fail"] = 10
         stats["total_critical_severity_pass"] = 2
         stats["total_critical_severity_fail"] = 4
+        stats["total_high_severity_fail"] = 1
+        stats["total_high_severity_pass"] = 1
+        stats["total_medium_severity_fail"] = 2
+        stats["total_medium_severity_pass"] = 1
+        stats["total_low_severity_fail"] = 5
+        stats["total_low_severity_pass"] = 3
+        stats["total_informational_severity_fail"] = 1
+        stats["total_informational_severity_pass"] = 3
         stats["resources_count"] = 20
         stats["findings_count"] = 22
 
@@ -331,6 +491,38 @@ class TestSlackIntegration:
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
+                    "text": "\nHigh:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nMedium:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nLow:\n"
+                    + "• 3",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nInformational:\n"
+                    + "• 3",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
                     "text": f"\n:x: *{stats['total_fail']} Failed findings* ({round(stats['total_fail'] / stats['findings_count'] * 100 , 2)}%)\n ",
                 },
             },
@@ -339,6 +531,38 @@ class TestSlackIntegration:
                 "text": {
                     "type": "mrkdwn",
                     "text": "\nCritical:\n" + "• 4",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nHigh:\n"
+                    + "• 1",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nMedium:\n"
+                    + "• 2",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nLow:\n"
+                    + "• 5",
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "\nInformational:\n"
+                    + "• 1",
                 },
             },
             {


### PR DESCRIPTION
### Context

Currently, the slack report aggregates the checks that are found for a specific user by displaying the amount of passed checks, the amount of failed checks, and the number of resources that were checked. However, this is not very descriptive for the customer and it would be nice to have an additional section that lists the checks that are included in the findings (passed and failed)

If fixes an issue please add it with `Fix #4843 

### Description

I changed the slack.py file and the outputs.py file. In the outputs.py file I added an additional 2 key value pair in the stats hashmap (critical_failed_findings and critical_failed_findings). Since we cannot list all the checks that are included in a customer's account across all 3 providers, because some accounts will have thousands of checks. However, instead, I made it so that it lists the checks are marked as critical for both passed and failed findings. 

In the slack.py file I added two additional sections below the parameter args markdown, where it will iterate through all the finding check_names and display the critical passed and critical failed findings.
### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
