### PR TITLE
fix(elasticache): get correct automatic failover attribute

### DIFF
--- a/prowler/providers/aws/services/elasticache/elasticache_service.py
+++ b/prowler/providers/aws/services/elasticache/elasticache_service.py
@@ -107,7 +107,7 @@ class ElastiCache(AWSService):
                                 "AutoMinorVersionUpgrade", False
                             ),
                             automatic_failover=repl_group.get(
-                                "AutomaticFailoverStatus", "disabled"
+                                "AutomaticFailover", "disabled"
                             ),
                         )
                 except Exception as error:
@@ -180,4 +180,4 @@ class ReplicationGroup(BaseModel):
     multi_az: str
     tags: Optional[list]
     auto_minor_version_upgrade: bool
-    automatic_failover: str
+    automatic_failover: Optional[str]

--- a/prowler/providers/aws/services/elasticache/elasticache_service.py
+++ b/prowler/providers/aws/services/elasticache/elasticache_service.py
@@ -180,4 +180,4 @@ class ReplicationGroup(BaseModel):
     multi_az: str
     tags: Optional[list]
     auto_minor_version_upgrade: bool
-    automatic_failover: Optional[str]
+    automatic_failover: str


### PR DESCRIPTION
### Context

I noticed a mistake in a published check I made recently, so I’ll correct it. The service is picking an incorrect parameter from the dict response of the API. The check might work well because it was tested but it can have been a bad testing due to the mistake itself. 

### Description

We should pick:

```
{
    'Marker': 'string',
    'ReplicationGroups': [
        {
        'AutomaticFailover': 'enabled'|'disabled'|'enabling'|'disabling',
        }
    ]
}
```

But we were picking instead:

```
{
    'Marker': 'string',
    'ReplicationGroups': [
        {
            'PendingModifiedValues': {
                'AutomaticFailoverStatus': 'enabled'|'disabled',
            }
        }
    ]
} 
```   

### Checklist

- Are there new checks included in this PR? No.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
