### PR TITLE
fix(iam): fill resource id with inline policy entity

### DIFF
--- a/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
@@ -19,7 +19,7 @@ class iam_inline_policy_allows_privilege_escalation(Check):
                 report.status = "PASS"
 
                 resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
-                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
+                resource_attached = report.resource_arn.split("/")[-1]
 
                 report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} does not allow privilege escalation."
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
@@ -12,7 +12,7 @@ class iam_inline_policy_allows_privilege_escalation(Check):
         for policy in iam_client.policies:
             if policy.type == "Inline":
                 report = Check_Report_AWS(self.metadata())
-                report.resource_id = policy.name
+                report.resource_id = f"{policy.entity}/{policy.name}"
                 report.resource_arn = policy.arn
                 report.region = iam_client.region
                 report.resource_tags = policy.tags

--- a/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
@@ -18,16 +18,10 @@ class iam_inline_policy_allows_privilege_escalation(Check):
                 report.resource_tags = policy.tags
                 report.status = "PASS"
 
-                if "role" in report.resource_arn:
-                    resource_type_str = "role"
-                elif "group" in report.resource_arn:
-                    resource_type_str = "group"
-                elif "user" in report.resource_arn:
-                    resource_type_str = "user"
-                else:
-                    resource_type_str = "resource"
+                resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
+                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
 
-                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} does not allow privilege escalation."
+                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} does not allow privilege escalation."
 
                 policies_affected = check_privilege_escalation(
                     getattr(policy, "document", {})
@@ -37,7 +31,7 @@ class iam_inline_policy_allows_privilege_escalation(Check):
                     report.status = "FAIL"
 
                     report.status_extended = (
-                        f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} allows privilege escalation using the following actions: {policies_affected}".rstrip()
+                        f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} allows privilege escalation using the following actions: {policies_affected}".rstrip()
                         + "."
                     )
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
@@ -27,7 +27,7 @@ class iam_inline_policy_allows_privilege_escalation(Check):
                 else:
                     resource_type_str = "resource"
 
-                report.status_extended = f"Inline Policy '{report.resource_id}'{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} does not allow privilege escalation."
+                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} does not allow privilege escalation."
 
                 policies_affected = check_privilege_escalation(
                     getattr(policy, "document", {})
@@ -37,7 +37,7 @@ class iam_inline_policy_allows_privilege_escalation(Check):
                     report.status = "FAIL"
 
                     report.status_extended = (
-                        f"Inline Policy '{report.resource_id}'{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} allows privilege escalation using the following actions: {policies_affected}".rstrip()
+                        f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} allows privilege escalation using the following actions: {policies_affected}".rstrip()
                         + "."
                     )
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
@@ -14,16 +14,10 @@ class iam_inline_policy_no_administrative_privileges(Check):
                 report.resource_tags = policy.tags
                 report.status = "PASS"
 
-                if "role" in report.resource_arn:
-                    resource_type_str = "role"
-                elif "group" in report.resource_arn:
-                    resource_type_str = "group"
-                elif "user" in report.resource_arn:
-                    resource_type_str = "user"
-                else:
-                    resource_type_str = "resource"
+                resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
+                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
 
-                report.status_extended = f"{policy.type} policy {policy.name} attached to {resource_type_str} {report.resource_arn} does not allow '*:*' administrative privileges."
+                report.status_extended = f"{policy.type} policy {policy.name} attached to {resource_type_str} {resource_attached} does not allow '*:*' administrative privileges."
                 if policy.document:
                     # Check the statements, if one includes *:* stop iterating over the rest
                     if not isinstance(policy.document["Statement"], list):
@@ -45,7 +39,7 @@ class iam_inline_policy_no_administrative_privileges(Check):
                             )
                         ):
                             report.status = "FAIL"
-                            report.status_extended = f"{policy.type} policy {policy.name} attached to {resource_type_str} {report.resource_arn} allows '*:*' administrative privileges."
+                            report.status_extended = f"{policy.type} policy {policy.name} attached to {resource_type_str} {resource_attached} allows '*:*' administrative privileges."
                             break
                 findings.append(report)
         return findings

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
@@ -15,7 +15,7 @@ class iam_inline_policy_no_administrative_privileges(Check):
                 report.status = "PASS"
 
                 resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
