### PR TITLE
feat(ecs): add new check `ecs_task_definitions_host_networking_mode_users`

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_host_networking_mode_users/ecs_task_definitions_host_networking_mode_users.metadata.json
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_host_networking_mode_users/ecs_task_definitions_host_networking_mode_users.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "aws",
-  "CheckID": "ecs_task_definitions_user_and_container_for_host_mode",
+  "CheckID": "ecs_task_definitions_host_networking_mode_users",
   "CheckTitle": "Amazon ECS task definitions should have secure networking modes and user definitions",
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices"
@@ -10,14 +10,14 @@
   "ResourceIdTemplate": "arn:aws:ecs:region:account-id:task-definition/resource-id",
   "Severity": "high",
   "ResourceType": "AwsEcsTaskDefinition",
-  "Description": "This control checks whether an active Amazon ECS task definition with host networking mode has privileged or user container definitions. The control fails for task definitions that have host network mode and container definitions of privileged=false, empty, and user=root or empty.",
+  "Description": "This control checks whether an active Amazon ECS task definition with host networking mode has privileged or user container definitions. The control fails for task definitions that have host network mode and container definitions of privileged=false or empty, and user=root or empty.",
   "Risk": "If ECS tasks are configured with host networking and either lack a defined user or run with elevated privileges, this can lead to privilege escalation, unauthorized access to resources, and increased exposure to vulnerabilities.",
   "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/ecs-task-definition-user-for-host-mode-check.html",
   "Remediation": {
     "Code": {
       "CLI": "aws ecs update-task-definition --task-definition <task-definition-name> --network-mode awsvpc --requires-compatibilities FARGATE --user <user-name>",
       "NativeIaC": "",
-      "Other": "https://docs.datadoghq.com/security/default_rules/aws-ecs-task-definition-aws-ecs-task-definitions-should-have-secure-networking-modes-and-user-definitions/",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-6",
       "Terraform": ""
     },
     "Recommendation": {

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -11,33 +11,48 @@ class ecs_task_definitions_no_environment_secrets(Check):
         secrets_ignore_patterns = ecs_client.audit_config.get(
             "secrets_ignore_patterns", []
         )
-        for task_definition in ecs_client.task_definitions:
+        for task_definition in ecs_client.task_definitions.values():
             report = Check_Report_AWS(self.metadata())
             report.region = task_definition.region
             report.resource_id = f"{task_definition.name}:{task_definition.revision}"
             report.resource_arn = task_definition.arn
             report.resource_tags = task_definition.tags
             report.status = "PASS"
-            report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} with revision {task_definition.revision}."
-            if task_definition.environment_variables:
-                dump_env_vars = {}
-                for env_var in task_definition.environment_variables:
-                    dump_env_vars.update({env_var.name: env_var.value})
+            extended_status_parts = []
 
-                env_data = dumps(dump_env_vars, indent=2)
-                detect_secrets_output = detect_secrets_scan(
-                    data=env_data, excluded_secrets=secrets_ignore_patterns
-                )
-                if detect_secrets_output:
-                    secrets_string = ", ".join(
-                        [
-                            f"{secret['type']} on line {secret['line_number']}"
-                            for secret in detect_secrets_output
-                        ]
+            for container in task_definition.container_definitions:
+                container_secrets_found = []
+
+                if container.environment:
+                    dump_env_vars = {}
+                    for env_var in container.environment:
+                        dump_env_vars.update({env_var.name: env_var.value})
+
+                    env_data = dumps(dump_env_vars, indent=2)
+                    detect_secrets_output = detect_secrets_scan(
+                        data=env_data, excluded_secrets=secrets_ignore_patterns
                     )
+                    if detect_secrets_output:
+                        secrets_string = ", ".join(
+                            [
+                                f"{secret['type']} on line {secret['line_number']}"
+                                for secret in detect_secrets_output
+                            ]
+                        )
+                        container_secrets_found.append(
+                            f"Secrets in container {container.name}: {secrets_string}"
+                        )
+                if container_secrets_found:
                     report.status = "FAIL"
-                    report.status_extended = f"Potential secret found in variables of ECS task definition {task_definition.name} with revision {task_definition.revision} -> {secrets_string}."
-
+                    extended_status_parts.extend(container_secrets_found)
+            if report.status == "FAIL":
+                report.status_extended = (
+                    f"Potential secrets found in ECS task definition {task_definition.name} with revision {task_definition.revision}: "
+                    + "; ".join(extended_status_parts)
+                    + "."
+                )
+            else:
+                report.status_extended = f"No secrets found in variables of ECS task definition {task_definition.name} with revision {task_definition.revision}."
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -40,7 +40,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
                             ]
                         )
                         container_secrets_found.append(
-                            f"Secrets in container {container.name}: {secrets_string}"
+                            f"Secrets in container {container.name} -> {secrets_string}"
                         )
                 if container_secrets_found:
                     report.status = "FAIL"

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode.metadata.json
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "ecs_task_definitions_user_and_container_for_host_mode",
+  "CheckTitle": "Amazon ECS task definitions should have secure networking modes and user definitions",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "ecs",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:ecs:region:account-id:task-definition/resource-id",
+  "Severity": "high",
+  "ResourceType": "AwsEcsTaskDefinition",
+  "Description": "This control checks whether an active Amazon ECS task definition with host networking mode has privileged or user container definitions. The control fails for task definitions that have host network mode and container definitions of privileged=false, empty, and user=root or empty.",
+  "Risk": "If ECS tasks are configured with host networking and either lack a defined user or run with elevated privileges, this can lead to privilege escalation, unauthorized access to resources, and increased exposure to vulnerabilities.",
+  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/ecs-task-definition-user-for-host-mode-check.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws ecs update-task-definition --task-definition <task-definition-name> --network-mode awsvpc --requires-compatibilities FARGATE --user <user-name>",
+      "NativeIaC": "",
+      "Other": "https://docs.datadoghq.com/security/default_rules/aws-ecs-task-definition-aws-ecs-task-definitions-should-have-secure-networking-modes-and-user-definitions/",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Ensure your ECS task definitions use the awsvpc networking mode and have secure user configurations when using host networking mode.",
+      "Url": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/update-task-definition-console-v2.html"
+    }
+  },
+  "Categories": [
+    "trustboundaries"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode.py
@@ -1,0 +1,35 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.ecs.ecs_client import ecs_client
+
+
+class ecs_task_definitions_user_and_container_for_host_mode(Check):
+    def execute(self):
+        findings = []
+        for task_definition in ecs_client.task_definitions.values():
+            report = Check_Report_AWS(self.metadata())
+            report.region = task_definition.region
+            report.resource_id = f"{task_definition.name}:{task_definition.revision}"
+            report.resource_arn = task_definition.arn
+            report.resource_tags = task_definition.tags
+            report.status = "PASS"
+            container_statuses = []
+            if task_definition.network_mode == "host":
+                for container in task_definition.container_definitions:
+                    if not container.privileged and (
+                        container.user == "root" or container.user == ""
+                    ):
+                        report.status = "FAIL"
+                        container_statuses.append(
+                            f"Container '{container.name}' is running as root user but is not privileged."
+                        )
+
+                if container_statuses:
+                    report.status_extended = (
+                        f"ECS task definition '{task_definition.name}' with host network mode has issues:"
+                        + " ".join(container_statuses)
+                    )
+                else:
+                    report.status_extended = f"ECS task definition '{task_definition.name}' has host network mode but there are no issues with container definitions."
+            else:
+                report.status_extended = f"ECS task definition '{task_definition.name}' does not have host network mode."
+        return findings

--- a/tests/providers/aws/services/ecs/ecs_service_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_test.py
@@ -1,10 +1,37 @@
 from unittest.mock import patch
 
-from boto3 import client
-from moto import mock_aws
+import botocore
 
 from prowler.providers.aws.services.ecs.ecs_service import ECS
 from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "ListTaskDefinitions":
+        return {
+            "taskDefinitionArns": [
+                "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_ecs_task:1"
+            ]
+        }
+    if operation_name == "DescribeTaskDefinition":
+        return {
+            "taskDefinition": {
+                "containerDefinitions": [
+                    {
+                        "name": "test-container",
+                        "image": "test-image",
+                        "environment": [
+                            {"name": "DB_PASSWORD", "value": "pass-12343"},
+                        ],
+                    }
+                ],
+                "networkMode": "host",
+                "tags": [],
+            }
+        }
+    return make_api_call(self, operation_name, kwarg)
 
 
 def mock_generate_regional_clients(provider, service):
@@ -40,94 +67,49 @@ class Test_ECS_Service:
         assert ecs.session.__class__.__name__ == "Session"
 
     # Test list ECS task definitions
-    @mock_aws
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_list_task_definitions(self):
-        ecs_client = client("ecs", region_name=AWS_REGION_EU_WEST_1)
-
-        definition = dict(
-            family="test_ecs_task",
-            containerDefinitions=[
-                {
-                    "name": "hello_world",
-                    "image": "hello-world:latest",
-                    "memory": 400,
-                }
-            ],
-        )
-
-        task_definition = ecs_client.register_task_definition(**definition)
         aws_provider = set_mocked_aws_provider()
         ecs = ECS(aws_provider)
 
-        assert len(ecs.task_definitions) == 1
-        assert (
-            ecs.task_definitions[0].name == task_definition["taskDefinition"]["family"]
-        )
-        assert (
-            ecs.task_definitions[0].arn
-            == task_definition["taskDefinition"]["taskDefinitionArn"]
-        )
-        assert ecs.task_definitions[0].environment_variables == []
+        task_arn = "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_ecs_task:1"
 
-    @mock_aws
+        assert len(ecs.task_definitions) == 1
+        assert ecs.task_definitions[task_arn].name == "test_ecs_task"
+        assert ecs.task_definitions[task_arn].arn == task_arn
+        assert ecs.task_definitions[task_arn].revision == "1"
+        assert ecs.task_definitions[task_arn].region == AWS_REGION_EU_WEST_1
+
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     # Test describe ECS task definitions
     def test__describe_task_definitions__(self):
-        ecs_client = client("ecs", region_name=AWS_REGION_EU_WEST_1)
-
-        definition = dict(
-            family="test_ecs_task",
-            containerDefinitions=[
-                {
-                    "name": "hello_world",
-                    "image": "hello-world:latest",
-                    "memory": 400,
-                    "environment": [
-                        {"name": "test-env", "value": "test-env-value"},
-                        {"name": "test-env2", "value": "test-env-value2"},
-                    ],
-                }
-            ],
-            tags=[
-                {"key": "test", "value": "test"},
-            ],
-        )
-
-        task_definition = ecs_client.register_task_definition(**definition)
         aws_provider = set_mocked_aws_provider()
         ecs = ECS(aws_provider)
 
+        task_arn = "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_ecs_task:1"
+
         assert len(ecs.task_definitions) == 1
+        assert ecs.task_definitions[task_arn].name == "test_ecs_task"
+        assert ecs.task_definitions[task_arn].arn == task_arn
+        assert ecs.task_definitions[task_arn].revision == "1"
+        assert ecs.task_definitions[task_arn].region == AWS_REGION_EU_WEST_1
+        assert len(ecs.task_definitions[task_arn].container_definitions) == 1
         assert (
-            ecs.task_definitions[0].name == task_definition["taskDefinition"]["family"]
-        )
-        assert ecs.task_definitions[0].tags == [
-            {"key": "test", "value": "test"},
-        ]
-        assert (
-            ecs.task_definitions[0].arn
-            == task_definition["taskDefinition"]["taskDefinitionArn"]
-        )
-        assert (
-            ecs.task_definitions[0].environment_variables[0].name
-            == task_definition["taskDefinition"]["containerDefinitions"][0][
-                "environment"
-            ][0]["name"]
+            ecs.task_definitions[task_arn].container_definitions[0].name
+            == "test-container"
         )
         assert (
-            ecs.task_definitions[0].environment_variables[0].value
-            == task_definition["taskDefinition"]["containerDefinitions"][0][
-                "environment"
-            ][0]["value"]
+            len(ecs.task_definitions[task_arn].container_definitions[0].environment)
+            == 1
         )
         assert (
-            ecs.task_definitions[0].environment_variables[1].name
-            == task_definition["taskDefinition"]["containerDefinitions"][0][
-                "environment"
-            ][1]["name"]
+            ecs.task_definitions[task_arn].container_definitions[0].environment[0].name
+            == "DB_PASSWORD"
         )
         assert (
-            ecs.task_definitions[0].environment_variables[1].value
-            == task_definition["taskDefinition"]["containerDefinitions"][0][
-                "environment"
-            ][1]["value"]
+            ecs.task_definitions[task_arn].container_definitions[0].environment[0].value
+            == "pass-12343"
         )
+        assert ecs.task_definitions[task_arn].network_mode == "host"
+        assert not ecs.task_definitions[task_arn].container_definitions[0].privileged
+        assert ecs.task_definitions[task_arn].container_definitions[0].user == ""

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -115,7 +115,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secrets found in ECS task definition {task_name} with revision {task_revision}: Secrets in container container1: Secret Keyword on line 2."
+                == f"Potential secrets found in ECS task definition {task_name} with revision {task_revision}: Secrets in container container1 -> Secret Keyword on line 2."
             )
             assert result[0].resource_id == f"{task_name}:1"
             assert (

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from prowler.providers.aws.services.ecs.ecs_service import (
+    ContainerDefinition,
     ContainerEnvVariable,
     TaskDefinition,
 )
@@ -9,6 +10,7 @@ AWS_REGION = "eu-west-1"
 AWS_ACCOUNT_NUMBER = "123456789012"
 task_name = "test-task"
 task_revision = "1"
+task_arn = f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}"
 env_var_name_no_secrets = "host"
 env_var_value_no_secrets = "localhost:1234"
 env_var_name_with_secrets = "DB_PASSWORD"
