### PR TITLE
test(aws): fix failing tests for `ecs_task_definitions_logging_enabled` and `ssm_managed_compliant_patching`

### DIFF
--- a/tests/providers/aws/services/ecs/ecs_task_definitions_logging_enabled/ecs_task_definitions_logging_enabled_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_logging_enabled/ecs_task_definitions_logging_enabled_test.py
@@ -1,50 +1,15 @@
 from unittest import mock
 
-import botocore
-
 from prowler.providers.aws.services.ecs.ecs_service import (
     ContainerDefinition,
     TaskDefinition,
 )
-from tests.providers.aws.utils import (
-    AWS_ACCOUNT_NUMBER,
-    AWS_REGION_US_EAST_1,
-    set_mocked_aws_provider,
-)
+from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
 
 TASK_NAME = "test-task"
 TASK_REVISION = "1"
 CONTAINER_NAME = "test-container"
 TASK_ARN = f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:task-definition/{TASK_NAME}:{TASK_REVISION}"
-
-
-make_api_call = botocore.client.BaseClient._make_api_call
-
-
-def mock_make_api_call(self, operation_name, kwarg):
-    if operation_name == "ListTaskDefinitions":
-        return {
-            "taskDefinitionArns": [
-                "arn:aws:ecs:eu-west-1:123456789012:task-definition/test-task:1"
-            ]
-        }
-    if operation_name == "DescribeTaskDefinition":
-        return {
-            "taskDefinition": {
-                "containerDefinitions": [
-                    {
-                        "name": "test-container",
-                        "image": "test-image",
-                        "environment": [
-                            {"name": "DB_PASSWORD", "value": "pass-12343"},
-                        ],
-                    }
-                ],
-                "networkMode": "host",
-                "tags": [],
-            }
-        }
-    return make_api_call(self, operation_name, kwarg)
 
 
 class Test_ecs_task_definitions_logging_enabled:
@@ -55,6 +20,9 @@ class Test_ecs_task_definitions_logging_enabled:
         with mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
+            ecs_client,
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (
                 ecs_task_definitions_logging_enabled,
@@ -64,19 +32,33 @@ class Test_ecs_task_definitions_logging_enabled:
             result = check.execute()
             assert len(result) == 0
 
-    @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_task_definition_no_logconfiguration(self):
+        ecs_client = mock.MagicMock
+        ecs_client.task_definitions = {}
 
-        from prowler.providers.aws.services.ecs.ecs_service import ECS
-
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        ecs_client.task_definitions[TASK_ARN] = TaskDefinition(
+            name=TASK_NAME,
+            arn=TASK_ARN,
+            revision=TASK_REVISION,
+            region=AWS_REGION_US_EAST_1,
+            network_mode="host",
+            container_definitions=[
+                ContainerDefinition(
+                    name=CONTAINER_NAME,
+                    image="test-image",
+                    privileged=False,
+                    user="user-1",
+                    environment=[{"name": "DB_PASSWORD", "value": "pass-12343"}],
+                )
+            ],
+        )
 
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
+            "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
         ), mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled.ecs_client",
-            new=ECS(aws_provider),
+            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
+            ecs_client,
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (
                 ecs_task_definitions_logging_enabled,
@@ -114,6 +96,9 @@ class Test_ecs_task_definitions_logging_enabled:
         with mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
             ecs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
+            ecs_client,
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (
                 ecs_task_definitions_logging_enabled,
@@ -150,6 +135,9 @@ class Test_ecs_task_definitions_logging_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.ecs.ecs_service.ECS",
+            ecs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
             ecs_client,
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (

--- a/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
+++ b/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
@@ -21,6 +21,9 @@ class Test_ssm_managed_compliant_patching:
             "prowler.providers.aws.services.ssm.ssm_service.SSM",
             new=ssm_client,
         ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
+            new=ssm_client,
+        ), mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ), mock.patch(
@@ -62,6 +65,9 @@ class Test_ssm_managed_compliant_patching:
 
         with mock.patch(
             "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
             new=ssm_client,
         ), mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -120,6 +126,9 @@ class Test_ssm_managed_compliant_patching:
 
         with mock.patch(
             "prowler.providers.aws.services.ssm.ssm_service.SSM",
+            new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_client.ssm_client",
             new=ssm_client,
         ), mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
+++ b/tests/providers/aws/services/ssm/ssm_managed_compliant_patching/ssm_managed_compliant_patching_test.py
@@ -15,9 +15,17 @@ class Test_ssm_managed_compliant_patching:
     def test_no_compliance_resources(self):
         ssm_client = mock.MagicMock
         ssm_client.compliance_resources = {}
+        ec2_client = mock.MagicMock
+
         with mock.patch(
             "prowler.providers.aws.services.ssm.ssm_service.SSM",
             new=ssm_client,
+        ), mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+        ), mock.patch(
+            "prowler.providers.aws.services.ssm.ssm_managed_compliant_patching.ssm_managed_compliant_patching.ec2_client",
+            new=ec2_client,
         ):
             # Test Check
             from prowler.providers.aws.services.ssm.ssm_managed_compliant_patching.ssm_managed_compliant_patching import (


### PR DESCRIPTION
### Context

Some tests were failing

### Description

- Improve patching for ECS test
- Add EC2 client patching to ssm check

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