-                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
+                resource_attached = report.resource_arn.split("/")[-1]
 
                 report.status_extended = f"{policy.type} policy {policy.name} attached to {resource_type_str} {resource_attached} does not allow '*:*' administrative privileges."
                 if policy.document:

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
@@ -20,7 +20,7 @@ class iam_inline_policy_no_full_access_to_cloudtrail(Check):
                 report.status = "PASS"
 
                 resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
-                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
+                resource_attached = report.resource_arn.split("/")[-1]
 
                 report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} does not allow '{critical_service}:*' privileges."
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
@@ -19,22 +19,16 @@ class iam_inline_policy_no_full_access_to_cloudtrail(Check):
                 report.resource_tags = policy.tags
                 report.status = "PASS"
 
-                if "role" in report.resource_arn:
-                    resource_type_str = "role"
-                elif "group" in report.resource_arn:
-                    resource_type_str = "group"
-                elif "user" in report.resource_arn:
-                    resource_type_str = "user"
-                else:
-                    resource_type_str = "resource"
+                resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
+                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
 
-                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} does not allow '{critical_service}:*' privileges."
+                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} does not allow '{critical_service}:*' privileges."
 
                 if policy.document and check_full_service_access(
                     critical_service, policy.document
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} allows '{critical_service}:*' privileges to all resources."
+                    report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} allows '{critical_service}:*' privileges to all resources."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
@@ -15,16 +15,16 @@ class iam_inline_policy_no_full_access_to_cloudtrail(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.region = iam_client.region
                 report.resource_arn = policy.arn
-                report.resource_id = policy.name
+                report.resource_id = f"{policy.entity}/{policy.name}"
                 report.resource_tags = policy.tags
                 report.status = "PASS"
-                report.status_extended = f"Inline Policy {policy.name} does not allow '{critical_service}:*' privileges."
+                report.status_extended = f"Inline Policy {report.resource_id} does not allow '{critical_service}:*' privileges."
 
                 if policy.document and check_full_service_access(
                     critical_service, policy.document
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"Inline Policy {policy.name} allows '{critical_service}:*' privileges to all resources."
+                    report.status_extended = f"Inline Policy {report.resource_id} allows '{critical_service}:*' privileges to all resources."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
@@ -18,13 +18,23 @@ class iam_inline_policy_no_full_access_to_cloudtrail(Check):
                 report.resource_id = f"{policy.entity}/{policy.name}"
                 report.resource_tags = policy.tags
                 report.status = "PASS"
-                report.status_extended = f"Inline Policy {report.resource_id} does not allow '{critical_service}:*' privileges."
+
+                if "role" in report.resource_arn:
+                    resource_type_str = "role"
+                elif "group" in report.resource_arn:
+                    resource_type_str = "group"
+                elif "user" in report.resource_arn:
+                    resource_type_str = "user"
+                else:
+                    resource_type_str = "resource"
+
+                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} does not allow '{critical_service}:*' privileges."
 
                 if policy.document and check_full_service_access(
                     critical_service, policy.document
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"Inline Policy {report.resource_id} allows '{critical_service}:*' privileges to all resources."
+                    report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} allows '{critical_service}:*' privileges to all resources."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
@@ -17,22 +17,17 @@ class iam_inline_policy_no_full_access_to_kms(Check):
                 report.resource_id = f"{policy.entity}/{policy.name}"
                 report.resource_tags = policy.tags
                 report.status = "PASS"
-                if "role" in report.resource_arn:
-                    resource_type_str = "role"
-                elif "group" in report.resource_arn:
-                    resource_type_str = "group"
-                elif "user" in report.resource_arn:
-                    resource_type_str = "user"
-                else:
-                    resource_type_str = "resource"
 
-                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} does not allow '{critical_service}:*' privileges."
+                resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
+                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
+
+                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} does not allow '{critical_service}:*' privileges."
 
                 if policy.document and check_full_service_access(
                     critical_service, policy.document
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} allows '{critical_service}:*' privileges."
+                    report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} allows '{critical_service}:*' privileges."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
@@ -17,13 +17,22 @@ class iam_inline_policy_no_full_access_to_kms(Check):
                 report.resource_id = f"{policy.entity}/{policy.name}"
                 report.resource_tags = policy.tags
                 report.status = "PASS"
