### PR TITLE
feat(mq): add new check `mq_broker_auto_minor_version_upgrades`

### DIFF
--- a/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.metadata.json
+++ b/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "mq_broker_auto_minor_version_upgrades",
+  "CheckTitle": "MQ Broker Auto Minor Version Upgrades should be enabled.",
+  "CheckType": [
+    "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
+  ],
+  "ServiceName": "mq",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:mq:region:account-id:broker:broker-name:broker-id",
+  "Severity": "low",
+  "ResourceType": "AwsAmazonMQBroker",
+  "Description": "Ensure that automatic minor version upgrades are enabled on Amazon MQ brokers.",
+  "Risk": "Amazon MQ brokers without automatic minor version upgrades may miss critical updates, leaving them vulnerable to security risks, bugs, and performance issues.",
+  "RelatedUrl": "https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/upgrading-brokers.html#upgrading-brokers-automatic-upgrades",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws mq update-broker --broker-id <broker-id> --auto-minor-version-upgrade",
+      "NativeIaC": "https://docs.prowler.com/checks/aws/general-policies/ensure-aws-mqbrokers-minor-version-updates-are-enabled/",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/mq-controls.html#mq-3",
+      "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/MQ/auto-minor-version-upgrade.html"
+    },
+    "Recommendation": {
+      "Text": "Ensure that automatic minor version upgrades are enabled on Amazon MQ brokers to receive the latest security patches and improvements automatically.",
+      "Url": "https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/upgrading-brokers.html#upgrading-brokers-automatic-upgrades.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.metadata.json
+++ b/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.metadata.json
@@ -7,7 +7,7 @@
   ],
   "ServiceName": "mq",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:aws:mq:region:account-id:broker:broker-name:broker-id",
+  "ResourceIdTemplate": "arn:aws:mq:region:account-id:broker:broker-id",
   "Severity": "low",
   "ResourceType": "AwsAmazonMQBroker",
   "Description": "Ensure that automatic minor version upgrades are enabled on Amazon MQ brokers.",

--- a/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.py
+++ b/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.py
@@ -1,0 +1,23 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.mq.mq_client import mq_client
+
+
+class mq_broker_auto_minor_version_upgrades(Check):
+    def execute(self):
+        findings = []
+        for broker in mq_client.brokers.values():
+            report = Check_Report_AWS(self.metadata())
+            report.region = broker.region
+            report.resource_id = broker.id
+            report.resource_arn = broker.arn
+            report.resource_tags = broker.tags
+            report.status = "PASS"
+            report.status_extended = f"MQ Broker {broker.id} does have automated minor version upgrades enabled."
+
+            if not broker.auto_minor_version_upgrade:
+                report.status = "FAIL"
+                report.status_extended = f"MQ Broker {broker.id} does not have automated minor version upgrades enabled."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.py
+++ b/prowler/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades.py
@@ -12,11 +12,11 @@ class mq_broker_auto_minor_version_upgrades(Check):
             report.resource_arn = broker.arn
             report.resource_tags = broker.tags
             report.status = "PASS"
-            report.status_extended = f"MQ Broker {broker.id} does have automated minor version upgrades enabled."
+            report.status_extended = f"MQ Broker {broker.name} does have automated minor version upgrades enabled."
 
             if not broker.auto_minor_version_upgrade:
                 report.status = "FAIL"
-                report.status_extended = f"MQ Broker {broker.id} does not have automated minor version upgrades enabled."
+                report.status_extended = f"MQ Broker {broker.name} does not have automated minor version upgrades enabled."
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/mq/mq_service.py
+++ b/prowler/providers/aws/services/mq/mq_service.py
@@ -11,6 +11,7 @@ class MQ(AWSService):
         super().__init__("mq", provider)
         self.brokers = {}
         self.__threading_call__(self._list_brokers)
+        self.__threading_call__(self._describe_broker, self.brokers.values())
 
     def _list_brokers(self, regional_client):
         logger.info("MQ - Listing brokers...")
