### PR TITLE
feat(redshift): add new check `redshift_cluster_non_default_username`

### DIFF
--- a/prowler/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username.metadata.json
+++ b/prowler/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "redshift_cluster_non_default_username",
+  "CheckTitle": "Check if Amazon Redshift clusters are using the default Admin username.",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "redshift",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:redshift:region:account-id:cluster/cluster-name",
+  "Severity": "medium",
+  "ResourceType": "AwsRedshiftCluster",
+  "Description": "This control checks whether an Amazon Redshift cluster has changed the admin username from its default value. The control fails if the admin username is set to 'awsuser'.",
+  "Risk": "Using the default admin username increases the risk of unauthorized access, as default credentials are publicly known and often targeted by attackers.",
+  "RelatedUrl": "https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-prereq.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws redshift create-cluster --cluster-identifier <cluster-id> --master-username <new-username> --master-user-password <password>",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/redshift-controls.html#redshift-8",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Change the default admin username by creating a new Redshift cluster with a unique admin username.",
+      "Url": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Redshift/master-username.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username.py
+++ b/prowler/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username.py
@@ -1,0 +1,24 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.redshift.redshift_client import redshift_client
+
+
+class redshift_cluster_public_access(Check):
+    def execute(self):
+        findings = []
+        for cluster in redshift_client.clusters:
+            report = Check_Report_AWS(self.metadata())
+            report.region = cluster.region
+            report.resource_id = cluster.id
+            report.resource_arn = cluster.arn
+            report.resource_tags = cluster.tags
+            report.status = "PASS"
+            report.status_extended = f"Redshift Cluster {cluster.id} does not have the default Admin username."
+            if cluster.masterusername == "awsuser":
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"Redshift Cluster {cluster.id} has the default Admin username."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username.py
+++ b/prowler/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username.py
@@ -2,7 +2,7 @@ from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.redshift.redshift_client import redshift_client
 
 
-class redshift_cluster_public_access(Check):
+class redshift_cluster_non_default_username(Check):
     def execute(self):
         findings = []
         for cluster in redshift_client.clusters:

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -32,6 +32,7 @@ class Redshift(AWSService):
                             id=cluster["ClusterIdentifier"],
                             region=regional_client.region,
                             tags=cluster.get("Tags"),
+                            masterusername=cluster.get("MasterUsername", ""),
                         )
                         if (
                             "PubliclyAccessible" in cluster
@@ -96,6 +97,7 @@ class Cluster(BaseModel):
     arn: str
     region: str
     public_access: bool = None
+    masterusername: str = None
     endpoint_address: str = None
     allow_version_upgrade: bool = None
     logging_enabled: bool = None

--- a/tests/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username_test.py
+++ b/tests/providers/aws/services/redshift/redshift_cluster_non_default_username/redshift_cluster_non_default_username_test.py
@@ -1,0 +1,132 @@
+from unittest import mock
+from uuid import uuid4
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+CLUSTER_ID = str(uuid4())
+CLUSTER_ARN = (
+    f"arn:aws:redshift:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:cluster:{CLUSTER_ID}"
+)
+
+
+class Test_redshift_cluster_non_default_username:
+    def test_no_clusters(self):
+        from prowler.providers.aws.services.redshift.redshift_service import Redshift
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.redshift.redshift_cluster_non_default_username.redshift_cluster_non_default_username.redshift_client",
+                new=Redshift(aws_provider),
+            ):
+                from prowler.providers.aws.services.redshift.redshift_cluster_non_default_username.redshift_cluster_non_default_username import (
+                    redshift_cluster_non_default_username,
+                )
+
+                check = redshift_cluster_non_default_username()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_cluster_default_username(self):
+        redshift_client = client("redshift", region_name=AWS_REGION_EU_WEST_1)
+        redshift_client.create_cluster(
+            DBName="test",
+            ClusterIdentifier=CLUSTER_ID,
+            ClusterType="single-node",
+            NodeType="ds2.xlarge",
+            MasterUsername="awsuser",
+            MasterUserPassword="password",
+            PubliclyAccessible=True,
+            Tags=[
+                {"Key": "test", "Value": "test"},
+            ],
+            Port=9439,
+            Encrypted=False,
+        )
+        from prowler.providers.aws.services.redshift.redshift_service import Redshift
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.redshift.redshift_cluster_non_default_username.redshift_cluster_non_default_username.redshift_client",
+                new=Redshift(aws_provider),
+            ):
+                from prowler.providers.aws.services.redshift.redshift_cluster_non_default_username.redshift_cluster_non_default_username import (
+                    redshift_cluster_non_default_username,
+                )
+
+                check = redshift_cluster_non_default_username()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert result[0].status_extended == (
+                    f"Redshift Cluster {CLUSTER_ID} has the default Admin username."
+                )
+                assert result[0].resource_id == CLUSTER_ID
+                assert result[0].resource_arn == CLUSTER_ARN
+                assert result[0].region == AWS_REGION_EU_WEST_1
+                assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]
+
+    @mock_aws
+    def test_cluster_non_default_username(self):
+        redshift_client = client("redshift", region_name=AWS_REGION_EU_WEST_1)
+        redshift_client.create_cluster(
+            DBName="test",
+            ClusterIdentifier=CLUSTER_ID,
+            ClusterType="single-node",
+            NodeType="ds2.xlarge",
+            MasterUsername="user",
+            MasterUserPassword="password",
+            PubliclyAccessible=True,
+            Tags=[
+                {"Key": "test", "Value": "test"},
+            ],
+            Port=9439,
+            Encrypted=True,
+        )
+        from prowler.providers.aws.services.redshift.redshift_service import Redshift
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.redshift.redshift_cluster_non_default_username.redshift_cluster_non_default_username.redshift_client",
+                new=Redshift(aws_provider),
+            ):
+                from prowler.providers.aws.services.redshift.redshift_cluster_non_default_username.redshift_cluster_non_default_username import (
+                    redshift_cluster_non_default_username,
+                )
+
+                check = redshift_cluster_non_default_username()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert result[0].status_extended == (
+                    f"Redshift Cluster {CLUSTER_ID} does not have the default Admin username."
+                )
+                assert result[0].resource_id == CLUSTER_ID
+                assert result[0].resource_arn == CLUSTER_ARN
+                assert result[0].region == AWS_REGION_EU_WEST_1
+                assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]

--- a/tests/providers/aws/services/redshift/redshift_service_test.py
+++ b/tests/providers/aws/services/redshift/redshift_service_test.py
@@ -112,6 +112,7 @@ class Test_Redshift_Service:
         assert redshift.clusters[0].tags == [
             {"Key": "test", "Value": "test"},
         ]
+        assert redshift.clusters[0].masterusername == "user"
 
     @mock_aws
     def test_describe_logging_status(self):


### PR DESCRIPTION
### Context

This new check verifies that Amazon Redshift clusters do not use the default admin username "awsuser". Using a non-default username is crucial for reducing the risk of unauthorized access, as default usernames are well-known and often targeted by attackers.

### Description

Added new check `redshift_cluster_non_default_username` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
