### PR TITLE
chore(ec2): add tags to report of EC2 launch templates

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_public_ip/ec2_launch_template_no_public_ip.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_public_ip/ec2_launch_template_no_public_ip.py
@@ -10,6 +10,7 @@ class ec2_launch_template_no_public_ip(Check):
             report.region = template.region
             report.resource_id = template.id
             report.resource_arn = template.arn
+            report.resource_tags = template.tags
 
             versions_with_autoassign_public_ip = []
             versions_with_network_interfaces_public_ip = []

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
@@ -19,6 +19,7 @@ class ec2_launch_template_no_secrets(Check):
             report.region = template.region
             report.resource_id = template.id
             report.resource_arn = template.arn
+            report.resource_tags = template.tags
 
             versions_with_secrets = []
 

--- a/tests/providers/aws/services/ec2/ec2_launch_template_no_public_ip/ec2_launch_template_no_public_ip_test.py
+++ b/tests/providers/aws/services/ec2/ec2_launch_template_no_public_ip/ec2_launch_template_no_public_ip_test.py
@@ -110,6 +110,11 @@ class Test_ec2_launch_template_no_public_ip:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     def test_launch_template_public_ip_auto_assign(self):
         ec2_client = mock.MagicMock()
@@ -166,6 +171,11 @@ class Test_ec2_launch_template_no_public_ip:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     def test_network_interface_with_public_ipv4_network_interface_autoassign_true_and_false(
         self,
@@ -258,6 +268,11 @@ class Test_ec2_launch_template_no_public_ip:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     def test_network_interface_with_public_ipv6_network_interface_autoassign_true_and_false(
         self,
@@ -340,3 +355,8 @@ class Test_ec2_launch_template_no_public_ip:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets_test.py
+++ b/tests/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets_test.py
@@ -42,6 +42,9 @@ def mock_make_api_call(self, operation_name, kwarg):
                 {
                     "LaunchTemplateName": "tester1",
                     "LaunchTemplateId": "lt-1234567890",
+                    "Tags": [
+                        {"Key": "Name", "Value": "tester1"},
+                    ],
                 }
             ]
         }
@@ -122,10 +125,13 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_one_launch_template_with_secrets(self):
-
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
@@ -153,6 +159,10 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == "lt-1234567890"
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_arn == (
+                "arn:aws:ec2:us-east-1:123456789012:launch-template/lt-1234567890"
+            )
+            assert result[0].resource_tags == [{"Key": "Name", "Value": "tester1"}]
 
     def test_one_launch_template_with_secrets_in_multiple_versions(self):
         ec2_client = mock.MagicMock()
@@ -217,6 +227,10 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     def test_one_launch_template_with_secrets_in_single_version(self):
         ec2_client = mock.MagicMock()
@@ -287,6 +301,10 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     def test_one_launch_template_with_secrets_gzip(self):
         ec2_client = mock.MagicMock()
@@ -347,6 +365,10 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     @mock_aws
     def test_one_launch_template_without_user_data(self):
@@ -392,6 +414,10 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
+            )
+            assert result[0].resource_tags == []
 
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_two_launch_templates_one_template_with_secrets(self):
@@ -480,6 +506,10 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == launch_template_id1
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id1}"
+            )
+            assert result[0].resource_tags == []
 
             assert result[1].status == "PASS"
             assert (
@@ -488,6 +518,10 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[1].resource_id == launch_template_id2
             assert result[1].region == AWS_REGION_US_EAST_1
+            assert result[1].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id2}"
+            )
+            assert result[1].resource_tags == []
 
     @mock_aws
     def test_one_launch_template_with_unicode_error(self):
@@ -535,8 +569,7 @@ class Test_ec2_launch_template_no_secrets:
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
-            assert (
-                result[0].resource_arn
-                == f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
+            assert result[0].resource_arn == (
+                f"arn:aws:ec2:us-east-1:123456789012:launch-template/{launch_template_id}"
             )
             assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ec2/ec2_service_test.py
+++ b/tests/providers/aws/services/ec2/ec2_service_test.py
@@ -676,6 +676,14 @@ class Test_EC2_Service:
                     KNOWN_SECRET_USER_DATA.encode(encoding_format_utf_8)
                 ).decode(encoding_format_utf_8),
             },
+            TagSpecifications=[
+                {
+                    "ResourceType": "launch-template",
+                    "Tags": [
+                        {"Key": "test", "Value": "test"},
+                    ],
+                }
+            ],
         )
 
         # EC2 client for this test class
@@ -691,6 +699,9 @@ class Test_EC2_Service:
             ec2.launch_templates[0].arn
             == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:launch-template/{ec2.launch_templates[0].id}"
         )
+        assert ec2.launch_templates[0].tags == [
+            {"Key": "test", "Value": "test"},
+        ]
 
     # Test EC2 Describe Launch Templates
     @mock_aws


### PR DESCRIPTION
### Context

Add tags to Launch Templates related checks.

### Description

- Add tags to LaunchTempates checks
- Add missing assert to tests

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
