### PR TITLE
feat(test_connection): Add optional AWS Account ID validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
         # For running trufflehog in docker, use the following entry instead:
         # entry: bash -c 'docker run -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --only-verified --fail'
         language: system
-        stages: ["commit", "push"]
+        stages: ["pre-commit", "pre-push"]
 
       - id: bandit
         name: bandit

--- a/prowler/exceptions/exceptions.py
+++ b/prowler/exceptions/exceptions.py
@@ -45,7 +45,10 @@ class ProwlerException(Exception):
 
     def __str__(self):
         """Overriding the __str__ method"""
-        return f"{self.__class__.__name__}[{self.code}]: {self.message} - {self.original_exception}"
+        default_str = f"{self.__class__.__name__}[{self.code}]: {self.message}"
+        if self.original_exception:
+            default_str += f" - {self.original_exception}"
+        return default_str
 
 
 class UnexpectedError(ProwlerException):

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -35,6 +35,7 @@ from prowler.providers.aws.exceptions.exceptions import (
     AWSIAMRoleARNPartitionEmpty,
     AWSIAMRoleARNRegionNotEmtpy,
     AWSIAMRoleARNServiceNotIAMnorSTS,
+    AWSInvalidAccountCredentials,
     AWSNoCredentialsError,
     AWSProfileNotFoundError,
     AWSSecretAccessKeyInvalid,
@@ -1004,6 +1005,7 @@ class AwsProvider(Provider):
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
         aws_session_token: Optional[str] = None,
+        aws_account_id: Optional[str] = None,
     ) -> Connection:
         """
         Test the connection to AWS with one of the Boto3 credentials methods.
@@ -1020,6 +1022,7 @@ class AwsProvider(Provider):
             aws_access_key_id (str): The AWS access key ID to use for the session.
             aws_secret_access_key (str): The AWS secret access key to use for the session.
             aws_session_token (str): The AWS session token to use for the session. Optional.
+            aws_account_id (str): The AWS account ID to validate that the provided credentials belongs to it.
 
         Returns:
             Connection: An object tha contains the result of the test connection operation.
@@ -1081,7 +1084,11 @@ class AwsProvider(Provider):
                     profile_name=profile,
                 )
 
-            _ = AwsProvider.validate_credentials(session, aws_region)
+            caller_identity = AwsProvider.validate_credentials(session, aws_region)
+            # Do an extra validation if the AWS account ID is provided
+            if aws_account_id and caller_identity.account != aws_account_id:
+                raise AWSInvalidAccountCredentials(file=pathlib.Path(__file__).name)
+
             return Connection(
                 is_connected=True,
             )
@@ -1183,6 +1190,12 @@ class AwsProvider(Provider):
             if raise_on_exception:
                 raise secret_access_key_invalid_error
             return Connection(error=secret_access_key_invalid_error)
+
+        except AWSInvalidAccountCredentials as invalid_account_credentials_error:
+            logger.error(str(invalid_account_credentials_error))
+            if raise_on_exception:
+                raise invalid_account_credentials_error
+            return Connection(error=invalid_account_credentials_error)
 
         except Exception as error:
             logger.critical(

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 from datetime import datetime
 from re import fullmatch
+from typing import Optional
 
 from boto3 import client
 from boto3.session import Session
@@ -24,6 +25,7 @@ from prowler.providers.aws.config import (
     ROLE_SESSION_NAME,
 )
 from prowler.providers.aws.exceptions.exceptions import (
+    AWSAccessKeyIDInvalid,
     AWSArgumentTypeValidationError,
     AWSAssumeRoleError,
     AWSClientError,
@@ -35,6 +37,7 @@ from prowler.providers.aws.exceptions.exceptions import (
     AWSIAMRoleARNServiceNotIAMnorSTS,
     AWSNoCredentialsError,
     AWSProfileNotFoundError,
+    AWSSecretAccessKeyInvalid,
     AWSSetUpSessionError,
 )
 from prowler.providers.aws.lib.arn.arn import parse_iam_credentials_arn
@@ -86,6 +89,9 @@ class AwsProvider(Provider):
         resource_arn: list[str] = [],
         audit_config: dict = {},
         fixer_config: dict = {},
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
+        aws_session_token: Optional[str] = None,
     ):
         """
         Initializes the AWS provider.
