### PR TITLE
chore(findings): add new properties

### DIFF
--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from prowler.config.config import prowler_version
 from prowler.lib.check.models import Check_Report, CheckMetadata
@@ -34,10 +34,10 @@ class Finding(BaseModel):
     auth_method: str
     timestamp: Union[int, datetime]
     account_uid: str
-    account_name: Optional[str]
-    account_email: Optional[str]
-    account_organization_uid: Optional[str]
-    account_organization_name: Optional[str]
+    account_name: Optional[str] = None
+    account_email: Optional[str] = None
+    account_organization_uid: Optional[str] = None
+    account_organization_name: Optional[str] = None
     metadata: CheckMetadata
     account_tags: dict = {}
     uid: str
@@ -47,24 +47,53 @@ class Finding(BaseModel):
     resource_uid: str
     resource_name: str
     resource_details: str
-    resource_tags: dict = {}
-    # Only present for AWS and Azure
-    partition: Optional[str]
+    resource_tags: dict = Field(default_factory=dict)
+    partition: Optional[str] = None
     region: str
     compliance: dict
     prowler_version: str = prowler_version
 
     @property
     def provider(self) -> str:
+        """
+        Returns the provider from the finding check's metadata.
+        """
         return self.metadata.Provider
 
     @property
     def check_id(self) -> str:
+        """
+        Returns the ID from the finding check's metadata.
+        """
         return self.metadata.CheckID
 
     @property
     def severity(self) -> str:
+        """
+        Returns the severity from the finding check's metadata.
+        """
         return self.metadata.Severity
+
+    @property
+    def resource_type(self) -> str:
+        """
+        Returns the resource type from the finding check's metadata.
+        """
+        return self.metadata.ResourceType
+
+    @property
+    def service_name(self) -> str:
+        """
+        Returns the service name from the finding check's metadata.
+        """
+        return self.metadata.ServiceName
+
+    @property
+    def raw_result(self) -> dict:
+        """
+        Returns the raw result(dict) of the finding without any post-processing.
+        """
+        return {}
 
     def get_metadata(self) -> dict:
         """

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -89,9 +89,9 @@ class Finding(BaseModel):
         return self.metadata.ServiceName
 
     @property
-    def raw_result(self) -> dict:
+    def raw(self) -> dict:
         """
-        Returns the raw result(dict) of the finding without any post-processing.
+        Returns the raw (dict) finding without any post-processing.
         """
         return {}
 

--- a/tests/lib/outputs/finding_test.py
+++ b/tests/lib/outputs/finding_test.py
@@ -170,6 +170,15 @@ class TestFinding:
         assert finding_output.metadata.Notes == "mock_notes"
         assert finding_output.metadata.Compliance == []
 
+        # Properties
+        assert finding_output.provider == "aws"
+        assert finding_output.check_id == "mock_check_id"
+        assert finding_output.severity == Severity.high.value
+        assert finding_output.status == Status.PASS.value
+        assert finding_output.resource_type == ""
+        assert finding_output.service_name == "mock_service_name"
+        assert finding_output.raw_result == {}
+
     @patch(
         "prowler.lib.outputs.finding.get_provider_data_mapping",
         new=mock_get_provider_data_mapping_azure,

--- a/tests/lib/outputs/finding_test.py
+++ b/tests/lib/outputs/finding_test.py
@@ -177,7 +177,7 @@ class TestFinding:
         assert finding_output.status == Status.PASS.value
         assert finding_output.resource_type == ""
         assert finding_output.service_name == "mock_service_name"
-        assert finding_output.raw_result == {}
+        assert finding_output.raw == {}
 
     @patch(
         "prowler.lib.outputs.finding.get_provider_data_mapping",


### PR DESCRIPTION
### Description

Add the following properties to the `Finding` class:

- `raw_result: {}` -> to be prepared for post-processors
- `severity: str`
- `status: str`
- `service_name: str`
- `resource_type: str`

### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
