### PR TITLE
chore(autoscaling): deprecate check `autoscaling_find_secrets_ec2_launch_configuration`

### DIFF
--- a/prowler/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration.metadata.json
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "autoscaling_find_secrets_ec2_launch_configuration",
-  "CheckTitle": "Find secrets in EC2 Auto Scaling Launch Configuration",
+  "CheckTitle": "[DEPRECATED] Find secrets in EC2 Auto Scaling Launch Configuration",
   "CheckType": [
     "IAM"
   ],
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:partition:autoscaling:region:account-id:autoScalingGroupName/resource-name",
   "Severity": "critical",
   "ResourceType": "AwsAutoScalingLaunchConfiguration",
-  "Description": "Find secrets in EC2 Auto Scaling Launch Configuration",
+  "Description": "[DEPRECATED] Find secrets in EC2 Auto Scaling Launch Configuration",
   "Risk": "The use of a hard-coded password increases the possibility of password guessing.  If hard-coded passwords are used, it is possible that malicious users gain access through the account in question.",
   "RelatedUrl": "",
   "Remediation": {


### PR DESCRIPTION
### Context

Launch Configurations are in the process of becoming deprecated and their use is not recommended. [Ref](https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html).

### Description

- Add DEPRECATED to check metadata.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