@@ -105,6 +111,9 @@ class AwsProvider(Provider):
             - resource_arn: A list of ARNs of the resources to audit.
             - audit_config: The audit configuration.
             - fixer_config: The fixer configuration.
+            - aws_access_key_id: The AWS access key ID.
+            - aws_secret_access_key: The AWS secret access key.
+            - aws_session_token: The AWS session token, optional.
 
         Raises:
             - ArgumentTypeError: If the input MFA ARN is invalid.
@@ -119,7 +128,13 @@ class AwsProvider(Provider):
         logger.info("Generating original session ...")
 
         # Configure the initial AWS Session using the local credentials: profile or environment variables
-        aws_session = self.setup_session(mfa, profile)
+        aws_session = self.setup_session(
+            mfa=mfa,
+            profile=profile,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+        )
         session_config = self.set_session_config(retries_max_attempts)
         # Current session and the original session points to the same session object until we get a new one, if needed
         self._session = AWSSession(
@@ -423,17 +438,29 @@ class AwsProvider(Provider):
     def setup_session(
         mfa: bool = False,
         profile: str = None,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
+        aws_session_token: Optional[str] = None,
     ) -> Session:
         try:
-            logger.info("Creating original session ...")
+            logger.debug("Creating original session ...")
+
+            session_arguments = {
+                "profile_name": profile,
+                "aws_access_key_id": aws_access_key_id,
+                "aws_secret_access_key": aws_secret_access_key,
+                "aws_session_token": aws_session_token,
+            }
+
             if mfa:
+                sts_client = client("sts", **session_arguments)
+
                 mfa_info = AwsProvider.input_role_mfa_token_and_code()
                 # TODO: validate MFA ARN here
                 get_session_token_arguments = {
                     "SerialNumber": mfa_info.arn,
                     "TokenCode": mfa_info.totp,
                 }
-                sts_client = client("sts")
                 session_credentials = sts_client.get_session_token(
                     **get_session_token_arguments
                 )
@@ -445,12 +472,11 @@ class AwsProvider(Provider):
                     aws_session_token=session_credentials["Credentials"][
                         "SessionToken"
                     ],
+                    # Do we really need the profile name here? I think not since we are getting a session token with either the profile or the static credentials
                     profile_name=profile,
                 )
             else:
-                return Session(
-                    profile_name=profile,
-                )
+                return Session(**session_arguments)
         except Exception as error:
             logger.critical(
                 f"AWSSetUpSessionError[{error.__traceback__.tb_lineno}]: {error}"
@@ -939,6 +965,26 @@ class AwsProvider(Provider):
                 arn=ARN(caller_identity.get("Arn")),
                 region=aws_region,
             )
