### PR TITLE
feat(containerregistry): add new check `containerregistry_uses_private_link`

### DIFF
--- a/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
+++ b/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
@@ -14,11 +14,11 @@ class appinsights_ensure_is_configured(Check):
             report.subscription = subscription_name
             report.resource_name = "AppInsights"
             report.resource_id = "AppInsights"
-            report.status_extended = f"There is at least one AppInsight configured in susbscription {subscription_name}."
+            report.status_extended = f"There is at least one AppInsight configured in subscription {subscription_name}."
 
             if len(components) < 1:
                 report.status = "FAIL"
-                report.status_extended = f"There are no AppInsight configured in susbscription {subscription_name}."
+                report.status_extended = f"There are no AppInsight configured in subscription {subscription_name}."
 
             findings.append(report)
 

--- a/prowler/providers/azure/services/containerregistry/containerregistry_service.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_service.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from azure.mgmt.containerregistry import ContainerRegistryManagementClient
+from azure.mgmt.containerregistry.models import PrivateEndpointConnection
 
 from prowler.lib.logger import logger
 from prowler.providers.azure.azure_provider import AzureProvider
@@ -41,6 +42,9 @@ class ContainerRegistry(AzureService):
                                 ),
                                 monitor_diagnostic_settings=self._get_registry_monitor_settings(
                                     registry.name, resource_group, subscription
+                                ),
+                                private_endpoint_connections=getattr(
+                                    registry, "private_endpoint_connections", []
                                 ),
                             )
                         }
@@ -85,4 +89,5 @@ class ContainerRegistryInfo:
     login_server: str
     public_network_access: str
     admin_user_enabled: bool
-    monitor_diagnostic_settings: list[DiagnosticSetting] = None
+    monitor_diagnostic_settings: list[DiagnosticSetting]
+    private_endpoint_connections: list[PrivateEndpointConnection]

--- a/prowler/providers/azure/services/containerregistry/containerregistry_service.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_service.py
@@ -98,4 +98,3 @@ class ContainerRegistryInfo:
     network_rule_set: NetworkRuleSet
     monitor_diagnostic_settings: list[DiagnosticSetting]
     private_endpoint_connections: list[PrivateEndpointConnection]
-    monitor_diagnostic_settings: list[DiagnosticSetting]

--- a/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.metadata.json
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.metadata.json
@@ -8,23 +8,23 @@
   "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "ContainerRegistry",
-  "Description": "Ensure that the admin user is disabled and Role-Based Access Control (RBAC) is used instead since it could grant unrestricted access to the registry",
-  "Risk": "If the admin user is enabled, it may lead to unauthorized access to the container registry and its resources, which could compromise the confidentiality, integrity, and availability of the images stored within.",
-  "RelatedUrl": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account",
+  "Description": "Ensure that a private link is used for accessing the Azure Container Registry to enhance security and restrict access to the registry over the public internet.",
+  "Risk": "Without using a private link, the Azure Container Registry may be exposed to the public internet, increasing the risk of unauthorized access and potential data breaches.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/azure/private-link/private-link-overview",
   "Remediation": {
     "Code": {
-      "CLI": "az acr update --name <RegistryName> --resource-group <ResourceGroupName> --admin-enabled false",
+      "CLI": "az network private-endpoint create  --connection-name <ConnectionName> --resource-group <ResourceGroupName> --name <Name> --private-connection-resource-id <PrivateConnectionResourceId> --subnet <SubnetName>",
       "NativeIaC": "",
       "Other": "",
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Disable the admin user on Azure Container Registry through the Azure Portal: 1. Navigate to your Container Registry. 2. In the settings, select 'Access keys'. 3. Ensure the 'Admin user' checkbox is not ticked. For all actions relying on registry access, switch to using Role-Based Access Control.",
-      "Url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account"
+      "Text": "Create a private link for Azure Container Registry through the Azure Portal: 1. Navigate to your Container Registry. 2. In the settings, select 'Networking'. 3. Select 'Private access'. 4. Configure a private endpoint for the registry.",
+      "Url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-private-link"
     }
   },
   "Categories": [],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": "The transition away from using the admin user to RBAC will facilitate a more secure and manageable access model, minimizing the potential risk of unauthorized access to your container images."
+  "Notes": "This feature is only available for Premium SKU registries."
 }

