### PR TITLE
chore(wafv2): migrated testing from magicmock to moto

### DIFF
--- a/tests/providers/aws/services/wafv2/wafv2_webacl_logging_enabled/wafv2_webacl_logging_enabled_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_webacl_logging_enabled/wafv2_webacl_logging_enabled_test.py
@@ -1,108 +1,472 @@
 from unittest import mock
-from uuid import uuid4
 
-from prowler.providers.aws.services.wafv2.wafv2_service import WebAclv2
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_EU_WEST_1
+from boto3 import client
+from moto import mock_aws
 
-waf_id = str(uuid4())
-waf_name = "waf-example"
-waf_arn = f"arn:aws:wafv2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:regional/webacl/{waf_name}/{waf_id}"
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
 
 
-class Test_wafv2_webacl_logging_enabled:
+class Test_wafv2_webacl_rule_logging_enabled:
+    @mock_aws
     def test_no_web_acls(self):
-        wafv2_client = mock.MagicMock
-        wafv2_client.web_acls = {}
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_service.WAFv2",
-            new=wafv2_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_client.wafv2_client",
-            new=wafv2_client,
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled.wafv2_client",
+            new=WAFv2(aws_provider),
         ):
-            from prowler.providers.aws.services.wafv2.wafv2_webacl_logging_enabled.wafv2_webacl_logging_enabled import (
-                wafv2_webacl_logging_enabled,
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled import (
+                wafv2_webacl_rule_logging_enabled,
             )
 
-            check = wafv2_webacl_logging_enabled()
+            check = wafv2_webacl_rule_logging_enabled()
             result = check.execute()
+
             assert len(result) == 0
 
-    def test_wafv2_wb_acl_with_logging(self):
-        wafv2_client = mock.MagicMock
-        wafv2_client.enabled = True
-        wafv2_client.web_acls = {
-            waf_arn: WebAclv2(
-                arn=waf_arn,
-                name=waf_name,
-                id=waf_id,
-                albs=[],
-                user_pools=[],
-                region=AWS_REGION_EU_WEST_1,
-                logging_enabled=True,
-                tags=[{"Key": "Name", "Value": waf_name}],
-            )
-        }
+    @mock_aws
+    def test_wafv2_web_acl_with_logging_in_rules(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rules",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rule-on",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        }
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": True,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                }
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rules"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_service.WAFv2",
-            new=wafv2_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_client.wafv2_client",
-            new=wafv2_client,
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled.wafv2_client",
+            new=WAFv2(aws_provider),
         ):
-            from prowler.providers.aws.services.wafv2.wafv2_webacl_logging_enabled.wafv2_webacl_logging_enabled import (
-                wafv2_webacl_logging_enabled,
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled import (
+                wafv2_webacl_rule_logging_enabled,
             )
 
-            check = wafv2_webacl_logging_enabled()
+            check = wafv2_webacl_rule_logging_enabled()
             result = check.execute()
+
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"AWS WAFv2 Web ACL {waf_name} has logging enabled."
+                == f"AWS WAFv2 Web ACL {waf_name} does have CloudWatch Metrics enabled in all its rules."
             )
             assert result[0].resource_id == waf_id
             assert result[0].resource_arn == waf_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]
 
-    def test_wafv2_wb_acl_without_logging(self):
-        wafv2_client = mock.MagicMock
-        wafv2_client.web_acls = {}
-        wafv2_client.enabled = True
-        wafv2_client.web_acls = {
-            waf_arn: WebAclv2(
-                arn=waf_arn,
-                name=waf_name,
-                id=waf_id,
-                albs=[],
-                user_pools=[],
-                region=AWS_REGION_EU_WEST_1,
-                logging_enabled=False,
-                tags=[{"Key": "Name", "Value": waf_name}],
-            )
-        }
+    @mock_aws
+    def test_wafv2_web_acl_without_logging_in_rules(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rules",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rule-off",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        }
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": False,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                }
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rules"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_service.WAFv2",
-            new=wafv2_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_client.wafv2_client",
-            new=wafv2_client,
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled.wafv2_client",
+            new=WAFv2(aws_provider),
         ):
-            from prowler.providers.aws.services.wafv2.wafv2_webacl_logging_enabled.wafv2_webacl_logging_enabled import (
-                wafv2_webacl_logging_enabled,
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled import (
+                wafv2_webacl_rule_logging_enabled,
             )
 
-            check = wafv2_webacl_logging_enabled()
+            check = wafv2_webacl_rule_logging_enabled()
             result = check.execute()
+
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"AWS WAFv2 Web ACL {waf_name} does not have logging enabled."
+                == f"AWS WAFv2 Web ACL {waf_name} does not have CloudWatch Metrics enabled in rules: rule-off."
             )
             assert result[0].resource_id == waf_id
             assert result[0].resource_arn == waf_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]