+        except ClientError as client_error:
+            logger.error(
+                f"{client_error.__class__.__name__}[{client_error.__traceback__.tb_lineno}]: {client_error}"
+            )
+            if client_error.response["Error"]["Code"] == "InvalidClientTokenId":
+                raise AWSAccessKeyIDInvalid(
+                    original_exception=client_error,
+                    file=pathlib.Path(__file__).name,
+                )
+            elif client_error.response["Error"]["Code"] == "SignatureDoesNotMatch":
+                raise AWSSecretAccessKeyInvalid(
+                    original_exception=client_error,
+                    file=pathlib.Path(__file__).name,
+                )
+            else:
+                raise AWSClientError(
+                    original_exception=client_error,
+                    file=pathlib.Path(__file__).name,
+                )
+
         except Exception as error:
             logger.critical(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -955,6 +1001,9 @@ class AwsProvider(Provider):
         external_id: str = None,
         mfa_enabled: bool = False,
         raise_on_exception: bool = True,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
+        aws_session_token: Optional[str] = None,
     ) -> Connection:
         """
         Test the connection to AWS with one of the Boto3 credentials methods.
@@ -968,6 +1017,9 @@ class AwsProvider(Provider):
             external_id (str): The external ID to use when assuming the role.
             mfa_enabled (bool): Whether MFA (Multi-Factor Authentication) is enabled.
             raise_on_exception (bool): Whether to raise an exception if an error occurs.
+            aws_access_key_id (str): The AWS access key ID to use for the session.
+            aws_secret_access_key (str): The AWS secret access key to use for the session.
+            aws_session_token (str): The AWS session token to use for the session. Optional.
 
         Returns:
             Connection: An object tha contains the result of the test connection operation.
@@ -994,9 +1046,17 @@ class AwsProvider(Provider):
             Connection(is_connected=False, Error=ProfileNotFound('The config profile (not-found) could not be found'))
             >>> AwsProvider.test_connection(raise_on_exception=False))
             Connection(is_connected=False, Error=NoCredentialsError('Unable to locate credentials'))
+            >>> AwsProvider.test_connection(aws_access_key_id="XXXXXXXX", aws_secret_access_key="XXXXXXXX", raise_on_exception=False))
+            Connection(is_connected=True, Error=None))
         """
         try:
-            session = AwsProvider.setup_session(mfa_enabled, profile)
+            session = AwsProvider.setup_session(
+                mfa=mfa_enabled,
+                profile=profile,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+            )
 
             if role_arn:
                 session_duration = validate_session_duration(session_duration)
@@ -1021,8 +1081,7 @@ class AwsProvider(Provider):
                     profile_name=profile,
                 )
 
-            sts_client = AwsProvider.create_sts_session(session, aws_region)
-            _ = sts_client.get_caller_identity()
+            _ = AwsProvider.validate_credentials(session, aws_region)
             return Connection(
                 is_connected=True,
             )
@@ -1112,6 +1171,18 @@ class AwsProvider(Provider):
                     original_exception=no_credentials_error,
                 ) from no_credentials_error
             return Connection(error=no_credentials_error)
+
+        except AWSAccessKeyIDInvalid as access_key_id_invalid_error:
+            logger.error(str(access_key_id_invalid_error))
+            if raise_on_exception:
+                raise access_key_id_invalid_error
+            return Connection(error=access_key_id_invalid_error)
+
+        except AWSSecretAccessKeyInvalid as secret_access_key_invalid_error:
+            logger.error(str(secret_access_key_invalid_error))
+            if raise_on_exception:
+                raise secret_access_key_invalid_error
+            return Connection(error=secret_access_key_invalid_error)
 
         except Exception as error:
             logger.critical(

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -1005,7 +1005,7 @@ class AwsProvider(Provider):
         aws_access_key_id: str = None,
         aws_secret_access_key: str = None,
         aws_session_token: Optional[str] = None,
-        aws_account_id: Optional[str] = None,
+        provider_id: Optional[str] = None,
     ) -> Connection:
         """
         Test the connection to AWS with one of the Boto3 credentials methods.
@@ -1022,7 +1022,7 @@ class AwsProvider(Provider):
             aws_access_key_id (str): The AWS access key ID to use for the session.
             aws_secret_access_key (str): The AWS secret access key to use for the session.
             aws_session_token (str): The AWS session token to use for the session. Optional.
-            aws_account_id (str): The AWS account ID to validate that the provided credentials belongs to it.
+            provider_id (str): The AWS account ID to validate that the provided credentials belongs to it.
 
         Returns:
             Connection: An object tha contains the result of the test connection operation.
@@ -1050,6 +1050,8 @@ class AwsProvider(Provider):
             >>> AwsProvider.test_connection(raise_on_exception=False))
             Connection(is_connected=False, Error=NoCredentialsError('Unable to locate credentials'))
             >>> AwsProvider.test_connection(aws_access_key_id="XXXXXXXX", aws_secret_access_key="XXXXXXXX", raise_on_exception=False))
+            Connection(is_connected=True, Error=None))
+            >>> AwsProvider.test_connection(aws_access_key_id="XXXXXXXX", aws_secret_access_key="XXXXXXXX", provider_id="111122223333", raise_on_exception=False))
             Connection(is_connected=True, Error=None))
         """
         try:
