### PR TITLE
feat(networkfirewall): change `network_firewalls` from list to dict

### DIFF
--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection.py
@@ -7,11 +7,11 @@ from prowler.providers.aws.services.networkfirewall.networkfirewall_client impor
 class networkfirewall_deletion_protection(Check):
     def execute(self):
         findings = []
-        for firewall in networkfirewall_client.network_firewalls.values():
+        for arn, firewall in networkfirewall_client.network_firewalls.items():
             report = Check_Report_AWS(self.metadata())
             report.region = firewall.region
             report.resource_id = firewall.name
-            report.resource_arn = firewall.arn
+            report.resource_arn = arn
             report.resource_tags = firewall.tags
             report.status = "FAIL"
             report.status_extended = f"Network Firewall {firewall.name} does not have deletion protection enabled."

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection.py
@@ -7,7 +7,7 @@ from prowler.providers.aws.services.networkfirewall.networkfirewall_client impor
 class networkfirewall_deletion_protection(Check):
     def execute(self):
         findings = []
-        for firewall in networkfirewall_client.network_firewalls:
+        for firewall in networkfirewall_client.network_firewalls.values():
             report = Check_Report_AWS(self.metadata())
             report.region = firewall.region
             report.resource_id = firewall.name

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc.py
@@ -17,7 +17,7 @@ class networkfirewall_in_all_vpc(Check):
                 report.resource_tags = vpc.tags
                 report.status = "FAIL"
                 report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} does not have Network Firewall enabled."
-                for firewall in networkfirewall_client.network_firewalls:
+                for firewall in networkfirewall_client.network_firewalls.values():
                     if firewall.vpc_id == vpc.id:
                         report.status = "PASS"
                         report.status_extended = f"VPC {vpc.name if vpc.name else vpc.id} has Network Firewall enabled."

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -10,7 +10,7 @@ class NetworkFirewall(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__
         super().__init__("network-firewall", provider)
-        self.network_firewalls = []
+        self.network_firewalls = {}
         self.__threading_call__(self._list_firewalls)
         self._describe_firewall()
 
@@ -27,13 +27,14 @@ class NetworkFirewall(AWSService):
                             network_firewall["FirewallArn"], self.audit_resources
                         )
                     ):