@@ -18,7 +20,7 @@ env_var_value_with_secrets = "pass-12343"
 class Test_ecs_task_definitions_no_environment_secrets:
     def test_no_task_definitions(self):
         ecs_client = mock.MagicMock
-        ecs_client.task_definitions = []
+        ecs_client.task_definitions = {}
 
         with mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
@@ -34,19 +36,24 @@ class Test_ecs_task_definitions_no_environment_secrets:
 
     def test_container_env_var_no_secrets(self):
         ecs_client = mock.MagicMock
-        ecs_client.task_definitions = []
-        ecs_client.task_definitions.append(
-            TaskDefinition(
-                name=task_name,
-                arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
-                revision="1",
-                region=AWS_REGION,
-                environment_variables=[
-                    ContainerEnvVariable(
-                        name=env_var_name_no_secrets, value=env_var_value_no_secrets
-                    )
-                ],
-            )
+        ecs_client.task_definitions = {}
+        ecs_client.task_definitions[task_arn] = TaskDefinition(
+            name=task_name,
+            arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
+            revision="1",
+            region=AWS_REGION,
+            container_definitions=[
+                ContainerDefinition(
+                    name="container1",
+                    privileged=False,
+                    user="",
+                    environment=[
+                        ContainerEnvVariable(
+                            name=env_var_name_no_secrets, value=env_var_value_no_secrets
+                        )
+                    ],
+                )
+            ],
         )
 
         with mock.patch(
@@ -73,19 +80,25 @@ class Test_ecs_task_definitions_no_environment_secrets:
 
     def test_container_env_var_with_secrets(self):
         ecs_client = mock.MagicMock
-        ecs_client.task_definitions = []
-        ecs_client.task_definitions.append(
-            TaskDefinition(
-                name=task_name,
-                arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
-                revision="1",
-                region=AWS_REGION,
-                environment_variables=[
-                    ContainerEnvVariable(
-                        name=env_var_name_with_secrets, value=env_var_value_with_secrets
-                    )
-                ],
-            )
+        ecs_client.task_definitions = {}
+        ecs_client.task_definitions[task_arn] = TaskDefinition(
+            name=task_name,
+            arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
+            revision="1",
+            region=AWS_REGION,
+            container_definitions=[
+                ContainerDefinition(
+                    name="container1",
+                    privileged=False,
+                    user="",
+                    environment=[
+                        ContainerEnvVariable(
+                            name=env_var_name_with_secrets,
+                            value=env_var_value_with_secrets,
+                        )
+                    ],
+                )
+            ],
         )
 
         with mock.patch(
@@ -102,7 +115,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secret found in variables of ECS task definition {task_name} with revision {task_revision} -> Secret Keyword on line 2."
+                == f"Potential secrets found in ECS task definition {task_name} with revision {task_revision}: Secrets in container container1: Secret Keyword on line 2."
             )
             assert result[0].resource_id == f"{task_name}:1"
             assert (

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode_test.py
@@ -1,0 +1,208 @@
+from unittest import mock
+
+from prowler.providers.aws.services.ecs.ecs_service import (
+    ContainerDefinition,
+    ContainerEnvVariable,
+    TaskDefinition,
+)
+from tests.providers.aws.utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+AWS_REGION = "eu-west-1"
+AWS_ACCOUNT_NUMBER = "123456789012"
+task_name = "test-task"
+task_revision = "1"
+container_name = "test-container"
+task_arn = f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}"
+
+
+class Test_ecs_task_definitions_user_and_container_for_host_mode:
+    def test_no_task_definitions(self):
+        ecs_client = mock.MagicMock()
+        ecs_client.task_definitions = {}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(
+                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            ),
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
+                ecs_task_definitions_user_and_container_for_host_mode,
+            )
+
+            check = ecs_task_definitions_user_and_container_for_host_mode()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_task_definition_no_host_network_mode(self):
+        ecs_client = mock.MagicMock()
+        ecs_client.task_definitions = {}
+        ecs_client.task_definitions[task_arn] = TaskDefinition(
+            name=task_name,
+            arn=task_arn,
+            revision="1",
+            region=AWS_REGION,
+            network_mode="bridge",
+            container_definitions=[
+                ContainerDefinition(
+                    name=container_name,
+                    privileged=False,
+                    user="",
+                    environment=[
+                        ContainerEnvVariable(
+                            name="env_var_name_no_secrets",
+                            value="env_var_value_no_secrets",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        with mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
+                ecs_task_definitions_user_and_container_for_host_mode,
+            )
+
+            check = ecs_task_definitions_user_and_container_for_host_mode()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"ECS task definition '{task_name}' does not have host network mode."
+            )
+
+    def test_task_definition_host_mode_container_root_non_privileged(self):
+        ecs_client = mock.MagicMock()
+        ecs_client.task_definitions = {}
+        ecs_client.task_definitions[task_arn] = TaskDefinition(
+            name=task_name,
+            arn=task_arn,
+            revision="1",
+            region=AWS_REGION,
+            network_mode="host",
+            container_definitions=[
+                ContainerDefinition(
+                    name=container_name,
+                    privileged=False,
+                    user="root",
+                    environment=[],
+                )
+            ],
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(
+                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            ),
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
+                ecs_task_definitions_user_and_container_for_host_mode,
+            )
+
+            check = ecs_task_definitions_user_and_container_for_host_mode()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"ECS task definition '{task_name}' with host network mode has issues: Container '{container_name}' is running as root user but is not privileged."
+            )
+
+    def test_task_definition_host_mode_container_privileged(self):
+        ecs_client = mock.MagicMock()
+        ecs_client.task_definitions = [
+            TaskDefinition(
+                name=task_name,
+                arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
+                revision="1",
+                region=AWS_REGION,
+                network_mode="host",
+                container_definitions=[
+                    ContainerDefinition(
+                        name=container_name,
+                        privileged=True,
+                        user="root",
+                        environment=[],
+                    )
+                ],
+            )
+        ]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(
+                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            ),
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
+                ecs_task_definitions_user_and_container_for_host_mode,
+            )
+
+            check = ecs_task_definitions_user_and_container_for_host_mode()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"ECS task definition '{task_name}' with host network mode has no issues with container definitions."
+            )
+
+    def test_task_definition_host_mode_container_not_root(self):
+        ecs_client = mock.MagicMock()
+        ecs_client.task_definitions = [
+            TaskDefinition(
+                name=task_name,
+                arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
+                revision="1",
+                region=AWS_REGION,
+                network_mode="host",
+                container_definitions=[
+                    ContainerDefinition(
+                        name=container_name,
+                        privileged=False,
+                        user="appuser",
+                        environment=[],
+                    )
+                ],
+            )
+        ]
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(
+                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+            ),
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
+                ecs_task_definitions_user_and_container_for_host_mode,
+            )
+
+            check = ecs_task_definitions_user_and_container_for_host_mode()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"ECS task definition '{task_name}' with host network mode has no issues with container definitions."
+            )

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode_test.py
@@ -6,49 +6,45 @@ from prowler.providers.aws.services.ecs.ecs_service import (
     TaskDefinition,
 )
 from tests.providers.aws.utils import (
-    AWS_REGION_EU_WEST_1,
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_provider,
 )
 
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
 task_name = "test-task"
 task_revision = "1"
 container_name = "test-container"
