### PR TITLE
chore(docs): change ResourceType link of Security Hub

### DIFF
--- a/docs/developer-guide/checks.md
+++ b/docs/developer-guide/checks.md
@@ -272,7 +272,7 @@ Each Prowler check has metadata associated which is stored at the same level of 
   # Severity holds the check's severity, always in lowercase (critical, high, medium, low or informational)
   "Severity": "critical",
   # ResourceType only for AWS, holds the type from here
-  # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Types_ResourceDetails.html
+  # https://docs.aws.amazon.com/securityhub/latest/userguide/asff-resources.html
   "ResourceType": "Other",
   # Description holds the title of the check, for now is the same as CheckTitle
   "Description": "Ensure there are no EC2 AMIs set as Public.",


### PR DESCRIPTION
### Description

Change the link where Prowler gets the resource types for the checks' metadata files.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
