### PR TITLE
feat(azure): add authentication method from static credentials

### DIFF
--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -711,6 +711,9 @@ class AzureProvider(Provider):
                         original_exception=error,
                     )
                 except ClientAuthenticationError as error:
+                    logger.error(
+                        f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+                    )
                     raise AzureGetTokenIdentityError(
                         file=os.path.basename(__file__),
                         original_exception=error,

--- a/prowler/providers/azure/exceptions/exceptions.py
+++ b/prowler/providers/azure/exceptions/exceptions.py
@@ -49,13 +49,53 @@ class AzureBaseException(ProwlerException):
             "message": "Error in HTTP response from Azure",
             "remediation": "",
         },
-        (1925, "AzureConfigCredentialsError"): {
-            "message": "Error trying to configure Azure credentials from dictionary",
+        (1925, "AzureCredentialsUnavailableError"): {
+            "message": "Error trying to configure Azure credentials because they are unavailable",
             "remediation": "Check the dictionary and ensure it is properly set up for Azure credentials. TENANT_ID, CLIENT_ID and CLIENT_SECRET are required.",
         },
         (1926, "AzureGetTokenIdentityError"): {
             "message": "Error trying to get token from Azure Identity",
             "remediation": "Check the Azure Identity and ensure it is properly set up.",
+        },
+        (1927, "AzureNotTenantIdButClientIdAndClienSecret"): {
+            "message": "The provided credentials are not a tenant ID but a client ID and client secret",
+            "remediation": "Tenant Id, Client Id and Client Secret are required for Azure credentials. Make sure you are using the correct credentials.",
+        },
+        (1928, "AzureClientAuthenticationError"): {
+            "message": "Error in client authentication",
+            "remediation": "Check the client authentication and ensure it is properly set up.",
+        },
+        (1929, "AzureSetUpSessionError"): {
+            "message": "Error setting up session",
+            "remediation": "Check the session setup and ensure it is properly set up.",
+        },
+        (1930, "AzureNotValidTenantIdError"): {
+            "message": "The provided tenant ID is not valid",
+            "remediation": "Check the tenant ID and ensure it is a valid ID.",
+        },
+        (1931, "AzureNotValidClientIdError"): {
+            "message": "The provided client ID is not valid",
+            "remediation": "Check the client ID and ensure it is a valid ID.",
+        },
+        (1932, "AzureNotValidClientSecretError"): {
+            "message": "The provided client secret is not valid",
+            "remediation": "Check the client secret and ensure it is a valid secret.",
+        },
+        (1933, "AzureConfigCredentialsError"): {
+            "message": "Error in configuration of Azure credentials",
+            "remediation": "Check the configuration of Azure credentials and ensure it is properly set up.",
+        },
+        (1934, "AzureClientIdAndClientSecretNotBelongingToTenantIdError"): {
+            "message": "The provided client ID and client secret do not belong to the provided tenant ID",
+            "remediation": "Check the client ID and client secret and ensure they belong to the provided tenant ID.",
+        },
+        (1935, "AzureTenantIdAndClientSecretNotBelongingToClientIdError"): {
+            "message": "The provided tenant ID and client secret do not belong to the provided client ID",
+            "remediation": "Check the tenant ID and client secret and ensure they belong to the provided client ID.",
+        },
+        (1936, "AzureTenantIdAndClientIdNotBelongingToClientSecretError"): {
+            "message": "The provided tenant ID and client ID do not belong to the provided client secret",
+            "remediation": "Check the tenant ID and client ID and ensure they belong to the provided client secret.",
         },
     }
 
@@ -157,7 +197,7 @@ class AzureHTTPResponseError(AzureBaseException):
         )
 
 
-class AzureConfigCredentialsError(AzureCredentialsError):
+class AzureCredentialsUnavailableError(AzureCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1925, file=file, original_exception=original_exception, message=message
@@ -168,4 +208,74 @@ class AzureGetTokenIdentityError(AzureBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1926, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureNotTenantIdButClientIdAndClienSecret(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1927, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureClientAuthenticationError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1928, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureSetUpSessionError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1929, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureNotValidTenantIdError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1930, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureNotValidClientIdError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1931, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureNotValidClientSecretError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1932, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureConfigCredentialsError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1933, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureClientIdAndClientSecretNotBelongingToTenantIdError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1934, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureTenantIdAndClientSecretNotBelongingToClientIdError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1935, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureTenantIdAndClientIdNotBelongingToClientSecretError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1936, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/azure/exceptions/exceptions.py
+++ b/prowler/providers/azure/exceptions/exceptions.py
@@ -49,6 +49,14 @@ class AzureBaseException(ProwlerException):
             "message": "Error in HTTP response from Azure",
             "remediation": "",
         },
+        (1925, "AzureConfigCredentialsError"): {
+            "message": "Error trying to configure Azure credentials from dictionary",
+            "remediation": "Check the dictionary and ensure it is properly set up for Azure credentials. TENANT_ID, CLIENT_ID and CLIENT_SECRET are required.",
+        },
+        (1926, "AzureGetTokenIdentityError"): {
+            "message": "Error trying to get token from Azure Identity",
+            "remediation": "Check the Azure Identity and ensure it is properly set up.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -146,4 +154,18 @@ class AzureHTTPResponseError(AzureBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1924, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureConfigCredentialsError(AzureCredentialsError):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1925, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AzureGetTokenIdentityError(AzureBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1926, file=file, original_exception=original_exception, message=message
         )

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -241,18 +241,27 @@ class TestAzureProvider:
             "prowler.providers.azure.azure_provider.AzureProvider.setup_session"
         ) as mock_setup_session, patch(
             "prowler.providers.azure.azure_provider.SubscriptionClient"
-        ) as mock_resource_client:
+        ) as mock_resource_client, patch(
+            "prowler.providers.azure.azure_provider.AzureProvider.validate_static_credentials"
+        ) as mock_validate_static_credentials:
 
             # Mock the return value of DefaultAzureCredential
             mock_credentials = MagicMock()
             mock_credentials.get_token.return_value = AccessToken(
                 token="fake_token", expires_on=9999999999
             )
-            mock_default_credential.return_value = mock_credentials
+            mock_default_credential.return_value = {
+                "client_id": str(uuid4()),
+                "client_secret": str(uuid4()),
+                "tenant_id": str(uuid4()),
+            }
 
             # Mock setup_session to return a mocked session object
             mock_session = MagicMock()
             mock_setup_session.return_value = mock_session
+
+            # Mock ValidateStaticCredentials to avoid real API calls
+            mock_validate_static_credentials.return_value = None
 
             # Mock ResourceManagementClient to avoid real API calls
             mock_client = MagicMock()


### PR DESCRIPTION
### Description

This Pull Request (PR) adds a new method for instantiating the Azure provider exclusively using `client_id`, `tenant_id` and `client_secret`.

Also, adds new exceptions.


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [X] Review if the code is being covered by tests.
- [X] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [X] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