+
+    @mock_aws
+    def test_wafv2_web_acl_with_logging_in_rule_groups(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rules",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rg-on",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        },
+                        "RuleGroupReferenceStatement": {
+                            "ARN": "arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/ManagedRuleGroup/af9d9b6b-1d1b-4e0d-8f3e-1d1d0e1d0e1d",
+                        },
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": True,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                }
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rules"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled.wafv2_client",
+            new=WAFv2(aws_provider),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled import (
+                wafv2_webacl_rule_logging_enabled,
+            )
+
+            check = wafv2_webacl_rule_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"AWS WAFv2 Web ACL {waf_name} does have CloudWatch Metrics enabled in all its rules."
+            )
+            assert result[0].resource_id == waf_id
+            assert result[0].resource_arn == waf_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]
+
+    @mock_aws
+    def test_wafv2_web_acl_without_logging_in_rule_groups(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rules",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rg-off",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        },
+                        "RuleGroupReferenceStatement": {
+                            "ARN": "arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/ManagedRuleGroup/af9d9b6b-1d1b-4e0d-8f3e-1d1d0e1d0e1d",
+                        },
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": False,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                }
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rules"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled.wafv2_client",
+            new=WAFv2(aws_provider),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled import (
+                wafv2_webacl_rule_logging_enabled,
+            )
+
+            check = wafv2_webacl_rule_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"AWS WAFv2 Web ACL {waf_name} does not have CloudWatch Metrics enabled in rule groups: rg-off."
+            )
+            assert result[0].resource_id == waf_id
+            assert result[0].resource_arn == waf_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]
+
+    @mock_aws
+    def test_wafv2_web_acl_with_logging_in_both(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rules",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rule-on",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        }
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": True,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                },
+                {
+                    "Name": "rg-on",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        },
+                        "RuleGroupReferenceStatement": {
+                            "ARN": "arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/ManagedRuleGroup/af9d9b6b-1d1b-4e0d-8f3e-1d1d0e1d0e1d",
+                        },
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": True,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                },
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rules"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled.wafv2_client",
+            new=WAFv2(aws_provider),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled import (
+                wafv2_webacl_rule_logging_enabled,
+            )
+
+            check = wafv2_webacl_rule_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"AWS WAFv2 Web ACL {waf_name} does have CloudWatch Metrics enabled in all its rules."
+            )
+            assert result[0].resource_id == waf_id
+            assert result[0].resource_arn == waf_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]
+
+    @mock_aws
+    def test_wafv2_web_acl_without_logging_in_both(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rules",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rule-off",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        }
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": False,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                },
+                {
+                    "Name": "rg-off",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        },
+                        "RuleGroupReferenceStatement": {
+                            "ARN": "arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/ManagedRuleGroup/af9d9b6b-1d1b-4e0d-8f3e-1d1d0e1d0e1d",
+                        },
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": False,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                },
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rules"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled.wafv2_client",
+            new=WAFv2(aws_provider),
+        ):
+            from prowler.providers.aws.services.wafv2.wafv2_webacl_rule_logging_enabled.wafv2_webacl_rule_logging_enabled import (
+                wafv2_webacl_rule_logging_enabled,
+            )
+
+            check = wafv2_webacl_rule_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"AWS WAFv2 Web ACL {waf_name} does not have CloudWatch Metrics enabled in rules: rule-off nor in rule groups: rg-off."
+            )
+            assert result[0].resource_id == waf_id
+            assert result[0].resource_arn == waf_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]

--- a/tests/providers/aws/services/wafv2/wafv2_webacl_with_rules/wafv2_webacl_with_rules_test.py
+++ b/tests/providers/aws/services/wafv2/wafv2_webacl_with_rules/wafv2_webacl_with_rules_test.py
@@ -1,24 +1,24 @@
 from unittest import mock
-from uuid import uuid4
 
-from prowler.providers.aws.services.wafv2.wafv2_service import Rule, WebAclv2
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_EU_WEST_1
+from boto3 import client
+from moto import mock_aws
 
-waf_id = str(uuid4())
-waf_name = "waf-example"
-waf_arn = f"arn:aws:wafv2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:regional/webacl/{waf_name}/{waf_id}"
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
 
 
 class Test_wafv2_webacl_with_rules:
+    @mock_aws
     def test_no_web_acls(self):
-        wafv2_client = mock.MagicMock
-        wafv2_client.web_acls = {}
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_service.WAFv2",
-            new=wafv2_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_client.wafv2_client",
-            new=wafv2_client,
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules.wafv2_client",
+            new=WAFv2(aws_provider),
         ):
             from prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules import (
                 wafv2_webacl_with_rules,
@@ -28,28 +28,53 @@ class Test_wafv2_webacl_with_rules:
             result = check.execute()
             assert len(result) == 0
 
-    def test_wafv2_wb_acl_with_rule(self):
-        wafv2_client = mock.MagicMock
-        wafv2_client.enabled = True
-        wafv2_client.web_acls = {
-            waf_arn: WebAclv2(
-                arn=waf_arn,
-                name=waf_name,
-                id=waf_id,
-                albs=[],
-                user_pools=[],
-                region=AWS_REGION_EU_WEST_1,
-                logging_enabled=True,
-                tags=[{"Key": "Name", "Value": waf_name}],
-                rules=[Rule(name="rule1", cloudwatch_metrics_enabled=True)],
-            )
-        }
+    @mock_aws
+    def test_wafv2_web_acl_with_rule(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rules",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rule-on",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        }
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": True,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                }
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rules"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_service.WAFv2",
-            new=wafv2_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_client.wafv2_client",
-            new=wafv2_client,
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules.wafv2_client",
+            new=WAFv2(aws_provider),
         ):
             from prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules import (
                 wafv2_webacl_with_rules,
@@ -65,31 +90,59 @@ class Test_wafv2_webacl_with_rules:
             )
             assert result[0].resource_id == waf_id
             assert result[0].resource_arn == waf_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]
 
