### PR TITLE
feat(ecs): Ensure public IP addresses are not assigned automatically

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -92,13 +92,14 @@ class ECS(AWSService):
                 service_arns.extend(page["serviceArns"])
 
             if service_arns:
-                describe_response = client.describe_services(
-                    cluster=cluster.arn,
-                    services=service_arns,
-                    include=["TAGS"],
-                )
+                for service_arn in service_arns:
+                    describe_response = client.describe_services(
+                        cluster=cluster.arn,
+                        services=service_arn,
+                        include=["TAGS"],
+                    )
 
-                for service_desc in describe_response["services"]:
+                    service_desc = describe_response["services"][0]
                     service_arn = service_desc["serviceArn"]
                     service_obj = Service(
                         name=sub(":.*", "", service_arn.split("/")[2]),

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -95,7 +95,7 @@ class ECS(AWSService):
                 for service_arn in service_arns:
                     describe_response = client.describe_services(
                         cluster=cluster.arn,
-                        services=service_arn,
+                        services=[service_arn],
                         include=["TAGS"],
                     )
 

--- a/prowler/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip.metadata.json
+++ b/prowler/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "ecs_service_no_assign_public_ip",
+  "CheckTitle": "ECS services should not assign public IPs automatically",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "ecs",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:ecs:{region}:{account-id}:service/{service-name}",
+  "Severity": "high",
+  "ResourceType": "AwsEcsService",
+  "Description": "This control checks whether Amazon ECS services are configured to automatically assign public IP addresses. The control fails if AssignPublicIP is ENABLED and passes if it is DISABLED.",
+  "Risk": "Having public IP addresses assigned to ECS services automatically can expose services to the internet, increasing the risk of unauthorized access, data breaches, and cyberattacks.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/Welcome.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws ecs update-service --cluster <cluster-name> --service <service-name> --network-configuration 'awsvpcConfiguration={assignPublicIp=DISABLED}'",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/ecs-controls.html#ecs-2",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Disable automatic public IP address assignment for your ECS services to ensure they are not publicly accessible.",
+      "Url": "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security.html"
+    }
+  },
+  "Categories": [
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip.py
+++ b/prowler/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip.py
@@ -1,0 +1,26 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.ecs.ecs_client import ecs_client
+
+
+class ecs_service_no_assign_public_ip(Check):
+    def execute(self):
+        findings = []
+        for service in ecs_client.services.values():
+            report = Check_Report_AWS(self.metadata())
+            report.region = service.region
+            report.resource_id = service.name
+            report.resource_arn = service.arn
+            report.resource_tags = service.tags
+            report.status = "PASS"
+            report.status_extended = (
+                f"ECS Service '{service.name}' does not assign public IP address."
+            )
+
+            if service.assign_public_ip:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"ECS Service '{service.name}' assigns public IP address."
+                )
+
+            findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip.py
+++ b/prowler/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip.py
@@ -12,14 +12,12 @@ class ecs_service_no_assign_public_ip(Check):
             report.resource_arn = service.arn
             report.resource_tags = service.tags
             report.status = "PASS"
-            report.status_extended = (
-                f"ECS Service '{service.name}' does not assign public IP address."
-            )
+            report.status_extended = f"ECS Service {service.name} does not have automatic public IP assignment."
 
             if service.assign_public_ip:
                 report.status = "FAIL"
                 report.status_extended = (
-                    f"ECS Service '{service.name}' assigns public IP address."
+                    f"ECS Service {service.name} has automatic public IP assignment."
                 )
 
             findings.append(report)

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_host_networking_mode_users/ecs_task_definitions_host_networking_mode_users.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_host_networking_mode_users/ecs_task_definitions_host_networking_mode_users.py
@@ -12,7 +12,7 @@ class ecs_task_definitions_host_networking_mode_users(Check):
             report.resource_arn = task_definition.arn
             report.resource_tags = task_definition.tags
             report.status = "PASS"
-            report.status_extended = f"ECS task definition '{task_definition.name}' does not have host network mode."
+            report.status_extended = f"ECS task definition {task_definition.name} does not have host network mode."
             failed_containers = []
             if task_definition.network_mode == "host":
                 for container in task_definition.container_definitions:
@@ -23,8 +23,8 @@ class ecs_task_definitions_host_networking_mode_users(Check):
                         failed_containers.append(container.name)
 
                 if failed_containers:
-                    report.status_extended = f"ECS task definition '{task_definition.name}' has containers with host network mode and non-privileged containers running as root or with no user specified: {', '.join(failed_containers)}"
+                    report.status_extended = f"ECS task definition {task_definition.name} has containers with host network mode and non-privileged containers running as root or with no user specified: {', '.join(failed_containers)}"
                 else:
-                    report.status_extended = f"ECS task definition '{task_definition.name}' has host network mode but no containers running as root or with no user specified."
+                    report.status_extended = f"ECS task definition {task_definition.name} has host network mode but no containers running as root or with no user specified."
             findings.append(report)
         return findings

--- a/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
@@ -1,27 +1,20 @@
 from unittest import mock
 
 from prowler.providers.aws.services.ecs.ecs_service import Service
-from tests.providers.aws.utils import (
-    AWS_ACCOUNT_NUMBER,
-    AWS_REGION_US_EAST_1,
-    set_mocked_aws_provider,
-)
+from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
 
-service_arn = (
+SERVICE_ARN = (
     f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-service"
 )
-service_name = "sample-service"
+SERVICE_NAME = "sample-service"
 
 
 class Test_ecs_service_no_assign_public_ip:
     def test_no_services(self):
-        ecs_client = mock.MagicMock()
+        ecs_client = mock.MagicMock
         ecs_client.services = {}
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
@@ -34,20 +27,17 @@ class Test_ecs_service_no_assign_public_ip:
             assert len(result) == 0
 
     def test_service_with_no_public_ip(self):
-        ecs_client = mock.MagicMock()
+        ecs_client = mock.MagicMock
         ecs_client.services = {}
-        ecs_client.services[service_arn] = Service(
-            name=service_name,
-            arn=service_arn,
+        ecs_client.services[SERVICE_ARN] = Service(
+            name=SERVICE_NAME,
+            arn=SERVICE_ARN,
             region=AWS_REGION_US_EAST_1,
             assign_public_ip=False,
             tags=[],
         )
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
@@ -61,40 +51,37 @@ class Test_ecs_service_no_assign_public_ip:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"ECS Service '{service_name}' does not assign public IP address"
+                == f"ECS Service {SERVICE_NAME} does not have automatic public IP assignment."
             )
-            assert result[0].resource_id == service_name
-            assert result[0].resource_arn == service_arn
+            assert result[0].resource_id == SERVICE_NAME
+            assert result[0].resource_arn == SERVICE_ARN
 
     def test_task_definition_no_host_network_mode(self):
         ecs_client = mock.MagicMock
-        ecs_client.task_services = {}
-        ecs_client.services[service_arn] = Service(
-            name=service_name,
-            arn=service_arn,
+        ecs_client.services = {}
+        ecs_client.services[SERVICE_ARN] = Service(
+            name=SERVICE_NAME,
+            arn=SERVICE_ARN,
             region=AWS_REGION_US_EAST_1,
             assign_public_ip=True,
             tags=[],
         )
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
-            from prowler.providers.aws.services.ecs.ecs_task_definitions_host_networking_mode_users.ecs_task_definitions_host_networking_mode_users import (
-                ecs_task_definitions_host_networking_mode_users,
+            from prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip import (
+                ecs_service_no_assign_public_ip,
             )
 
-            check = ecs_task_definitions_host_networking_mode_users()
+            check = ecs_service_no_assign_public_ip()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"ECS Service '{service_name}' assigns public IP address"
+                == f"ECS Service {SERVICE_NAME} has automatic public IP assignment."
             )
-            assert result[0].resource_id == service_name
-            assert result[0].resource_arn == service_arn
+            assert result[0].resource_id == SERVICE_NAME
+            assert result[0].resource_arn == SERVICE_ARN

--- a/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
@@ -1,0 +1,100 @@
+from unittest import mock
+
+from prowler.providers.aws.services.ecs.ecs_service import Service
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+service_arn = (
+    f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-service"
+)
+service_name = "sample-service"
+
+
+class Test_ecs_service_no_assign_public_ip:
+    def test_no_services(self):
+        ecs_client = mock.MagicMock()
+        ecs_client.services = {}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip import (
+                ecs_service_no_assign_public_ip,
+            )
+
+            check = ecs_service_no_assign_public_ip()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_service_with_no_public_ip(self):
+        ecs_client = mock.MagicMock()
+        ecs_client.services = {}
+        ecs_client.services[service_arn] = Service(
+            name=service_name,
+            arn=service_arn,
+            region=AWS_REGION_US_EAST_1,
+            assign_public_ip=False,
+            tags=[],
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip import (
+                ecs_service_no_assign_public_ip,
+            )
+
+            check = ecs_service_no_assign_public_ip()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"ECS Service '{service_name}' does not assign public IP address"
+            )
+            assert result[0].resource_id == service_name
+            assert result[0].resource_arn == service_arn
+
+    def test_task_definition_no_host_network_mode(self):
+        ecs_client = mock.MagicMock
+        ecs_client.task_services = {}
+        ecs_client.services[service_arn] = Service(
+            name=service_name,
+            arn=service_arn,
+            region=AWS_REGION_US_EAST_1,
+            assign_public_ip=True,
+            tags=[],
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_host_networking_mode_users.ecs_task_definitions_host_networking_mode_users import (
+                ecs_task_definitions_host_networking_mode_users,
+            )
+
+            check = ecs_task_definitions_host_networking_mode_users()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"ECS Service '{service_name}' assigns public IP address"
+            )
+            assert result[0].resource_id == service_name
+            assert result[0].resource_arn == service_arn

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_user_and_container_for_host_mode/ecs_task_definitions_user_and_container_for_host_mode_test.py
@@ -5,11 +5,7 @@ from prowler.providers.aws.services.ecs.ecs_service import (
     ContainerEnvVariable,
     TaskDefinition,
 )
-from tests.providers.aws.utils import (
-    AWS_ACCOUNT_NUMBER,
-    AWS_REGION_US_EAST_1,
-    set_mocked_aws_provider,
-)
+from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
 
 task_name = "test-task"
 task_revision = "1"
@@ -23,9 +19,6 @@ class Test_ecs_task_definitions_host_networking_mode_users:
         ecs_client.task_definitions = {}
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
@@ -62,9 +55,6 @@ class Test_ecs_task_definitions_host_networking_mode_users:
         )
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
@@ -78,7 +68,7 @@ class Test_ecs_task_definitions_host_networking_mode_users:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"ECS task definition '{task_name}' does not have host network mode."
+                == f"ECS task definition {task_name} does not have host network mode."
             )
 
     def test_task_definition_host_mode_container_root_non_privileged(self):