-task_arn = f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}"
+task_arn = f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}"
 
 
-class Test_ecs_task_definitions_user_and_container_for_host_mode:
+class Test_ecs_task_definitions_host_networking_mode_users:
     def test_no_task_definitions(self):
-        ecs_client = mock.MagicMock()
+        ecs_client = mock.MagicMock
         ecs_client.task_definitions = {}
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider(
-                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-            ),
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
-            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
-                ecs_task_definitions_user_and_container_for_host_mode,
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_host_networking_mode_users.ecs_task_definitions_host_networking_mode_users import (
+                ecs_task_definitions_host_networking_mode_users,
             )
 
-            check = ecs_task_definitions_user_and_container_for_host_mode()
+            check = ecs_task_definitions_host_networking_mode_users()
             result = check.execute()
             assert len(result) == 0
 
     def test_task_definition_no_host_network_mode(self):
-        ecs_client = mock.MagicMock()
+        ecs_client = mock.MagicMock
         ecs_client.task_definitions = {}
         ecs_client.task_definitions[task_arn] = TaskDefinition(
             name=task_name,
             arn=task_arn,
-            revision="1",
-            region=AWS_REGION,
+            revision=task_revision,
+            region=AWS_REGION_US_EAST_1,
             network_mode="bridge",
             container_definitions=[
                 ContainerDefinition(
@@ -66,14 +62,17 @@ class Test_ecs_task_definitions_user_and_container_for_host_mode:
         )
 
         with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
-            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
-                ecs_task_definitions_user_and_container_for_host_mode,
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_host_networking_mode_users.ecs_task_definitions_host_networking_mode_users import (
+                ecs_task_definitions_host_networking_mode_users,
             )
 
-            check = ecs_task_definitions_user_and_container_for_host_mode()
+            check = ecs_task_definitions_host_networking_mode_users()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"
@@ -83,13 +82,13 @@ class Test_ecs_task_definitions_user_and_container_for_host_mode:
             )
 
     def test_task_definition_host_mode_container_root_non_privileged(self):
-        ecs_client = mock.MagicMock()
+        ecs_client = mock.MagicMock
         ecs_client.task_definitions = {}
         ecs_client.task_definitions[task_arn] = TaskDefinition(
             name=task_name,
             arn=task_arn,
-            revision="1",
-            region=AWS_REGION,
+            revision=task_revision,
+            region=AWS_REGION_US_EAST_1,
             network_mode="host",
             container_definitions=[
                 ContainerDefinition(
@@ -103,106 +102,98 @@ class Test_ecs_task_definitions_user_and_container_for_host_mode:
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider(
-                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-            ),
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
-            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
-                ecs_task_definitions_user_and_container_for_host_mode,
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_host_networking_mode_users.ecs_task_definitions_host_networking_mode_users import (
+                ecs_task_definitions_host_networking_mode_users,
             )
 
-            check = ecs_task_definitions_user_and_container_for_host_mode()
+            check = ecs_task_definitions_host_networking_mode_users()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"ECS task definition '{task_name}' with host network mode has issues: Container '{container_name}' is running as root user but is not privileged."
+                == f"ECS task definition '{task_name}' has containers with host network mode and non-privileged containers running as root or with no user specified: {container_name}"
             )
 
     def test_task_definition_host_mode_container_privileged(self):
-        ecs_client = mock.MagicMock()
-        ecs_client.task_definitions = [
-            TaskDefinition(
-                name=task_name,
-                arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
-                revision="1",
-                region=AWS_REGION,
-                network_mode="host",
-                container_definitions=[
-                    ContainerDefinition(
-                        name=container_name,
-                        privileged=True,
-                        user="root",
-                        environment=[],
-                    )
-                ],
-            )
-        ]
+        ecs_client = mock.MagicMock
+        ecs_client.task_definitions = {}
+        ecs_client.task_definitions[task_arn] = TaskDefinition(
+            name=task_name,
+            arn=f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
+            revision=task_revision,
+            region=AWS_REGION_US_EAST_1,
+            network_mode="host",
+            container_definitions=[
+                ContainerDefinition(
+                    name=container_name,
+                    privileged=True,
+                    user="root",
+                    environment=[],
+                )
+            ],
+        )
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider(
-                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-            ),
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
-            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
-                ecs_task_definitions_user_and_container_for_host_mode,
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_host_networking_mode_users.ecs_task_definitions_host_networking_mode_users import (
+                ecs_task_definitions_host_networking_mode_users,
             )
 
-            check = ecs_task_definitions_user_and_container_for_host_mode()
+            check = ecs_task_definitions_host_networking_mode_users()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"ECS task definition '{task_name}' with host network mode has no issues with container definitions."
+                == f"ECS task definition '{task_name}' has host network mode but no containers running as root or with no user specified."
             )
 
     def test_task_definition_host_mode_container_not_root(self):
-        ecs_client = mock.MagicMock()
-        ecs_client.task_definitions = [
-            TaskDefinition(
-                name=task_name,
-                arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
-                revision="1",
-                region=AWS_REGION,
-                network_mode="host",
-                container_definitions=[
-                    ContainerDefinition(
-                        name=container_name,
-                        privileged=False,
-                        user="appuser",
-                        environment=[],
-                    )
-                ],
-            )
-        ]
+        ecs_client = mock.MagicMock
+        ecs_client.task_definitions = {}
+        ecs_client.task_definitions[task_arn] = TaskDefinition(
+            name=task_name,
+            arn=task_arn,
+            revision=task_revision,
+            region=AWS_REGION_US_EAST_1,
+            network_mode="host",
+            container_definitions=[
+                ContainerDefinition(
+                    name=container_name,
+                    privileged=False,
+                    user="appuser",
+                    environment=[],
+                )
+            ],
+        )
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider(
-                [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
-            ),
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
-            from prowler.providers.aws.services.ecs.ecs_task_definitions_user_and_container_for_host_mode.ecs_task_definitions_user_and_container_for_host_mode import (
-                ecs_task_definitions_user_and_container_for_host_mode,
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_host_networking_mode_users.ecs_task_definitions_host_networking_mode_users import (
+                ecs_task_definitions_host_networking_mode_users,
             )
 
-            check = ecs_task_definitions_user_and_container_for_host_mode()
+            check = ecs_task_definitions_host_networking_mode_users()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"ECS task definition '{task_name}' with host network mode has no issues with container definitions."
+                == f"ECS task definition '{task_name}' has host network mode but no containers running as root or with no user specified."
             )


### PR DESCRIPTION
### Context

This check verifies if an active Amazon ECS task definition using host networking mode includes container definitions with privileged settings or user configurations. The check fails if the task definition has host network mode and any container definitions where privileged=false and either user=root or an empty user field.

It is recommended to avoid granting elevated privileges in Amazon ECS task definitions. When privileged is set to true, the container is granted elevated permissions on the host container instance, similar to the root user.

Similarly, it is recommended to avoid running tasks in host network mode when running containers with the root user (UID 0). As a security best practice, you should always use a non-root user.

### Description

Added new check `ecs_task_definitions_host_networking_mode_users`. Modify the `ecs_service` adding `ContainerDefinition` model and changing `TaskDefinition` model. Changed ECS check `ecs_task_definitions_no_environment_secrets` to adjust to the service changes. Added tests for everything.

### Checklist

- Are there new checks included in this PR? Yes
    - If so, do we need to update permissions for the provider? No.
- [X] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
