### PR TITLE
feat(eventbridge): add new check `eventbridge_global_endpoint_event_replication_enabled`

### DIFF
--- a/prowler/providers/aws/services/eventbridge/eventbridge_global_endpoint_event_replication_enabled/eventbridge_global_endpoint_event_replication_enabled.metadata.json
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_global_endpoint_event_replication_enabled/eventbridge_global_endpoint_event_replication_enabled.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "eventbridge_global_endpoint_event_replication_enabled",
+  "CheckTitle": "Check if EventBridge global endpoints have event replication enabled.",
+  "CheckType": [
+    "Software and Configuration Checks/Vulnerabilities"
+  ],
+  "ServiceName": "eventbridge",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:events:{region}:{account-id}:endpoint/{endpoint-id}",
+  "Severity": "medium",
+  "ResourceType": "AwsEventsEndpoint",
+  "Description": "Check if event replication is enabled for an Amazon EventBridge global endpoint. The control fails if event replication isn't enabled.",
+  "Risk": "Without event replication, automatic failover in case of Regional failure may not work as expected, increasing the risk of service disruption.",
+  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/global-endpoint-event-replication-enabled.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws events update-endpoint --name <endpoint-name> --event-replication-enabled",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/eventbridge-controls.html#eventbridge-4",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable event replication for your EventBridge global endpoints to ensure failover and regional fault tolerance.",
+      "Url": "https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-global-endpoints.html"
+    }
+  },
+  "Categories": [
+    "redundancy"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/eventbridge/eventbridge_global_endpoint_event_replication_enabled/eventbridge_global_endpoint_event_replication_enabled.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_global_endpoint_event_replication_enabled/eventbridge_global_endpoint_event_replication_enabled.py
@@ -1,0 +1,22 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.eventbridge.eventbridge_client import (
+    eventbridge_client,
+)
+
+
+class eventbridge_global_endpoint_event_replication_enabled(Check):
+    def execute(self):
+        findings = []
+        for endpoint in eventbridge_client.endpoints.values():
+            report = Check_Report_AWS(self.metadata())
+            report.status = "PASS"
+            report.status_extended = f"EventBridge global endpoint {endpoint.name} has event replication enabled."
+            report.resource_id = endpoint.name
+            report.resource_arn = endpoint.arn
+            report.resource_tags = endpoint.tags
+            report.region = endpoint.region
+            if endpoint.replication_state == "DISABLED":
+                report.status = "FAIL"
+                report.status_extended = f"EventBridge global endpoint {endpoint.name} does not have event replication enabled."
+            findings.append(report)
+        return findings

--- a/prowler/providers/aws/services/eventbridge/eventbridge_service.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_service.py
@@ -70,8 +70,8 @@ class EventBridge(AWSService):
                         arn=endpoint_arn,
                         region=regional_client.region,
                         replication_state=endpoint.get(
-                            "ReplicationConfig", {"State": "ENABLED"}
-                        ).get("State", "ENABLED"),
+                            "ReplicationConfig", {}
+                        ).get("State", "DISABLED"),
                     )
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/eventbridge/eventbridge_service.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_service.py
@@ -15,8 +15,10 @@ class EventBridge(AWSService):
         # Call AWSService's __init__
         super().__init__("events", provider)
         self.buses = {}
+        self.endpoints = {}
         self.__threading_call__(self._list_event_buses)
         self.__threading_call__(self._describe_event_bus)
+        self.__threading_call__(self._list_endpoints)
         self._list_tags_for_resource()
 
     def _list_event_buses(self, regional_client):
@@ -55,6 +57,27 @@ class EventBridge(AWSService):
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
+    def _list_endpoints(self, regional_client):
+        logger.info("EventBridge - Listing Endpoints...")
+        try:
+            for endpoint in regional_client.list_endpoints()["Endpoints"]:
+                endpoint_arn = endpoint["Arn"]
+                if not self.audit_resources or (
+                    is_resource_filtered(endpoint_arn, self.audit_resources)
+                ):
+                    self.endpoints[endpoint_arn] = Endpoint(
+                        name=endpoint.get("Name", ""),
+                        arn=endpoint_arn,
+                        region=regional_client.region,
+                        replication_state=endpoint.get(
+                            "ReplicationConfig", {"State": "ENABLED"}
+                        ).get("State", "ENABLED"),
+                    )
+        except Exception as error:
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
     def _list_tags_for_resource(self):
         logger.info("EventBridge - Listing Tags...")
         try:
@@ -90,6 +113,14 @@ class Bus(BaseModel):
     kms_key_id: Optional[str]
     policy: Optional[str]
     tags: Optional[list]
+
+
+class Endpoint(BaseModel):
+    name: str
+    arn: str
+    region: str
+    replication_state: str
+    tags: Optional[list] = []
 
 
 ################################ Schema

--- a/prowler/providers/aws/services/eventbridge/eventbridge_service.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_service.py
@@ -69,9 +69,9 @@ class EventBridge(AWSService):
                         name=endpoint.get("Name", ""),
                         arn=endpoint_arn,
                         region=regional_client.region,
