### PR TITLE
feat(waf): change WAF Classic `web_acls` from `list` to `dict`

### DIFF
--- a/prowler/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached.py
@@ -22,7 +22,7 @@ class elbv2_waf_acl_attached(Check):
                     if lb_arn in acl.albs:
                         report.status = "PASS"
                         report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv2 Web ACL {acl.name}."
-                for acl in waf_client.web_acls:
+                for acl in waf_client.web_acls.values():
                     if lb_arn in acl.albs:
                         report.status = "PASS"
                         report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv1 Web ACL {acl.name}."

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -20,7 +20,7 @@ class WAF(AWSService):
                 if not self.audit_resources or (
                     is_resource_filtered(waf["WebACLId"], self.audit_resources)
                 ):
-                    arn = f"arn:aws:waf-regional:{regional_client.region}:{self.audited_account}:webacl/{waf["WebACLId"]}"
+                    arn = f"arn:aws:waf-regional:{regional_client.region}:{self.audited_account}:webacl/{waf['WebACLId']}"
                     self.web_acls[arn] = WebAcl(
                         arn=arn,
                         name=waf["Name"],

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -5,12 +5,11 @@ from prowler.lib.scan_filters.scan_filters import is_resource_filtered
 from prowler.providers.aws.lib.service.service import AWSService
 
 
-################### WAF
 class WAF(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__
         super().__init__("waf-regional", provider)
-        self.web_acls = []
+        self.web_acls = {}
         self.__threading_call__(self._list_web_acls)
         self.__threading_call__(self._list_resources_for_web_acl)
 
@@ -21,13 +20,13 @@ class WAF(AWSService):
                 if not self.audit_resources or (
                     is_resource_filtered(waf["WebACLId"], self.audit_resources)
                 ):
-                    self.web_acls.append(
-                        WebAcl(
-                            name=waf["Name"],
-                            id=waf["WebACLId"],
-                            albs=[],
-                            region=regional_client.region,
-                        )
+                    arn = f"arn:aws:waf-regional:{regional_client.region}:{self.audited_account}:webacl/{waf["WebACLId"]}"
+                    self.web_acls[arn] = WebAcl(
+                        arn=arn,
+                        name=waf["Name"],
+                        id=waf["WebACLId"],
+                        albs=[],
+                        region=regional_client.region,
                     )
         except Exception as error:
             logger.error(
@@ -37,7 +36,7 @@ class WAF(AWSService):
     def _list_resources_for_web_acl(self, regional_client):
         logger.info("WAF - Describing resources...")
         try:
-            for acl in self.web_acls:
+            for acl in self.web_acls.values():
                 if acl.region == regional_client.region:
                     for resource in regional_client.list_resources_for_web_acl(
                         WebACLId=acl.id, ResourceType="APPLICATION_LOAD_BALANCER"
@@ -51,6 +50,7 @@ class WAF(AWSService):
 
 
 class WebAcl(BaseModel):
+    arn: str
     name: str
     id: str
     albs: list[str]

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -70,16 +70,18 @@ class Test_WAF_Service:
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
-        assert waf.web_acls[0].name == "my-web-acl"
-        assert waf.web_acls[0].region == AWS_REGION_EU_WEST_1
-        assert waf.web_acls[0].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
 
     # Test WAF Describe Web ACLs Resources
     def test_list_resources_for_web_acl(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
-        assert len(waf.web_acls[0].albs) == 1
-        assert "alb-arn" in waf.web_acls[0].albs
+        assert len(waf.web_acls[waf_arn].albs) == 1
+        assert "alb-arn" in waf.web_acls[waf_arn].albs


### PR DESCRIPTION
### Context

Until now, `web_acls` parameter in `WAF Classic` Service was a `list`.

### Description

Changed `web_acls`parameter from `list` to `dict` in `WAF` service to enhance code usability and make it more consistent.

### Checklist

- Are there new checks included in this PR? No.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
