### PR TITLE
chore(aws): add more cases to public IAM resource policies

### DIFF
--- a/prowler/providers/aws/services/iam/lib/policy.py
+++ b/prowler/providers/aws/services/iam/lib/policy.py
@@ -187,9 +187,14 @@ def is_policy_public(
                         or (  # Check if function can be invoked by other AWS services
                             (
                                 ".amazonaws.com" in principal.get("Service", "")
+                                or ".amazon.com" in principal.get("Service", "")
                                 or "*" in principal.get("Service", "")
                             )
                         )
+                        and "secretsmanager.amazonaws.com"
+                        not in principal.get(
+                            "Service", ""
+                        )  # AWS ensures that the Lambda function called by SecretsManager is executed in the same AWS account
                     )
                 )
             ) and (
@@ -276,6 +281,7 @@ def is_condition_block_restrictive(
             "aws:sourcearn",
             "aws:sourcevpc",
             "aws:sourcevpce",
+            "lambda:eventsourcetoken",
         ],
         "StringLike": [
             "aws:sourceaccount",
@@ -333,7 +339,6 @@ def is_condition_block_restrictive(
                                 in condition_statement[condition_operator][value]
                             ):
                                 is_condition_valid = True
-
     return is_condition_valid
 
 

--- a/prowler/providers/aws/services/iam/lib/policy.py
+++ b/prowler/providers/aws/services/iam/lib/policy.py
@@ -194,7 +194,7 @@ def is_policy_public(
                         and "secretsmanager.amazonaws.com"
                         not in principal.get(
                             "Service", ""
-                        )  # AWS ensures that the Lambda function called by SecretsManager is executed in the same AWS account
+                        )  # AWS ensures that resources called by SecretsManager are executed in the same AWS account
                     )
                 )
             ) and (
@@ -281,7 +281,7 @@ def is_condition_block_restrictive(
             "aws:sourcearn",
             "aws:sourcevpc",
             "aws:sourcevpce",
-            "lambda:eventsourcetoken",
+            "lambda:eventsourcetoken",  # For Alexa Home functions, a token that the invoker must supply.
         ],
         "StringLike": [
             "aws:sourceaccount",
@@ -339,6 +339,7 @@ def is_condition_block_restrictive(
                                 in condition_statement[condition_operator][value]
                             ):
                                 is_condition_valid = True
+
     return is_condition_valid
 
 

--- a/tests/providers/aws/services/iam/lib/policy_test.py
+++ b/tests/providers/aws/services/iam/lib/policy_test.py
@@ -1867,6 +1867,39 @@ class Test_Policy:
         }
         assert is_policy_public(policy)
 
+    def test__is_policy_public_secrets_manager(
+        self,
+    ):
+        policy = {
+            "Statement": [
+                {
+                    "Sid": "test",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "secretsmanager.amazonaws.com"},
+                    "Action": "lambda:GetFunction",
+                    "Resource": "*",
+                }
+            ]
+        }
+        assert not is_policy_public(policy)
+
+    def test__is_policy_public_alexa_condition(
+        self,
+    ):
+        policy = {
+            "Statement": [
+                {
+                    "Sid": "test",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "alexa-connectedhome.amazon.com"},
+                    "Action": "lambda:GetFunction",
+                    "Resource": "*",
+                    "Condition": {"StringEquals": {"lambda:EventSourceToken": "test"}},
+                }
+            ]
+        }
+        assert not is_policy_public(policy)
+
     def test_check_admin_access(self):
         policy = {
             "Version": "2012-10-17",


### PR DESCRIPTION
### Context

AWS ensures that the Lambda function called by SecretsManager is executed in the same AWS account, also Alexa services has their own condition `lambda:eventsourcetoken`.

Thanks @kagahd for the heads up in #5300!

### Description

Add the mentioned cases to the logic of checking public AWS public resource policies as well as the tests covering them.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
