### PR TITLE
FIX Update elasticache_redis_cluster_backup_enabled.metadata.json

### DIFF
--- a/prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.metadata.json
+++ b/prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.metadata.json
@@ -6,7 +6,7 @@
   "ServiceName": "elasticache",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
-  "Severity": "high",
+  "Severity": "low",
   "ResourceType": "Other",
   "Description": "Ensure Elasticache Redis cache cluster has automatic backups enabled.",
   "Risk": "Ensure that your Amazon ElastiCache Redis cache clusters have a sufficient backup retention period set in order to fulfill your organization's compliance requirements. The retention period represents the number of days for which Amazon ElastiCache service retains automatic Redis cluster backups before deleting them.",


### PR DESCRIPTION
Set the Severity with the same value as the Severity set on the check.

### Context

The check `prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.py` sets the Severity as `low` on line 26. 
The metadata file `prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.metadata.json` sets the Severity as `high`. 


### Description

This makes prowler publish results with a Low severity when running with --severity high.

The check test is asserting against "low" so the Metadata file has to be changed to low in order to prevent it from being launched when running with --severity high.


### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