@@ -31,6 +32,19 @@ class MQ(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
+    def _describe_broker(self, broker):
+        try:
+            describe_broker = self.regional_clients[broker.region].describe_broker(
+                BrokerId=broker.id
+            )
+            broker.auto_minor_version_upgrade = describe_broker.get(
+                "AutoMinorVersionUpgrade", False
+            )
+        except Exception as error:
+            logger.error(
+                f"{broker.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
 
 class Broker(BaseModel):
     """Broker model for MQ"""
@@ -39,3 +53,4 @@ class Broker(BaseModel):
     name: str
     id: str
     region: str
+    auto_minor_version_upgrade: bool = False

--- a/prowler/providers/aws/services/mq/mq_service.py
+++ b/prowler/providers/aws/services/mq/mq_service.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -42,6 +42,7 @@ class MQ(AWSService):
             broker.auto_minor_version_upgrade = describe_broker.get(
                 "AutoMinorVersionUpgrade", False
             )
+            broker.tags = [describe_broker.get("Tags", {})]
         except Exception as error:
             logger.error(
                 f"{broker.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -56,4 +57,4 @@ class Broker(BaseModel):
     id: str
     region: str
     auto_minor_version_upgrade: bool = False
-    tags: Optional[list] = []
+    tags: Optional[List[Dict[str, str]]]

--- a/prowler/providers/aws/services/mq/mq_service.py
+++ b/prowler/providers/aws/services/mq/mq_service.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 from prowler.lib.logger import logger
@@ -54,3 +56,4 @@ class Broker(BaseModel):
     id: str
     region: str
     auto_minor_version_upgrade: bool = False
+    tags: Optional[list] = []

--- a/tests/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades_test.py
+++ b/tests/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades_test.py
@@ -1,0 +1,140 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_mq_broker_auto_minor_version_upgrades:
+    @mock_aws
+    def test_no_brokers(self):
+        from prowler.providers.aws.services.mq.mq_service import MQ
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
+                new=MQ(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
+                    mq_broker_auto_minor_version_upgrades,
+                )
+
+                check = mq_broker_auto_minor_version_upgrades()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_broker_auto_minor_version_upgrades_enabled(self):
+        mq_client = client("mq", region_name=AWS_REGION_US_EAST_1)
+        broker_id = mq_client.create_broker(
+            BrokerName="test-broker",
+            EngineType="ACTIVEMQ",
+            EngineVersion="5.15.0",
+            HostInstanceType="mq.t2.micro",
+            Users=[
+                {
+                    "Username": "admin",
+                    "Password": "admin",
+                },
+            ],
+            DeploymentMode="SINGLE_INSTANCE",
+            PubliclyAccessible=False,
+            AutoMinorVersionUpgrade=True,
+        )["BrokerId"]
+
+        from prowler.providers.aws.services.mq.mq_service import MQ
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
+                new=MQ(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
+                    mq_broker_auto_minor_version_upgrades,
+                )
+
+                check = mq_broker_auto_minor_version_upgrades()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"MQ Broker {broker_id} does have automated minor version upgrades enabled."
+                )
+                assert result[0].resource_id == broker_id
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_broker_auto_minor_version_upgrades_disabled(self):
+        mq_client = client("mq", region_name=AWS_REGION_US_EAST_1)
+        broker_id = mq_client.create_broker(
+            BrokerName="test-broker",
+            EngineType="ACTIVEMQ",
+            EngineVersion="5.15.0",
+            HostInstanceType="mq.t2.micro",
+            Users=[
+                {
+                    "Username": "admin",
+                    "Password": "admin",
+                },
+            ],
+            DeploymentMode="SINGLE_INSTANCE",
+            PubliclyAccessible=False,
+            AutoMinorVersionUpgrade=False,
+        )["BrokerId"]
+
+        from prowler.providers.aws.services.mq.mq_service import MQ
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
+                new=MQ(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
+                    mq_broker_auto_minor_version_upgrades,
+                )
+
+                check = mq_broker_auto_minor_version_upgrades()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"MQ Broker {broker_id} does not have automated minor version upgrades enabled."
+                )
+                assert result[0].resource_id == broker_id
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades_test.py
+++ b/tests/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades_test.py
@@ -20,20 +20,19 @@ class Test_mq_broker_auto_minor_version_upgrades:
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
+            new=MQ(aws_provider),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
-                new=MQ(aws_provider),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
-                    mq_broker_auto_minor_version_upgrades,
-                )
+            # Test Check
+            from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
+                mq_broker_auto_minor_version_upgrades,
+            )
 
-                check = mq_broker_auto_minor_version_upgrades()
-                result = check.execute()
+            check = mq_broker_auto_minor_version_upgrades()
+            result = check.execute()
 
