### PR TITLE
feat(macie): add new check `macie_automated_sensitive_data_discovery_enabled`

### DIFF
--- a/permissions/create_role_to_assume_cfn.yaml
+++ b/permissions/create_role_to_assume_cfn.yaml
@@ -82,6 +82,7 @@ Resources:
                 - 'logs:FilterLogEvents'
                 - 'lightsail:GetRelationalDatabases'
                 - 'macie2:GetMacieSession'
+                - 'macie2:GetAutomatedDiscoveryConfiguration'
                 - 's3:GetAccountPublicAccessBlock'
                 - 'shield:DescribeProtection'
                 - 'shield:GetSubscriptionState'

--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -30,6 +30,7 @@
         "logs:FilterLogEvents",
         "lightsail:GetRelationalDatabases",
         "macie2:GetMacieSession",
+        "macie2:GetAutomatedDiscoveryConfiguration",
         "s3:GetAccountPublicAccessBlock",
         "shield:DescribeProtection",
         "shield:GetSubscriptionState",

--- a/prowler/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled.metadata.json
+++ b/prowler/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "macie_automated_sensitive_data_discovery_enabled",
+  "CheckTitle": "Check if Macie automated sensitive data discovery is enabled.",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "macie",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "Severity": "high",
+  "ResourceType": "AwsAccount",
+  "Description": "Check if automated sensitive data discovery is enabled for an Amazon Macie account. The control fails if it isn't enabled.",
+  "Risk": "Without automated sensitive data discovery, there could be delays in identifying sensitive data, leading to data exposure risks in Amazon S3 buckets.",
+  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/macie-auto-sensitive-data-discovery-check.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws macie2 update-automated-discovery-configuration --status ENABLED",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/macie-controls.html#macie-2",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "To enable and configure automated sensitive data discovery jobs for S3 buckets, refer to the Configuring automated sensitive data discovery tutorial.",
+      "Url": "https://docs.aws.amazon.com/macie/latest/user/discovery-asdd-account-enable.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled.py
+++ b/prowler/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled.py
@@ -14,11 +14,13 @@ class macie_automated_sensitive_data_discovery_enabled(Check):
                 )
                 report.resource_id = macie_client.audited_account
                 report.status = "FAIL"
-                report.status_extended = f"Macie does not have automated sensitive data discovery enabled in account: {macie_client.audited_account}."
+                report.status_extended = "Macie is enabled but it does not have automated sensitive data discovery."
 
                 if session.automated_discovery_status == "ENABLED":
                     report.status = "PASS"
-                    report.status_extended = f"Macie has automated sensitive data discovery enabled in account: {macie_client.audited_account}."
+                    report.status_extended = (
+                        "Macie has automated sensitive data discovery enabled."
+                    )
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled.py
+++ b/prowler/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled.py
@@ -1,0 +1,25 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.macie.macie_client import macie_client
+
+
+class macie_automated_sensitive_data_discovery_enabled(Check):
+    def execute(self):
+        findings = []
+        for session in macie_client.sessions:
+            if session.status == "ENABLED":
+                report = Check_Report_AWS(self.metadata())
+                report.region = session.region
+                report.resource_arn = macie_client._get_session_arn_template(
+                    session.region
+                )
+                report.resource_id = macie_client.audited_account
+                report.status = "FAIL"
+                report.status_extended = f"Macie does not have automated sensitive data discovery enabled in account: {macie_client.audited_account}."
+
+                if session.automated_discovery_status == "ENABLED":
+                    report.status = "PASS"
+                    report.status_extended = f"Macie has automated sensitive data discovery enabled in account: {macie_client.audited_account}."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/macie/macie_service.py
+++ b/prowler/providers/aws/services/macie/macie_service.py
@@ -11,6 +11,9 @@ class Macie(AWSService):
         super().__init__("macie2", provider)
         self.sessions = []
         self.__threading_call__(self._get_macie_session)
+        self.__threading_call__(
+            self._get_automated_discovery_configuration, self.sessions
+        )
 
     def _get_session_arn_template(self, region):
         return f"arn:{self.audited_partition}:macie:{region}:{self.audited_account}:session"
