### PR TITLE
chore(secrets): Add TelegramBotToken detector

### DIFF
--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -133,7 +133,7 @@ def detect_secrets_scan(
                 {"name": "SoftlayerDetector"},
                 {"name": "SquareOAuthDetector"},
                 {"name": "StripeDetector"},
-                # {"name": "TelegramBotTokenDetector"}, https://github.com/Yelp/detect-secrets/pull/878
+                {"name": "TelegramBotTokenDetector"},
                 {"name": "TwilioKeyDetector"},
             ],
             "filters_used": [


### PR DESCRIPTION
### Context

The issue related with the `TelegramBotToken` detector in https://github.com/Yelp/detect-secrets is now fixed since https://github.com/Yelp/detect-secrets/pull/878 got merged.

Also fixes https://github.com/prowler-cloud/prowler/issues/4893

### Description

Enable the `TelegramBotToken` plugin in detect-secrets.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
