### PR TITLE
fix(ecs): Adjust code to the new ARN formats in the ECS service

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -35,7 +35,7 @@ class ECS(AWSService):
                     ):
                         self.task_definitions[task_definition] = TaskDefinition(
                             # we want the family name without the revision
-                            name=sub(":.*", "", task_definition.split("/")[1]),
+                            name=sub(":.*", "", task_definition.split("/")[-1]),
                             arn=task_definition,
                             revision=task_definition.split(":")[-1],
                             region=regional_client.region,
@@ -111,7 +111,7 @@ class ECS(AWSService):
                     service_desc = describe_response["services"][0]
                     service_arn = service_desc["serviceArn"]
                     service_obj = Service(
-                        name=sub(":.*", "", service_arn.split("/")[2]),
+                        name=sub(":.*", "", service_arn.split("/")[-1]),
                         arn=service_arn,
                         region=cluster.region,
                         assign_public_ip=(
@@ -139,7 +139,7 @@ class ECS(AWSService):
                         is_resource_filtered(cluster, self.audit_resources)
                     ):
                         self.clusters[cluster] = Cluster(
-                            name=sub(":.*", "", cluster.split("/")[1]),
+                            name=sub(":.*", "", cluster.split("/")[-1]),
                             arn=cluster,
                             region=regional_client.region,
                         )

--- a/tests/providers/aws/services/ecs/ecs_service_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_test.py
@@ -12,7 +12,7 @@ def mock_make_api_call(self, operation_name, kwarg):
     if operation_name == "ListTaskDefinitions":
         return {
             "taskDefinitionArns": [
-                "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_ecs_task:1"
+                "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_cluster_1/test_ecs_task:1"
             ]
         }
     if operation_name == "DescribeTaskDefinition":
@@ -117,7 +117,7 @@ class Test_ECS_Service:
         aws_provider = set_mocked_aws_provider()
         ecs = ECS(aws_provider)
 
-        task_arn = "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_ecs_task:1"
+        task_arn = "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_cluster_1/test_ecs_task:1"
 
         assert len(ecs.task_definitions) == 1
         assert ecs.task_definitions[task_arn].name == "test_ecs_task"
@@ -131,7 +131,7 @@ class Test_ECS_Service:
         aws_provider = set_mocked_aws_provider()
         ecs = ECS(aws_provider)
 
-        task_arn = "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_ecs_task:1"
+        task_arn = "arn:aws:ecs:eu-west-1:123456789012:task-definition/test_cluster_1/test_ecs_task:1"
 
         assert len(ecs.task_definitions) == 1
         assert ecs.task_definitions[task_arn].name == "test_ecs_task"


### PR DESCRIPTION
### Context

While doing a check I noticed that AWS was updating some ARNs that would break our current ecs service. In order to stop that from happening we need to adjust the code to the new ARN format and making it that works with the actual ARN. 

Link to the ARN updates [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids). Chapter: Amazon Resource Name (ARN) format

### Description

Changed how we get the name of services and task definitions to avoid it to fail once the new ARN format is implemented.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
