### PR TITLE
chore(severities): Use enum

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -22,7 +22,6 @@ orange_color = "\033[38;5;208m"
 banner_color = "\033[1;92m"
 
 finding_statuses = ["PASS", "FAIL", "MANUAL"]
-valid_severities = ["critical", "high", "medium", "low", "informational"]
 
 # Compliance
 actual_directory = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -21,7 +21,6 @@ gcp_logo = "https://user-images.githubusercontent.com/38561120/235928332-eb4accd
 orange_color = "\033[38;5;208m"
 banner_color = "\033[1;92m"
 
-finding_statuses = ["PASS", "FAIL", "MANUAL"]
 
 # Compliance
 actual_directory = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))

--- a/prowler/lib/check/checks_loader.py
+++ b/prowler/lib/check/checks_loader.py
@@ -1,10 +1,10 @@
 from colorama import Fore, Style
 
-from prowler.config.config import valid_severities
 from prowler.lib.check.check import (
     parse_checks_from_compliance_framework,
     parse_checks_from_file,
 )
+from prowler.lib.check.models import Severity
 from prowler.lib.check.utils import (
     recover_checks_from_provider,
     recover_checks_from_service,
@@ -29,7 +29,7 @@ def load_checks_to_execute(
         # Local subsets
         checks_to_execute = set()
         check_aliases = {}
-        check_severities = {key: [] for key in valid_severities}
+        check_severities = {severity.value: [] for severity in Severity}
         check_categories = {}
 
         # First, loop over the bulk_checks_metadata to extract the needed subsets

--- a/prowler/lib/check/custom_checks_metadata.py
+++ b/prowler/lib/check/custom_checks_metadata.py
@@ -3,7 +3,7 @@ import sys
 import yaml
 from jsonschema import validate
 
-from prowler.config.config import valid_severities
+from prowler.lib.check.models import Severity
 from prowler.lib.logger import logger
 
 custom_checks_metadata_schema = {
@@ -17,7 +17,7 @@ custom_checks_metadata_schema = {
                     "properties": {
                         "Severity": {
                             "type": "string",
-                            "enum": valid_severities,
+                            "enum": [severity.value for severity in Severity],
                         },
                         "CheckTitle": {
                             "type": "string",

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -11,8 +11,8 @@ from prowler.config.config import (
     default_fixer_config_file_path,
     default_output_directory,
     finding_statuses,
-    valid_severities,
 )
+from prowler.lib.check.models import Severity
 from prowler.providers.common.arguments import (
     init_providers_parser,
     validate_provider_arguments,
@@ -257,8 +257,8 @@ Detailed documentation at https://docs.prowler.com
             "--severity",
             "--severities",
             nargs="+",
-            help=f"Severities to be executed {valid_severities}",
-            choices=valid_severities,
+            help=f"Severities to be executed {[severity.value for severity in Severity]}",
+            choices=[severity.value for severity in Severity],
         )
         group.add_argument(
             "--compliance",

--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -10,9 +10,9 @@ from prowler.config.config import (
     default_config_file_path,
     default_fixer_config_file_path,
     default_output_directory,
-    finding_statuses,
 )
 from prowler.lib.check.models import Severity
+from prowler.lib.outputs.finding import Status
 from prowler.providers.common.arguments import (
     init_providers_parser,
     validate_provider_arguments,
@@ -138,8 +138,8 @@ Detailed documentation at https://docs.prowler.com
         common_outputs_parser.add_argument(
             "--status",
             nargs="+",
-            help=f"Filter by the status of the findings {finding_statuses}",
-            choices=finding_statuses,
+            help=f"Filter by the status of the findings {[status.value for status in Status]}",
+            choices=[status.value for status in Status],
         )
         common_outputs_parser.add_argument(
             "--output-formats",


### PR DESCRIPTION
### Description

- Remove `valid_severities` and use the `Severity` enum.
- Remove `valid_statuses` and use the `Status` enum.


### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
