### PR TITLE
chore(ecs): mock all tests using moto

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -8,7 +8,6 @@ from prowler.lib.scan_filters.scan_filters import is_resource_filtered
 from prowler.providers.aws.lib.service.service import AWSService
 
 
-################################ ECS
 class ECS(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__

--- a/tests/providers/aws/services/ecs/ecs_service_fargate_latest_platform_version/ecs_service_fargate_latest_platform_version_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_fargate_latest_platform_version/ecs_service_fargate_latest_platform_version_test.py
@@ -1,22 +1,139 @@
-from unittest import mock
+from unittest.mock import patch
 
-from prowler.providers.aws.services.ecs.ecs_service import Service
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
+import botocore
+from boto3 import client
+from moto import mock_aws
 
-SERVICE_ARN = (
-    f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-service"
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
 )
-SERVICE_NAME = "sample-service"
+
+orig = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "DescribeServices":
+        if kwarg["services"] == [
+            f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-linux-service"
+        ]:
+            return {
+                "services": [
+                    {
+                        "serviceName": "test-latest-linux-service",
+                        "clusterArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster/test-cluster",
+                        "taskDefinition": "test-task",
+                        "loadBalancers": [],
+                        "serviceArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-linux-service",
+                        "desiredCount": 1,
+                        "launchType": "FARGATE",
+                        "platformVersion": "1.4.0",
+                        "platformFamily": "Linux",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": ["subnet-12345678"],
+                                "securityGroups": ["sg-12345678"],
+                                "assignPublicIp": "DISABLED",
+                            },
+                        },
+                        "tags": [],
+                    },
+                ],
+            }
+        elif kwarg["services"] == [
+            f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-windows-service"
+        ]:
+            return {
+                "services": [
+                    {
+                        "serviceName": "test-latest-windows-service",
+                        "clusterArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster/test-cluster",
+                        "taskDefinition": "test-task",
+                        "loadBalancers": [],
+                        "serviceArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-windows-service",
+                        "desiredCount": 1,
+                        "launchType": "FARGATE",
+                        "platformVersion": "1.0.0",
+                        "platformFamily": "Windows",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": ["subnet-12345678"],
+                                "securityGroups": ["sg-12345678"],
+                                "assignPublicIp": "DISABLED",
+                            },
+                        },
+                        "tags": [],
+                    },
+                ],
+            }
+        elif kwarg["services"] == [
+            f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-linux-service"
+        ]:
+            return {
+                "services": [
+                    {
+                        "serviceName": "test-no-latest-linux-service",
+                        "clusterArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster/test-cluster",
+                        "taskDefinition": "test-task",
+                        "loadBalancers": [],
+                        "serviceArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-linux-service",
+                        "desiredCount": 1,
+                        "launchType": "FARGATE",
+                        "platformVersion": "1.2.0",
+                        "platformFamily": "Linux",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": ["subnet-12345678"],
+                                "securityGroups": ["sg-12345678"],
+                                "assignPublicIp": "DISABLED",
+                            },
+                        },
+                        "tags": [],
+                    },
+                ],
+            }
+        elif kwarg["services"] == [
+            f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-windows-service"
+        ]:
+            return {
+                "services": [
+                    {
+                        "serviceName": "test-no-latest-windows-service",
+                        "clusterArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster/test-cluster",
+                        "taskDefinition": "test-task",
+                        "loadBalancers": [],
+                        "serviceArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-windows-service",
+                        "desiredCount": 1,
+                        "launchType": "FARGATE",
+                        "platformVersion": "0.9.0",
+                        "platformFamily": "Windows",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": ["subnet-12345678"],
+                                "securityGroups": ["sg-12345678"],
+                                "assignPublicIp": "DISABLED",
+                            },
+                        },
+                        "tags": [],
+                    },
+                ],
+            }
+    return orig(self, operation_name, kwarg)
 
 
 class Test_ecs_service_fargate_latest_platform_version:
     def test_no_services(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -26,21 +143,31 @@ class Test_ecs_service_fargate_latest_platform_version:
             result = check.execute()
             assert len(result) == 0
 
+    @mock_aws
     def test_service_ec2_type(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
-        ecs_client.services[SERVICE_ARN] = Service(
-            name=SERVICE_NAME,
-            arn=SERVICE_ARN,
-            region=AWS_REGION_US_EAST_1,
-            launch_type="EC2",
-            assign_public_ip=False,
-            tags=[],
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        ecs_client.create_cluster(clusterName="test-cluster")
+
+        ecs_client.create_service(
+            cluster="test-cluster",
+            serviceName="test-service",
+            launchType="EC2",
+            platformVersion="1.4.0",
+            desiredCount=1,
+            clientToken="test-token",
         )
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -50,27 +177,34 @@ class Test_ecs_service_fargate_latest_platform_version:
             result = check.execute()
             assert len(result) == 0
 
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+    @mock_aws
     def test_service_linux_latest_version(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
-        ecs_client.services[SERVICE_ARN] = Service(
-            name=SERVICE_NAME,
-            arn=SERVICE_ARN,
-            region=AWS_REGION_US_EAST_1,
-            launch_type="FARGATE",
-            platform_family="Linux",
-            platform_version="1.4.0",
-            assign_public_ip=False,
-            tags=[],
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        ecs_client.create_cluster(clusterName="test-cluster")
+
+        ecs_client.create_service(
+            cluster="test-cluster",
+            serviceName="test-latest-linux-service",
+            launchType="FARGATE",
+            platformVersion="1.4.0",
+            desiredCount=1,
+            clientToken="test-token",
         )
 
-        ecs_client.audit_config = {
-            "fargate_linux_latest_version": "1.4.0",
-        }
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        mocked_ecs_client = ECS(mocked_aws_provider)
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+            new=mocked_ecs_client,
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -81,32 +215,46 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == (
-                f"ECS Service {SERVICE_NAME} is using latest FARGATE Linux version 1.4.0."
+                "ECS Service test-latest-linux-service is using latest FARGATE Linux version 1.4.0."
             )
-            assert result[0].resource_id == SERVICE_NAME
-            assert result[0].resource_arn == SERVICE_ARN
+            assert result[0].resource_id == "test-latest-linux-service"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-linux-service"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
 
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+    @mock_aws
     def test_service_windows_latest_version(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
-        ecs_client.services[SERVICE_ARN] = Service(
-            name=SERVICE_NAME,
-            arn=SERVICE_ARN,
-            region=AWS_REGION_US_EAST_1,
-            launch_type="FARGATE",
-            platform_family="Windows",
-            platform_version="1.0.0",
-            assign_public_ip=False,
-            tags=[],
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        ecs_client.create_cluster(clusterName="test-cluster")
+
+        ecs_client.create_service(
+            cluster="test-cluster",
+            serviceName="test-latest-windows-service",
+            launchType="FARGATE",
+            platformVersion="1.0.0",
+            desiredCount=1,
+            clientToken="test-token",
         )
 
         ecs_client.audit_config = {
             "fargate_windows_latest_version": "1.0.0",
         }
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -117,32 +265,42 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == (
-                f"ECS Service {SERVICE_NAME} is using latest FARGATE Windows version 1.0.0."
+                "ECS Service test-latest-windows-service is using latest FARGATE Windows version 1.0.0."
             )
-            assert result[0].resource_id == SERVICE_NAME
-            assert result[0].resource_arn == SERVICE_ARN
+            assert result[0].resource_id == "test-latest-windows-service"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-windows-service"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
 
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+    @mock_aws
     def test_service_linux_no_latest_version(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
-        ecs_client.services[SERVICE_ARN] = Service(
-            name=SERVICE_NAME,
-            arn=SERVICE_ARN,
-            region=AWS_REGION_US_EAST_1,
-            launch_type="FARGATE",
-            platform_family="Linux",
-            platform_version="1.2.0",
-            assign_public_ip=False,
-            tags=[],
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        ecs_client.create_cluster(clusterName="test-cluster")
+
+        ecs_client.create_service(
+            cluster="test-cluster",
+            serviceName="test-no-latest-linux-service",
+            launchType="FARGATE",
+            platformVersion="1.2.0",
+            desiredCount=1,
+            clientToken="test-token",
         )
 
-        ecs_client.audit_config = {
-            "fargate_linux_latest_version": "1.4.0",
-        }
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -153,32 +311,42 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].status_extended == (
-                f"ECS Service {SERVICE_NAME} is not using latest FARGATE Linux version 1.4.0, currently using 1.2.0."
+                "ECS Service test-no-latest-linux-service is not using latest FARGATE Linux version 1.4.0, currently using 1.2.0."
             )
-            assert result[0].resource_id == SERVICE_NAME
-            assert result[0].resource_arn == SERVICE_ARN
+            assert result[0].resource_id == "test-no-latest-linux-service"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-linux-service"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
 
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+    @mock_aws
     def test_service_windows_no_latest_version(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
-        ecs_client.services[SERVICE_ARN] = Service(
-            name=SERVICE_NAME,
-            arn=SERVICE_ARN,
-            region=AWS_REGION_US_EAST_1,
-            launch_type="FARGATE",
-            platform_family="Windows",
-            platform_version="0.9.0",
-            assign_public_ip=False,
-            tags=[],
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        ecs_client.create_cluster(clusterName="test-cluster")
+
+        ecs_client.create_service(
+            cluster="test-cluster",
+            serviceName="test-no-latest-windows-service",
+            launchType="FARGATE",
+            platformVersion="0.9.0",
+            desiredCount=1,
+            clientToken="test-token",
         )
 
-        ecs_client.audit_config = {
-            "fargate_windows_latest_version": "1.0.0",
-        }
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -189,7 +357,12 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].status_extended == (
-                f"ECS Service {SERVICE_NAME} is not using latest FARGATE Windows version 1.0.0, currently using 0.9.0."
+                "ECS Service test-no-latest-windows-service is not using latest FARGATE Windows version 1.0.0, currently using 0.9.0."
             )
-            assert result[0].resource_id == SERVICE_NAME
-            assert result[0].resource_arn == SERVICE_ARN
+            assert result[0].resource_id == "test-no-latest-windows-service"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-windows-service"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
@@ -1,22 +1,87 @@
-from unittest import mock
+from unittest.mock import patch
 
-from prowler.providers.aws.services.ecs.ecs_service import Service
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
+import botocore
+from boto3 import client
+from moto import mock_aws
 
-SERVICE_ARN = (
-    f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-service"
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
 )
-SERVICE_NAME = "sample-service"
+
+orig = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "DescribeServices":
+        if kwarg["services"] == [
+            f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-cluster/service-with-no-public-ip"
+        ]:
+            return {
+                "services": [
+                    {
+                        "serviceName": "test-latest-linux-service",
+                        "clusterArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster/sample-cluster",
+                        "taskDefinition": "test-task",
+                        "loadBalancers": [],
+                        "serviceArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-cluster/service-with-no-public-ip",
+                        "desiredCount": 1,
+                        "launchType": "FARGATE",
+                        "platformVersion": "1.4.0",
+                        "platformFamily": "Linux",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": ["subnet-12345678"],
+                                "securityGroups": ["sg-12345678"],
+                                "assignPublicIp": "DISABLED",
+                            },
+                        },
+                        "tags": [],
+                    },
+                ],
+            }
+        elif kwarg["services"] == [
+            f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-cluster/service-with-public-ip"
+        ]:
+            return {
+                "services": [
+                    {
+                        "serviceName": "test-latest-linux-service",
+                        "clusterArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster/sample-cluster",
+                        "taskDefinition": "test-task",
+                        "loadBalancers": [],
+                        "serviceArn": f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/sample-cluster/service-with-public-ip",
+                        "desiredCount": 1,
+                        "launchType": "FARGATE",
+                        "platformVersion": "1.4.0",
+                        "platformFamily": "Linux",
+                        "networkConfiguration": {
+                            "awsvpcConfiguration": {
+                                "subnets": ["subnet-12345678"],
+                                "securityGroups": ["sg-12345678"],
+                                "assignPublicIp": "ENABLED",
+                            },
+                        },
+                        "tags": [],
+                    },
+                ],
+            }
+    return orig(self, operation_name, kwarg)
 
 
 class Test_ecs_service_no_assign_public_ip:
     def test_no_services(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip import (
                 ecs_service_no_assign_public_ip,
@@ -26,20 +91,37 @@ class Test_ecs_service_no_assign_public_ip:
             result = check.execute()
             assert len(result) == 0
 
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+    @mock_aws
     def test_service_with_no_public_ip(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
-        ecs_client.services[SERVICE_ARN] = Service(
-            name=SERVICE_NAME,
-            arn=SERVICE_ARN,
-            region=AWS_REGION_US_EAST_1,
-            assign_public_ip=False,
-            tags=[],
-        )
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        ecs_client.create_cluster(clusterName="sample-cluster")
+
+        service_arn = ecs_client.create_service(
+            cluster="sample-cluster",
+            serviceName="service-with-no-public-ip",
+            desiredCount=1,
+            launchType="FARGATE",
+            networkConfiguration={
+                "awsvpcConfiguration": {
+                    "subnets": ["subnet-123456"],
+                    "securityGroups": ["sg-123456"],
+                    "assignPublicIp": "DISABLED",
+                }
+            },
+        )["service"]["serviceArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip import (
                 ecs_service_no_assign_public_ip,
@@ -51,25 +133,44 @@ class Test_ecs_service_no_assign_public_ip:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"ECS Service {SERVICE_NAME} does not have automatic public IP assignment."
+                == "ECS Service service-with-no-public-ip does not have automatic public IP assignment."
             )
-            assert result[0].resource_id == SERVICE_NAME
-            assert result[0].resource_arn == SERVICE_ARN
+            assert result[0].resource_id == "service-with-no-public-ip"
+            assert result[0].resource_arn == service_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1
 
+    @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+    @mock_aws
     def test_task_definition_no_host_network_mode(self):
-        ecs_client = mock.MagicMock
-        ecs_client.services = {}
-        ecs_client.services[SERVICE_ARN] = Service(
-            name=SERVICE_NAME,
-            arn=SERVICE_ARN,
-            region=AWS_REGION_US_EAST_1,
-            assign_public_ip=True,
-            tags=[],
-        )
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        ecs_client.create_cluster(clusterName="sample-cluster")
+
+        service_arn = ecs_client.create_service(
+            cluster="sample-cluster",
+            serviceName="service-with-public-ip",
+            desiredCount=1,
+            launchType="FARGATE",
+            networkConfiguration={
+                "awsvpcConfiguration": {
+                    "subnets": ["subnet-123456"],
+                    "securityGroups": ["sg-123456"],
+                    "assignPublicIp": "ENABLED",
+                }
+            },
+        )["service"]["serviceArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_no_assign_public_ip.ecs_service_no_assign_public_ip import (
                 ecs_service_no_assign_public_ip,
@@ -81,7 +182,9 @@ class Test_ecs_service_no_assign_public_ip:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"ECS Service {SERVICE_NAME} has automatic public IP assignment."
+                == "ECS Service service-with-public-ip has automatic public IP assignment."
             )
-            assert result[0].resource_id == SERVICE_NAME
-            assert result[0].resource_arn == SERVICE_ARN
+            assert result[0].resource_id == "service-with-public-ip"
+            assert result[0].resource_arn == service_arn
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_containers_readonly_access/ecs_task_definitions_containers_readonly_access_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_containers_readonly_access/ecs_task_definitions_containers_readonly_access_test.py
@@ -1,10 +1,13 @@
-from unittest import mock
+from unittest.mock import patch
 
-from prowler.providers.aws.services.ecs.ecs_service import (
-    ContainerDefinition,
-    TaskDefinition,
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
 )
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
 
 TASK_NAME = "test-task-readonly"
 TASK_REVISION = "1"
@@ -14,12 +17,16 @@ TASK_ARN = f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:task-defini
 
 class Test_ecs_task_definitions_containers_readonly_access:
     def test_no_task_definitions(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access import (
                 ecs_task_definitions_containers_readonly_access,
@@ -29,29 +36,35 @@ class Test_ecs_task_definitions_containers_readonly_access:
             result = check.execute()
             assert len(result) == 0
 
+    @mock_aws
     def test_task_definition_all_containers_readonly(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
-        ecs_client.task_definitions[TASK_ARN] = TaskDefinition(
-            name=TASK_NAME,
-            arn=TASK_ARN,
-            revision=TASK_REVISION,
-            region=AWS_REGION_US_EAST_1,
-            network_mode="bridge",
-            container_definitions=[
-                ContainerDefinition(
-                    name=CONTAINER_NAME,
-                    readonly_rootfilesystem=True,
-                    privileged=False,
-                    user="appuser",
-                    environment=[],
-                )
-            ],
-        )
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        task_definition_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access import (
                 ecs_task_definitions_containers_readonly_access,
@@ -65,30 +78,40 @@ class Test_ecs_task_definitions_containers_readonly_access:
                 result[0].status_extended
                 == f"ECS task definition {TASK_NAME} with revision {TASK_REVISION} does not have containers with write access to the root filesystems."
             )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_definition_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
 
+    @mock_aws
     def test_task_definition_some_containers_not_readonly(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
-        ecs_client.task_definitions[TASK_ARN] = TaskDefinition(
-            name=TASK_NAME,
-            arn=TASK_ARN,
-            revision=TASK_REVISION,
-            region=AWS_REGION_US_EAST_1,
-            network_mode="bridge",
-            container_definitions=[
-                ContainerDefinition(
-                    name=CONTAINER_NAME,
-                    readonly_rootfilesystem=False,
-                    privileged=False,
-                    user="appuser",
-                    environment=[],
-                )
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        task_definition_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": False,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [],
+                }
             ],
-        )
+        )["taskDefinition"]["taskDefinitionArn"]
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access import (
                 ecs_task_definitions_containers_readonly_access,
@@ -102,38 +125,49 @@ class Test_ecs_task_definitions_containers_readonly_access:
                 result[0].status_extended
                 == f"ECS task definition {TASK_NAME} with revision {TASK_REVISION} has containers with write access to the root filesystem: {CONTAINER_NAME}"
             )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_definition_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
 
+    @mock_aws
     def test_task_definition_mixed_containers(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {
-            TASK_ARN: TaskDefinition(
-                name=TASK_NAME,
-                arn=TASK_ARN,
-                revision=TASK_REVISION,
-                region=AWS_REGION_US_EAST_1,
-                network_mode="bridge",
-                container_definitions=[
-                    ContainerDefinition(
-                        name=CONTAINER_NAME,
-                        readonly_rootfilesystem=False,
-                        privileged=False,
-                        user="appuser",
-                        environment=[],
-                    ),
-                    ContainerDefinition(
-                        name="readonly-container",
-                        readonly_rootfilesystem=True,
-                        privileged=False,
-                        user="appuser",
-                        environment=[],
-                    ),
-                ],
-            )
-        }
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        task_definition_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": False,  # Not readonly
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [],
+                },
+                {
+                    "name": "readonly-container",
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,  # Readonly
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [],
+                },
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_containers_readonly_access.ecs_task_definitions_containers_readonly_access import (
                 ecs_task_definitions_containers_readonly_access,
@@ -147,3 +181,7 @@ class Test_ecs_task_definitions_containers_readonly_access:
                 result[0].status_extended
                 == f"ECS task definition {TASK_NAME} with revision {TASK_REVISION} has containers with write access to the root filesystem: {CONTAINER_NAME}"
             )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_definition_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_logging_enabled/ecs_task_definitions_logging_enabled_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_logging_enabled/ecs_task_definitions_logging_enabled_test.py
@@ -1,28 +1,27 @@
-from unittest import mock
+from unittest.mock import patch
 
-from prowler.providers.aws.services.ecs.ecs_service import (
-    ContainerDefinition,
-    TaskDefinition,
-)
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_US_EAST_1
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
 
 TASK_NAME = "test-task"
 TASK_REVISION = "1"
 CONTAINER_NAME = "test-container"
-TASK_ARN = f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:task-definition/{TASK_NAME}:{TASK_REVISION}"
 
 
 class Test_ecs_task_definitions_logging_enabled:
     def test_no_task_definitions(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
-        ), mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (
                 ecs_task_definitions_logging_enabled,
@@ -32,33 +31,35 @@ class Test_ecs_task_definitions_logging_enabled:
             result = check.execute()
             assert len(result) == 0
 
+    @mock_aws
     def test_task_definition_no_logconfiguration(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        ecs_client.task_definitions[TASK_ARN] = TaskDefinition(
-            name=TASK_NAME,
-            arn=TASK_ARN,
-            revision=TASK_REVISION,
-            region=AWS_REGION_US_EAST_1,
-            network_mode="host",
-            container_definitions=[
-                ContainerDefinition(
-                    name=CONTAINER_NAME,
-                    image="test-image",
-                    privileged=False,
-                    user="user-1",
-                    environment=[{"name": "DB_PASSWORD", "value": "pass-12343"}],
-                )
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [],
+                }
             ],
-        )
+        )["taskDefinition"]["taskDefinitionArn"]
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
-        ), mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
-            ecs_client,
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (
                 ecs_task_definitions_logging_enabled,
@@ -72,73 +73,41 @@ class Test_ecs_task_definitions_logging_enabled:
                 result[0].status_extended
                 == f"ECS task definition {TASK_NAME} with revision {TASK_REVISION} has containers running with no logging configuration: {CONTAINER_NAME}"
             )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
 
-    def test_task_definition_no_logdriver(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
-        ecs_client.task_definitions[TASK_ARN] = TaskDefinition(
-            name=TASK_NAME,
-            arn=TASK_ARN,
-            revision=TASK_REVISION,
-            region=AWS_REGION_US_EAST_1,
-            network_mode="host",
-            container_definitions=[
-                ContainerDefinition(
-                    name=CONTAINER_NAME,
-                    privileged=True,
-                    user="root",
-                    environment=[],
-                    log_driver="",
-                )
-            ],
-        )
-
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
-        ), mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
-            ecs_client,
-        ):
-            from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (
-                ecs_task_definitions_logging_enabled,
-            )
-
-            check = ecs_task_definitions_logging_enabled()
-            result = check.execute()
-            assert len(result) == 1
-            assert result[0].status == "FAIL"
-            assert (
-                result[0].status_extended
-                == f"ECS task definition {TASK_NAME} with revision {TASK_REVISION} has containers running with no logging configuration: {CONTAINER_NAME}"
-            )
-
+    @mock_aws
     def test_task_definition_privileged_container(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
-        ecs_client.task_definitions[TASK_ARN] = TaskDefinition(
-            name=TASK_NAME,
-            arn=TASK_ARN,
-            revision=TASK_REVISION,
-            region=AWS_REGION_US_EAST_1,
-            network_mode="host",
-            container_definitions=[
-                ContainerDefinition(
-                    name=CONTAINER_NAME,
-                    privileged=True,
-                    user="root",
-                    environment=[],
-                    log_driver="awslogs",
-                )
-            ],
-        )
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
-        ), mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_client.ecs_client",
-            ecs_client,
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": True,
+                    "user": "root",
+                    "environment": [],
+                    "logConfiguration": {"logDriver": "awslogs"},
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_logging_enabled.ecs_task_definitions_logging_enabled import (
                 ecs_task_definitions_logging_enabled,
@@ -152,3 +121,7 @@ class Test_ecs_task_definitions_logging_enabled:
                 result[0].status_extended
                 == f"ECS task definition {TASK_NAME} with revision {TASK_REVISION} containers have logging configured."
             )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -1,30 +1,31 @@
-from unittest import mock
+from unittest.mock import patch
 
-from prowler.providers.aws.services.ecs.ecs_service import (
-    ContainerDefinition,
-    ContainerEnvVariable,
-    TaskDefinition,
-)
+from boto3 import client
+from moto import mock_aws
 
-AWS_REGION = "eu-west-1"
-AWS_ACCOUNT_NUMBER = "123456789012"
-task_name = "test-task"
-task_revision = "1"
-task_arn = f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}"
-env_var_name_no_secrets = "host"
-env_var_value_no_secrets = "localhost:1234"
-env_var_name_with_secrets = "DB_PASSWORD"
-env_var_value_with_secrets = "pass-12343"
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+TASK_NAME = "test-task"
+TASK_REVISION = "1"
+CONTAINER_NAME = "test-container"
+ENV_VAR_NAME_NO_SECRETS = "host"
+ENV_VAR_VALUE_NO_SECRETS = "localhost:1234"
+ENV_VAR_NAME_WITH_SECRETS = "DB_PASSWORD"
+ENV_VAR_VALUE_WITH_SECRETS = "pass-12343"
 
 
 class Test_ecs_task_definitions_no_environment_secrets:
     def test_no_task_definitions(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
                 ecs_task_definitions_no_environment_secrets,
@@ -34,31 +35,40 @@ class Test_ecs_task_definitions_no_environment_secrets:
             result = check.execute()
             assert len(result) == 0
 
+    @mock_aws
     def test_container_env_var_no_secrets(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
-        ecs_client.task_definitions[task_arn] = TaskDefinition(
-            name=task_name,
-            arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
-            revision="1",
-            region=AWS_REGION,
-            container_definitions=[
-                ContainerDefinition(
-                    name="container1",
-                    privileged=False,
-                    user="",
-                    environment=[
-                        ContainerEnvVariable(
-                            name=env_var_name_no_secrets, value=env_var_value_no_secrets
-                        )
-                    ],
-                )
-            ],
-        )
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [
+                        {
+                            "name": ENV_VAR_NAME_NO_SECRETS,
+                            "value": ENV_VAR_VALUE_NO_SECRETS,
+                        }
+                    ],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
                 ecs_task_definitions_no_environment_secrets,
@@ -70,40 +80,47 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"No secrets found in variables of ECS task definition {task_name} with revision {task_revision}."
+                == f"No secrets found in variables of ECS task definition {TASK_NAME} with revision {TASK_REVISION}."
             )
-            assert result[0].resource_id == f"{task_name}:1"
-            assert (
-                result[0].resource_arn
-                == f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}"
-            )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
 
+    @mock_aws
     def test_container_env_var_with_secrets(self):
-        ecs_client = mock.MagicMock
-        ecs_client.task_definitions = {}
-        ecs_client.task_definitions[task_arn] = TaskDefinition(
-            name=task_name,
-            arn=f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}",
-            revision="1",
-            region=AWS_REGION,
-            container_definitions=[
-                ContainerDefinition(
-                    name="container1",
-                    privileged=False,
-                    user="",
-                    environment=[
-                        ContainerEnvVariable(
-                            name=env_var_name_with_secrets,
-                            value=env_var_value_with_secrets,
-                        )
-                    ],
-                )
-            ],
-        )
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
-        with mock.patch(
-            "prowler.providers.aws.services.ecs.ecs_service.ECS",
-            ecs_client,
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [
+                        {
+                            "name": ENV_VAR_NAME_WITH_SECRETS,
+                            "value": ENV_VAR_VALUE_WITH_SECRETS,
+                        }
+                    ],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
         ):
             from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
                 ecs_task_definitions_no_environment_secrets,
@@ -115,10 +132,9 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secrets found in ECS task definition {task_name} with revision {task_revision}: Secrets in container container1 -> Secret Keyword on line 2."
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on line 2."
             )
-            assert result[0].resource_id == f"{task_name}:1"
-            assert (
-                result[0].resource_arn
-                == f"arn:aws:ecs:{AWS_REGION}:{AWS_ACCOUNT_NUMBER}:task-definition/{task_name}:{task_revision}"
-            )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

ECS test were giving problems because the mock was mixed between MagicMock and moto.

### Description

Change all ECS tests to use moto. Tests for checks `ecs_service_fargate_latest_platform_version` and `ecs_service_no_assign_public_ip` use manual DescribeServices mock due to missing attributes in moto.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