-                assert len(result) == 0
+            assert len(result) == 0
 
     @mock_aws
     def test_broker_auto_minor_version_upgrades_enabled(self):
@@ -62,31 +61,30 @@ class Test_mq_broker_auto_minor_version_upgrades:
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
+            new=MQ(aws_provider),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
-                new=MQ(aws_provider),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
-                    mq_broker_auto_minor_version_upgrades,
-                )
+            # Test Check
+            from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
+                mq_broker_auto_minor_version_upgrades,
+            )
 
-                check = mq_broker_auto_minor_version_upgrades()
-                result = check.execute()
+            check = mq_broker_auto_minor_version_upgrades()
+            result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "PASS"
-                assert (
-                    result[0].status_extended
-                    == f"MQ Broker {broker_name} does have automated minor version upgrades enabled."
-                )
-                assert result[0].resource_id == broker_id
-                assert (
-                    result[0].resource_arn
-                    == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
-                )
-                assert result[0].region == AWS_REGION_US_EAST_1
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"MQ Broker {broker_name} does have automated minor version upgrades enabled."
+            )
+            assert result[0].resource_id == broker_id
+            assert (
+                result[0].resource_arn
+                == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
 
     @mock_aws
     def test_broker_auto_minor_version_upgrades_disabled(self):
@@ -115,28 +113,27 @@ class Test_mq_broker_auto_minor_version_upgrades:
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
+            new=MQ(aws_provider),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades.mq_client",
-                new=MQ(aws_provider),
-            ):
-                # Test Check
-                from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
-                    mq_broker_auto_minor_version_upgrades,
-                )
+            # Test Check
+            from prowler.providers.aws.services.mq.mq_broker_auto_minor_version_upgrades.mq_broker_auto_minor_version_upgrades import (
+                mq_broker_auto_minor_version_upgrades,
+            )
 
-                check = mq_broker_auto_minor_version_upgrades()
-                result = check.execute()
+            check = mq_broker_auto_minor_version_upgrades()
+            result = check.execute()
 