@@ -38,7 +41,20 @@ class Macie(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
+    def _get_automated_discovery_configuration(self, session):
+        logger.info("Macie - Get Automated Discovery Configuration...")
+        try:
+            regional_client = self.regional_clients[session.region]
+            response = regional_client.get_automated_discovery_configuration()
+            session.automated_discovery_status = response["status"]
+
+        except Exception as error:
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
 
 class Session(BaseModel):
     status: str
+    automated_discovery_status: str = None
     region: str

--- a/prowler/providers/aws/services/macie/macie_service.py
+++ b/prowler/providers/aws/services/macie/macie_service.py
@@ -44,9 +44,13 @@ class Macie(AWSService):
     def _get_automated_discovery_configuration(self, session):
         logger.info("Macie - Get Automated Discovery Configuration...")
         try:
-            regional_client = self.regional_clients[session.region]
-            response = regional_client.get_automated_discovery_configuration()
-            session.automated_discovery_status = response["status"]
+            if session.status == "ENABLED":
+                regional_client = self.regional_clients[session.region]
+                session.automated_discovery_status = (
+                    regional_client.get_automated_discovery_configuration().get(
+                        "status", "DISABLED"
+                    )
+                )
 
         except Exception as error:
             logger.error(
@@ -56,5 +60,5 @@ class Macie(AWSService):
 
 class Session(BaseModel):
     status: str
-    automated_discovery_status: str = None
+    automated_discovery_status: str = "DISABLED"
     region: str

--- a/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
+++ b/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
@@ -13,10 +13,6 @@ from tests.providers.aws.utils import (
 class Test_macie_automated_sensitive_data_discovery_enabled:
     @mock_aws
     def test_macie_disabled(self):
-        s3_client = mock.MagicMock
-        s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
-        s3_client.buckets = {}
-        s3_client.regions_with_buckets = []
 
         macie_client = mock.MagicMock
         macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -43,9 +39,6 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
         ), mock.patch(
             "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.macie_client",
             new=macie_client,
-        ), mock.patch(
-            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.s3_client",
-            new=s3_client,
         ):
             # Test Check
             from prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled import (
@@ -59,10 +52,6 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
 
     @mock_aws
     def test_macie_enabled_automated_discovery_disabled(self):
-        s3_client = mock.MagicMock
-        s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
-        s3_client.buckets = {}
-        s3_client.regions_with_buckets = []
 
         macie_client = mock.MagicMock
         macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -89,9 +78,6 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
         ), mock.patch(
             "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.macie_client",
             new=macie_client,
-        ), mock.patch(
-            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.s3_client",
-            new=s3_client,
         ):
             # Test Check
             from prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled import (
@@ -115,10 +101,6 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
 
     @mock_aws
     def test_macie_enabled_automated_discovery_enabled(self):
-        s3_client = mock.MagicMock
-        s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
-        s3_client.buckets = {}
-        s3_client.regions_with_buckets = []
 
         macie_client = mock.MagicMock
         macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
@@ -145,9 +127,6 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
         ), mock.patch(
             "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.macie_client",
             new=macie_client,
-        ), mock.patch(
-            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.s3_client",
-            new=s3_client,
         ):
             # Test Check
             from prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled import (

--- a/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
+++ b/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
@@ -91,7 +91,7 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Macie does not have automated sensitive data discovery enabled in account: {AWS_ACCOUNT_NUMBER}."
+                == "Macie is enabled but it does not have automated sensitive data discovery."
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert (
@@ -140,7 +140,7 @@ class Test_macie_automated_sensitive_data_discovery_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Macie has automated sensitive data discovery enabled in account: {AWS_ACCOUNT_NUMBER}."
+                == "Macie has automated sensitive data discovery enabled."
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
             assert (

--- a/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
+++ b/tests/providers/aws/services/macie/macie_automated_sensitive_data_discovery_enabled/macie_automated_sensitive_data_discovery_enabled_test.py
@@ -1,0 +1,170 @@
+from unittest import mock
+
+from moto import mock_aws
+
+from prowler.providers.aws.services.macie.macie_service import Session
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_macie_automated_sensitive_data_discovery_enabled:
+    @mock_aws
+    def test_macie_disabled(self):
+        s3_client = mock.MagicMock
+        s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        s3_client.buckets = {}
+        s3_client.regions_with_buckets = []
+
+        macie_client = mock.MagicMock
+        macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        macie_client.audited_account = AWS_ACCOUNT_NUMBER
+        macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        macie_client.audited_partition = "aws"
+        macie_client.region = AWS_REGION_EU_WEST_1
+        macie_client.sessions = [
+            Session(
+                status="DISABLED",
+                region="eu-west-1",
+                automated_discovery_status="DISABLED",
+            )
+        ]
+        macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
+        macie_client._get_session_arn_template = mock.MagicMock(
+            return_value=macie_client.session_arn_template
+        )
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.macie_client",
+            new=macie_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.s3_client",
+            new=s3_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled import (
+                macie_automated_sensitive_data_discovery_enabled,
+            )
+
+            check = macie_automated_sensitive_data_discovery_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_macie_enabled_automated_discovery_disabled(self):
+        s3_client = mock.MagicMock
+        s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        s3_client.buckets = {}
+        s3_client.regions_with_buckets = []
+
+        macie_client = mock.MagicMock
+        macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        macie_client.audited_account = AWS_ACCOUNT_NUMBER
+        macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        macie_client.audited_partition = "aws"
+        macie_client.region = AWS_REGION_EU_WEST_1
+        macie_client.sessions = [
+            Session(
+                status="ENABLED",
+                region="eu-west-1",
+                automated_discovery_status="DISABLED",
+            )
+        ]
+        macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
+        macie_client._get_session_arn_template = mock.MagicMock(
+            return_value=macie_client.session_arn_template
+        )
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.macie_client",
+            new=macie_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.s3_client",
+            new=s3_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled import (
+                macie_automated_sensitive_data_discovery_enabled,
+            )
+
+            check = macie_automated_sensitive_data_discovery_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Macie does not have automated sensitive data discovery enabled in account: {AWS_ACCOUNT_NUMBER}."
+            )
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:macie:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:session"
+            )
+
+    @mock_aws
+    def test_macie_enabled_automated_discovery_enabled(self):
+        s3_client = mock.MagicMock
+        s3_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        s3_client.buckets = {}
+        s3_client.regions_with_buckets = []
+
+        macie_client = mock.MagicMock
+        macie_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        macie_client.audited_account = AWS_ACCOUNT_NUMBER
+        macie_client.audited_account_arn = f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        macie_client.audited_partition = "aws"
+        macie_client.region = AWS_REGION_EU_WEST_1
+        macie_client.sessions = [
+            Session(
+                status="ENABLED",
+                region="eu-west-1",
+                automated_discovery_status="ENABLED",
+            )
+        ]
+        macie_client.session_arn_template = f"arn:{macie_client.audited_partition}:macie:{macie_client.region}:{macie_client.audited_account}:session"
+        macie_client._get_session_arn_template = mock.MagicMock(
+            return_value=macie_client.session_arn_template
+        )
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.macie_client",
+            new=macie_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled.s3_client",
+            new=s3_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.macie.macie_automated_sensitive_data_discovery_enabled.macie_automated_sensitive_data_discovery_enabled import (
+                macie_automated_sensitive_data_discovery_enabled,
+            )
+
+            check = macie_automated_sensitive_data_discovery_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Macie has automated sensitive data discovery enabled in account: {AWS_ACCOUNT_NUMBER}."
+            )
+            assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:macie:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:session"
+            )

--- a/tests/providers/aws/services/macie/macie_service_test.py
+++ b/tests/providers/aws/services/macie/macie_service_test.py
@@ -73,3 +73,18 @@ class Test_Macie_Service:
         assert len(macie.sessions) == 1
         assert macie.sessions[0].status == "ENABLED"
         assert macie.sessions[0].region == AWS_REGION_EU_WEST_1
+
+    def test_get_automated_discovery_configuration(self):
+        # Set partition for the service
+        macie = Macie(set_mocked_aws_provider([AWS_REGION_EU_WEST_1]))
+        macie.sessions = [
+            Session(
+                status="ENABLED",
+                region="eu-west-1",
+                automated_discovery_status="ENABLED",
+            )
+        ]
+        assert len(macie.sessions) == 1
+        assert macie.sessions[0].status == "ENABLED"
+        assert macie.sessions[0].region == AWS_REGION_EU_WEST_1
+        assert macie.sessions[0].automated_discovery_status == "ENABLED"


### PR DESCRIPTION
### Context

Implement a check to ensure that Amazon Macie’s automated sensitive data discovery is enabled. This check will help enhance data protection by verifying that Macie is configured to automatically identify and classify sensitive data across your AWS environment.

Macie automates discovery and reporting of sensitive data, such as personally identifiable information (PII), in Amazon Simple Storage Service (Amazon S3) buckets. With automated sensitive data discovery, Macie continually evaluates your bucket inventory and uses sampling techniques to identify and select representative S3 objects from your buckets. Macie then analyzes the selected objects, inspecting them for sensitive data. As the analyses progress, Macie updates statistics, inventory data, and other information that it provides about your S3 data. Macie also generates findings to report sensitive data that it finds.

### Description

Added new check `macie_automated_sensitive_data_discovery_enabled` with respective unit tests and metadata. Added a new attribute to `Session` model in `macie` service.

### Checklist

- Are there new checks included in this PR? Yes
    - If so, do we need to update permissions for the provider? Maybe.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
