### PR TITLE
chore(secrets): use `master` branch of Yelp/detect-secrets

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1302,15 +1302,13 @@ wrapt = ">=1.10,<2"
 dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
 
 [[package]]
-name = "detect-secrets"
+name = "detect_secrets"
 version = "1.5.0"
 description = "Tool for detecting secrets in the codebase"
 optional = false
 python-versions = "*"
-files = [
-    {file = "detect_secrets-1.5.0-py3-none-any.whl", hash = "sha256:e24e7b9b5a35048c313e983f76c4bd09dad89f045ff059e354f9943bf45aa060"},
-    {file = "detect_secrets-1.5.0.tar.gz", hash = "sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pyyaml = "*"
@@ -1319,6 +1317,12 @@ requests = "*"
 [package.extras]
 gibberish = ["gibberish-detector"]
 word-list = ["pyahocorasick"]
+
+[package.source]
+type = "git"
+url = "https://github.com/Yelp/detect-secrets.git"
+reference = "master"
+resolved_reference = "462720710ec337300fab2b4f2290949c7ee141eb"
 
 [[package]]
 name = "dill"
@@ -5068,4 +5072,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "f99a8859e7618ddc32babfd9b742ee8f8cc4520c274e245b358a0df252d56ee6"
+content-hash = "0b367fa80501022efe43dc1beaa7f3da278fb64ffaddece72a0e88b09a0e53a2"

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -337,7 +337,8 @@ aws:
 
   # AWS Secrets Configuration
   # Patterns to ignore in the secrets checks
-  secrets_ignore_patterns: []
+  # The Metadata API is ignored by default
+  secrets_ignore_patterns: ["169.254.169.254"]
 
 # Azure Configuration
 azure:

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -337,7 +337,6 @@ aws:
 
   # AWS Secrets Configuration
   # Patterns to ignore in the secrets checks
-  # The Metadata API is ignored by default
   secrets_ignore_patterns: []
 
 # Azure Configuration

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -335,8 +335,8 @@ aws:
   elbv2_min_azs: 2
 
 
-  # Known secrets to ignore on detection
-  # this will include a list of regex patterns to ignore on detection
+  # AWS Secrets Configuration
+  # Patterns to ignore in the secrets checks
   secrets_ignore_patterns: []
 
 # Azure Configuration

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -338,7 +338,7 @@ aws:
   # AWS Secrets Configuration
   # Patterns to ignore in the secrets checks
   # The Metadata API is ignored by default
-  secrets_ignore_patterns: ["169.254.169.254"]
+  secrets_ignore_patterns: []
 
 # Azure Configuration
 azure:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ colorama = "0.4.6"
 cryptography = "43.0.1"
 dash = "2.18.1"
 dash-bootstrap-components = "1.6.0"
-detect-secrets = "1.5.0"
+detect-secrets = {git = "https://github.com/Yelp/detect-secrets.git", rev = "master"}
 google-api-python-client = "2.147.0"
 google-auth-httplib2 = ">=0.1,<0.3"
 jsonschema = "4.23.0"

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -293,7 +293,7 @@ config_aws = {
     "excluded_sensitive_environment_variables": [],
     "elb_min_azs": 2,
     "elbv2_min_azs": 2,
-    "secrets_ignore_patterns": [],
+    "secrets_ignore_patterns": ["169.254.169.254"],
 }
 
 config_azure = {

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -293,7 +293,7 @@ config_aws = {
     "excluded_sensitive_environment_variables": [],
     "elb_min_azs": 2,
     "elbv2_min_azs": 2,
-    "secrets_ignore_patterns": ["169.254.169.254"],
+    "secrets_ignore_patterns": [],
 }
 
 config_azure = {

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -335,7 +335,6 @@ aws:
 
   # AWS Secrets Configuration
   # Patterns to ignore in the secrets checks
-  # The Metadata API is ignored by default
   secrets_ignore_patterns: []
 
 # Azure Configuration

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -336,7 +336,7 @@ aws:
   # AWS Secrets Configuration
   # Patterns to ignore in the secrets checks
   # The Metadata API is ignored by default
-  secrets_ignore_patterns: ["169.254.169.254"]
+  secrets_ignore_patterns: []
 
 # Azure Configuration
 azure:

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -333,9 +333,10 @@ aws:
   # Minimum number of Availability Zones that an ELBv2 must be in
   elbv2_min_azs: 2
 
-  # Known secrets to ignore on detection
-  # this will include a list of regex patterns to ignore on detection
-  secrets_ignore_patterns: []
+  # AWS Secrets Configuration
+  # Patterns to ignore in the secrets checks
+  # The Metadata API is ignored by default
+  secrets_ignore_patterns: ["169.254.169.254"]
 
 # Azure Configuration
 azure:

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
@@ -162,7 +162,7 @@ class Test_awslambda_function_no_secrets_in_code:
         lambda_client.functions = {LAMBDA_FUNCTION_ARN: create_lambda_function()}
 
         lambda_client._get_function_code = mock_get_function_codewith_metadata_api
-        lambda_client.audit_config = {"secrets_ignore_patterns": ["169.254.169.254"]}
+        lambda_client.audit_config = {"secrets_ignore_patterns": []}
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code_test.py
@@ -28,6 +28,12 @@ def lambda_handler(event, context):
         print("custom log event")
         return event
 """
+LAMBDA_FUNCTION_CODE_WITH_METADATA_API = """
+def lambda_handler(event, context):
+        metadata_api = "169.254.169.254"
+        print("custom log event")
+        return event
+"""
 
 
 def create_lambda_function() -> Function:
@@ -56,6 +62,12 @@ def mock_get_function_codewith_secrets():
 def mock_get_function_codewithout_secrets():
     yield create_lambda_function(), get_lambda_code_with_secrets(
         LAMBDA_FUNCTION_CODE_WITHOUT_SECRETS
+    )
+
+
+def mock_get_function_codewith_metadata_api():
+    yield create_lambda_function(), get_lambda_code_with_secrets(
+        LAMBDA_FUNCTION_CODE_WITH_METADATA_API
     )
 
 
@@ -118,6 +130,39 @@ class Test_awslambda_function_no_secrets_in_code:
 
         lambda_client._get_function_code = mock_get_function_codewithout_secrets
         lambda_client.audit_config = {"secrets_ignore_patterns": []}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_code.awslambda_function_no_secrets_in_code.awslambda_client",
+            new=lambda_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_code.awslambda_function_no_secrets_in_code import (
+                awslambda_function_no_secrets_in_code,
+            )
+
+            check = awslambda_function_no_secrets_in_code()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == LAMBDA_FUNCTION_NAME
+            assert result[0].resource_arn == LAMBDA_FUNCTION_ARN
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"No secrets found in Lambda function {LAMBDA_FUNCTION_NAME} code."
+            )
+            assert result[0].resource_tags == []
+
+    def test_function_code_with_metadata_api(self):
+        lambda_client = mock.MagicMock
+        lambda_client.functions = {LAMBDA_FUNCTION_ARN: create_lambda_function()}
+
+        lambda_client._get_function_code = mock_get_function_codewith_metadata_api
+        lambda_client.audit_config = {"secrets_ignore_patterns": ["169.254.169.254"]}
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",


### PR DESCRIPTION
### Context

Fix #5282.

### Description

Use the latest version of https://github.com/Yelp/detect-secrets since it fixes a bug flagging IPv4 Link Local addresses as public -> https://github.com/Yelp/detect-secrets/pull/885

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
