### PR TITLE
fix(bedrock): add filtering and handle different ARNs

### DIFF
--- a/prowler/providers/aws/services/bedrock/bedrock_model_invocation_logs_encryption_enabled/bedrock_model_invocation_logs_encryption_enabled.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_model_invocation_logs_encryption_enabled/bedrock_model_invocation_logs_encryption_enabled.py
@@ -31,6 +31,9 @@ class bedrock_model_invocation_logs_encryption_enabled(Check):
                     if (
                         log_group_arn in logs_client.log_groups
                         and not logs_client.log_groups[log_group_arn].kms_id
+                    ) or (
+                        log_group_arn + ":*" in logs_client.log_groups
+                        and not logs_client.log_groups[log_group_arn + ":*"].kms_id
                     ):
                         cloudwatch_encryption = False
                 if not s3_encryption and not cloudwatch_encryption:


### PR DESCRIPTION
### Description

As per https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html, Log Groups can have two different ARNs, so we need to check both types.
Also, add the resource filtering to Bedrock Guardrails.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
