### PR TITLE
fix(regions): show all for empty regions

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -540,6 +540,7 @@ class AwsProvider(Provider):
         regions = (
             ", ".join(self._identity.audited_regions)
             if self._identity.audited_regions is not None
+            and self._identity.audited_regions != set()
             else "all"
         )
         # Beautify audited profile, set "default" if there is no profile set

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1728,3 +1728,73 @@ class TestPrintCredentials:
         )
 
         mock_print_boxes.assert_called_once_with(expected_lines, expected_title)
+
+    @mock.patch("prowler.providers.aws.aws_provider.print_boxes")
+    def test_print_credentials_no_regions_None(self, mock_print_boxes):
+        from prowler.providers.aws.aws_provider import AwsProvider
+
+        mock_self = AwsProvider.__new__(AwsProvider)
+
+        mock_self._identity = mock.MagicMock()
+        mock_self._identity.audited_regions = None
+        mock_self._identity.profile = "my-profile"
+        mock_self._identity.account = "123456789012"
+        mock_self._identity.user_id = "AID1234567890"
+        mock_self._identity.identity_arn = "arn:aws:iam::123456789012:user/my-user"
+
+        mock_self._assumed_role = mock.MagicMock()
+        mock_self._assumed_role.info.role_arn.arn = (
+            "arn:aws:sts::123456789012:assumed-role/my-role"
+        )
+
+        mock_self.print_credentials()
+
+        expected_lines = [
+            f"AWS-CLI Profile: {Fore.YELLOW}my-profile{Style.RESET_ALL}",
+            f"AWS Regions: {Fore.YELLOW}all{Style.RESET_ALL}",
+            f"AWS Account: {Fore.YELLOW}123456789012{Style.RESET_ALL}",
+            f"User Id: {Fore.YELLOW}AID1234567890{Style.RESET_ALL}",
+            f"Caller Identity ARN: {Fore.YELLOW}arn:aws:iam::123456789012:user/my-user{Style.RESET_ALL}",
+            f"Assumed Role ARN: {Fore.YELLOW}[arn:aws:sts::123456789012:assumed-role/my-role]{Style.RESET_ALL}",
+        ]
+
+        expected_title = (
+            f"{Style.BRIGHT}Using the AWS credentials below:{Style.RESET_ALL}"
+        )
+
+        mock_print_boxes.assert_called_once_with(expected_lines, expected_title)
+
+    @mock.patch("prowler.providers.aws.aws_provider.print_boxes")
+    def test_print_credentials_no_regions_empty_set(self, mock_print_boxes):
+        from prowler.providers.aws.aws_provider import AwsProvider
+
+        mock_self = AwsProvider.__new__(AwsProvider)
+
+        mock_self._identity = mock.MagicMock()
+        mock_self._identity.audited_regions = set()
+        mock_self._identity.profile = "my-profile"
+        mock_self._identity.account = "123456789012"
+        mock_self._identity.user_id = "AID1234567890"
+        mock_self._identity.identity_arn = "arn:aws:iam::123456789012:user/my-user"
+
+        mock_self._assumed_role = mock.MagicMock()
+        mock_self._assumed_role.info.role_arn.arn = (
+            "arn:aws:sts::123456789012:assumed-role/my-role"
+        )
+
+        mock_self.print_credentials()
+
+        expected_lines = [
+            f"AWS-CLI Profile: {Fore.YELLOW}my-profile{Style.RESET_ALL}",
+            f"AWS Regions: {Fore.YELLOW}all{Style.RESET_ALL}",
+            f"AWS Account: {Fore.YELLOW}123456789012{Style.RESET_ALL}",
+            f"User Id: {Fore.YELLOW}AID1234567890{Style.RESET_ALL}",
+            f"Caller Identity ARN: {Fore.YELLOW}arn:aws:iam::123456789012:user/my-user{Style.RESET_ALL}",
+            f"Assumed Role ARN: {Fore.YELLOW}[arn:aws:sts::123456789012:assumed-role/my-role]{Style.RESET_ALL}",
+        ]
+
+        expected_title = (
+            f"{Style.BRIGHT}Using the AWS credentials below:{Style.RESET_ALL}"
+        )
+
+        mock_print_boxes.assert_called_once_with(expected_lines, expected_title)

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -7,9 +7,11 @@ from datetime import datetime, timedelta
 from json import dumps
 from os import rmdir
 from re import search
+from unittest import mock
 
 import botocore
 from boto3 import client, resource, session
+from colorama import Fore, Style
 from freezegun import freeze_time
 from mock import patch
 from moto import mock_aws
@@ -1685,3 +1687,44 @@ aws:
 
         assert len(session_token) == 356
         assert search(r"^FQoGZXIvYXdzE.*$", session_token)
+
+
+def mock_print_boxes(report_lines, report_title):
+    return report_lines, report_title
+
+
+class TestPrintCredentials:
+    @mock.patch("prowler.providers.aws.aws_provider.print_boxes")
+    def test_print_credentials(self, mock_print_boxes):
+        from prowler.providers.aws.aws_provider import AwsProvider
+
+        mock_self = AwsProvider.__new__(AwsProvider)
+
+        mock_self._identity = mock.MagicMock()
+        mock_self._identity.audited_regions = ["us-east-1", "us-west-2"]
+        mock_self._identity.profile = "my-profile"
+        mock_self._identity.account = "123456789012"
+        mock_self._identity.user_id = "AID1234567890"
+        mock_self._identity.identity_arn = "arn:aws:iam::123456789012:user/my-user"
+
+        mock_self._assumed_role = mock.MagicMock()
+        mock_self._assumed_role.info.role_arn.arn = (
+            "arn:aws:sts::123456789012:assumed-role/my-role"
+        )
+
+        mock_self.print_credentials()
+
+        expected_lines = [
+            f"AWS-CLI Profile: {Fore.YELLOW}my-profile{Style.RESET_ALL}",
+            f"AWS Regions: {Fore.YELLOW}us-east-1, us-west-2{Style.RESET_ALL}",
+            f"AWS Account: {Fore.YELLOW}123456789012{Style.RESET_ALL}",
+            f"User Id: {Fore.YELLOW}AID1234567890{Style.RESET_ALL}",
+            f"Caller Identity ARN: {Fore.YELLOW}arn:aws:iam::123456789012:user/my-user{Style.RESET_ALL}",
+            f"Assumed Role ARN: {Fore.YELLOW}[arn:aws:sts::123456789012:assumed-role/my-role]{Style.RESET_ALL}",
+        ]
+
+        expected_title = (
+            f"{Style.BRIGHT}Using the AWS credentials below:{Style.RESET_ALL}"
+        )
+
+        mock_print_boxes.assert_called_once_with(expected_lines, expected_title)


### PR DESCRIPTION
### Description

Add "all" in banner for regions when executing prowler for aws.
<img width="411" alt="Screenshot 2024-09-23 at 11 17 07" src="https://github.com/user-attachments/assets/3ea6fe28-d915-474e-b050-ba70ef35e2b6">


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
