### PR TITLE
feat(rds): add new check `rds_cluster_non_default_port`

### DIFF
--- a/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.metadata.json
@@ -9,7 +9,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:cluster:db-cluster",
   "Severity": "low",
-  "ResourceType": "AwsRdsDbInstance",
+  "ResourceType": "AwsRdsDbCluster",
   "Description": "Checks if an cluster uses a port other than the default port of the database engine. The control fails if the RDS cluster uses the default port.",
   "Risk": "Using a default database port exposes the cluster to potential security vulnerabilities, as attackers are more likely to target known, commonly-used ports. This may result in unauthorized access to the database or increased susceptibility to automated attacks.",
   "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html",

--- a/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "rds_cluster_non_default_port",
+  "CheckTitle": "Check if RDS clusters are using non-default ports.",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "rds",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
+  "Severity": "low",
+  "ResourceType": "AwsRdsDbInstance",
+  "Description": "Checks if an cluster uses a port other than the default port of the database engine. The control fails if the RDS cluster uses the default port.",
+  "Risk": "Using a default database port exposes the cluster to potential security vulnerabilities, as attackers are more likely to target known, commonly-used ports. This may result in unauthorized access to the database or increased susceptibility to automated attacks.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws rds modify-db-cluster --db-cluster-identifier <db-cluster-id> --port <non-default-port>",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-23",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Modify the RDS cluster to use a non-default port, and ensure that the security group permits access to the new port.",
+      "Url": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.metadata.json
@@ -7,7 +7,7 @@
   ],
   "ServiceName": "rds",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
+  "ResourceIdTemplate": "arn:aws:rds:region:account-id:cluster:db-cluster",
   "Severity": "low",
   "ResourceType": "AwsRdsDbInstance",
   "Description": "Checks if an cluster uses a port other than the default port of the database engine. The control fails if the RDS cluster uses the default port.",

--- a/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
@@ -1,0 +1,38 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+class rds_cluster_non_default_port(Check):
+    def execute(self):
+        findings = []
+        default_ports = {
+            3306: ["mysql", "mariadb"],
+            5432: ["postgres"],
+            1521: ["oracle"],
+            1433: ["sqlserver"],
+            50000: ["db2"],
+        }
+        for db_cluster_arn, db_cluster in rds_client.db_clusters.items():
+            report = Check_Report_AWS(self.metadata())
+            report.region = db_cluster.region
+            report.resource_id = db_cluster.id
+            report.resource_arn = db_cluster_arn
+            report.resource_tags = db_cluster.tags
+            report.status = "PASS"
+            report.status_extended = (
+                f"RDS Cluster {db_cluster.id} is not using the default port "
+                f"{db_cluster.port} for {db_cluster.engine}."
+            )
+            if db_cluster.port in default_ports:
+                default_engines = default_ports[db_cluster.port]
+                for default_engine in default_engines:
+                    if default_engine in db_cluster.engine.lower():
+                        report.status = "FAIL"
+                        report.status_extended = (
+                            f"RDS Cluster {db_cluster.id} is using the default port "
+                            f"{db_cluster.port} for {db_cluster.engine}."
+                        )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
@@ -6,9 +6,11 @@ class rds_cluster_non_default_port(Check):
     def execute(self):
         findings = []
         default_ports = {
-            3306: ["mysql"],
+            3306: ["mysql", "mariadb"],
             5432: ["postgres"],
-            8182: ["neptune"],
+            1521: ["oracle"],
+            1433: ["sqlserver"],
+            50000: ["db2"],
         }
         for db_cluster_arn, db_cluster in rds_client.db_clusters.items():
             report = Check_Report_AWS(self.metadata())

--- a/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
@@ -6,11 +6,9 @@ class rds_cluster_non_default_port(Check):
     def execute(self):
         findings = []
         default_ports = {
-            3306: ["mysql", "mariadb"],
+            3306: ["mysql"],
             5432: ["postgres"],
-            1521: ["oracle"],
-            1433: ["sqlserver"],
-            50000: ["db2"],
+            8182: ["neptune"],
         }
         for db_cluster_arn, db_cluster in rds_client.db_clusters.items():
             report = Check_Report_AWS(self.metadata())

--- a/prowler/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port.metadata.json
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-instance",
   "Severity": "low",
   "ResourceType": "AwsRdsDbInstance",
