### PR TITLE
fix(Dockerfile): install git dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.12-alpine
 
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 
-# Update system dependencies
+# Update system dependencies and install essential tools
 #hadolint ignore=DL3018
-RUN apk --no-cache upgrade && apk --no-cache add curl
+RUN apk --no-cache upgrade && apk --no-cache add curl git
 
 # Create nonroot user
 RUN mkdir -p /home/prowler && \
@@ -13,18 +13,17 @@ RUN mkdir -p /home/prowler && \
     chown -R prowler:prowler /home/prowler
 USER prowler
 
-# Copy necessary files
+# Copy necessary files
 WORKDIR /home/prowler
 COPY prowler/  /home/prowler/prowler/
 COPY dashboard/ /home/prowler/dashboard/
 COPY pyproject.toml /home/prowler
 COPY README.md /home/prowler
 
-# Install dependencies
+# Install Python dependencies
 ENV HOME='/home/prowler'
 ENV PATH="$HOME/.local/bin:$PATH"
-#hadolint ignore=DL3013
-RUN pip install --no-cache-dir --upgrade pip && \
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel && \
     pip install --no-cache-dir .
 
 # Remove deprecated dash dependencies


### PR DESCRIPTION
### Context

Until `detect-secrets` cuts a new release we need to build it from `git` -> https://github.com/prowler-cloud/prowler/pull/5298

### Description

Install `git` dependency in `Dockerfile` for installing Prowler dependencies that come from GitHub repositories.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