@@ -101,9 +91,6 @@ class Test_ecs_task_definitions_host_networking_mode_users:
         )
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
@@ -117,7 +104,7 @@ class Test_ecs_task_definitions_host_networking_mode_users:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"ECS task definition '{task_name}' has containers with host network mode and non-privileged containers running as root or with no user specified: {container_name}"
+                == f"ECS task definition {task_name} has containers with host network mode and non-privileged containers running as root or with no user specified: {container_name}"
             )
 
     def test_task_definition_host_mode_container_privileged(self):
@@ -140,9 +127,6 @@ class Test_ecs_task_definitions_host_networking_mode_users:
         )
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
@@ -156,7 +140,7 @@ class Test_ecs_task_definitions_host_networking_mode_users:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"ECS task definition '{task_name}' has host network mode but no containers running as root or with no user specified."
+                == f"ECS task definition {task_name} has host network mode but no containers running as root or with no user specified."
             )
 
     def test_task_definition_host_mode_container_not_root(self):
@@ -179,9 +163,6 @@ class Test_ecs_task_definitions_host_networking_mode_users:
         )
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
-        ), mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
         ):
@@ -195,5 +176,5 @@ class Test_ecs_task_definitions_host_networking_mode_users:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"ECS task definition '{task_name}' has host network mode but no containers running as root or with no user specified."
+                == f"ECS task definition {task_name} has host network mode but no containers running as root or with no user specified."
             )


### PR DESCRIPTION
### Context

Added a new check that verifies whether Amazon ECS services are configured to automatically assign public IP addresses. The check fails if AssignPublicIP is ENABLED and passes if AssignPublicIP is DISABLED.

A public IP address is an IP address that is reachable from the internet. If you launch your Amazon ECS instances with a public IP address, then your Amazon ECS instances are reachable from the internet. Amazon ECS services should not be publicly accessible, as this may allow unintended access to your container application servers.

### Description

Changed `ecs_service.py` to add the new `Service` model and two new methods to list and describe services. Added new `ecs_service_no_assign_public_ip.py` with respective unit tests.

### Checklist

- Are there new checks included in this PR? Yes 
    - If so, do we need to update permissions for the provider? No
- [X] Review if the code is being covered by tests.
- [X] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [X] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