@@ -1086,7 +1088,7 @@ class AwsProvider(Provider):
 
             caller_identity = AwsProvider.validate_credentials(session, aws_region)
             # Do an extra validation if the AWS account ID is provided
-            if aws_account_id and caller_identity.account != aws_account_id:
+            if provider_id and caller_identity.account != provider_id:
                 raise AWSInvalidAccountCredentials(file=pathlib.Path(__file__).name)
 
             return Connection(

--- a/prowler/providers/aws/exceptions/exceptions.py
+++ b/prowler/providers/aws/exceptions/exceptions.py
@@ -65,6 +65,10 @@ class AWSBaseException(ProwlerException):
             "message": "AWS Secret Access Key is invalid",
             "remediation": "Check your AWS Secret Access Key and signing method and ensure it is valid.",
         },
+        (1917, "AWSInvalidAccountCredentials"): {
+            "message": "The AWS credentials provided belongs to a different account",
+            "remediation": "Check your AWS credentials and review if belongs to the account you want to use.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -196,4 +200,11 @@ class AWSSecretAccessKeyInvalid(AWSBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1916, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AWSInvalidAccountCredentials(AWSBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1917, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/aws/exceptions/exceptions.py
+++ b/prowler/providers/aws/exceptions/exceptions.py
@@ -57,6 +57,14 @@ class AWSBaseException(ProwlerException):
             "message": "AWS assume role error",
             "remediation": "Check the AWS assume role configuration and ensure it is properly set up, please visit https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/aws/role-assumption/ and https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-role-session-name",
         },
+        (1915, "AWSAccessKeyIDInvalid"): {
+            "message": "AWS Access Key ID or Session Token is invalid",
+            "remediation": "Check your AWS Access Key ID or Session Token and ensure it is valid.",
+        },
+        (1916, "AWSSecretAccessKeyInvalid"): {
+            "message": "AWS Secret Access Key is invalid",
+            "remediation": "Check your AWS Secret Access Key and signing method and ensure it is valid.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -174,4 +182,18 @@ class AWSAssumeRoleError(AWSBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1914, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AWSAccessKeyIDInvalid(AWSBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1915, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AWSSecretAccessKeyInvalid(AWSBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1916, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/aws/exceptions/exceptions.py
+++ b/prowler/providers/aws/exceptions/exceptions.py
@@ -66,8 +66,8 @@ class AWSBaseException(ProwlerException):
             "remediation": "Check your AWS Secret Access Key and signing method and ensure it is valid.",
         },
         (1917, "AWSInvalidAccountCredentials"): {
-            "message": "The AWS credentials provided belongs to a different account",
-            "remediation": "Check your AWS credentials and review if belongs to the account you want to use.",
+            "message": "The provided AWS credentials belong to a different account",
+            "remediation": "Check the provided AWS credentials and review if belong to the account you want to use.",
         },
     }
 

--- a/prowler/providers/aws/exceptions/exceptions.py
+++ b/prowler/providers/aws/exceptions/exceptions.py
@@ -189,21 +189,21 @@ class AWSAssumeRoleError(AWSBaseException):
         )
 
 
-class AWSAccessKeyIDInvalid(AWSBaseException):
+class AWSAccessKeyIDInvalid(AWSCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1915, file=file, original_exception=original_exception, message=message
         )
 
 
-class AWSSecretAccessKeyInvalid(AWSBaseException):
+class AWSSecretAccessKeyInvalid(AWSCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1916, file=file, original_exception=original_exception, message=message
         )
 
 