--- a/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.metadata.json
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.metadata.json
@@ -13,7 +13,7 @@
   "RelatedUrl": "https://learn.microsoft.com/en-us/azure/private-link/private-link-overview",
   "Remediation": {
     "Code": {
-      "CLI": "az network private-endpoint create  --connection-name <ConnectionName> --resource-group <ResourceGroupName> --name <Name> --private-connection-resource-id <PrivateConnectionResourceId> --subnet <SubnetName>",
+      "CLI": "az network private-endpoint create  --connection-name <ConnectionName> --resource-group <ResourceGroupName> --name <Name> --private-connection-resource-id <RegistryId> --vnet-name <VnetName> --subnet <SubnetName> --group-ids registry",
       "NativeIaC": "",
       "Other": "",
       "Terraform": ""

--- a/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.metadata.json
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "azure",
+  "CheckID": "containerregistry_uses_private_link",
+  "CheckTitle": "Ensure to use a private link for accessing the Azure Container Registry",
+  "CheckType": [],
+  "ServiceName": "containerregistry",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "ContainerRegistry",
+  "Description": "Ensure that the admin user is disabled and Role-Based Access Control (RBAC) is used instead since it could grant unrestricted access to the registry",
+  "Risk": "If the admin user is enabled, it may lead to unauthorized access to the container registry and its resources, which could compromise the confidentiality, integrity, and availability of the images stored within.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account",
+  "Remediation": {
+    "Code": {
+      "CLI": "az acr update --name <RegistryName> --resource-group <ResourceGroupName> --admin-enabled false",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Disable the admin user on Azure Container Registry through the Azure Portal: 1. Navigate to your Container Registry. 2. In the settings, select 'Access keys'. 3. Ensure the 'Admin user' checkbox is not ticked. For all actions relying on registry access, switch to using Role-Based Access Control.",
+      "Url": "https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#admin-account"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "The transition away from using the admin user to RBAC will facilitate a more secure and manageable access model, minimizing the potential risk of unauthorized access to your container images."
+}

--- a/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.py
@@ -1,0 +1,28 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.containerregistry.containerregistry_client import (
+    containerregistry_client,
+)
+
+
+class containerregistry_uses_private_link(Check):
+    def execute(self) -> list[Check_Report_Azure]:
+        findings = []
+
+        for subscription, registries in containerregistry_client.registries.items():
+            for registry_id, container_registry_info in registries.items():
+                report = Check_Report_Azure(self.metadata())
+                report.subscription = subscription
+                report.resource_name = container_registry_info.name
+                report.resource_id = registry_id
+                report.location = container_registry_info.location
+                report.status = "FAIL"
+                report.status_extended = f"Container Registry {container_registry_info.name} from subscription {subscription} does not use a private link."
+
+                print(container_registry_info)
+                if container_registry_info.private_endpoint_connections:
+                    report.status = "PASS"
+                    report.status_extended = f"Container Registry {container_registry_info.name} from subscription {subscription} uses a private link."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/defender/defender_additional_email_configured_with_a_security_contact/defender_additional_email_configured_with_a_security_contact.py
+++ b/prowler/providers/azure/services/defender/defender_additional_email_configured_with_a_security_contact/defender_additional_email_configured_with_a_security_contact.py
@@ -18,7 +18,7 @@ class defender_additional_email_configured_with_a_security_contact(Check):
                 report.subscription = subscription_name
                 report.resource_name = contact_name
                 report.resource_id = contact_info.resource_id
-                report.status_extended = f"There is another correct email configured for susbscription {subscription_name}."
+                report.status_extended = f"There is another correct email configured for subscription {subscription_name}."
 
                 emails = contact_info.emails.split(";")
 
@@ -29,7 +29,7 @@ class defender_additional_email_configured_with_a_security_contact(Check):
                         break
                 else:
                     report.status = "FAIL"
-                    report.status_extended = f"There is not another correct email configured for susbscription {subscription_name}."
+                    report.status_extended = f"There is not another correct email configured for subscription {subscription_name}."
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on.py
@@ -30,11 +30,11 @@ class defender_ensure_iot_hub_defender_is_on(Check):
                 report.subscription = subscription_name
                 report.resource_name = iot_security_solution_name
                 report.resource_id = iot_security_solution.resource_id
-                report.status_extended = f"The security solution {iot_security_solution_name} is enabled in susbscription {subscription_name}."
+                report.status_extended = f"The security solution {iot_security_solution_name} is enabled in subscription {subscription_name}."
 
                 if iot_security_solution.status != "Enabled":
                     report.status = "FAIL"
-                    report.status_extended = f"The security solution {iot_security_solution_name} is disabled in susbscription {subscription_name}"
+                    report.status_extended = f"The security solution {iot_security_solution_name} is disabled in subscription {subscription_name}"
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/defender/defender_ensure_notify_alerts_severity_is_high/defender_ensure_notify_alerts_severity_is_high.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_notify_alerts_severity_is_high/defender_ensure_notify_alerts_severity_is_high.py
@@ -16,11 +16,11 @@ class defender_ensure_notify_alerts_severity_is_high(Check):
                 report.subscription = subscription_name
                 report.resource_name = contact_name
                 report.resource_id = contact_info.resource_id
-                report.status_extended = f"Notifiy alerts are enabled for severity high in susbscription {subscription_name}."
+                report.status_extended = f"Notifiy alerts are enabled for severity high in subscription {subscription_name}."
 
                 if contact_info.alert_notifications_minimal_severity != "High":
                     report.status = "FAIL"
-                    report.status_extended = f"Notifiy alerts are not enabled for severity high in susbscription {subscription_name}."
+                    report.status_extended = f"Notifiy alerts are not enabled for severity high in subscription {subscription_name}."
 
                 findings.append(report)
 

--- a/tests/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured_test.py
+++ b/tests/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured_test.py
@@ -52,7 +52,7 @@ class Test_appinsights_ensure_is_configured:
             assert result[0].location == "global"
             assert (
                 result[0].status_extended
-                == f"There are no AppInsight configured in susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There are no AppInsight configured in subscription {AZURE_SUBSCRIPTION_ID}."
             )
 
     def test_appinsights_configured(self):
@@ -89,5 +89,5 @@ class Test_appinsights_ensure_is_configured:
             assert result[0].location == "global"
             assert (
                 result[0].status_extended
-                == f"There is at least one AppInsight configured in susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is at least one AppInsight configured in subscription {AZURE_SUBSCRIPTION_ID}."
             )

--- a/tests/providers/azure/services/containerregistry/containerregistry_admin_user_disabled/containerregistry_admin_user_disabled_test.py
+++ b/tests/providers/azure/services/containerregistry/containerregistry_admin_user_disabled/containerregistry_admin_user_disabled_test.py
@@ -59,6 +59,7 @@ class TestContainerRegistryAdminUserDisabled:
                         admin_user_enabled=True,
                         network_rule_set=None,
                         monitor_diagnostic_settings=[],
+                        private_endpoint_connections=[],
                     )
                 }
             }