-  "Description": "Checks if an instance uses a port other than the default port of the database engine. The control fails if the RDS instance uses the default port or a non-default port that is not configured in the security group.",
+  "Description": "Checks if an instance uses a port other than the default port of the database engine. The control fails if the RDS instance uses the default port.",
   "Risk": "Using a default database port exposes the instance to potential security vulnerabilities, as attackers are more likely to target known, commonly-used ports. This may result in unauthorized access to the database or increased susceptibility to automated attacks.",
   "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html",
   "Remediation": {

--- a/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
@@ -1,0 +1,227 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_rds_cluster_non_default_port:
+    @mock_aws
+    def test_rds_no_clusters(self):
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_rds_cluster_using_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            Engine="aurora-postgresql",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="master",
+            MasterUserPassword="password",
+            Port=5432,
+            Tags=[{"Key": "test", "Value": "test"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-master-1 is using the default port 5432 for postgres."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]
+
+    @mock_aws
+    def test_rds_cluster_using_non_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            Engine="aurora-postgresql",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="master",
+            MasterUserPassword="password",
+            Port=5433,
+            Tags=[{"Key": "test", "Value": "test"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-master-1 is not using the default port 5433 for postgres."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == [
+                    {"Key": "env", "Value": "production"}
+                ]
+
+    @mock_aws
+    def test_rds_cluster_mariadb_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            Engine="mariadb",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="master",
+            MasterUserPassword="password",
+            Port=3306,
+            Tags=[{"Key": "test", "Value": "test"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-master-1 is using the default port 3306 for mariadb."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
+
+    @mock_aws
+    def test_rds_cluster_mariadb_non_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-1",
+            Engine="mariadb",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="master",
+            MasterUserPassword="password",
+            Port=3307,
+            Tags=[{"Key": "test", "Value": "test"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-master-1 is not using the default port 3307 for mariadb."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == [
+                    {"Key": "env", "Value": "production"}
+                ]

--- a/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
@@ -131,16 +131,16 @@ class Test_rds_cluster_non_default_port:
                 ]
 
     @mock_aws
-    def test_rds_cluster_neptune_default_port(self):
+    def test_rds_cluster_mysql_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
-            Engine="neptune",
+            Engine="mysql",
             StorageEncrypted=True,
             DeletionProtection=True,
             MasterUsername="cluster",
             MasterUserPassword="password",
-            Port=8182,
+            Port=3306,
             Tags=[{"Key": "env", "Value": "staging"}],
         )
 
@@ -167,7 +167,7 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-cluster-1 is using the default port 8182 for neptune."
+                    == "RDS Cluster db-cluster-1 is using the default port 3306 for mysql."
                 )
                 assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
@@ -178,16 +178,16 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
 
     @mock_aws
-    def test_rds_cluster_neptune_non_default_port(self):
+    def test_rds_cluster_mysql_non_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
-            Engine="neptune",
+            Engine="mysql",
             StorageEncrypted=True,
             DeletionProtection=True,
             MasterUsername="cluster",
             MasterUserPassword="password",
-            Port=8183,
+            Port=3307,
             Tags=[{"Key": "env", "Value": "production"}],
         )
 
@@ -214,7 +214,7 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-cluster-1 is not using the default port 8183 for neptune."
+                    == "RDS Cluster db-cluster-1 is not using the default port 3307 for mysql."
                 )
                 assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
@@ -42,7 +42,7 @@ class Test_rds_cluster_non_default_port:
             Engine="aurora-postgresql",
             StorageEncrypted=True,
             DeletionProtection=True,
-            MasterUsername="master",
+            MasterUsername="cluster",
             MasterUserPassword="password",
             Port=5432,
             Tags=[{"Key": "test", "Value": "test"}],
@@ -71,13 +71,13 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-master-1 is using the default port 5432 for postgres."
+                    == "RDS Cluster db-cluster-1 is using the default port 5432 for aurora-postgresql."
                 )
-                assert result[0].resource_id == "db-master-1"
+                assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
                 assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]
 
@@ -89,10 +89,10 @@ class Test_rds_cluster_non_default_port:
             Engine="aurora-postgresql",
             StorageEncrypted=True,
             DeletionProtection=True,
-            MasterUsername="master",
+            MasterUsername="cluster",
             MasterUserPassword="password",
             Port=5433,
-            Tags=[{"Key": "test", "Value": "test"}],
+            Tags=[{"Key": "env", "Value": "production"}],
         )
 
         from prowler.providers.aws.services.rds.rds_service import RDS
@@ -118,30 +118,30 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-master-1 is not using the default port 5433 for postgres."
+                    == "RDS Cluster db-cluster-1 is not using the default port 5433 for aurora-postgresql."
                 )
-                assert result[0].resource_id == "db-master-1"
+                assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
                 assert result[0].resource_tags == [
                     {"Key": "env", "Value": "production"}
                 ]
 
     @mock_aws
