### PR TITLE
fix(tests): patch `head_bucket` function correctly

### DIFF
--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket_test.py
@@ -18,7 +18,7 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
         # Distributions
         cloudfront_client = mock.MagicMock
         cloudfront_client.distributions = {}
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         # Buckets
         s3_client.buckets = {}
 
@@ -38,10 +38,6 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
 
             assert len(result) == 0
 
-    @mock.patch(
-        "prowler.providers.aws.services.s3.s3_service.S3._head_bucket",
-        new=mock.MagicMock(return_value=False),
-    )
     def test_distribution_nonexistent_origins(self):
         # Distributions
         domain = "nonexistent-bucket.s3.eu-west-1.amazonaws.com"
@@ -64,7 +60,7 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
         }
         # Buckets
         nonexistent_bucket = "nonexistent-bucket"
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         s3_client.buckets = {}
 
         with mock.patch(
@@ -72,6 +68,9 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
         ), mock.patch(
             "prowler.providers.aws.services.cloudfront.cloudfront_service.CloudFront",
             new=cloudfront_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudfront.cloudfront_distributions_s3_origin_non_existent_bucket.cloudfront_distributions_s3_origin_non_existent_bucket.s3_client._head_bucket",
+            new=mock.MagicMock(return_value=False),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudfront.cloudfront_distributions_s3_origin_non_existent_bucket.cloudfront_distributions_s3_origin_non_existent_bucket import (
@@ -91,10 +90,6 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
                 == f"CloudFront Distribution {DISTRIBUTION_ID} has non-existent S3 buckets as origins: {nonexistent_bucket}."
             )
 
-    @mock.patch(
-        "prowler.providers.aws.services.s3.s3_service.S3._head_bucket",
-        new=mock.MagicMock(return_value=True),
-    )
     def test_distribution_no_nonexistent_origins(self):
         # Distributions
         domain = "existent-bucket.s3.eu-west-1.amazonaws.com"
@@ -117,7 +112,7 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
         }
         # Buckets
         bucket_name = "existent-bucket"
-        s3_client = mock.MagicMock
+        s3_client = mock.MagicMock()
         s3_client.audited_account = AWS_ACCOUNT_NUMBER
         s3_client.buckets = {
             f"arn:aws:s3:::{bucket_name}": Bucket(
@@ -131,6 +126,9 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
         ), mock.patch(
             "prowler.providers.aws.services.cloudfront.cloudfront_service.CloudFront",
             new=cloudfront_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudfront.cloudfront_distributions_s3_origin_non_existent_bucket.cloudfront_distributions_s3_origin_non_existent_bucket.s3_client._head_bucket",
+            new=mock.MagicMock(return_value=True),
         ):
             # Test Check
             from prowler.providers.aws.services.cloudfront.cloudfront_distributions_s3_origin_non_existent_bucket.cloudfront_distributions_s3_origin_non_existent_bucket import (


### PR DESCRIPTION
### Context

Tests for the check `cloudfront_distributions_s3_origin_non_existent_bucket` were failing because of mocking the `head_bucket` function incorrectly.

### Description

By specifically patching `s3_client._head_bucket` within the context of each test, we're ensuring that it returns the correct values.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