-                        self.network_firewalls.append(
+                        self.network_firewalls[network_firewall.get("FirewallArn")] = (
                             Firewall(
                                 arn=network_firewall.get("FirewallArn"),
                                 region=regional_client.region,
                                 name=network_firewall.get("FirewallName"),
                             )
                         )
+
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -42,20 +43,29 @@ class NetworkFirewall(AWSService):
     def _describe_firewall(self):
         logger.info("Network Firewall - Describe Network Firewalls...")
         try:
-            for network_firewall in self.network_firewalls:
+            for network_firewall in self.network_firewalls.values():
                 regional_client = self.regional_clients[network_firewall.region]
-                describe_firewall = regional_client.describe_firewall(
-                    FirewallArn=network_firewall.arn
-                )["Firewall"]
-                network_firewall.policy_arn = describe_firewall.get("FirewallPolicyArn")
-                network_firewall.vpc_id = describe_firewall.get("VpcId")
-                network_firewall.tags = describe_firewall.get("Tags")
-                network_firewall.encryption_type = describe_firewall.get(
-                    "EncryptionConfiguration"
-                ).get("Type")
-                network_firewall.deletion_protection = describe_firewall.get(
-                    "DeleteProtection"
-                )
+                try:
+                    describe_firewall = regional_client.describe_firewall(
+                        FirewallArn=network_firewall.arn
+                    )["Firewall"]
+                    network_firewall.policy_arn = describe_firewall.get(
+                        "FirewallPolicyArn"
+                    )
+                    network_firewall.vpc_id = describe_firewall.get("VpcId")
+                    network_firewall.tags = describe_firewall.get("Tags", [])
+                    encryption_config = describe_firewall.get(
+                        "EncryptionConfiguration", {}
+                    )
+                    network_firewall.encryption_type = encryption_config.get("Type")
+                    network_firewall.deletion_protection = describe_firewall.get(
+                        "DeleteProtection", False
+                    )
+                except Exception as error:
+                    logger.error(
+                        f"Error describing firewall {network_firewall.arn} in region {network_firewall.region}: "
+                        f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
         except Exception as error:
             logger.error(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -27,12 +27,11 @@ class NetworkFirewall(AWSService):
                             network_firewall["FirewallArn"], self.audit_resources
                         )
                     ):
-                        self.network_firewalls[network_firewall.get("FirewallArn")] = (
-                            Firewall(
-                                arn=network_firewall.get("FirewallArn"),
-                                region=regional_client.region,
-                                name=network_firewall.get("FirewallName"),
-                            )
+                        self.network_firewalls[
+                            network_firewall.get("FirewallArn", "")
+                        ] = Firewall(
+                            region=regional_client.region,
+                            name=network_firewall.get("FirewallName"),
                         )
 
         except Exception as error:
@@ -43,11 +42,11 @@ class NetworkFirewall(AWSService):
     def _describe_firewall(self):
         logger.info("Network Firewall - Describe Network Firewalls...")
         try:
-            for network_firewall in self.network_firewalls.values():
+            for arn, network_firewall in self.network_firewalls.items():
                 regional_client = self.regional_clients[network_firewall.region]
                 try:
                     describe_firewall = regional_client.describe_firewall(
-                        FirewallArn=network_firewall.arn
+                        FirewallArn=arn,
                     )["Firewall"]
                     network_firewall.policy_arn = describe_firewall.get(
                         "FirewallPolicyArn"
@@ -73,7 +72,6 @@ class NetworkFirewall(AWSService):
 
 
 class Firewall(BaseModel):
-    arn: str
     name: str
     region: str
     policy_arn: str = None

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection_test.py
@@ -19,7 +19,7 @@ class Test_networkfirewall_deletion_protection:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = []
+        networkfirewall_client.network_firewalls = {}
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
@@ -41,14 +41,14 @@ class Test_networkfirewall_deletion_protection:
 
                 assert len(result) == 0
 
-    def Test_networkfirewall_deletion_protection_disabled(self):
+    def test_networkfirewall_deletion_protection_disabled(self):
         networkfirewall_client = mock.MagicMock
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = [
-            Firewall(
+        networkfirewall_client.network_firewalls = {
+            FIREWALL_ARN: Firewall(
                 arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
@@ -58,8 +58,7 @@ class Test_networkfirewall_deletion_protection:
                 encryption_type="CUSTOMER_KMS",
                 deletion_protection=False,
             )
-        ]
-
+        }
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
         with mock.patch(
@@ -89,14 +88,14 @@ class Test_networkfirewall_deletion_protection:
                 assert result[0].resource_tags == []
                 assert result[0].resource_arn == FIREWALL_ARN
 
-    def Test_networkfirewall_deletion_protection_enabled(self):
+    def test_networkfirewall_deletion_protection_enabled(self):
         networkfirewall_client = mock.MagicMock
         networkfirewall_client.provider = set_mocked_aws_provider(
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = [
-            Firewall(
+        networkfirewall_client.network_firewalls = {
+            FIREWALL_ARN: Firewall(
                 arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
@@ -106,7 +105,7 @@ class Test_networkfirewall_deletion_protection:
                 encryption_type="CUSTOMER_KMS",
                 deletion_protection=True,
             )
-        ]
+        }
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection_test.py
@@ -49,7 +49,6 @@ class Test_networkfirewall_deletion_protection:
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {
             FIREWALL_ARN: Firewall(
-                arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
                 policy_arn=POLICY_ARN,
@@ -96,7 +95,6 @@ class Test_networkfirewall_deletion_protection:
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {
             FIREWALL_ARN: Firewall(
-                arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
                 policy_arn=POLICY_ARN,

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
@@ -20,7 +20,7 @@ class Test_networkfirewall_in_all_vpc:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = []
+        networkfirewall_client.network_firewalls = {}
         vpc_client = mock.MagicMock
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
@@ -56,8 +56,8 @@ class Test_networkfirewall_in_all_vpc:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = [
-            Firewall(
+        networkfirewall_client.network_firewalls = {
+            FIREWALL_ARN: Firewall(
                 arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
@@ -67,7 +67,7 @@ class Test_networkfirewall_in_all_vpc:
                 encryption_type="CUSTOMER_KMS",
                 deletion_protection=True,
             )
-        ]
+        }
         vpc_client = mock.MagicMock
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
@@ -139,7 +139,7 @@ class Test_networkfirewall_in_all_vpc:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = []
+        networkfirewall_client.network_firewalls = {}
         vpc_client = mock.MagicMock
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
@@ -211,7 +211,7 @@ class Test_networkfirewall_in_all_vpc:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = []
+        networkfirewall_client.network_firewalls = {}
 
         vpc_client = mock.MagicMock
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
@@ -284,8 +284,8 @@ class Test_networkfirewall_in_all_vpc:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = [
-            Firewall(
+        networkfirewall_client.network_firewalls = {
+            FIREWALL_ARN: Firewall(
                 arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
@@ -295,7 +295,7 @@ class Test_networkfirewall_in_all_vpc:
                 encryption_type="CUSTOMER_KMS",
                 deletion_protection=True,
             )
-        ]
+        }
         vpc_client = mock.MagicMock
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
@@ -405,7 +405,7 @@ class Test_networkfirewall_in_all_vpc:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = []
+        networkfirewall_client.network_firewalls = {}
         vpc_client = mock.MagicMock
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1
@@ -469,7 +469,7 @@ class Test_networkfirewall_in_all_vpc:
             [AWS_REGION_US_EAST_1]
         )
         networkfirewall_client.region = AWS_REGION_US_EAST_1
-        networkfirewall_client.network_firewalls = []
+        networkfirewall_client.network_firewalls = {}
         vpc_client = mock.MagicMock
         vpc_client.provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         vpc_client.region = AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc_test.py
@@ -58,7 +58,6 @@ class Test_networkfirewall_in_all_vpc:
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {
             FIREWALL_ARN: Firewall(
-                arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
                 policy_arn=POLICY_ARN,
@@ -286,7 +285,6 @@ class Test_networkfirewall_in_all_vpc:
         networkfirewall_client.region = AWS_REGION_US_EAST_1
         networkfirewall_client.network_firewalls = {
             FIREWALL_ARN: Firewall(
-                arn=FIREWALL_ARN,
                 name=FIREWALL_NAME,
                 region=AWS_REGION_US_EAST_1,
                 policy_arn=POLICY_ARN,

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
@@ -80,21 +80,30 @@ class Test_NetworkFirewall_Service:
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         networkfirewall = NetworkFirewall(aws_provider)
         assert len(networkfirewall.network_firewalls) == 1
-        assert networkfirewall.network_firewalls[0].arn == FIREWALL_ARN
-        assert networkfirewall.network_firewalls[0].region == AWS_REGION_US_EAST_1
-        assert networkfirewall.network_firewalls[0].name == FIREWALL_NAME
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].arn == FIREWALL_ARN
+        assert (
+            networkfirewall.network_firewalls[FIREWALL_ARN].region
+            == AWS_REGION_US_EAST_1
+        )
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].name == FIREWALL_NAME
 
     def test_describe_firewall(self):
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         networkfirewall = NetworkFirewall(aws_provider)
         assert len(networkfirewall.network_firewalls) == 1
-        assert networkfirewall.network_firewalls[0].arn == FIREWALL_ARN
-        assert networkfirewall.network_firewalls[0].region == AWS_REGION_US_EAST_1
-        assert networkfirewall.network_firewalls[0].name == FIREWALL_NAME
-        assert networkfirewall.network_firewalls[0].policy_arn == POLICY_ARN
-        assert networkfirewall.network_firewalls[0].vpc_id == VPC_ID
-        assert networkfirewall.network_firewalls[0].tags == [
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].arn == FIREWALL_ARN
+        assert (
+            networkfirewall.network_firewalls[FIREWALL_ARN].region
+            == AWS_REGION_US_EAST_1
+        )
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].name == FIREWALL_NAME
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].policy_arn == POLICY_ARN
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].vpc_id == VPC_ID
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].tags == [
             {"Key": "test_tag", "Value": "test_value"}
         ]
-        assert networkfirewall.network_firewalls[0].encryption_type == "CUSTOMER_KMS"
-        assert networkfirewall.network_firewalls[0].deletion_protection
+        assert (
+            networkfirewall.network_firewalls[FIREWALL_ARN].encryption_type
+            == "CUSTOMER_KMS"
+        )
+        assert networkfirewall.network_firewalls[FIREWALL_ARN].deletion_protection

--- a/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
+++ b/tests/providers/aws/services/networkfirewall/networkfirewall_service_test.py
@@ -80,7 +80,6 @@ class Test_NetworkFirewall_Service:
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         networkfirewall = NetworkFirewall(aws_provider)
         assert len(networkfirewall.network_firewalls) == 1
-        assert networkfirewall.network_firewalls[FIREWALL_ARN].arn == FIREWALL_ARN
         assert (
             networkfirewall.network_firewalls[FIREWALL_ARN].region
             == AWS_REGION_US_EAST_1
@@ -91,7 +90,6 @@ class Test_NetworkFirewall_Service:
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         networkfirewall = NetworkFirewall(aws_provider)
         assert len(networkfirewall.network_firewalls) == 1
-        assert networkfirewall.network_firewalls[FIREWALL_ARN].arn == FIREWALL_ARN
         assert (
             networkfirewall.network_firewalls[FIREWALL_ARN].region
             == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

`network_firewalls` variable is a list, but this does not align with other services structure and scalability.

### Description

`network_firewalls` has been changed from list to dict. This change will improve performance when accessing this variable and make the code more readable and maintainable. The new structure maintains backward compatibility and include necessary adjustments to any methods or functions interacting with the firewall list.

### Checklist

- Are there new checks included in this PR? No.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