-    def test_wafv2_wb_acl_with_rule_group(self):
-        wafv2_client = mock.MagicMock
-        wafv2_client.enabled = True
-        wafv2_client.web_acls = {
-            waf_arn: WebAclv2(
-                arn=waf_arn,
-                name=waf_name,
-                id=waf_id,
-                albs=[],
-                user_pools=[],
-                region=AWS_REGION_EU_WEST_1,
-                logging_enabled=True,
-                tags=[{"Key": "Name", "Value": waf_name}],
-                rule_groups=[Rule(name="rule_group1", cloudwatch_metrics_enabled=True)],
-            )
-        }
+    @mock_aws
+    def test_wafv2_web_acl_with_rule_group(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-rule-groups",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[
+                {
+                    "Name": "rg-on",
+                    "Priority": 1,
+                    "Statement": {
+                        "ByteMatchStatement": {
+                            "SearchString": "test",
+                            "FieldToMatch": {"UriPath": {}},
+                            "TextTransformations": [{"Type": "NONE", "Priority": 0}],
+                            "PositionalConstraint": "CONTAINS",
+                        },
+                        "RuleGroupReferenceStatement": {
+                            "ARN": "arn:aws:wafv2:us-east-1:123456789012:regional/rulegroup/ManagedRuleGroup/af9d9b6b-1d1b-4e0d-8f3e-1d1d0e1d0e1d",
+                        },
+                    },
+                    "VisibilityConfig": {
+                        "SampledRequestsEnabled": True,
+                        "CloudWatchMetricsEnabled": True,
+                        "MetricName": "web-acl-test-metric",
+                    },
+                }
+            ],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-rule-groups"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_service.WAFv2",
-            new=wafv2_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_client.wafv2_client",
-            new=wafv2_client,
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules.wafv2_client",
+            new=WAFv2(aws_provider),
         ):
             from prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules import (
                 wafv2_webacl_with_rules,
@@ -105,31 +158,38 @@ class Test_wafv2_webacl_with_rules:
             )
             assert result[0].resource_id == waf_id
             assert result[0].resource_arn == waf_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]
 
-    def test_wafv2_wb_acl_without_rule_or_rule_group(self):
-        wafv2_client = mock.MagicMock
-        wafv2_client.web_acls = {}
-        wafv2_client.enabled = True
-        wafv2_client.web_acls = {
-            waf_arn: WebAclv2(
-                arn=waf_arn,
-                name=waf_name,
-                id=waf_id,
-                albs=[],
-                user_pools=[],
-                region=AWS_REGION_EU_WEST_1,
-                logging_enabled=False,
-                tags=[{"Key": "Name", "Value": waf_name}],
-            )
-        }
+    @mock_aws
+    def test_wafv2_web_acl_without_rule_or_rule_group(self):
+        wafv2_client = client("wafv2", region_name=AWS_REGION_US_EAST_1)
+        waf = wafv2_client.create_web_acl(
+            Name="test-none",
+            Scope="REGIONAL",
+            DefaultAction={"Allow": {}},
+            Rules=[],
+            VisibilityConfig={
+                "SampledRequestsEnabled": True,
+                "CloudWatchMetricsEnabled": False,
+                "MetricName": "web-acl-test-metric",
+            },
+            Tags=[{"Key": "Name", "Value": "test-none"}],
+        )["Summary"]
+        waf_id = waf["Id"]
+        waf_name = waf["Name"]
+        waf_arn = waf["ARN"]
+
+        from prowler.providers.aws.services.wafv2.wafv2_service import WAFv2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
         with mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_service.WAFv2",
-            new=wafv2_client,
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.wafv2.wafv2_client.wafv2_client",
-            new=wafv2_client,
+            "prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules.wafv2_client",
+            new=WAFv2(aws_provider),
         ):
             from prowler.providers.aws.services.wafv2.wafv2_webacl_with_rules.wafv2_webacl_with_rules import (
                 wafv2_webacl_with_rules,
@@ -145,5 +205,5 @@ class Test_wafv2_webacl_with_rules:
             )
             assert result[0].resource_id == waf_id
             assert result[0].resource_arn == waf_arn
-            assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == [{"Key": "Name", "Value": waf_name}]


### PR DESCRIPTION
### Context

To avoid possible issues between different checks and overlapping we will use a different approach in testing. 

### Description

Until now there were some checks in `WAFv2` service where we used `MagicMock` but now we will use `Moto`.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
