### PR TITLE
fix(aws): exclude secretsmanager while checking policies

### DIFF
--- a/prowler/providers/aws/services/iam/lib/policy.py
+++ b/prowler/providers/aws/services/iam/lib/policy.py
@@ -189,6 +189,8 @@ def is_policy_public(
                                 ".amazonaws.com" in principal.get("Service", "")
                                 or "*" in principal.get("Service", "")
                             )
+                            and "secretsmanager.amazonaws.com"
+                            not in principal.get("Service", "")
                         )
                     )
                 )


### PR DESCRIPTION
### Context

While I appreciate a lot the improvements that have been discussed and implemented in #4870, the check [awslambda_function_not_publicly_accessible](https://github.com/prowler-cloud/prowler/blob/aa3425a7dea2d9fb67299a46668165c8cd2da11d/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.py#L18) needs an exception for the AWS service `secretsmanager.amazonaws.com`.

Background: It is possible to add a source ARN to a resource-based policy of a lambda function for all AWS services **except** for `SecretsManager` as you can see in the following screenshots of editing a resource-based policy for a lambda function.

AWS Services to grant permission to:

![servicesToGrantPermission](https://github.com/user-attachments/assets/4bb053fd-06e7-4580-94fc-33d22810b1a7)

Only the service `SecretsManager` does not allow to specify a source ARN:

![policyWithoutSourceArn](https://github.com/user-attachments/assets/cb807552-cda5-45c3-8e8b-dfcc0600f89d)

Adding a source ARN would lead to a `condition` statement in the resource-based policy of the Lambda function. Such `condition` statement may be required by prowler's check in certain circumstances to pass the check. 

However, we can't add a source ARN for `SecretsManager`, because `SecretsManager's` rotation configuration binds a lambda function **only from within the same** AWS account. It is not possible to select a Lambda function in an AWS account other than the current one. 
It is therefore not necessary or even allowed to add a source ARN for `SecretsManager`, as AWS ensures that the Lambda function called by `SecretsManager` is executed in the same AWS account.

### Description

I added an exception for the service `secretsmanager.amazonaws.com` in the function [is_policy_public](https://github.com/prowler-cloud/prowler/blob/c239ede3f9c8f33508b7399064f834a6e6d71ead/prowler/providers/aws/services/iam/lib/policy.py#L189).
While I'm confident that this is required for the check [awslambda_function_not_publicly_accessible](https://github.com/prowler-cloud/prowler/blob/aa3425a7dea2d9fb67299a46668165c8cd2da11d/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.py), I'm not sure if other prowler checks that use function [is_policy_public](https://github.com/prowler-cloud/prowler/blob/c239ede3f9c8f33508b7399064f834a6e6d71ead/prowler/providers/aws/services/iam/lib/policy.py#L189) require this modification as well.

### Checklist

- Are there new checks included in this PR?  -> No
- [x] Review if the code is being covered by tests. 
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
