### PR TITLE
fix(organizations): no finding for access denied in listing policies

### DIFF
--- a/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
+++ b/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
@@ -9,17 +9,17 @@ class organizations_opt_out_ai_services_policy(Check):
         findings = []
 
         for org in organizations_client.organizations:
-            report = Check_Report_AWS(self.metadata())
-            report.resource_id = org.id
-            report.resource_arn = org.arn
-            report.region = organizations_client.region
-            report.status = "FAIL"
-            report.status_extended = (
-                "AWS Organizations is not in-use for this AWS Account."
-            )
-            if org.status == "ACTIVE":
-                report.status_extended = f"AWS Organization {org.id} has not opted out of all AI services, granting consent for AWS to access its data."
-                if org.policies is not None:  # Access Denied to list_policies
+            if org.policies is not None:  # Access Denied to list_policies
+                report = Check_Report_AWS(self.metadata())
+                report.resource_id = org.id
+                report.resource_arn = org.arn
+                report.region = organizations_client.region
+                report.status = "FAIL"
+                report.status_extended = (
+                    "AWS Organizations is not in-use for this AWS Account."
+                )
+                if org.status == "ACTIVE":
+                    report.status_extended = f"AWS Organization {org.id} has not opted out of all AI services, granting consent for AWS to access its data."
                     for policy in org.policies.get("AISERVICES_OPT_OUT_POLICY", []):
                         if (
                             policy.content.get("services", {})
@@ -32,6 +32,6 @@ class organizations_opt_out_ai_services_policy(Check):
                             report.status_extended = f"AWS Organization {org.id} has opted out of all AI services, not granting consent for AWS to access its data."
                             break
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached.py
+++ b/prowler/providers/aws/services/organizations/organizations_tags_policies_enabled_and_attached/organizations_tags_policies_enabled_and_attached.py
@@ -9,26 +9,26 @@ class organizations_tags_policies_enabled_and_attached(Check):
         findings = []
 
         for org in organizations_client.organizations:
-            report = Check_Report_AWS(self.metadata())
-            report.resource_id = org.id
-            report.resource_arn = org.arn
-            report.region = organizations_client.region
-            report.status = "FAIL"
-            report.status_extended = (
-                "AWS Organizations is not in-use for this AWS Account."
-            )
-
-            if org.status == "ACTIVE":
+            if org.policies is not None:  # Access Denied to list_policies
+                report = Check_Report_AWS(self.metadata())
+                report.resource_id = org.id
+                report.resource_arn = org.arn
+                report.region = organizations_client.region
+                report.status = "FAIL"
                 report.status_extended = (
-                    f"AWS Organizations {org.id} does not have tag policies."
+                    "AWS Organizations is not in-use for this AWS Account."
                 )
-                if org.policies is not None:  # Access Denied to list_policies
+
+                if org.status == "ACTIVE":
+                    report.status_extended = (
+                        f"AWS Organizations {org.id} does not have tag policies."
+                    )
                     for policy in org.policies.get("TAG_POLICY", []):
                         report.status_extended = f"AWS Organization {org.id} has tag policies enabled but not attached."
                         if policy.targets:
                             report.status = "PASS"
                             report.status_extended = f"AWS Organization {org.id} has tag policies enabled and attached to an AWS account."
 
-            findings.append(report)
+                findings.append(report)
 
         return findings


### PR DESCRIPTION
### Description

Do not create a finding in AWS Organizations checks when an AccessDenied occurs.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
