### PR TITLE
fix(aws): always use audited partition

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.py
@@ -28,7 +28,8 @@ class awslambda_function_invoke_api_operations_cloudtrail_logging_enabled(Check)
                             for resource in data_event.event_selector["DataResources"]:
                                 if resource["Type"] == "AWS::Lambda::Function" and (
                                     function.arn in resource["Values"]
-                                    or "arn:aws:lambda" in resource["Values"]
+                                    or f"arn:{awslambda_client.audited_partition}:lambda"
+                                    in resource["Values"]
                                 ):
                                     lambda_recorded_cloudtrail = True
                                     break

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -508,7 +508,7 @@ class EC2(AWSService):
 
             for page in describe_launch_templates_paginator.paginate():
                 for template in page["LaunchTemplates"]:
-                    template_arn = f"arn:aws:ec2:{regional_client.region}:{self.audited_account}:launch-template/{template['LaunchTemplateId']}"
+                    template_arn = f"arn:{self.audited_partition}:ec2:{regional_client.region}:{self.audited_account}:launch-template/{template['LaunchTemplateId']}"
                     if not self.audit_resources or (
                         is_resource_filtered(template_arn, self.audit_resources)
                     ):
@@ -575,7 +575,7 @@ class EC2(AWSService):
 
             for page in describe_client_vpn_endpoints_paginator.paginate():
                 for vpn_endpoint in page["ClientVpnEndpoints"]:
-                    vpn_endpoint_arn = f"arn:aws:ec2:{regional_client.region}:{self.audited_account}:client-vpn-endpoint/{vpn_endpoint['ClientVpnEndpointId']}"
+                    vpn_endpoint_arn = f"arn:{self.audited_partition}:ec2:{regional_client.region}:{self.audited_account}:client-vpn-endpoint/{vpn_endpoint['ClientVpnEndpointId']}"
                     if not self.audit_resources or (
                         is_resource_filtered(vpn_endpoint_arn, self.audit_resources)
                     ):

--- a/prowler/providers/aws/services/elasticache/elasticache_service.py
+++ b/prowler/providers/aws/services/elasticache/elasticache_service.py
@@ -98,7 +98,7 @@ class ElastiCache(AWSService):
                         member_clusters = repl_group.get("MemberClusters", [])
                         engine_version = "0.0"
                         if member_clusters:
-                            cluster_arn = f"arn:aws:elasticache:{regional_client.region}:{self.audited_account}:cluster:{member_clusters[0]}"
+                            cluster_arn = f"arn:{self.audited_partition}:elasticache:{regional_client.region}:{self.audited_account}:cluster:{member_clusters[0]}"
                             engine_version = self.clusters[cluster_arn].engine_version
 
                         self.replication_groups[replication_arn] = ReplicationGroup(

--- a/prowler/providers/aws/services/eventbridge/eventbridge_service.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_service.py
@@ -107,7 +107,7 @@ class Schema(AWSService):
             for registry in regional_client.list_registries()["Registries"]:
                 registry_arn = registry.get(
                     "RegistryArn",
-                    f"arn:aws:schemas:{regional_client.region}:{self.audited_account}:registry/{registry.get('RegistryName', '')}",
+                    f"arn:{self.audited_partition}:schemas:{regional_client.region}:{self.audited_account}:registry/{registry.get('RegistryName', '')}",
                 )
                 if not self.audit_resources or (
                     is_resource_filtered(registry_arn, self.audit_resources)

--- a/prowler/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa.py
+++ b/prowler/providers/aws/services/iam/iam_administrator_access_with_mfa/iam_administrator_access_with_mfa.py
@@ -22,7 +22,7 @@ class iam_administrator_access_with_mfa(Check):
                 for group_policy in group.attached_policies:
                     if (
                         group_policy["PolicyArn"]
-                        == "arn:aws:iam::aws:policy/AdministratorAccess"
+                        == f"arn:{iam_client.audited_partition}:iam::aws:policy/AdministratorAccess"
                     ):
                         # users in group are Administrators
                         if group.users:

--- a/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.py
+++ b/prowler/providers/aws/services/iam/iam_securityaudit_role_created/iam_securityaudit_role_created.py
@@ -9,7 +9,9 @@ class iam_securityaudit_role_created(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = iam_client.region
             report.resource_id = "SecurityAudit"
-            report.resource_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+            report.resource_arn = (
+                f"arn:{iam_client.audited_partition}:iam::aws:policy/SecurityAudit"
+            )
             if iam_client.entities_role_attached_to_securityaudit_policy:
                 report.status = "PASS"
                 report.status_extended = f"SecurityAudit policy attached to role {iam_client.entities_role_attached_to_securityaudit_policy[0]['RoleName']}."

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -69,13 +69,13 @@ class IAM(AWSService):
         self._list_attached_role_policies()
         self._list_mfa_devices()
         self.password_policy = self._get_password_policy()
-        support_policy_arn = (
-            "arn:aws:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
-        )
+        support_policy_arn = f"arn:{self.audited_partition}:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
         self.entities_role_attached_to_support_policy = (
             self._list_entities_role_for_policy(support_policy_arn)
         )
-        securityaudit_policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+        securityaudit_policy_arn = (
+            f"arn:{self.audited_partition}:iam::aws:policy/SecurityAudit"
+        )
         self.entities_role_attached_to_securityaudit_policy = (
             self._list_entities_role_for_policy(securityaudit_policy_arn)
         )

--- a/prowler/providers/aws/services/iam/iam_support_role_created/iam_support_role_created.py
+++ b/prowler/providers/aws/services/iam/iam_support_role_created/iam_support_role_created.py
@@ -9,9 +9,7 @@ class iam_support_role_created(Check):
             report = Check_Report_AWS(self.metadata())
             report.region = iam_client.region
             report.resource_id = "AWSSupportServiceRolePolicy"
-            report.resource_arn = (
-                "arn:aws:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
-            )
+            report.resource_arn = f"arn:{iam_client.audited_partition}:iam::aws:policy/aws-service-role/AWSSupportServiceRolePolicy"
             if iam_client.entities_role_attached_to_support_policy:
                 report.status = "PASS"
                 report.status_extended = f"Support policy attached to role {iam_client.entities_role_attached_to_support_policy[0]['RoleName']}."


### PR DESCRIPTION
### Context

Fix #5171 since Prowler was using by default the AWS commercial partition in some lines of code.

### Description

Use always the AWS partition of the account is being audited.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