-                report.status_extended = f"Inline Policy {report.resource_id} does not allow '{critical_service}:*' privileges."
+                if "role" in report.resource_arn:
+                    resource_type_str = "role"
+                elif "group" in report.resource_arn:
+                    resource_type_str = "group"
+                elif "user" in report.resource_arn:
+                    resource_type_str = "user"
+                else:
+                    resource_type_str = "resource"
+
+                report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} does not allow '{critical_service}:*' privileges."
 
                 if policy.document and check_full_service_access(
                     critical_service, policy.document
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"Inline Policy {report.resource_id} allows '{critical_service}:*' privileges."
+                    report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + report.resource_arn if policy.attached else ''} allows '{critical_service}:*' privileges."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
@@ -14,16 +14,16 @@ class iam_inline_policy_no_full_access_to_kms(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.region = iam_client.region
                 report.resource_arn = policy.arn
-                report.resource_id = policy.name
+                report.resource_id = f"{policy.entity}/{policy.name}"
                 report.resource_tags = policy.tags
                 report.status = "PASS"
-                report.status_extended = f"Inline Policy {policy.name} does not allow '{critical_service}:*' privileges."
+                report.status_extended = f"Inline Policy {report.resource_id} does not allow '{critical_service}:*' privileges."
 
                 if policy.document and check_full_service_access(
                     critical_service, policy.document
                 ):
                     report.status = "FAIL"
-                    report.status_extended = f"Inline Policy {policy.name} allows '{critical_service}:*' privileges."
+                    report.status_extended = f"Inline Policy {report.resource_id} allows '{critical_service}:*' privileges."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
@@ -19,7 +19,7 @@ class iam_inline_policy_no_full_access_to_kms(Check):
                 report.status = "PASS"
 
                 resource_type_str = report.resource_arn.split(":")[-1].split("/")[0]
-                resource_attached = report.resource_arn.split(":")[-1].split("/")[1]
+                resource_attached = report.resource_arn.split("/")[-1]
 
                 report.status_extended = f"{policy.type} policy {policy.name}{' attached to ' + resource_type_str + ' ' + resource_attached if policy.attached else ''} does not allow '{critical_service}:*' privileges."
 

--- a/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
@@ -106,9 +106,9 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy '{policy_name}' attached to role {role_arn} does not allow privilege escalation."
+                == f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} does not allow privilege escalation."
             )
-            assert result[0].resource_id == policy_name
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
@@ -162,9 +162,9 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy '{policy_name}' attached to user {user_arn} does not allow privilege escalation."
+                == f"Inline Policy 'test_user/{policy_name}' attached to user {user_arn} does not allow privilege escalation."
             )
-            assert result[0].resource_id == policy_name
+            assert result[0].resource_id == f"test_user/{policy_name}"
             assert result[0].resource_arn == user_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
@@ -228,9 +228,9 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy '{policy_name}' attached to group {group_arn} does not allow privilege escalation."
+                == f"Inline Policy 'test_group/{policy_name}' attached to group {group_arn} does not allow privilege escalation."
             )
-            assert result[0].resource_id == policy_name
+            assert result[0].resource_id == f"test_group/{policy_name}"
             assert result[0].resource_arn == group_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
@@ -289,13 +289,13 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].resource_id == policy_name
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy '{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -348,13 +348,13 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].resource_id == policy_name
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy '{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -425,13 +425,13 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].resource_id == policy_name
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy '{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -491,13 +491,13 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
-            assert result[0].resource_id == policy_name
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy '{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -551,13 +551,13 @@ class Test_iam_inline_policy_allows_privilege_escalation:
                 result = check.execute()
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
-                assert result[0].resource_id == policy_name
+                assert result[0].resource_id == f"test_role/{policy_name}"
                 assert result[0].resource_arn == role_arn
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_tags == []
 
                 assert search(
-                    f"Inline Policy '{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                    f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
                     result[0].status_extended,
                 )
 

--- a/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
@@ -106,7 +106,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} does not allow privilege escalation."
+                == f"Inline policy {policy_name} attached to role {role_name} does not allow privilege escalation."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -162,7 +162,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to user {user_arn} does not allow privilege escalation."
+                == f"Inline policy {policy_name} attached to user {user_name} does not allow privilege escalation."
             )
             assert result[0].resource_id == f"test_user/{policy_name}"
             assert result[0].resource_arn == user_arn
@@ -228,7 +228,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to group {group_arn} does not allow privilege escalation."
+                == f"Inline policy {policy_name} attached to group {group_name} does not allow privilege escalation."
             )
             assert result[0].resource_id == f"test_group/{policy_name}"
             assert result[0].resource_arn == group_arn
