### PR TITLE
feat(gcp): add static credentials for gcp provider

### DIFF
--- a/prowler/providers/gcp/exceptions/exceptions.py
+++ b/prowler/providers/gcp/exceptions/exceptions.py
@@ -53,6 +53,13 @@ class GCPBaseException(ProwlerException):
         )
 
 
+class GCPCredentialsError(GCPBaseException):
+    """Base class for GCP credentials errors."""
+
+    def __init__(self, code, file=None, original_exception=None, message=None):
+        super().__init__(code, file, original_exception, message)
+
+
 class GCPCloudResourceManagerAPINotUsedError(GCPBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
@@ -67,21 +74,21 @@ class GCPHTTPError(GCPBaseException):
         )
 
 
-class GCPNoAccesibleProjectsError(GCPBaseException):
+class GCPNoAccesibleProjectsError(GCPCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1927, file=file, original_exception=original_exception, message=message
         )
 
 
-class GCPSetUpSessionError(GCPBaseException):
+class GCPSetUpSessionError(GCPCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1928, file=file, original_exception=original_exception, message=message
         )
 
 
-class GCPGetProjectError(GCPBaseException):
+class GCPGetProjectError(GCPCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1929, file=file, original_exception=original_exception, message=message
@@ -95,14 +102,14 @@ class GCPTestConnectionError(GCPBaseException):
         )
 
 
-class GCPLoadCredentialsFromDictError(GCPBaseException):
+class GCPLoadCredentialsFromDictError(GCPCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1931, file=file, original_exception=original_exception, message=message
         )
 
 
-class GCPStaticCredentialsError(GCPBaseException):
+class GCPStaticCredentialsError(GCPCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1932, file=file, original_exception=original_exception, message=message

--- a/prowler/providers/gcp/exceptions/exceptions.py
+++ b/prowler/providers/gcp/exceptions/exceptions.py
@@ -29,6 +29,14 @@ class GCPBaseException(ProwlerException):
             "message": "Error testing connection to GCP",
             "remediation": "Check the connection and ensure it is properly set up.",
         },
+        (1931, "GCPLoadCredentialsFromDictError"): {
+            "message": "Error loading credentials from dictionary",
+            "remediation": "Check the credentials and ensure they are properly set up. client_id, client_secret and refresh_token are required.",
+        },
+        (1932, "GCPStaticCredentialsError"): {
+            "message": "Error loading static credentials",
+            "remediation": "Check the credentials and ensure they are properly set up. client_id, client_secret and refresh_token are required.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -84,4 +92,18 @@ class GCPTestConnectionError(GCPBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1930, file=file, original_exception=original_exception, message=message
+        )
+
+
+class GCPLoadCredentialsFromDictError(GCPBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1931, file=file, original_exception=original_exception, message=message
+        )
+
+
+class GCPStaticCredentialsError(GCPBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1932, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -241,7 +241,7 @@ class GcpProvider(Provider):
             scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
             if gcp_credentials:
-                logger.info(f"Using GCP credentials: {gcp_credentials}")
+                logger.info("Using GCP static credentials")
                 logger.info("GCP provider: Setting credentials from dict...")
                 try:
                     credentials, default_project_id = load_credentials_from_dict(


### PR DESCRIPTION
### Description

This Pull Request (PR) adds a new method for instantiating the GCP provider exclusively using `client_id`, `client_secret` and `refresh_token`.

Also, new exceptions are added.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