@@ -115,6 +116,7 @@ class TestContainerRegistryAdminUserDisabled:
                         admin_user_enabled=False,
                         network_rule_set=None,
                         monitor_diagnostic_settings=[],
+                        private_endpoint_connections=[],
                     )
                 }
             }

--- a/tests/providers/azure/services/containerregistry/containerregistry_not_publicly_accessible/containerregistry_not_publicly_accessible_test.py
+++ b/tests/providers/azure/services/containerregistry/containerregistry_not_publicly_accessible/containerregistry_not_publicly_accessible_test.py
@@ -60,6 +60,7 @@ class Test_containerregistry_not_publicly_accessible:
                         public_network_access="Enabled",
                         admin_user_enabled=True,
                         network_rule_set=NetworkRuleSet(default_action="Allow"),
+                        private_endpoint_connections=[],
                         monitor_diagnostic_settings=[
                             {
                                 "id": "id1/id1",
@@ -133,6 +134,7 @@ class Test_containerregistry_not_publicly_accessible:
                         public_network_access="Enabled",
                         admin_user_enabled=False,
                         network_rule_set=NetworkRuleSet(default_action="Deny"),
+                        private_endpoint_connections=[],
                         monitor_diagnostic_settings=[
                             {
                                 "id": "id1/id1",

--- a/tests/providers/azure/services/containerregistry/containerregistry_service_test.py
+++ b/tests/providers/azure/services/containerregistry/containerregistry_service_test.py
@@ -35,6 +35,7 @@ class TestContainerRegistryService:
                         public_network_access="Enabled",
                         admin_user_enabled=True,
                         network_rule_set=None,
+                        private_endpoint_connections=[],
                         monitor_diagnostic_settings=[
                             {
                                 "id": "id1/id1",

--- a/tests/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link_test.py
+++ b/tests/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link_test.py
@@ -1,0 +1,157 @@
+from unittest import mock
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from azure.mgmt.containerregistry.models import (
+    PrivateEndpoint,
+    PrivateEndpointConnection,
+    PrivateLinkServiceConnectionState,
+)
+
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_ID,
+    set_mocked_azure_provider,
+)
+
+
+class Test_containerregistry_uses_private_link:
+    def test_no_container_registries(self):
+        containerregistry_client = MagicMock()
+        containerregistry_client.registries = {}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_azure_provider(),
+        ), mock.patch(
+            "prowler.providers.azure.services.containerregistry.containerregistry_uses_private_link.containerregistry_uses_private_link.containerregistry_client",
+            new=containerregistry_client,
+        ):
+            from prowler.providers.azure.services.containerregistry.containerregistry_uses_private_link.containerregistry_uses_private_link import (
+                containerregistry_uses_private_link,
+            )
+
+            check = containerregistry_uses_private_link()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_container_registry_not_uses_private_link(self):
+        containerregistry_client = MagicMock()
+        registry_id = str(uuid4())
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_azure_provider(),
+        ), mock.patch(
+            "prowler.providers.azure.services.containerregistry.containerregistry_uses_private_link.containerregistry_uses_private_link.containerregistry_client",
+            new=containerregistry_client,
+        ):
+            from prowler.providers.azure.services.containerregistry.containerregistry_service import (
+                ContainerRegistryInfo,
+            )
+            from prowler.providers.azure.services.containerregistry.containerregistry_uses_private_link.containerregistry_uses_private_link import (
+                containerregistry_uses_private_link,
+            )
+
+            containerregistry_client.registries = {
+                AZURE_SUBSCRIPTION_ID: {
+                    registry_id: ContainerRegistryInfo(
+                        id=registry_id,
+                        name="mock_registry",
+                        location="westeurope",
+                        resource_group="mock_resource_group",
+                        sku="Basic",
+                        login_server="mock_login_server.azurecr.io",
+                        public_network_access="Enabled",
+                        admin_user_enabled=True,
+                        monitor_diagnostic_settings=[],
+                        private_endpoint_connections=[],
+                    )
+                }
+            }
+
+            check = containerregistry_uses_private_link()
+
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Container Registry mock_registry from subscription {AZURE_SUBSCRIPTION_ID} does not use a private link."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == "mock_registry"
+            assert (
+                result[0].resource_id
+                == containerregistry_client.registries[AZURE_SUBSCRIPTION_ID][
+                    registry_id
+                ].id
+            )
+            assert result[0].location == "westeurope"
+
+    def test_container_registry_uses_private_link(self):
+        containerregistry_client = mock.MagicMock()
+        containerregistry_client.registries = {}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_azure_provider(),
+        ), mock.patch(
+            "prowler.providers.azure.services.containerregistry.containerregistry_uses_private_link.containerregistry_uses_private_link.containerregistry_client",
+            new=containerregistry_client,
+        ):
+            from prowler.providers.azure.services.containerregistry.containerregistry_service import (
+                ContainerRegistryInfo,
+            )
+            from prowler.providers.azure.services.containerregistry.containerregistry_uses_private_link.containerregistry_uses_private_link import (
+                containerregistry_uses_private_link,
+            )
+
+            registry_id = str(uuid4())
+
+            containerregistry_client.registries = {
+                AZURE_SUBSCRIPTION_ID: {
+                    registry_id: ContainerRegistryInfo(
+                        id=registry_id,
+                        name="mock_registry",
+                        location="westeurope",
+                        resource_group="mock_resource_group",
+                        sku="Basic",
+                        login_server="mock_login_server.azurecr.io",
+                        public_network_access="Enabled",
+                        admin_user_enabled=False,
+                        monitor_diagnostic_settings=[],
+                        private_endpoint_connections=[
+                            PrivateEndpointConnection(
+                                id="/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/mock_resource_group/providers/Microsoft.ContainerRegistry/registries/mock_registry/privateEndpointConnections/myConnection",
+                                private_endpoint=PrivateEndpoint(
+                                    id="/subscriptions/AZURE_SUBSCRIPTION_ID/resourceGroups/mock_resource_group/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                                ),
+                                private_link_service_connection_state=PrivateLinkServiceConnectionState(
+                                    status="Approved",
+                                    description="Auto-approved connection",
+                                    actions_required="None",
+                                ),
+                                provisioning_state="Succeeded",
+                            )
+                        ],
+                    )
+                }
+            }
+
+            check = containerregistry_uses_private_link()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Container Registry mock_registry from subscription {AZURE_SUBSCRIPTION_ID} uses a private link."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == "mock_registry"
+            assert (
+                result[0].resource_id
+                == containerregistry_client.registries[AZURE_SUBSCRIPTION_ID][
+                    registry_id
+                ].id
+            )
+            assert result[0].location == "westeurope"

--- a/tests/providers/azure/services/defender/defender_additional_email_configured_with_a_security_contact/defender_additional_email_configured_with_a_security_contact_test.py
+++ b/tests/providers/azure/services/defender/defender_additional_email_configured_with_a_security_contact/defender_additional_email_configured_with_a_security_contact_test.py
@@ -62,7 +62,7 @@ class Test_defender_additional_email_configured_with_a_security_contact:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"There is not another correct email configured for susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is not another correct email configured for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"
@@ -102,7 +102,7 @@ class Test_defender_additional_email_configured_with_a_security_contact:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"There is not another correct email configured for susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is not another correct email configured for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"
@@ -142,7 +142,7 @@ class Test_defender_additional_email_configured_with_a_security_contact:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"There is not another correct email configured for susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is not another correct email configured for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"
@@ -182,7 +182,7 @@ class Test_defender_additional_email_configured_with_a_security_contact:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"There is another correct email configured for susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is another correct email configured for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"
@@ -222,7 +222,7 @@ class Test_defender_additional_email_configured_with_a_security_contact:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"There is another correct email configured for susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is another correct email configured for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"
@@ -261,7 +261,7 @@ class Test_defender_additional_email_configured_with_a_security_contact:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"There is not another correct email configured for susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is not another correct email configured for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"

--- a/tests/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on_test.py
@@ -84,7 +84,7 @@ class Test_defender_ensure_iot_hub_defender_is_on:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"The security solution iot_sec_solution is disabled in susbscription {AZURE_SUBSCRIPTION_ID}"
+                == f"The security solution iot_sec_solution is disabled in subscription {AZURE_SUBSCRIPTION_ID}"
             )
             assert result[0].resource_name == "iot_sec_solution"
             assert result[0].resource_id == resource_id
@@ -117,7 +117,7 @@ class Test_defender_ensure_iot_hub_defender_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"The security solution iot_sec_solution is enabled in susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"The security solution iot_sec_solution is enabled in subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].resource_name == "iot_sec_solution"
             assert result[0].resource_id == resource_id
@@ -155,7 +155,7 @@ class Test_defender_ensure_iot_hub_defender_is_on:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"The security solution iot_sec_solution_enabled is enabled in susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"The security solution iot_sec_solution_enabled is enabled in subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].resource_name == "iot_sec_solution_enabled"
             assert result[0].resource_id == resource_id_enabled
