### PR TITLE
chore(aws): Set scan_unused_services False by default

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -84,7 +84,7 @@ class AwsProvider(Provider):
         profile: str = None,
         regions: set = set(),
         organizations_role_arn: str = None,
-        scan_unused_services: bool = None,
+        scan_unused_services: bool = False,
         resource_tags: list[str] = [],
         resource_arn: list[str] = [],
         audit_config: dict = {},
@@ -106,7 +106,7 @@ class AwsProvider(Provider):
             - profile: The name of the AWS CLI profile to use.
             - regions: A set of regions to audit.
             - organizations_role_arn: The ARN of the AWS Organizations IAM role to assume.
-            - scan_unused_services: A boolean indicating whether to scan unused services.
+            - scan_unused_services: A boolean indicating whether to scan unused services. False by default.
             - resource_tags: A list of tags to filter the resources to audit.
             - resource_arn: A list of ARNs of the resources to audit.
             - audit_config: The audit configuration.
@@ -122,6 +122,7 @@ class AwsProvider(Provider):
             - ArgumentTypeError: If the input role session name is invalid.
 
         """
+
         logger.info("Initializing AWS provider ...")
 
         ######## AWS Session

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -451,7 +451,7 @@ class TestAWSProvider:
             aws_provider = AwsProvider(mfa=mfa)
 
             assert aws_provider.type == "aws"
-            assert aws_provider.scan_unused_services is None
+            assert aws_provider.scan_unused_services is False
             assert aws_provider.audit_config == {}
             assert (
                 aws_provider.session.current_session.region_name == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Description

Set `scan_unused_services: bool = False` in the AWS provider. It is already being set to `False` from the CLI.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