-class AWSInvalidAccountCredentials(AWSBaseException):
+class AWSInvalidAccountCredentials(AWSCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1917, file=file, original_exception=original_exception, message=message

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1408,7 +1408,7 @@ aws:
             "aws_access_key_id": session_token["Credentials"]["AccessKeyId"],
             "aws_secret_access_key": session_token["Credentials"]["SecretAccessKey"],
             "aws_session_token": session_token["Credentials"]["SessionToken"],
-            "aws_account_id": AWS_ACCOUNT_NUMBER,
+            "provider_id": AWS_ACCOUNT_NUMBER,
         }
 
         connection = AwsProvider.test_connection(**session_credentials)
@@ -1426,7 +1426,7 @@ aws:
             "aws_access_key_id": session_token["Credentials"]["AccessKeyId"],
             "aws_secret_access_key": session_token["Credentials"]["SecretAccessKey"],
             "aws_session_token": session_token["Credentials"]["SessionToken"],
-            "aws_account_id": "111122223333",
+            "provider_id": "111122223333",
         }
 
         with raises(AWSIAMRoleARNInvalidResourceType) as exception:
@@ -1447,7 +1447,7 @@ aws:
             "aws_access_key_id": session_token["Credentials"]["AccessKeyId"],
             "aws_secret_access_key": session_token["Credentials"]["SecretAccessKey"],
             "aws_session_token": session_token["Credentials"]["SessionToken"],
-            "aws_account_id": "111122223333",
+            "provider_id": "111122223333",
         }
 
         connection = AwsProvider.test_connection(

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1429,7 +1429,7 @@ aws:
             "provider_id": "111122223333",
         }
 
-        with raises(AWSIAMRoleARNInvalidResourceType) as exception:
+        with raises(AWSInvalidAccountCredentials) as exception:
             AwsProvider.test_connection(**session_credentials)
 
         assert exception.type == AWSInvalidAccountCredentials

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1435,7 +1435,7 @@ aws:
         assert exception.type == AWSInvalidAccountCredentials
         assert (
             exception.value.args[0]
-            == "[1917] The AWS credentials provided belongs to a different account"
+            == "[1917] The provided AWS credentials belong to a different account"
         )
 
     @mock_aws
@@ -1459,7 +1459,7 @@ aws:
         assert isinstance(connection.error, AWSInvalidAccountCredentials)
         assert (
             connection.error.message
-            == "The AWS credentials provided belongs to a different account"
+            == "The provided AWS credentials belong to a different account"
         )
         assert connection.error.code == 1917
 

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -261,6 +261,72 @@ class TestAWSProvider:
         assert aws_provider.session.current_session.region_name == AWS_REGION_US_EAST_1
 
     @mock_aws
