### PR TITLE
feat(gcp): add provider id validation inside test_connection

### DIFF
--- a/prowler/providers/gcp/exceptions/exceptions.py
+++ b/prowler/providers/gcp/exceptions/exceptions.py
@@ -37,6 +37,10 @@ class GCPBaseException(ProwlerException):
             "message": "Error loading static credentials",
             "remediation": "Check the credentials and ensure they are properly set up. client_id, client_secret and refresh_token are required.",
         },
+        (1933, "GCPNotValidProviderIdError"): {
+            "message": "Provider does not match with the expected project_id",
+            "remediation": "Check the provider and ensure it matches the expected project_id.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -113,4 +117,11 @@ class GCPStaticCredentialsError(GCPCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1932, file=file, original_exception=original_exception, message=message
+        )
+
+
+class GCPNotValidProviderIdError(GCPBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1933, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/gcp/exceptions/exceptions.py
+++ b/prowler/providers/gcp/exceptions/exceptions.py
@@ -37,7 +37,7 @@ class GCPBaseException(ProwlerException):
             "message": "Error loading static credentials",
             "remediation": "Check the credentials and ensure they are properly set up. client_id, client_secret and refresh_token are required.",
         },
-        (1933, "GCPNotValidProviderIdError"): {
+        (1933, "GCPInvalidAccountCredentials"): {
             "message": "Provider does not match with the expected project_id",
             "remediation": "Check the provider and ensure it matches the expected project_id.",
         },
@@ -120,7 +120,7 @@ class GCPStaticCredentialsError(GCPCredentialsError):
         )
 
 
-class GCPNotValidProviderIdError(GCPBaseException):
+class GCPInvalidAccountCredentials(GCPBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1933, file=file, original_exception=original_exception, message=message

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -19,9 +19,9 @@ from prowler.providers.gcp.exceptions.exceptions import (
     GCPCloudResourceManagerAPINotUsedError,
     GCPGetProjectError,
     GCPHTTPError,
+    GCPInvalidAccountCredentials,
     GCPLoadCredentialsFromDictError,
     GCPNoAccesibleProjectsError,
-    GCPNotValidProviderIdError,
     GCPSetUpSessionError,
     GCPStaticCredentialsError,
     GCPTestConnectionError,
@@ -367,7 +367,7 @@ class GcpProvider(Provider):
                 raise http_error
             return Connection(error=http_error)
         # Exceptions from validating Provider ID
-        except GCPNotValidProviderIdError as not_valid_provider_id_error:
+        except GCPInvalidAccountCredentials as not_valid_provider_id_error:
             logger.critical(str(not_valid_provider_id_error))
             if raise_on_exception:
                 raise not_valid_provider_id_error
@@ -563,13 +563,13 @@ class GcpProvider(Provider):
             bool
 
         Raises:
-            GCPNotValidProviderIdError if the provider ID does not match with the expected project_id
+            GCPInvalidAccountCredentials if the provider ID does not match with the expected project_id
         """
 
         available_projects = GcpProvider.get_projects(credentials=credentials)
 
         if provider_id not in available_projects:
-            raise GCPNotValidProviderIdError(
+            raise GCPInvalidAccountCredentials(
                 file=__file__,
                 message="The provider ID does not match with the expected project_id.",
             )

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -327,7 +327,6 @@ class GcpProvider(Provider):
             session, project_id = GcpProvider.setup_session(
                 credentials_file, service_account, gcp_credentials
             )
-
             if provider_id and project_id != provider_id:
                 # Logic to check if the provider ID matches the project ID
                 GcpProvider.validate_project_id(
@@ -552,7 +551,7 @@ class GcpProvider(Provider):
         }
 
     @staticmethod
-    def validate_project_id(provider_id: str, credentials: str = None) -> bool:
+    def validate_project_id(provider_id: str, credentials: str = None) -> None:
         """
         Validate the provider ID given the credentials, checking if the provider ID matches with the expected project_id using the method get_projects
 
@@ -561,18 +560,23 @@ class GcpProvider(Provider):
             credentials: str
 
         Returns:
-            bool
+            None
 
         Raises:
             GCPInvalidAccountCredentials if the provider ID does not match with the expected project_id
         """
 
-        available_projects = GcpProvider.get_projects(credentials=credentials)
+        available_projects = list(
+            GcpProvider.get_projects(credentials=credentials).keys()
+        )
 
-        if provider_id not in available_projects:
+        if len(available_projects) == 0:
+            raise GCPNoAccesibleProjectsError(
+                file=__file__,
+                message="No Project IDs can be accessed via Google Credentials.",
+            )
+        elif provider_id not in available_projects:
             raise GCPInvalidAccountCredentials(
                 file=__file__,
                 message="The provider ID does not match with the expected project_id.",
             )
-        else:
-            return True

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -554,10 +554,11 @@ class GcpProvider(Provider):
     @staticmethod
     def validate_project_id(provider_id: str, credentials: str = None) -> bool:
         """
-        Validate the provider ID
+        Validate the provider ID given the credentials, checking if the provider ID matches with the expected project_id using the method get_projects
 
         Args:
             provider_id: str
+            credentials: str
 
         Returns:
             bool


### PR DESCRIPTION
### Description

This PR adds a validation inside test_connection in order to check that the `provider_id` provided is reachable for the given credentials.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
