### PR TITLE
refactor(output_options): remove output options from provider

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -580,6 +580,19 @@ def execute(
     custom_checks_metadata: Any,
     output_options: Any = None,
 ):
+    """
+    Execute the check and report the findings
+
+    Args:
+        service (str): service name
+        check_name (str): check name
+        global_provider (Any): provider object
+        custom_checks_metadata (Any): custom checks metadata
+        output_options (Any): output options, depending on the provider
+
+    Returns:
+        list: list of findings
+    """
     try:
         # Import check module
         check_module_path = f"prowler.providers.{global_provider.type}.services.{service}.{check_name}.{check_name}"
@@ -597,11 +610,20 @@ def execute(
             )
 
         # Run check
-        verbose = output_options.verbose or output_options.fixer
-        check_findings = run_check(check_class, verbose, output_options.only_logs)
+        verbose = False
+        if hasattr(output_options, "verbose"):
+            verbose = output_options.verbose
+        elif hasattr(output_options, "fixer"):
+            verbose = output_options.fixer
+
+        only_logs = False
+        if hasattr(output_options, "only_logs"):
+            only_logs = output_options.only_logs
+
+        check_findings = run_check(check_class, verbose, only_logs)
 
         # Exclude findings per status
-        if output_options.status:
+        if hasattr(output_options, "status") and output_options.status:
             check_findings = [
                 finding
                 for finding in check_findings

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -435,6 +435,7 @@ def execute_checks(
     global_provider: Any,
     custom_checks_metadata: Any,
     config_file: str,
+    output_options: Any,
 ) -> list:
     # List to store all the check's findings
     all_findings = []
@@ -471,7 +472,7 @@ def execute_checks(
             )
 
     # Execution with the --only-logs flag
-    if global_provider.output_options.only_logs:
+    if output_options.only_logs:
         for check_name in checks_to_execute:
             # Recover service from check name
             service = check_name.split("_")[0]
@@ -481,6 +482,7 @@ def execute_checks(
                     check_name,
                     global_provider,
                     custom_checks_metadata,
+                    output_options,
                 )
                 all_findings.extend(check_findings)
 
@@ -544,6 +546,7 @@ def execute_checks(
                         check_name,
                         global_provider,
                         custom_checks_metadata,
+                        output_options,
                     )
                     all_findings.extend(check_findings)
                     services_executed.add(service)
@@ -575,6 +578,7 @@ def execute(
     check_name: str,
     global_provider: Any,
     custom_checks_metadata: Any,
+    output_options: Any = None,
 ):
     try:
         # Import check module
@@ -593,20 +597,15 @@ def execute(
             )
 
         # Run check
-        verbose = (
-            global_provider.output_options.verbose
-            or global_provider.output_options.fixer
-        )
-        check_findings = run_check(
-            check_class, verbose, global_provider.output_options.only_logs
-        )
+        verbose = output_options.verbose or output_options.fixer
+        check_findings = run_check(check_class, verbose, output_options.only_logs)
 
         # Exclude findings per status
-        if global_provider.output_options.status:
+        if output_options.status:
             check_findings = [
                 finding
                 for finding in check_findings
-                if finding.status in global_provider.output_options.status
+                if finding.status in output_options.status
             ]
 
         # Mutelist findings
@@ -628,7 +627,7 @@ def execute(
 
         # Refactor(Outputs)
         # Report the check's findings
-        report(check_findings, global_provider)
+        report(check_findings, global_provider, output_options)
 
         # Refactor(Outputs)
         if os.environ.get("PROWLER_REPORT_LIB_PATH"):
@@ -638,10 +637,8 @@ def execute(
                 outputs_module = importlib.import_module(lib)
                 custom_report_interface = getattr(outputs_module, "report")
 
-                # TODO: review this call and see if we can remove the global_provider.output_options since it is contained in the global_provider
-                custom_report_interface(
-                    check_findings, global_provider.output_options, global_provider
-                )
+                # TODO: review this call and see if we can remove the output_options since it is contained in the global_provider
+                custom_report_interface(check_findings, output_options, global_provider)
             except Exception:
                 sys.exit(1)
     except ModuleNotFoundError:

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -88,7 +88,7 @@ class Finding(BaseModel):
 
     @classmethod
     def generate_output(
-        cls, provider: Provider, check_output: Check_Report
+        cls, provider: Provider, check_output: Check_Report, output_options
     ) -> "Finding":
         """Generates the output for a finding based on the provider and output options
 
@@ -99,7 +99,6 @@ class Finding(BaseModel):
             finding_output (Finding): the finding output object
 
         """
-        output_options = provider.output_options
         # TODO: think about get_provider_data_mapping
         provider_data_mapping = get_provider_data_mapping(provider)
         # TODO: move fill_common_finding_data

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -95,21 +95,30 @@ class Finding(BaseModel):
         Args:
             provider (Provider): the provider object
             check_output (Check_Report): the check output object
+            output_options: the output options object, depending on the provider
         Returns:
             finding_output (Finding): the finding output object
 
         """
         # TODO: think about get_provider_data_mapping
         provider_data_mapping = get_provider_data_mapping(provider)
+
         # TODO: move fill_common_finding_data
-        common_finding_data = fill_common_finding_data(
-            check_output, output_options.unix_timestamp
-        )
+        unix_timestamp = False
+        if hasattr(output_options, "unix_timestamp"):
+            unix_timestamp = output_options.unix_timestamp
+
+        common_finding_data = fill_common_finding_data(check_output, unix_timestamp)
         output_data = {}
         output_data.update(provider_data_mapping)
         output_data.update(common_finding_data)
+
+        bulk_checks_metadata = {}
+        if hasattr(output_options, "bulk_checks_metadata"):
+            bulk_checks_metadata = output_options.bulk_checks_metadata
+
         output_data["compliance"] = get_check_compliance(
-            check_output, provider.type, output_options.bulk_checks_metadata
+            check_output, provider.type, bulk_checks_metadata
         )
         try:
             if provider.type == "aws":

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -26,9 +26,8 @@ def stdout_report(finding, color, verbose, status, fix):
 
 
 # TODO: Only pass check_findings, provider.output_options and provider.type
-def report(check_findings, provider):
+def report(check_findings, provider, output_options):
     try:
-        output_options = provider.output_options
         if check_findings:
             # TO-DO Generic Function
             if provider.type == "aws":

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -25,9 +25,12 @@ def stdout_report(finding, color, verbose, status, fix):
             )
 
 
-# TODO: Only pass check_findings, provider.output_options and provider.type
+# TODO: Only pass check_findings, output_options and provider.type
 def report(check_findings, provider, output_options):
     try:
+        verbose = False
+        if hasattr(output_options, "verbose"):
+            verbose = output_options.verbose
         if check_findings:
             # TO-DO Generic Function
             if provider.type == "aws":
@@ -38,21 +41,27 @@ def report(check_findings, provider, output_options):
 
             for finding in check_findings:
                 # Print findings by stdout
+                status = []
+                if hasattr(output_options, "status"):
+                    status = output_options.status
+                fixer = False
+                if hasattr(output_options, "fixer"):
+                    fixer = output_options.fixer
                 color = set_report_color(finding.status, finding.muted)
                 stdout_report(
                     finding,
                     color,
-                    output_options.verbose,
-                    output_options.status,
-                    output_options.fixer,
+                    verbose,
+                    status,
+                    fixer,
                 )
 
         else:  # No service resources in the whole account
             color = set_report_color("MANUAL")
-            if output_options.verbose:
+            if verbose:
                 print(f"\t{color}INFO{Style.RESET_ALL} There are no resources")
         # Separator between findings and bar
-        if output_options.verbose:
+        if verbose:
             print()
     except Exception as error:
         logger.error(

--- a/prowler/lib/scan/scan.py
+++ b/prowler/lib/scan/scan.py
@@ -106,6 +106,7 @@ class Scan:
                         check_name,
                         self._provider,
                         custom_checks_metadata,
+                        output_options=None,
                     )
 
                     # Store findings
@@ -131,7 +132,9 @@ class Scan:
                     )
 
                     findings = [
-                        Finding.generate_output(self._provider, finding)
+                        Finding.generate_output(
+                            self._provider, finding, output_options=None
+                        )
                         for finding in check_findings
                     ]
 

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -52,7 +52,6 @@ from prowler.providers.aws.models import (
     AWSIdentityInfo,
     AWSMFAInfo,
     AWSOrganizationsInfo,
-    AWSOutputOptions,
     AWSSession,
 )
 from prowler.providers.common.models import Audit_Metadata, Connection
@@ -68,7 +67,6 @@ class AwsProvider(Provider):
     _audit_config: dict
     _scan_unused_services: bool = False
     _enabled_regions: set = set()
-    _output_options: AWSOutputOptions
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
 
@@ -303,17 +301,6 @@ class AwsProvider(Provider):
     @property
     def fixer_config(self):
         return self._fixer_config
-
-    @property
-    def output_options(self):
-        return self._output_options
-
-    @output_options.setter
-    def output_options(self, options: tuple):
-        arguments, bulk_checks_metadata = options
-        self._output_options = AWSOutputOptions(
-            arguments, bulk_checks_metadata, self._identity
-        )
 
     @property
     def mutelist(self) -> AWSMutelist:

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -29,11 +29,7 @@ from prowler.providers.azure.exceptions.exceptions import (
 from prowler.providers.azure.lib.arguments.arguments import validate_azure_region
 from prowler.providers.azure.lib.mutelist.mutelist import AzureMutelist
 from prowler.providers.azure.lib.regions.regions import get_regions_config
-from prowler.providers.azure.models import (
-    AzureIdentityInfo,
-    AzureOutputOptions,
-    AzureRegionConfig,
-)
+from prowler.providers.azure.models import AzureIdentityInfo, AzureRegionConfig
 from prowler.providers.common.models import Audit_Metadata, Connection
 from prowler.providers.common.provider import Provider
 
@@ -53,7 +49,6 @@ class AzureProvider(Provider):
         _audit_config (dict): The audit configuration for the Azure provider.
         _region_config (AzureRegionConfig): The region configuration for the Azure provider.
         _locations (dict): A dictionary containing the available locations for the Azure provider.
-        _output_options (AzureOutputOptions): The output options for the Azure provider.
         _mutelist (AzureMutelist): The mutelist object associated with the Azure provider.
         audit_metadata (Audit_Metadata): The audit metadata for the Azure provider.
 
@@ -81,7 +76,6 @@ class AzureProvider(Provider):
     _audit_config: dict
     _region_config: AzureRegionConfig
     _locations: dict
-    _output_options: AzureOutputOptions
     _mutelist: AzureMutelist
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
@@ -196,28 +190,6 @@ class AzureProvider(Provider):
     def fixer_config(self):
         """Returns the fixer configuration."""
         return self._fixer_config
-
-    @property
-    def output_options(self):
-        """Returns the output options for the Azure provider."""
-        return self._output_options
-
-    @output_options.setter
-    def output_options(self, options: tuple):
-        """Set output options for the Azure provider.
-
-        Sets the output options for the Azure provider using the provided arguments and bulk checks metadata.
-
-        Args:
-            options (tuple): A tuple containing the arguments and bulk checks metadata.
-
-        Returns:
-            None
-        """
-        arguments, bulk_checks_metadata = options
-        self._output_options = AzureOutputOptions(
-            arguments, bulk_checks_metadata, self._identity
-        )
 
     @property
     def mutelist(self) -> AzureMutelist:

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -37,7 +37,6 @@ class Provider(ABC):
         identity (property): The identity of the provider for auditing.
         session (property): The session of the provider for auditing.
         audit_config (property): The audit configuration of the provider.
-        output_options (property): The output configuration of the provider for auditing.
 
     Methods:
         print_credentials(): Displays the provider's credentials used for auditing in the command-line interface.
@@ -104,26 +103,6 @@ class Provider(ABC):
     def print_credentials(self) -> None:
         """
         print_credentials is used to display in the CLI the provider's credentials used to audit.
-
-        This method needs to be created in each provider.
-        """
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
-    def output_options(self) -> str:
-        """
-        output_options method returns the provider's audit output configuration.
-
-        This method needs to be created in each provider.
-        """
-        raise NotImplementedError()
-
-    @output_options.setter
-    @abstractmethod
-    def output_options(self, value: str) -> Any:
-        """
-        output_options.setter sets the provider's audit output configuration.
 
         This method needs to be created in each provider.
         """

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -23,12 +23,7 @@ from prowler.providers.gcp.exceptions.exceptions import (
     GCPTestConnectionError,
 )
 from prowler.providers.gcp.lib.mutelist.mutelist import GCPMutelist
-from prowler.providers.gcp.models import (
-    GCPIdentityInfo,
-    GCPOrganization,
-    GCPOutputOptions,
-    GCPProject,
-)
+from prowler.providers.gcp.models import GCPIdentityInfo, GCPOrganization, GCPProject
 
 
 class GcpProvider(Provider):
@@ -38,7 +33,6 @@ class GcpProvider(Provider):
     _excluded_project_ids: list
     _identity: GCPIdentityInfo
     _audit_config: dict
-    _output_options: GCPOutputOptions
     _mutelist: GCPMutelist
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
@@ -177,17 +171,6 @@ class GcpProvider(Provider):
     @property
     def fixer_config(self):
         return self._fixer_config
-
-    @property
-    def output_options(self):
-        return self._output_options
-
-    @output_options.setter
-    def output_options(self, options: tuple):
-        arguments, bulk_checks_metadata = options
-        self._output_options = GCPOutputOptions(
-            arguments, bulk_checks_metadata, self._identity
-        )
 
     @property
     def mutelist(self) -> GCPMutelist:

--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -21,7 +21,6 @@ from prowler.providers.kubernetes.exceptions.exceptions import (
 from prowler.providers.kubernetes.lib.mutelist.mutelist import KubernetesMutelist
 from prowler.providers.kubernetes.models import (
     KubernetesIdentityInfo,
-    KubernetesOutputOptions,
     KubernetesSession,
 )
 
@@ -32,7 +31,6 @@ class KubernetesProvider(Provider):
     _namespaces: list
     _audit_config: dict
     _identity: KubernetesIdentityInfo
-    _output_options: KubernetesOutputOptions
     _mutelist: dict
     # TODO: this is not optional, enforce for all providers
     audit_metadata: Audit_Metadata
@@ -105,17 +103,6 @@ class KubernetesProvider(Provider):
     @property
     def fixer_config(self):
         return self._fixer_config
-
-    @property
-    def output_options(self):
-        return self._output_options
-
-    @output_options.setter
-    def output_options(self, options: tuple):
-        arguments, bulk_checks_metadata = options
-        self._output_options = KubernetesOutputOptions(
-            arguments, bulk_checks_metadata, self._identity
-        )
 
     @property
     def mutelist(self) -> KubernetesMutelist:

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -826,6 +826,7 @@ class TestCheck:
                     expected_checks=["accessanalyzer_enabled"]
                 ),
                 custom_checks_metadata=None,
+                output_options=None,
             )
             assert len(findings) == 1
 
@@ -843,6 +844,8 @@ class TestCheck:
             )
         ]
         status = ["PASS"]
+        output_options = mock.MagicMock()
+        output_options.status = status
         with mock.patch(
             "prowler.providers.aws.services.accessanalyzer.accessanalyzer_service.AccessAnalyzer",
             accessanalyzer_client,
@@ -851,9 +854,10 @@ class TestCheck:
                 service="accessanalyzer",
                 check_name="accessanalyzer_enabled",
                 global_provider=set_mocked_aws_provider(
-                    status=status, expected_checks=["accessanalyzer_enabled"]
+                    expected_checks=["accessanalyzer_enabled"]
                 ),
                 custom_checks_metadata=None,
+                output_options=output_options,
             )
             assert len(findings) == 0
 

--- a/tests/lib/outputs/finding_test.py
+++ b/tests/lib/outputs/finding_test.py
@@ -215,10 +215,8 @@ class TestFinding:
         check_output.region = "us-west-1"
         output_options = MagicMock()
         output_options.unix_timestamp = 1234567890
-        global_provider = MagicMock()
-        global_provider.output_options = output_options
         # Call the method under test
-        finding_output = Finding.generate_output(provider, check_output)
+        finding_output = Finding.generate_output(provider, check_output, output_options)
 
         # Assertions to verify expected behavior
         assert finding_output is not None
@@ -293,10 +291,8 @@ class TestFinding:
         check_output.region = "us-west-1"
         output_options = MagicMock()
         output_options.unix_timestamp = 1234567890
-        global_provider = MagicMock()
-        global_provider.output_options = output_options
         # Call the method under test
-        finding_output = Finding.generate_output(provider, check_output)
+        finding_output = Finding.generate_output(provider, check_output, output_options)
 
         # Assertions to verify expected behavior
         assert finding_output is not None
@@ -367,7 +363,7 @@ class TestFinding:
         output_options = MagicMock()
         output_options.unix_timestamp = 1234567890
 
-        finding_output = Finding.generate_output(provider, check_output)
+        finding_output = Finding.generate_output(provider, check_output, output_options)
 
         assert finding_output is not None
         assert finding_output.auth_method == "Principal: mock_auth"
@@ -438,7 +434,7 @@ class TestFinding:
         output_options = MagicMock()
         output_options.unix_timestamp = 1234567890
 
-        finding_output = Finding.generate_output(provider, check_output)
+        finding_output = Finding.generate_output(provider, check_output, output_options)
 
         assert finding_output is not None
         assert finding_output.auth_method == "in-cluster"

--- a/tests/lib/outputs/output_options/output_options_test.py
+++ b/tests/lib/outputs/output_options/output_options_test.py
@@ -1,0 +1,43 @@
+from argparse import Namespace
+from datetime import datetime
+from unittest import mock
+
+from freezegun import freeze_time
+
+from prowler.config.config import output_file_timestamp
+from prowler.providers.aws.models import AWSOutputOptions
+
+
+class Test_Output_Options:
+    @freeze_time(datetime.today())
+    def test_set_output_options_aws_no_output_filename(self):
+        arguments = Namespace()
+        arguments.status = ["FAIL"]
+        arguments.output_formats = ["csv"]
+        arguments.output_directory = "output_test_directory"
+        arguments.verbose = True
+        arguments.security_hub = True
+        arguments.shodan = None
+        arguments.only_logs = False
+        arguments.unix_timestamp = False
+        arguments.send_sh_only_fails = True
+
+        identity = mock.MagicMock()
+        identity.account = "123456789012"
+
+        output_options = AWSOutputOptions(arguments, None, identity)
+
+        assert output_options.status == ["FAIL"]
+        assert output_options.output_modes == ["csv", "json-asff"]
+        assert output_options.output_directory == "output_test_directory"
+        assert output_options.verbose
+        assert output_options.security_hub_enabled
+        assert not output_options.shodan_api_key
+        assert not output_options.only_logs
+        assert not output_options.unix_timestamp
+        assert output_options.send_sh_only_fails
+        assert (
+            output_options.output_filename
+            == f"prowler-output-{identity.account}-{output_file_timestamp}"
+        )
+        assert not output_options.bulk_checks_metadata

--- a/tests/lib/outputs/outputs_test.py
+++ b/tests/lib/outputs/outputs_test.py
@@ -460,12 +460,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "aws"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_1, finding_2]
@@ -503,12 +502,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "aws"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_1, finding_2]
@@ -546,12 +544,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "aws"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_1, finding_2]
@@ -589,12 +586,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "aws"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_1, finding_2]
@@ -634,12 +630,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "azure"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -679,12 +674,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "azure"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -724,12 +718,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "azure"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -769,12 +762,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "azure"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -812,12 +804,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "gcp"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -855,12 +846,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "gcp"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -898,12 +888,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "gcp"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -941,12 +930,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "gcp"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -984,12 +972,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "kubernetes"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -1027,12 +1014,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "kubernetes"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -1070,12 +1056,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "kubernetes"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -1113,12 +1098,11 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "kubernetes"
-        provider.output_options = output_options
 
         # Assertions
         with mock.patch("builtins.print") as mocked_print:
             # Call the report method
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             check_findings_sorted = [finding_2, finding_1]
@@ -1142,10 +1126,9 @@ class TestOutputs:
 
         provider = MagicMock()
         provider.type = "azure"
-        provider.output_options = output_options
 
         with mock.patch("builtins.print") as mocked_print:
-            report(check_findings, provider)
+            report(check_findings, provider, output_options)
 
             # Assertions
             mocked_print.assert_any_call(

--- a/tests/lib/scan/scan_test.py
+++ b/tests/lib/scan/scan_test.py
@@ -64,7 +64,7 @@ def mock_generate_output():
     with mock.patch(
         "prowler.lib.outputs.finding.Finding.generate_output", autospec=True
     ) as mock_gen_output:
-        mock_gen_output.side_effect = lambda provider, finding: finding
+        mock_gen_output.side_effect = lambda provider, finding, output_options: finding
         yield mock_gen_output
 
 

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -2,17 +2,14 @@ import json
 import os
 import re
 import tempfile
-from argparse import Namespace
 from datetime import datetime, timedelta
 from json import dumps
-from os import rmdir
 from re import search
 from unittest import mock
 
 import botocore
 import botocore.exceptions
 from boto3 import client, resource, session
-from freezegun import freeze_time
 from mock import patch
 from moto import mock_aws
 from pytest import raises
@@ -42,7 +39,6 @@ from prowler.providers.aws.models import (
     AWSCredentials,
     AWSMFAInfo,
     AWSOrganizationsInfo,
-    AWSOutputOptions,
 )
 from prowler.providers.common.models import Connection
 from prowler.providers.common.provider import Provider
@@ -1037,97 +1033,6 @@ aws:
         )
 
         assert aws_provider.audit_resources == [AWS_ACCOUNT_ARN]
-
-    @mock_aws
-    @freeze_time(datetime.today())
-    def test_set_provider_output_options_aws_no_output_filename(self):
-        arguments = Namespace()
-        arguments.status = ["FAIL"]
-        arguments.output_formats = ["csv"]
-        arguments.output_directory = "output_test_directory"
-        arguments.verbose = True
-        arguments.security_hub = True
-        arguments.shodan = "test-api-key"
-        arguments.only_logs = False
-        arguments.unix_timestamp = False
-        arguments.send_sh_only_fails = True
-
-        aws_provider = AwsProvider()
-        # This is needed since the output_options requires to get the global provider to get the audit config
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ):
-
-            aws_provider.output_options = arguments, {}
-
-            assert isinstance(aws_provider.output_options, AWSOutputOptions)
-            assert aws_provider.output_options.security_hub_enabled
-            assert aws_provider.output_options.send_sh_only_fails
-            assert aws_provider.output_options.status == ["FAIL"]
-            assert aws_provider.output_options.output_modes == ["csv", "json-asff"]
-            assert (
-                aws_provider.output_options.output_directory
-                == arguments.output_directory
-            )
-            assert aws_provider.output_options.bulk_checks_metadata == {}
-            assert aws_provider.output_options.verbose
-            assert (
-                f"prowler-output-{AWS_ACCOUNT_NUMBER}"
-                in aws_provider.output_options.output_filename
-            )
-            # Flaky due to the millisecond part of the timestamp
-            # assert (
-            #     aws_provider.output_options.output_filename
-            #     == f"prowler-output-{AWS_ACCOUNT_NUMBER}-{datetime.today().strftime('%Y%m%d%H%M%S')}"
-            # )
-
-            # Delete testing directory
-            rmdir(f"{arguments.output_directory}/compliance")
-            rmdir(arguments.output_directory)
-
-    @mock_aws
-    @freeze_time(datetime.today())
-    def test_set_provider_output_options_aws(self):
-        arguments = Namespace()
-        arguments.status = []
-        arguments.output_formats = ["csv"]
-        arguments.output_directory = "output_test_directory"
-        arguments.verbose = True
-        arguments.output_filename = "output_test_filename"
-        arguments.security_hub = True
-        arguments.shodan = "test-api-key"
-        arguments.only_logs = False
-        arguments.unix_timestamp = False
-        arguments.send_sh_only_fails = True
-
-        aws_provider = AwsProvider()
-        # This is needed since the output_options requires to get the global provider to get the audit config
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ):
-
-            aws_provider.output_options = arguments, {}
-
-            assert isinstance(aws_provider.output_options, AWSOutputOptions)
-            assert aws_provider.output_options.security_hub_enabled
-            assert aws_provider.output_options.send_sh_only_fails
-            assert aws_provider.output_options.status == []
-            assert aws_provider.output_options.output_modes == ["csv", "json-asff"]
-            assert (
-                aws_provider.output_options.output_directory
-                == arguments.output_directory
-            )
-            assert aws_provider.output_options.bulk_checks_metadata == {}
-            assert aws_provider.output_options.verbose
-            assert (
-                aws_provider.output_options.output_filename == arguments.output_filename
-            )
-
-            # Delete testing directory
-            rmdir(f"{arguments.output_directory}/compliance")
-            rmdir(arguments.output_directory)
 
     @mock_aws
     def test_validate_credentials_commercial_partition_with_regions(self):

--- a/tests/providers/aws/utils.py
+++ b/tests/providers/aws/utils.py
@@ -120,13 +120,6 @@ def set_mocked_aws_provider(
     # AWS Provider
     provider = AwsProvider()
 
-    # Set output options
-    provider.output_options = arguments, {}
-
-    # Output options
-
-    provider.output_options = arguments, {}
-
     # Mock Session
     provider._session.session_config = None
     provider._session.original_session = original_session

--- a/tests/providers/gcp/gcp_provider_test.py
+++ b/tests/providers/gcp/gcp_provider_test.py
@@ -1,6 +1,6 @@
 from argparse import Namespace
 from datetime import datetime
-from os import environ, rmdir
+from os import environ
 
 from freezegun import freeze_time
 from mock import MagicMock, patch
@@ -11,8 +11,7 @@ from prowler.config.config import (
     load_and_validate_config_file,
 )
 from prowler.providers.gcp.gcp_provider import GcpProvider
-from prowler.providers.gcp.models import GCPIdentityInfo, GCPOutputOptions, GCPProject
-from tests.providers.gcp.gcp_fixtures import mock_api_client
+from prowler.providers.gcp.models import GCPIdentityInfo, GCPProject
 
 
 class TestGCPProvider:
@@ -71,99 +70,6 @@ class TestGCPProvider:
             assert gcp_provider.default_project_id == "test-project"
             assert gcp_provider.identity == GCPIdentityInfo(profile="default")
             assert gcp_provider.audit_config == {"shodan_api_key": None}
-
-    @freeze_time(datetime.today())
-    def test_gcp_provider_output_options(self):
-        arguments = Namespace()
-        arguments.project_id = []
-        arguments.excluded_project_id = []
-        arguments.list_project_id = False
-        arguments.credentials_file = ""
-        arguments.impersonate_service_account = ""
-        arguments.config_file = default_config_file_path
-        arguments.fixer_config = default_fixer_config_file_path
-
-        # Output options
-        arguments.status = []
-        arguments.output_formats = ["csv"]
-        arguments.output_directory = "output_test_directory"
-        arguments.verbose = True
-        arguments.only_logs = False
-        arguments.unix_timestamp = False
-        arguments.shodan = "test-api-key"
-
-        projects = {
-            "test-project": GCPProject(
-                number="55555555",
-                id="project/55555555",
-                name="test-project",
-                labels={"test": "value"},
-                lifecycle_state="",
-            )
-        }
-
-        mocked_service = MagicMock()
-
-        mocked_service.projects.list.return_value = MagicMock(
-            execute=MagicMock(return_value={"projects": projects})
-        )
-        with patch(
-            "prowler.providers.gcp.gcp_provider.GcpProvider.setup_session",
-            return_value=(None, None),
-        ), patch(
-            "prowler.providers.gcp.gcp_provider.GcpProvider.get_projects",
-            return_value=projects,
-        ), patch(
-            "prowler.providers.gcp.gcp_provider.GcpProvider.update_projects_with_organizations",
-            return_value=None,
-        ), patch(
-            "prowler.providers.gcp.gcp_provider.discovery.build",
-            new=mock_api_client,
-        ), patch(
-            "prowler.providers.gcp.gcp_provider.discovery.build",
-            return_value=mocked_service,
-        ):
-            gcp_provider = GcpProvider(
-                arguments.project_id,
-                arguments.excluded_project_id,
-                arguments.credentials_file,
-                arguments.impersonate_service_account,
-                arguments.list_project_id,
-                arguments.config_file,
-                arguments.fixer_config,
-            )
-            # This is needed since the output_options requires to get the global provider to get the audit config
-            with patch(
-                "prowler.providers.common.provider.Provider.get_global_provider",
-                return_value=gcp_provider,
-            ):
-                gcp_provider.output_options = arguments, {}
-
-                assert isinstance(gcp_provider.output_options, GCPOutputOptions)
-                assert gcp_provider.output_options.status == []
-                assert gcp_provider.output_options.output_modes == [
-                    "csv",
-                ]
-                assert (
-                    gcp_provider.output_options.output_directory
-                    == arguments.output_directory
-                )
-                assert gcp_provider.output_options.bulk_checks_metadata == {}
-                assert gcp_provider.output_options.verbose
-                assert (
-                    f"prowler-output-{gcp_provider.identity.profile}"
-                    in gcp_provider.output_options.output_filename
-                )
-                # Flaky due to the millisecond part of the timestamp
-                # assert (
-                #     gcp_provider.output_options.output_filename
-                #     == f"prowler-output-{gcp_provider.identity.profile}-{datetime.today().strftime('%Y%m%d%H%M%S')}"
-                # )
-
-                # Delete testing directory
-                # TODO: move this to a fixtures file
-                rmdir(f"{arguments.output_directory}/compliance")
-                rmdir(arguments.output_directory)
 
     @freeze_time(datetime.today())
     def test_is_project_matching(self):


### PR DESCRIPTION
### Description

Remove output options inside the provider since it won't be used by the API.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