-    def test_rds_cluster_mariadb_default_port(self):
+    def test_rds_cluster_neptune_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
-            Engine="mariadb",
+            Engine="neptune",
             StorageEncrypted=True,
             DeletionProtection=True,
-            MasterUsername="master",
+            MasterUsername="cluster",
             MasterUserPassword="password",
-            Port=3306,
-            Tags=[{"Key": "test", "Value": "test"}],
+            Port=8182,
+            Tags=[{"Key": "env", "Value": "staging"}],
         )
 
         from prowler.providers.aws.services.rds.rds_service import RDS
@@ -167,28 +167,28 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-master-1 is using the default port 3306 for mariadb."
+                    == "RDS Cluster db-cluster-1 is using the default port 8182 for neptune."
                 )
-                assert result[0].resource_id == "db-master-1"
+                assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
                 assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
 
     @mock_aws
-    def test_rds_cluster_mariadb_non_default_port(self):
+    def test_rds_cluster_neptune_non_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
-            Engine="mariadb",
+            Engine="neptune",
             StorageEncrypted=True,
             DeletionProtection=True,
-            MasterUsername="master",
+            MasterUsername="cluster",
             MasterUserPassword="password",
-            Port=3307,
-            Tags=[{"Key": "test", "Value": "test"}],
+            Port=8183,
+            Tags=[{"Key": "env", "Value": "production"}],
         )
 
         from prowler.providers.aws.services.rds.rds_service import RDS
@@ -214,13 +214,13 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-master-1 is not using the default port 3307 for mariadb."
+                    == "RDS Cluster db-cluster-1 is not using the default port 8183 for neptune."
                 )
-                assert result[0].resource_id == "db-master-1"
+                assert result[0].resource_id == "db-cluster-1"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
                 )
                 assert result[0].resource_tags == [
                     {"Key": "env", "Value": "production"}

--- a/tests/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port_test.py
@@ -25,7 +25,6 @@ class Test_rds_instance_non_default_port:
                 "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
                 new=RDS(aws_provider),
             ):
-                # Test del check
                 from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
                     rds_instance_non_default_port,
                 )
@@ -49,7 +48,7 @@ class Test_rds_instance_non_default_port:
             PubliclyAccessible=True,
             AutoMinorVersionUpgrade=True,
             BackupRetentionPeriod=10,
-            Port=5432,  # Puerto por defecto para postgres
+            Port=5432,
             Tags=[{"Key": "test", "Value": "test"}],
         )
 
@@ -65,7 +64,6 @@ class Test_rds_instance_non_default_port:
                 "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
                 new=RDS(aws_provider),
             ):
-                # Test del check
                 from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
                     rds_instance_non_default_port,
                 )
@@ -101,7 +99,7 @@ class Test_rds_instance_non_default_port:
             PubliclyAccessible=True,
             AutoMinorVersionUpgrade=True,
             BackupRetentionPeriod=10,
-            Port=5433,  # Puerto no por defecto para postgres
+            Port=5433,
             Tags=[{"Key": "env", "Value": "production"}],
         )
 
@@ -117,7 +115,6 @@ class Test_rds_instance_non_default_port:
                 "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
                 new=RDS(aws_provider),
             ):
-                # Test del check
                 from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
                     rds_instance_non_default_port,
                 )
@@ -155,7 +152,7 @@ class Test_rds_instance_non_default_port:
             PubliclyAccessible=True,
             AutoMinorVersionUpgrade=True,
             BackupRetentionPeriod=10,
-            Port=3306,  # Puerto por defecto para mariadb
+            Port=3306,
             Tags=[{"Key": "env", "Value": "staging"}],
         )
 
@@ -171,7 +168,6 @@ class Test_rds_instance_non_default_port:
                 "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
                 new=RDS(aws_provider),
             ):
-                # Test del check
                 from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
                     rds_instance_non_default_port,
                 )
@@ -207,7 +203,7 @@ class Test_rds_instance_non_default_port:
             PubliclyAccessible=True,
             AutoMinorVersionUpgrade=True,
             BackupRetentionPeriod=10,
-            Port=3307,  # Puerto no por defecto para mariadb
+            Port=3307,
             Tags=[{"Key": "env", "Value": "production"}],
         )
 
@@ -223,7 +219,6 @@ class Test_rds_instance_non_default_port:
                 "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
                 new=RDS(aws_provider),
             ):
-                # Test del check
                 from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
                     rds_instance_non_default_port,
                 )


### PR DESCRIPTION
### Context

There’s a [control](https://docs.aws.amazon.com/securityhub/latest/userguide/rds-controls.html#rds-23) on SH that its tittle says it’s about instances but it verifies whether instances or clusters, so I preferred to separate this control into two new checks.
### Description

Added new check `rds_cluster_non_default_port` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