@@ -295,7 +295,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -354,7 +354,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -431,7 +431,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -497,7 +497,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -557,7 +557,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
                 assert result[0].resource_tags == []
 
                 assert search(
-                    f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
+                    f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
                     result[0].status_extended,
                 )
 

--- a/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
@@ -106,7 +106,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} does not allow privilege escalation."
+                == f"Inline policy {policy_name} attached to role {role_arn} does not allow privilege escalation."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -162,7 +162,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy 'test_user/{policy_name}' attached to user {user_arn} does not allow privilege escalation."
+                == f"Inline policy {policy_name} attached to user {user_arn} does not allow privilege escalation."
             )
             assert result[0].resource_id == f"test_user/{policy_name}"
             assert result[0].resource_arn == user_arn
@@ -228,7 +228,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy 'test_group/{policy_name}' attached to group {group_arn} does not allow privilege escalation."
+                == f"Inline policy {policy_name} attached to group {group_arn} does not allow privilege escalation."
             )
             assert result[0].resource_id == f"test_group/{policy_name}"
             assert result[0].resource_arn == group_arn
@@ -295,7 +295,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -354,7 +354,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -431,7 +431,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -497,7 +497,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
                 result[0].status_extended,
             )
             assert search("iam:PassRole", result[0].status_extended)
@@ -557,7 +557,7 @@ class Test_iam_inline_policy_allows_privilege_escalation:
                 assert result[0].resource_tags == []
 
                 assert search(
-                    f"Inline Policy 'test_role/{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions: ",
+                    f"Inline policy {policy_name} attached to role {role_arn} allows privilege escalation using the following actions: ",
                     result[0].status_extended,
                 )
 

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges_test.py
@@ -103,7 +103,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "FAIL"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} attached to group {group_arn} allows '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to group {group_name} allows '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -147,7 +147,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "PASS"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} attached to group {group_arn} does not allow '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to group {group_name} does not allow '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -201,7 +201,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "FAIL"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_admin} attached to group {group_arn} allows '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_admin} attached to group {group_name} allows '*:*' administrative privileges."
                     )
 
                 elif result.resource_id == policy_name_not_admin:
@@ -212,7 +212,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "PASS"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_not_admin} attached to group {group_arn} does not allow '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_not_admin} attached to group {group_name} does not allow '*:*' administrative privileges."
                     )
 
     # Roles
@@ -291,7 +291,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "FAIL"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} allows '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} allows '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -338,7 +338,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "PASS"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} does not allow '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} does not allow '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -394,7 +394,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "FAIL"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_admin} attached to group {role_arn} allows '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_admin} attached to group {role_name} allows '*:*' administrative privileges."
                     )
 
                 elif result.resource_id == policy_name_not_admin:
@@ -405,7 +405,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "PASS"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_not_admin} attached to group {role_arn} does not allow '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_not_admin} attached to group {role_name} does not allow '*:*' administrative privileges."
                     )
 
     # Users
@@ -484,7 +484,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "FAIL"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} attached to user {user_arn} allows '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to user {user_name} allows '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -532,7 +532,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
             assert results[0].status == "PASS"
             assert (
                 results[0].status_extended
-                == f"Inline policy {policy_name} attached to user {user_arn} does not allow '*:*' administrative privileges."
+                == f"Inline policy {policy_name} attached to user {user_name} does not allow '*:*' administrative privileges."
             )
 
     @mock_aws
@@ -589,7 +589,7 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "FAIL"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_admin} attached to user {user_arn} allows '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_admin} attached to user {user_name} allows '*:*' administrative privileges."
                     )
 
                 elif result.resource_id == policy_name_not_admin:
@@ -600,5 +600,5 @@ class Test_iam_inline_policy_no_administrative_privileges:
                     assert result.status == "PASS"
                     assert (
                         result.status_extended
-                        == f"Inline policy {policy_name_not_admin} attached to user {user_arn} does not allow '*:*' administrative privileges."
+                        == f"Inline policy {policy_name_not_admin} attached to user {user_name} does not allow '*:*' administrative privileges."
                     )

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail_test.py
@@ -54,7 +54,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline policy {policy_name} attached to role {role_arn} allows 'cloudtrail:*' privileges to all resources."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -101,7 +101,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} does not allow 'cloudtrail:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'cloudtrail:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -148,7 +148,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline policy {policy_name} attached to role {role_arn} allows 'cloudtrail:*' privileges to all resources."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -199,7 +199,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} does not allow 'cloudtrail:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'cloudtrail:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -250,7 +250,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline policy {policy_name} attached to role {role_arn} allows 'cloudtrail:*' privileges to all resources."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail_test.py
@@ -54,9 +54,9 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline Policy test_role/{policy_name} allows 'cloudtrail:*' privileges to all resources."
             )