-                assert len(result) == 1
-                assert result[0].status == "FAIL"
-                assert (
-                    result[0].status_extended
-                    == f"MQ Broker {broker_name} does not have automated minor version upgrades enabled."
-                )
-                assert result[0].resource_id == broker_id
-                assert (
-                    result[0].resource_arn
-                    == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
-                )
-                assert result[0].region == AWS_REGION_US_EAST_1
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"MQ Broker {broker_name} does not have automated minor version upgrades enabled."
+            )
+            assert result[0].resource_id == broker_id
+            assert (
+                result[0].resource_arn
+                == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades_test.py
+++ b/tests/providers/aws/services/mq/mq_broker_auto_minor_version_upgrades/mq_broker_auto_minor_version_upgrades_test.py
@@ -38,8 +38,9 @@ class Test_mq_broker_auto_minor_version_upgrades:
     @mock_aws
     def test_broker_auto_minor_version_upgrades_enabled(self):
         mq_client = client("mq", region_name=AWS_REGION_US_EAST_1)
+        broker_name = "test-broker"
         broker_id = mq_client.create_broker(
-            BrokerName="test-broker",
+            BrokerName=broker_name,
             EngineType="ACTIVEMQ",
             EngineVersion="5.15.0",
             HostInstanceType="mq.t2.micro",
@@ -78,7 +79,7 @@ class Test_mq_broker_auto_minor_version_upgrades:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == f"MQ Broker {broker_id} does have automated minor version upgrades enabled."
+                    == f"MQ Broker {broker_name} does have automated minor version upgrades enabled."
                 )
                 assert result[0].resource_id == broker_id
                 assert (
@@ -90,8 +91,9 @@ class Test_mq_broker_auto_minor_version_upgrades:
     @mock_aws
     def test_broker_auto_minor_version_upgrades_disabled(self):
         mq_client = client("mq", region_name=AWS_REGION_US_EAST_1)
+        broker_name = "test-broker"
         broker_id = mq_client.create_broker(
-            BrokerName="test-broker",
+            BrokerName=broker_name,
             EngineType="ACTIVEMQ",
             EngineVersion="5.15.0",
             HostInstanceType="mq.t2.micro",
@@ -130,7 +132,7 @@ class Test_mq_broker_auto_minor_version_upgrades:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"MQ Broker {broker_id} does not have automated minor version upgrades enabled."
+                    == f"MQ Broker {broker_name} does not have automated minor version upgrades enabled."
                 )
                 assert result[0].resource_id == broker_id
                 assert (

--- a/tests/providers/aws/services/mq/mq_service_test.py
+++ b/tests/providers/aws/services/mq/mq_service_test.py
@@ -34,7 +34,7 @@ class Test_MQ_Service:
     # Test MQ List Brokers
     @mock_aws
     def test_list_brokers(self):
-        # Generate MQ client
+        # Generate moto MQ client
         mq_client = client("mq", region_name=AWS_REGION_EU_WEST_1)
         broker = mq_client.create_broker(
             AutoMinorVersionUpgrade=True,
@@ -55,7 +55,7 @@ class Test_MQ_Service:
         )
         broker_arn = broker["BrokerArn"]
 
-        # MQ Client for this test class
+        # MQ client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         mq = MQ(aws_provider)
 
@@ -68,7 +68,7 @@ class Test_MQ_Service:
     # Test MQ Describe Broker
     @mock_aws
     def test_describe_broker(self):
-        # Generate MQ client
+        # Generate moto MQ client
         mq_client = client("mq", region_name=AWS_REGION_EU_WEST_1)
         broker = mq_client.create_broker(
             AutoMinorVersionUpgrade=True,
@@ -86,11 +86,12 @@ class Test_MQ_Service:
                     "Username": "user",
                 }
             ],
+            Tags={"key": "value"},
         )
         broker_arn = broker["BrokerArn"]
         broker["BrokerId"]
 
-        # MQ Client for this test class
+        # MQ client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         mq = MQ(aws_provider)
 
@@ -100,3 +101,4 @@ class Test_MQ_Service:
         assert mq.brokers[broker_arn].region == AWS_REGION_EU_WEST_1
         assert mq.brokers[broker_arn].id == broker["BrokerId"]
         assert mq.brokers[broker_arn].auto_minor_version_upgrade
+        assert mq.brokers[broker_arn].tags == [{"key": "value"}]

--- a/tests/providers/aws/services/mq/mq_service_test.py
+++ b/tests/providers/aws/services/mq/mq_service_test.py
@@ -64,3 +64,39 @@ class Test_MQ_Service:
         assert mq.brokers[broker_arn].name == "my-broker"
         assert mq.brokers[broker_arn].region == AWS_REGION_EU_WEST_1
         assert mq.brokers[broker_arn].id == broker["BrokerId"]
+
+    # Test MQ Describe Broker
+    @mock_aws
+    def test_describe_broker(self):
+        # Generate MQ client
+        mq_client = client("mq", region_name=AWS_REGION_EU_WEST_1)
+        broker = mq_client.create_broker(
+            AutoMinorVersionUpgrade=True,
+            BrokerName="my-broker",
+            DeploymentMode="SINGLE_INSTANCE",
+            EngineType="ActiveMQ",
+            EngineVersion="5.15.0",
+            HostInstanceType="mq.t2.micro",
+            PubliclyAccessible=True,
+            Users=[
+                {
+                    "ConsoleAccess": False,
+                    "Groups": [],
+                    "Password": "password",
+                    "Username": "user",
+                }
+            ],
+        )
+        broker_arn = broker["BrokerArn"]
+        broker["BrokerId"]
+
+        # MQ Client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        mq = MQ(aws_provider)
+
+        assert len(mq.brokers) == 1
+        assert mq.brokers[broker_arn].arn == broker_arn
+        assert mq.brokers[broker_arn].name == "my-broker"
+        assert mq.brokers[broker_arn].region == AWS_REGION_EU_WEST_1
+        assert mq.brokers[broker_arn].id == broker["BrokerId"]
+        assert mq.brokers[broker_arn].auto_minor_version_upgrade


### PR DESCRIPTION
### Context

`Amazon MQ` is a managed message broker service that simplifies the setup and maintenance of message brokers for applications. It supports multiple messaging protocols and is designed to work with various broker engines like `ActiveMQ` and `RabbitMQ`.

Keeping the broker engines up to date is crucial for maintaining security and performance, especially as vulnerabilities and bugs are discovered over time.

### Description

This check verifies whether Amazon `MQ brokers` have `automatic minor version upgrades` enabled. The check fails if this feature is not activated, which could expose the broker to security vulnerabilities and performance issues.

### Checklist

- Are there new checks included in this PR? Yes.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
