### PR TITLE
feat(color): add `--no-color` flag

### DIFF
--- a/docs/tutorials/misc.md
+++ b/docs/tutorials/misc.md
@@ -27,7 +27,7 @@ prowler <provider> -b/--no-banner
 ## Disable Colors
 Prowler can run without showing colors:
 ```console
-prowler <provider> -Q/--no-color
+prowler <provider> --no-color
 ```
 ## Checks
 Prowler has checks per provider, there are options related with them:

--- a/docs/tutorials/misc.md
+++ b/docs/tutorials/misc.md
@@ -24,6 +24,11 @@ Prowler can run without showing its banner:
 ```console
 prowler <provider> -b/--no-banner
 ```
+## Disable Colors
+Prowler can run without showing colors:
+```console
+prowler <provider> -Q/--no-color
+```
 ## Checks
 Prowler has checks per provider, there are options related with them:
 

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -115,8 +115,6 @@ def prowler():
 
     if args.no_color:
         colorama_init(strip=True)
-    else:
-        colorama_init(strip=False)
 
     if not args.no_banner:
         legend = args.verbose or getattr(args, "fixer", None)

--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -5,6 +5,7 @@ import sys
 from os import environ
 
 from colorama import Fore, Style
+from colorama import init as colorama_init
 
 from prowler.config.config import (
     csv_file_suffix,
@@ -111,6 +112,11 @@ def prowler():
         and not checks_file
         and not checks_folder
     )
+
+    if args.no_color:
+        colorama_init(strip=True)
+    else:
+        colorama_init(strip=False)
 
     if not args.no_banner:
         legend = args.verbose or getattr(args, "fixer", None)

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -179,7 +179,6 @@ Detailed documentation at https://docs.prowler.com
         )
         common_outputs_parser.add_argument(
             "--no-color",
-            "-Q",
             action="store_true",
             help="Disable color codes in output",
         )

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -178,6 +178,13 @@ Detailed documentation at https://docs.prowler.com
             "--no-banner", "-b", action="store_true", help="Hide Prowler banner"
         )
         common_outputs_parser.add_argument(
+            "--no-color",
+            "-Q",
+            action="store_true",
+            help="Disable color codes in output",
+        )
+
+        common_outputs_parser.add_argument(
             "--unix-timestamp",
             action="store_true",
             default=False,

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -52,6 +52,7 @@ class Test_Parser:
         assert "output" in parsed.output_directory
         assert not parsed.verbose
         assert not parsed.no_banner
+        assert not parsed.no_color
         assert not parsed.slack
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
@@ -100,6 +101,7 @@ class Test_Parser:
         assert "output" in parsed.output_directory
         assert not parsed.verbose
         assert not parsed.no_banner
+        assert not parsed.no_color
         assert not parsed.slack
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
@@ -140,6 +142,7 @@ class Test_Parser:
         assert "output" in parsed.output_directory
         assert not parsed.verbose
         assert not parsed.no_banner
+        assert not parsed.no_color
         assert not parsed.slack
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
@@ -175,6 +178,7 @@ class Test_Parser:
         assert "output" in parsed.output_directory
         assert not parsed.verbose
         assert not parsed.no_banner
+        assert not parsed.no_color
         assert not parsed.slack
         assert not parsed.unix_timestamp
         assert parsed.log_level == "CRITICAL"
@@ -354,6 +358,16 @@ class Test_Parser:
         command = [prowler_command, "--no-banner"]
         parsed = self.parser.parse(command)
         assert parsed.no_banner
+
+    def test_root_parser_no_color_short(self):
+        command = [prowler_command, "-Q"]
+        parsed = self.parser.parse(command)
+        assert parsed.no_color
+
+    def test_root_parser_no_color_long(self):
+        command = [prowler_command, "--no-color"]
+        parsed = self.parser.parse(command)
+        assert parsed.no_color
 
     def test_root_parser_slack(self):
         command = [prowler_command, "--slack"]

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -360,11 +360,6 @@ class Test_Parser:
         parsed = self.parser.parse(command)
         assert parsed.no_banner
 
-    def test_root_parser_no_color_short(self):
-        command = [prowler_command, "-Q"]
-        parsed = self.parser.parse(command)
-        assert parsed.no_color
-
     def test_root_parser_no_color_long(self):
         command = [prowler_command, "--no-color"]
         parsed = self.parser.parse(command)

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -25,6 +25,7 @@ def mock_get_available_providers():
     return ["aws", "azure", "gcp", "kubernetes"]
 
 
+@pytest.mark.arg_parser
 class Test_Parser:
     def setup_method(self):
         # We need this to mock the get_available_providers function call


### PR DESCRIPTION
### Context

Fix #5294 

### Description

- Import colorama's `init`
- Add `--no-color` command line option (default `False`)
- Use `no_color` option to control colorama init.


### Checklist

- Are there new checks included in this PR? **No**
- [x] Review if the code is being covered by tests.
  - Tests added to the parser testing library
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
