### PR TITLE
fix(lightsail): Remove second call to `is_resource_filtered`

### DIFF
--- a/prowler/providers/aws/services/lightsail/lightsail_service.py
+++ b/prowler/providers/aws/services/lightsail/lightsail_service.py
@@ -28,7 +28,7 @@ class Lightsail(AWSService):
                         f"arn:{self.audited_partition}:lightsail:{regional_client.region}:{self.audited_account}:Instance",
                     )
 
-                    if not self.audit_resources or is_resource_filtered(
+                    if not self.audit_resources or (
                         is_resource_filtered(arn, self.audit_resources)
                     ):
                         ports = []


### PR DESCRIPTION
### Context
Closes #5043 

### Description

Corrected the conditional statement to call is_resource_filtered only once.

### License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.