-                        replication_state=endpoint.get(
-                            "ReplicationConfig", {}
-                        ).get("State", "DISABLED"),
+                        replication_state=endpoint.get("ReplicationConfig", {}).get(
+                            "State", "DISABLED"
+                        ),
                     )
         except Exception as error:
             logger.error(

--- a/tests/providers/aws/services/eventbridge/eventbridge_global_endpoint_event_replication_enabled/eventbridge_global_endpoint_event_replication_enabled_test.py
+++ b/tests/providers/aws/services/eventbridge/eventbridge_global_endpoint_event_replication_enabled/eventbridge_global_endpoint_event_replication_enabled_test.py
@@ -1,0 +1,135 @@
+from unittest import mock
+
+import botocore
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == "ListEndpoints":
+        return {
+            "Endpoints": [
+                {
+                    "Name": "test-endpoint-disabled",
+                    "Arn": f"arn:aws:events:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:endpoint/test-endpoint-disabled",
+                    "ReplicationConfig": {"State": "DISABLED"},
+                }
+            ]
+        }
+
+    return make_api_call(self, operation_name, kwarg)
+
+
+def mock_make_api_call_v2(self, operation_name, kwarg):
+    if operation_name == "ListEndpoints":
+        return {
+            "Endpoints": [
+                {
+                    "Name": "test-endpoint-enabled",
+                    "Arn": f"arn:aws:events:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:endpoint/test-endpoint-enabled",
+                    "ReplicationConfig": {"State": "ENABLED"},
+                }
+            ]
+        }
+
+    return make_api_call(self, operation_name, kwarg)
+
+
+class Test_eventbridge_global_endpoint_event_replication_enabled:
+    @mock_aws
+    def test_no_endpoints(self):
+        from prowler.providers.aws.services.eventbridge.eventbridge_service import (
+            EventBridge,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.eventbridge.eventbridge_global_endpoint_event_replication_enabled.eventbridge_global_endpoint_event_replication_enabled.eventbridge_client",
+            new=EventBridge(aws_provider),
+        ):
+            from prowler.providers.aws.services.eventbridge.eventbridge_global_endpoint_event_replication_enabled.eventbridge_global_endpoint_event_replication_enabled import (
+                eventbridge_global_endpoint_event_replication_enabled,
+            )
+
+            check = eventbridge_global_endpoint_event_replication_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
+    def test_replication_disabled(self):
+        from prowler.providers.aws.services.eventbridge.eventbridge_service import (
+            EventBridge,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.eventbridge.eventbridge_global_endpoint_event_replication_enabled.eventbridge_global_endpoint_event_replication_enabled.eventbridge_client",
+            new=EventBridge(aws_provider),
+        ):
+            from prowler.providers.aws.services.eventbridge.eventbridge_global_endpoint_event_replication_enabled.eventbridge_global_endpoint_event_replication_enabled import (
+                eventbridge_global_endpoint_event_replication_enabled,
+            )
+
+            check = eventbridge_global_endpoint_event_replication_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].status_extended == (
+                "EventBridge global endpoint test-endpoint-disabled does not have event replication enabled."
+            )
+            assert result[0].resource_id == "test-endpoint-disabled"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:events:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:endpoint/test-endpoint-disabled"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_EU_WEST_1
+
+    @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call_v2)
+    def test_replication_enabled(self):
+        from prowler.providers.aws.services.eventbridge.eventbridge_service import (
+            EventBridge,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.eventbridge.eventbridge_global_endpoint_event_replication_enabled.eventbridge_global_endpoint_event_replication_enabled.eventbridge_client",
+            new=EventBridge(aws_provider),
+        ):
+            from prowler.providers.aws.services.eventbridge.eventbridge_global_endpoint_event_replication_enabled.eventbridge_global_endpoint_event_replication_enabled import (
+                eventbridge_global_endpoint_event_replication_enabled,
+            )
+
+            check = eventbridge_global_endpoint_event_replication_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].status_extended == (
+                "EventBridge global endpoint test-endpoint-enabled has event replication enabled."
+            )
+            assert result[0].resource_id == "test-endpoint-enabled"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:events:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:endpoint/test-endpoint-enabled"
+            )
+            assert result[0].resource_tags == []
+            assert result[0].region == AWS_REGION_EU_WEST_1


### PR DESCRIPTION
### Context

Add a new check to ensure event replication is enabled for Amazon EventBridge global endpoints. The control fails if event replication is not enabled for a global endpoint.

Global endpoints are used to enhance the fault tolerance of your application across Regions. By enabling event replication, you ensure that all custom events are replicated to event buses in both the primary and secondary Regions. This setup is crucial for automatic recovery from failover events and ensures that events are processed correctly even if there is a failure in the primary Region. Without event replication, you must manually manage failover and recovery processes, which can be less efficient and prone to errors.

### Description

Added a new check `eventbridge_global_endpoint_event_replication_enabled` with respective unit tests and metadata. Added `Endpoint` model in `Eventbridge` service and a new method `list_endpoints` with respective unit test.

### Checklist

- Are there new checks included in this PR? Yes
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
