### PR TITLE
feat(guardduty): add new check `guardduty_eks_audit_log_enabled`

### DIFF
--- a/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
@@ -7,10 +7,10 @@
   ],
   "ServiceName": "guardduty",
   "SubServiceName": "",
-  "ResourceIdTemplate": "",
+  "ResourceIdTemplate": "arn:aws:guardduty:region:account-id/detector-id",
   "Severity": "high",
   "ResourceType": "AwsEksCluster",
-  "Description": "This control checks whether GuardDuty EKS Audit Log Monitoring is enabled. For a standalone account, the control fails if GuardDuty EKS Audit Log Monitoring is disabled in the account. In a multi-account environment, the control fails if the delegated GuardDuty administrator account and all member accounts don't have EKS Audit Log Monitoring enabled.",
+  "Description": "Checks whether GuardDuty EKS Audit Log Monitoring is enabled as source in a detector.",
   "Risk": "Without GuardDuty EKS Audit Log Monitoring enabled, you may not be able to detect potentially suspicious activities in your Amazon Elastic Kubernetes Service (Amazon EKS) clusters.",
   "RelatedUrl": "https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html",
   "Remediation": {
@@ -21,8 +21,8 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Enable GuardDuty EKS Audit Log Monitoring in your account. In a multi-account environment, the delegated GuardDuty administrator must enable EKS Audit Log Monitoring for all member accounts.",
-      "Url": "https://docs.aws.amazon.com/guardduty/latest/ug/eks-protection-enable-standalone-account.html"
+      "Text": "Enable GuardDuty EKS Audit Log Monitoring to detect potentially suspicious activities in your Amazon Elastic Kubernetes Service (Amazon EKS) clusters.",
+      "Url": "https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-5"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "guardduty_eks_audit_log_enabled",
+  "CheckTitle": "GuardDuty EKS Audit Log Monitoring Enabled",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices/Runtime Behavior Analysis"
+  ],
+  "ServiceName": "guardduty",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "AwsEksCluster",
+  "Description": "This control checks whether GuardDuty EKS Audit Log Monitoring is enabled. For a standalone account, the control fails if GuardDuty EKS Audit Log Monitoring is disabled in the account. In a multi-account environment, the control fails if the delegated GuardDuty administrator account and all member accounts don't have EKS Audit Log Monitoring enabled.",
+  "Risk": "Without GuardDuty EKS Audit Log Monitoring enabled, you may not be able to detect potentially suspicious activities in your Amazon Elastic Kubernetes Service (Amazon EKS) clusters.",
+  "RelatedUrl": "https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws guardduty update-detector --detector-id <detector-id> --data-sources '{\"Kubernetes\": {\"AuditLogs\": {\"Enabled\": true}}}'",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable GuardDuty EKS Audit Log Monitoring in your account. In a multi-account environment, the delegated GuardDuty administrator must enable EKS Audit Log Monitoring for all member accounts.",
+      "Url": "https://docs.aws.amazon.com/guardduty/latest/ug/eks-protection-enable-standalone-account.html"
+    }
+  },
+  "Categories": [
+    "logging"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
@@ -9,7 +9,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:guardduty:region:account-id/detector-id",
   "Severity": "high",
-  "ResourceType": "AwsEksCluster",
+  "ResourceType": "AwsGuardDutyDetector",
   "Description": "Checks whether GuardDuty EKS Audit Log Monitoring is enabled as source in a detector.",
   "Risk": "Without GuardDuty EKS Audit Log Monitoring enabled, you may not be able to detect potentially suspicious activities in your Amazon Elastic Kubernetes Service (Amazon EKS) clusters.",
   "RelatedUrl": "https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html",

--- a/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
@@ -15,7 +15,7 @@
   "RelatedUrl": "https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html",
   "Remediation": {
     "Code": {
-      "CLI": "aws guardduty update-detector --detector-id <detector-id> --data-sources '{\"Kubernetes\": {\"AuditLogs\": {\"Enabled\": true}}}'",
+      "CLI": "aws guardduty update-detector --detector-id <detector-id> --data-sources Kubernetes={AuditLogs={Enable=true}}",
       "NativeIaC": "",
       "Other": "",
       "Terraform": ""

--- a/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.metadata.json
@@ -17,12 +17,12 @@
     "Code": {
       "CLI": "aws guardduty update-detector --detector-id <detector-id> --data-sources Kubernetes={AuditLogs={Enable=true}}",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-5",
       "Terraform": ""
     },
     "Recommendation": {
       "Text": "Enable GuardDuty EKS Audit Log Monitoring to detect potentially suspicious activities in your Amazon Elastic Kubernetes Service (Amazon EKS) clusters.",
-      "Url": "https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-5"
+      "Url": "https://docs.aws.amazon.com/guardduty/latest/ug/eks-protection-enable-standalone-account.html"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.py
@@ -13,9 +13,9 @@ class guardduty_eks_audit_log_enabled(Check):
                 report.resource_arn = detector.arn
                 report.resource_tags = detector.tags
                 report.status = "FAIL"
-                report.status_extended = f"GuardDuty detector {detector.id} does not have EKS Audit Log Protection enabled."
+                report.status_extended = f"GuardDuty detector {detector.id} does not have EKS Audit Log Monitoring enabled."
                 if detector.eks_audit_log_protection:
                     report.status = "PASS"
-                    report.status_extended = f"GuardDuty detector {detector.id} has EKS Audit Log Protection enabled."
+                    report.status_extended = f"GuardDuty detector {detector.id} has EKS Audit Log Monitoring enabled."
                 findings.append(report)
         return findings

--- a/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled.py
@@ -1,0 +1,21 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.guardduty.guardduty_client import guardduty_client
+
+
+class guardduty_eks_audit_log_enabled(Check):
+    def execute(self):
+        findings = []
+        for detector in guardduty_client.detectors:
+            if detector.status:
+                report = Check_Report_AWS(self.metadata())
+                report.region = detector.region
+                report.resource_id = detector.id
+                report.resource_arn = detector.arn
+                report.resource_tags = detector.tags
+                report.status = "FAIL"
+                report.status_extended = f"GuardDuty detector {detector.id} does not have EKS Audit Log Protection enabled."
+                if detector.eks_audit_log_protection:
+                    report.status = "PASS"
+                    report.status_extended = f"GuardDuty detector {detector.id} has EKS Audit Log Protection enabled."
+                findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/guardduty/guardduty_rds_protection_enabled/guardduty_rds_protection_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_rds_protection_enabled/guardduty_rds_protection_enabled.metadata.json
@@ -15,7 +15,7 @@
   "RelatedUrl": "https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/guard-duty-rds-protection.html",
   "Remediation": {
     "Code": {
-      "CLI": "",
+      "CLI": "aws guardduty update-detector --detector-id <detector-id> --features Name=RDS_LOGIN_EVENTS,Status=ENABLED",
       "NativeIaC": "",
       "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-9",
       "Terraform": ""

--- a/prowler/providers/aws/services/guardduty/guardduty_s3_protection_enabled/guardduty_s3_protection_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_s3_protection_enabled/guardduty_s3_protection_enabled.metadata.json
@@ -15,7 +15,7 @@
   "RelatedUrl": "https://docs.aws.amazon.com/guardduty/latest/ug/s3_detection.html",
   "Remediation": {
     "Code": {
-      "CLI": "aws guardduty update-detector --detector-id <detector-id> --data-sources '{\"S3Logs\": {\"Enable\": true}}'",
+      "CLI": "aws guardduty update-detector --detector-id <detector-id> --data-sources S3Logs={Enable=true}}'",
       "NativeIaC": "",
       "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-10",
       "Terraform": ""

--- a/prowler/providers/aws/services/guardduty/guardduty_service.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_service.py
@@ -212,4 +212,4 @@ class Detector(BaseModel):
     tags: Optional[list] = []
     s3_protection: bool = False
     rds_protection: bool = False
-    eks_audit_log_protection: Optional[bool]
+    eks_audit_log_protection: bool = False

--- a/tests/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled_test.py
@@ -1,0 +1,143 @@
+from unittest.mock import patch
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_guardduty_eks_audit_log_enabled:
+    def test_no_detectors(self):
+        aws_provider = set_mocked_aws_provider()
+
+        from prowler.providers.aws.services.guardduty.guardduty_service import GuardDuty
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled.guardduty_client",
+            new=GuardDuty(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled import (
+                guardduty_eks_audit_log_enabled,
+            )
+
+            check = guardduty_eks_audit_log_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_detector_disabled(self):
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
+
+        guardduty_client.create_detector(Enable=False)
+
+        aws_provider = set_mocked_aws_provider()
+
+        from prowler.providers.aws.services.guardduty.guardduty_service import GuardDuty
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled.guardduty_client",
+            new=GuardDuty(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled import (
+                guardduty_eks_audit_log_enabled,
+            )
+
+            check = guardduty_eks_audit_log_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_detector_eks_audit_log_enabled(self):
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
+
+        detector_id = guardduty_client.create_detector(
+            Enable=True, DataSources={"Kubernetes": {"AuditLogs": {"Enable": True}}}
+        )["DetectorId"]
+
+        aws_provider = set_mocked_aws_provider()
+
+        from prowler.providers.aws.services.guardduty.guardduty_service import GuardDuty
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled.guardduty_client",
+            new=GuardDuty(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled import (
+                guardduty_eks_audit_log_enabled,
+            )
+
+            check = guardduty_eks_audit_log_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"GuardDuty detector {detector_id} has EKS Audit Log Protection enabled."
+            )
+            assert result[0].resource_id == detector_id
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{detector_id}"
+            )
+            assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_detector_eks_audit_log_disabled(self):
+        guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
+
+        detector_id = guardduty_client.create_detector(
+            Enable=True, DataSources={"Kubernetes": {"AuditLogs": {"Enable": False}}}
+        )["DetectorId"]
+
+        aws_provider = set_mocked_aws_provider()
+
+        from prowler.providers.aws.services.guardduty.guardduty_service import GuardDuty
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled.guardduty_client",
+            new=GuardDuty(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.guardduty.guardduty_eks_audit_log_enabled.guardduty_eks_audit_log_enabled import (
+                guardduty_eks_audit_log_enabled,
+            )
+
+            check = guardduty_eks_audit_log_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"GuardDuty detector {detector_id} does not have EKS Audit Log Protection enabled."
+            )
+            assert result[0].resource_id == detector_id
+            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{detector_id}"
+            )
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_eks_audit_log_enabled/guardduty_eks_audit_log_enabled_test.py
@@ -91,7 +91,7 @@ class Test_guardduty_eks_audit_log_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {detector_id} has EKS Audit Log Protection enabled."
+                == f"GuardDuty detector {detector_id} has EKS Audit Log Monitoring enabled."
             )
             assert result[0].resource_id == detector_id
             assert result[0].region == AWS_REGION_EU_WEST_1
@@ -132,7 +132,7 @@ class Test_guardduty_eks_audit_log_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"GuardDuty detector {detector_id} does not have EKS Audit Log Protection enabled."
+                == f"GuardDuty detector {detector_id} does not have EKS Audit Log Monitoring enabled."
             )
             assert result[0].resource_id == detector_id
             assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/guardduty/guardduty_service_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_service_test.py
@@ -111,7 +111,10 @@ class Test_GuardDuty_Service:
         guardduty_client = client("guardduty", region_name=AWS_REGION_EU_WEST_1)
         response = guardduty_client.create_detector(
             Enable=True,
-            DataSources={"S3Logs": {"Enable": True}},
+            DataSources={
+                "S3Logs": {"Enable": True},
+                "Kubernetes": {"AuditLogs": {"Enable": True}},
+            },
         )
 
         aws_provider = set_mocked_aws_provider()
@@ -129,6 +132,7 @@ class Test_GuardDuty_Service:
         assert guardduty.detectors[0].administrator_account == "123456789013"
         assert guardduty.detectors[0].s3_protection
         assert not guardduty.detectors[0].rds_protection
+        assert guardduty.detectors[0].eks_audit_log_protection
         assert guardduty.detectors[0].region == AWS_REGION_EU_WEST_1
         assert guardduty.detectors[0].tags == [{"test": "test"}]
 


### PR DESCRIPTION
### Context

Checks if GuardDuty EKS Audit Log Monitoring is enabled in the detector.

### Description

- [x]  Modify service to add EKS Audit Log Monitoring as source in Detector
- [x]  Test new Detector parameter
- [x]  Add check logic
- [x]  Add unit testing for the check

### Checklist

- Are there new checks included in this PR? Yes 
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