-            assert result[0].resource_id == "policy_cloudtrail_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -101,9 +101,9 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} does not allow 'cloudtrail:*' privileges."
+                == f"Inline Policy test_role/{policy_name} does not allow 'cloudtrail:*' privileges."
             )
-            assert result[0].resource_id == "policy_no_cloudtrail_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -148,9 +148,9 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline Policy test_role/{policy_name} allows 'cloudtrail:*' privileges to all resources."
             )
-            assert result[0].resource_id == "policy_cloudtrail_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -199,9 +199,9 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} does not allow 'cloudtrail:*' privileges."
+                == f"Inline Policy test_role/{policy_name} does not allow 'cloudtrail:*' privileges."
             )
-            assert result[0].resource_id == "policy_no_cloudtrail_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -250,8 +250,8 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline Policy test_role/{policy_name} allows 'cloudtrail:*' privileges to all resources."
             )
-            assert result[0].resource_id == "policy_cloudtrail_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail_test.py
@@ -54,7 +54,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline policy {policy_name} attached to role {role_name} allows 'cloudtrail:*' privileges to all resources."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -101,7 +101,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'cloudtrail:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} does not allow 'cloudtrail:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -148,7 +148,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline policy {policy_name} attached to role {role_name} allows 'cloudtrail:*' privileges to all resources."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -199,7 +199,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'cloudtrail:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} does not allow 'cloudtrail:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -250,7 +250,7 @@ class Test_iam_inline_policy_no_full_access_to_cloudtrail:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} allows 'cloudtrail:*' privileges to all resources."
+                == f"Inline policy {policy_name} attached to role {role_name} allows 'cloudtrail:*' privileges to all resources."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms_test.py
@@ -54,7 +54,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} allows 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} allows 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -101,7 +101,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} does not allow 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -148,7 +148,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} allows 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} allows 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -199,7 +199,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} does not allow 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -250,7 +250,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy test_role/{policy_name} allows 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_arn} allows 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms_test.py
@@ -54,7 +54,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} allows 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} allows 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -101,7 +101,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} does not allow 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -148,7 +148,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} allows 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} allows 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -199,7 +199,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} does not allow 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} does not allow 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
@@ -250,7 +250,7 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline policy {policy_name} attached to role {role_arn} allows 'kms:*' privileges."
+                == f"Inline policy {policy_name} attached to role {role_name} allows 'kms:*' privileges."
             )
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn

--- a/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms_test.py
@@ -54,9 +54,9 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} allows 'kms:*' privileges."
+                == f"Inline Policy test_role/{policy_name} allows 'kms:*' privileges."
             )
-            assert result[0].resource_id == "policy_kms_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -101,9 +101,9 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} does not allow 'kms:*' privileges."
+                == f"Inline Policy test_role/{policy_name} does not allow 'kms:*' privileges."
             )
-            assert result[0].resource_id == "policy_no_kms_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -148,9 +148,9 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} allows 'kms:*' privileges."
+                == f"Inline Policy test_role/{policy_name} allows 'kms:*' privileges."
             )
-            assert result[0].resource_id == "policy_kms_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -199,9 +199,9 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} does not allow 'kms:*' privileges."
+                == f"Inline Policy test_role/{policy_name} does not allow 'kms:*' privileges."
             )
-            assert result[0].resource_id == "policy_no_kms_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"
 
@@ -250,8 +250,8 @@ class Test_iam_inline_policy_no_full_access_to_kms:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Inline Policy {policy_name} allows 'kms:*' privileges."
+                == f"Inline Policy test_role/{policy_name} allows 'kms:*' privileges."
             )
-            assert result[0].resource_id == "policy_kms_full"
+            assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == "eu-west-1"


### PR DESCRIPTION
### Description

Some checks from inline policies were not adding info related with the policy entity inside the resource id.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