+    def test_aws_provider_with_static_credentials(self):
+        # Create a mock IAM user
+        iam_client = client("iam", region_name=AWS_REGION_EU_WEST_1)
+        username = "test-user"
+        iam_user = iam_client.create_user(UserName=username)["User"]
+        # Create a mock IAM access keys
+        access_key = iam_client.create_access_key(UserName=iam_user["UserName"])[
+            "AccessKey"
+        ]
+
+        credentials = {
+            "aws_access_key_id": access_key["AccessKeyId"],
+            "aws_secret_access_key": access_key["SecretAccessKey"],
+        }
+
+        aws_provider = AwsProvider(**credentials)
+        assert aws_provider.type == "aws"
+        # Session
+        assert aws_provider.session.current_session.region_name == AWS_REGION_US_EAST_1
+        assert aws_provider.session.current_session.profile_name == "default"
+        assert aws_provider.session.original_session.region_name == AWS_REGION_US_EAST_1
+        assert aws_provider.session.original_session.profile_name == "default"
+
+        # Identity
+        assert aws_provider.identity.account == AWS_ACCOUNT_NUMBER
+        assert aws_provider.identity.account_arn == AWS_ACCOUNT_ARN
+        assert (
+            aws_provider.identity.identity_arn
+            == f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:user/{username}"
+        )
+        assert aws_provider.identity.partition == AWS_COMMERCIAL_PARTITION
+        assert aws_provider.identity.profile is None
+        assert aws_provider.identity.profile_region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_aws_provider_with_session_credentials(self):
+        sts_client = client("sts", region_name=AWS_REGION_EU_WEST_1)
+        session_token = sts_client.get_session_token()
+
+        session_credentials = {
+            "aws_access_key_id": session_token["Credentials"]["AccessKeyId"],
+            "aws_secret_access_key": session_token["Credentials"]["SecretAccessKey"],
+            "aws_session_token": session_token["Credentials"]["SessionToken"],
+        }
+
+        aws_provider = AwsProvider(**session_credentials)
+        assert aws_provider.type == "aws"
+        # Session
+        assert aws_provider.session.current_session.region_name == AWS_REGION_US_EAST_1
+        assert aws_provider.session.current_session.profile_name == "default"
+        assert aws_provider.session.original_session.region_name == AWS_REGION_US_EAST_1
+        assert aws_provider.session.original_session.profile_name == "default"
+
+        # Identity
+        assert aws_provider.identity.account == AWS_ACCOUNT_NUMBER
+        assert aws_provider.identity.account_arn == AWS_ACCOUNT_ARN
+        # moto is the default user created by moto
+        assert (
+            aws_provider.identity.identity_arn
+            == f"arn:aws:sts::{AWS_ACCOUNT_NUMBER}:user/moto"
+        )
+        assert aws_provider.identity.partition == AWS_COMMERCIAL_PARTITION
+        assert aws_provider.identity.profile is None
+        assert aws_provider.identity.profile_region == AWS_REGION_US_EAST_1
+
+    @mock_aws
     def test_aws_provider_organizations_delegated_administrator(self):
         organizations_client = client("organizations", region_name=AWS_REGION_EU_WEST_1)
         organization = organizations_client.create_organization()["Organization"]
@@ -1292,6 +1358,45 @@ aws:
             exception.value.args[0]
             == "[1912] AWS IAM Role ARN resource type is invalid"
         )
+
+    @mock_aws
+    def test_test_connection_with_static_credentials(self):
+        # Create a mock IAM user
+        iam_client = client("iam", region_name=AWS_REGION_EU_WEST_1)
+        username = "test-user"
+        iam_user = iam_client.create_user(UserName=username)["User"]
+        # Create a mock IAM access keys
+        access_key = iam_client.create_access_key(UserName=iam_user["UserName"])[
+            "AccessKey"
+        ]
+
+        credentials = {
+            "aws_access_key_id": access_key["AccessKeyId"],
+            "aws_secret_access_key": access_key["SecretAccessKey"],
+        }
+
+        connection = AwsProvider.test_connection(**credentials)
+
+        assert isinstance(connection, Connection)
+        assert connection.is_connected
+        assert connection.error is None
+
+    @mock_aws
+    def test_test_connection_with_session_credentials(self):
+        sts_client = client("sts", region_name=AWS_REGION_EU_WEST_1)
+        session_token = sts_client.get_session_token()
+
+        session_credentials = {
+            "aws_access_key_id": session_token["Credentials"]["AccessKeyId"],
+            "aws_secret_access_key": session_token["Credentials"]["SecretAccessKey"],
+            "aws_session_token": session_token["Credentials"]["SessionToken"],
+        }
+
+        connection = AwsProvider.test_connection(**session_credentials)
+
+        assert isinstance(connection, Connection)
+        assert connection.is_connected
+        assert connection.error is None
 
     @mock_aws
     def test_create_sts_session(self):


### PR DESCRIPTION
### Context

**Review and merge first #5360**

### Description

Add optional validation for the AWS Account ID in the `test_connection` method. If set, raises a `AWSInvalidAccountCredentials` if the AWS STS GetCallerIdentity API call returns a different Account value.

### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. -> Nope.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