@@ -164,7 +164,7 @@ class Test_defender_ensure_iot_hub_defender_is_on:
             assert result[1].status == "FAIL"
             assert (
                 result[1].status_extended
-                == f"The security solution iot_sec_solution_disabled is disabled in susbscription {AZURE_SUBSCRIPTION_ID}"
+                == f"The security solution iot_sec_solution_disabled is disabled in subscription {AZURE_SUBSCRIPTION_ID}"
             )
             assert result[1].resource_name == "iot_sec_solution_disabled"
             assert result[1].resource_id == resource_id_disabled

--- a/tests/providers/azure/services/defender/defender_ensure_notify_alerts_severity_is_high/defender_ensure_notify_alerts_severity_is_high_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_notify_alerts_severity_is_high/defender_ensure_notify_alerts_severity_is_high_test.py
@@ -62,7 +62,7 @@ class Test_defender_ensure_notify_alerts_severity_is_high:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Notifiy alerts are not enabled for severity high in susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"Notifiy alerts are not enabled for severity high in subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"
@@ -102,7 +102,7 @@ class Test_defender_ensure_notify_alerts_severity_is_high:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Notifiy alerts are enabled for severity high in susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"Notifiy alerts are enabled for severity high in subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"
@@ -141,7 +141,7 @@ class Test_defender_ensure_notify_alerts_severity_is_high:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Notifiy alerts are not enabled for severity high in susbscription {AZURE_SUBSCRIPTION_ID}."
+                == f"Notifiy alerts are not enabled for severity high in subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == "default"


### PR DESCRIPTION
### Context

Without using a private link, the Azure Container Registry may be exposed to the public internet, increasing the risk of unauthorized access and potential data breaches.

### Description

This PR adds an check for a private link connection for the Azure Container Registry.

### Checklist

- Are there new checks included in this PR? **Yes**
    - If so, do we need to update permissions for the provider? Please review this carefully. **No**
- [X] Review if the code is being covered by tests.
- [X] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [X] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
