### PR TITLE
feat(waf): add new check `waf_global_rule_with_conditions`

### DIFF
--- a/prowler/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions.metadata.json
+++ b/prowler/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "waf_global_rule_with_conditions",
+  "CheckTitle": "AWS WAF Classic Global Rules Should Have at Least One Condition.",
+  "CheckType": [
+    "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
+  ],
+  "ServiceName": "waf",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:waf:region:account-id:rule/rule-id",
+  "Severity": "medium",
+  "ResourceType": "AwsWafRule",
+  "Description": "Ensure that every AWS WAF Classic Global Rule contains at least one condition.",
+  "Risk": "An AWS WAF Classic Global rule without any conditions cannot inspect or filter traffic, potentially allowing malicious requests to pass unchecked.",
+  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/waf-global-rule-not-empty.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws waf update-rule --rule-id <your-rule-id> --change-token <your-change-token> --updates '[{\"Action\":\"INSERT\",\"Predicate\":{\"Negated\":false,\"Type\":\"IPMatch\",\"DataId\":\"<your-ipset-id>\"}}]' --region <your-region>",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-6",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Ensure that every AWS WAF Classic Global rule has at least one condition to properly inspect and manage web traffic.",
+      "Url": "https://docs.aws.amazon.com/waf/latest/developerguide/classic-web-acl-rules-editing.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions.metadata.json
+++ b/prowler/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions.metadata.json
@@ -7,7 +7,7 @@
   ],
   "ServiceName": "waf",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:aws:waf:region:account-id:rule/rule-id",
+  "ResourceIdTemplate": "arn:aws:waf:account-id:rule/rule-id",
   "Severity": "medium",
   "ResourceType": "AwsWafRule",
   "Description": "Ensure that every AWS WAF Classic Global Rule contains at least one condition.",

--- a/prowler/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions.py
+++ b/prowler/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions.py
@@ -1,0 +1,27 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.waf.waf_client import waf_client
+
+
+class waf_global_rule_with_conditions(Check):
+    def execute(self):
+        findings = []
+        for rule in waf_client.rules.values():
+            report = Check_Report_AWS(self.metadata())
+            report.region = rule.region
+            report.resource_id = rule.id
+            report.resource_arn = rule.arn
+            report.resource_tags = rule.tags
+            report.status = "FAIL"
+            report.status_extended = (
+                f"AWS WAF Global Rule {rule.name} does not have any conditions."
+            )
+
+            if rule.predicates:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"AWS WAF Global Rule {rule.name} has at least one condition."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -44,7 +44,7 @@ class WAF(AWSService):
             )
 
     def _get_rule(self, rule):
-        logger.info(f"WAF - Getting Rule {rule.name}...")
+        logger.info(f"WAF - Getting Global Rule {rule.name}...")
         try:
             get_rule = self.client.get_rule(RuleId=rule.id)
             for predicate in get_rule.get("Rule", {}).get("Predicates", []):
@@ -77,7 +77,9 @@ class WAF(AWSService):
             )
 
     def _list_activated_rules_in_rule_group(self, rule_group):
-        logger.info(f"WAF - Listing activated rules in Rule Group {rule_group.name}...")
+        logger.info(
+            f"WAF - Listing activated rules in Global Rule Group {rule_group.name}..."
+        )
         try:
             for rule in self.client.list_activated_rules_in_rule_group(
                 RuleGroupId=rule_group.id

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -30,17 +30,17 @@ class WAF(AWSService):
         logger.info("WAF - Listing Global Rules...")
         try:
             for rule in self.client.list_rules().get("Rules", []):
-                arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule['RuleId']}"
+                arn = f"arn:{self.audited_partition}:waf:{self.region}:{self.audited_account}:rule/{rule['RuleId']}"
                 self.rules[arn] = Rule(
                     arn=arn,
                     id=rule.get("RuleId", ""),
-                    region="us-east-1",
+                    region=self.region,
                     name=rule.get("Name", ""),
                 )
 
         except Exception as error:
             logger.error(
-                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
     def _get_rule(self, rule):
@@ -56,24 +56,26 @@ class WAF(AWSService):
                     )
                 )
 
-        except KeyError:
-            logger.error(f"Rule {rule.name} not found in {rule.region}.")
+        except Exception as error:
+            logger.error(
+                f"{rule.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
 
     def _list_rule_groups(self):
         logger.info("WAF - Listing Global Rule Groups...")
         try:
             for rule_group in self.client.list_rule_groups().get("RuleGroups", []):
-                arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rulegroup/{rule_group['RuleGroupId']}"
+                arn = f"arn:{self.audited_partition}:waf:{self.region}:{self.audited_account}:rulegroup/{rule_group['RuleGroupId']}"
                 self.rule_groups[arn] = RuleGroup(
                     arn=arn,
-                    region="us-east-1",
+                    region=self.region,
                     id=rule_group.get("RuleGroupId", ""),
                     name=rule_group.get("Name", ""),
                 )
 
         except Exception as error:
             logger.error(
-                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
     def _list_activated_rules_in_rule_group(self, rule_group):
@@ -84,7 +86,7 @@ class WAF(AWSService):
             for rule in self.client.list_activated_rules_in_rule_group(
                 RuleGroupId=rule_group.id
             ).get("ActivatedRules", []):
-                rule_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule.get('RuleId', '')}"
+                rule_arn = f"arn:{self.audited_partition}:waf:{self.region}:{self.audited_account}:rule/{rule.get('RuleId', '')}"
                 rule_group.rules.append(self.rules[rule_arn])
 
         except Exception as error:
@@ -99,18 +101,18 @@ class WAF(AWSService):
                 if not self.audit_resources or (
                     is_resource_filtered(waf["WebACLId"], self.audit_resources)
                 ):
-                    arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:webacl/{waf['WebACLId']}"
+                    arn = f"arn:{self.audited_partition}:waf:{self.region}:{self.audited_account}:webacl/{waf['WebACLId']}"
                     self.web_acls[arn] = WebAcl(
                         arn=arn,
                         name=waf["Name"],
                         id=waf["WebACLId"],
                         albs=[],
-                        region="us-east-1",
+                        region=self.region,
                     )
 
         except Exception as error:
             logger.error(
-                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
     def _get_web_acl(self, acl):
@@ -120,10 +122,10 @@ class WAF(AWSService):
             for rule in get_web_acl.get("WebACL", {}).get("Rules", []):
                 rule_id = rule.get("RuleId", "")
                 if rule.get("Type", "") == "GROUP":
-                    rule_group_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rulegroup/{rule_id}"
+                    rule_group_arn = f"arn:{self.audited_partition}:waf:{self.region}:{self.audited_account}:rulegroup/{rule_id}"
                     acl.rule_groups.append(self.rule_groups[rule_group_arn])
                 else:
-                    rule_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule_id}"
+                    rule_arn = f"arn:{self.audited_partition}:waf:{self.region}:{self.audited_account}:rule/{rule_id}"
                     acl.rules.append(self.rules[rule_arn])
 
         except Exception as error:
@@ -131,19 +133,17 @@ class WAF(AWSService):
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def _list_resources_for_web_acl(self):
+    def _list_resources_for_web_acl(self, acl):
         logger.info("WAF Global - Describing resources...")
         try:
-            for acl in self.web_acls.values():
-                if acl.region == "us-east-1":
-                    for resource in self.client.list_resources_for_web_acl(
-                        WebACLId=acl.id, ResourceType="APPLICATION_LOAD_BALANCER"
-                    ).get("ResourceArns", []):
-                        acl.albs.append(resource)
+            for resource in self.client.list_resources_for_web_acl(
+                WebACLId=acl.id, ResourceType="APPLICATION_LOAD_BALANCER"
+            ).get("ResourceArns", []):
+                acl.albs.append(resource)
 
         except Exception as error:
             logger.error(
-                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
 
@@ -192,8 +192,10 @@ class WAFRegional(AWSService):
                         data_id=predicate.get("DataId", ""),
                     )
                 )
-        except KeyError:
-            logger.error(f"Rule {rule.name} not found in {rule.region}.")
+        except Exception as error:
+            logger.error(
+                f"{rule.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
 
     def _list_rule_groups(self, regional_client):
         logger.info("WAFRegional - Listing Regional Rule Groups...")

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -11,46 +11,134 @@ class WAF(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__
         super().__init__("waf", provider)
+        self.rules = {}
+        self.rule_groups = {}
         self.web_acls = {}
+        self._list_rules()
+        self.__threading_call__(self._get_rule, self.rules.values())
         self.__threading_call__(self._list_web_acls)
         self.__threading_call__(
             self._list_resources_for_web_acl, self.web_acls.values()
         )
 
-    def _list_web_acls(self, regional_client):
-        logger.info("WAF - Listing Regional Web ACLs...")
+    def _list_rules(self):
+        logger.info("WAF - Listing Global Rules...")
         try:
-            for waf in regional_client.list_web_acls()["WebACLs"]:
+            for rule in self.client.list_rules().get("Rules", []):
+                arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule['RuleId']}"
+                self.rules[arn] = Rule(
+                    arn=arn,
+                    id=rule.get("RuleId", ""),
+                    region="us-east-1",
+                    name=rule.get("Name", ""),
+                )
+
+        except Exception as error:
+            logger.error(
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _get_rule(self, rule):
+        logger.info(f"WAF - Getting Rule {rule.name}...")
+        try:
+            get_rule = self.client.get_rule(RuleId=rule.id)
+            for predicate in get_rule.get("Rule", {}).get("Predicates", []):
+                rule.predicates.append(
+                    Predicate(
+                        negated=predicate.get("Negated", False),
+                        type=predicate.get("Type", "IPMatch"),
+                        data_id=predicate.get("DataId", ""),
+                    )
+                )
+
+        except KeyError:
+            logger.error(f"Rule {rule.name} not found in {rule.region}.")
+
+    def _list_rule_groups(self):
+        logger.info("WAF - Listing Global Rule Groups...")
+        try:
+            for rule_group in self.client.list_rule_groups().get("RuleGroups", []):
+                arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rulegroup/{rule_group['RuleGroupId']}"
+                self.rule_groups[arn] = RuleGroup(
+                    arn=arn,
+                    region="us-east-1",
+                    id=rule_group.get("RuleGroupId", ""),
+                    name=rule_group.get("Name", ""),
+                )
+
+        except Exception as error:
+            logger.error(
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_activated_rules_in_rule_group(self, rule_group):
+        logger.info(f"WAF - Listing activated rules in Rule Group {rule_group.name}...")
+        try:
+            for rule in (
+                self.regional_clients[rule_group.region]
+                .list_activated_rules_in_rule_group(RuleGroupId=rule_group.id)
+                .get("ActivatedRules", [])
+            ):
+                rule_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule.get('RuleId', '')}"
+                rule_group.rules.append(self.rules[rule_arn])
+
+        except Exception as error:
+            logger.error(
+                f"{rule_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_web_acls(self):
+        logger.info("WAF - Listing Global Web ACLs...")
+        try:
+            for waf in self.client.list_web_acls()["WebACLs"]:
                 if not self.audit_resources or (
                     is_resource_filtered(waf["WebACLId"], self.audit_resources)
                 ):
-                    arn = f"arn:{self.audited_partition}:waf:{regional_client.region}:{self.audited_account}:webacl/{waf['WebACLId']}"
+                    arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:webacl/{waf['WebACLId']}"
                     self.web_acls[arn] = WebAcl(
                         arn=arn,
                         name=waf["Name"],
                         id=waf["WebACLId"],
                         albs=[],
-                        region=regional_client.region,
+                        region="us-east-1",
                     )
 
         except Exception as error:
             logger.error(
-                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def _list_resources_for_web_acl(self, regional_client):
-        logger.info("WAF - Describing resources...")
+    def _get_web_acl(self, acl):
+        logger.info(f"WAF - Getting Globall Web ACL {acl.name}...")
+        try:
+            get_web_acl = self.client.get_web_acl(WebACLId=acl.id)
+            for rule in get_web_acl.get("WebACL", {}).get("Rules", []):
+                rule_id = rule.get("RuleId", "")
+                if rule.get("Type", "") == "GROUP":
+                    rule_group_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rulegroup/{rule_id}"
+                    acl.rule_groups.append(self.rule_groups[rule_group_arn])
+                else:
+                    rule_arn = f"arn:{self.audited_partition}:waf::{self.audited_account}:rule/{rule_id}"
+                    acl.rules.append(self.rules[rule_arn])
+
+        except Exception as error:
+            logger.error(
+                f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_resources_for_web_acl(self):
+        logger.info("WAFRegional - Describing resources...")
         try:
             for acl in self.web_acls.values():
-                if acl.region == regional_client.region:
-                    for resource in regional_client.list_resources_for_web_acl(
+                if acl.region == "us-east-1":
+                    for resource in self.client.list_resources_for_web_acl(
                         WebACLId=acl.id, ResourceType="APPLICATION_LOAD_BALANCER"
-                    )["ResourceArns"]:
+                    ).get("ResourceArns", []):
                         acl.albs.append(resource)
 
         except Exception as error:
             logger.error(
-                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
 
@@ -159,7 +247,7 @@ class WAFRegional(AWSService):
             )
 
     def _get_web_acl(self, acl):
-        logger.info(f"WAFRegional - Getting Web ACL {acl.name}...")
+        logger.info(f"WAFRegional - Getting Regional Web ACL {acl.name}...")
         try:
             get_web_acl = self.regional_clients[acl.region].get_web_acl(WebACLId=acl.id)
             for rule in get_web_acl.get("WebACL", {}).get("Rules", []):

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -22,9 +22,6 @@ class WAF(AWSService):
         )
         self._list_web_acls()
         self.__threading_call__(self._get_web_acl, self.web_acls.values())
-        self.__threading_call__(
-            self._list_resources_for_web_acl, self.web_acls.values()
-        )
 
     def _list_rules(self):
         logger.info("WAF - Listing Global Rules...")
@@ -127,19 +124,6 @@ class WAF(AWSService):
                 else:
                     rule_arn = f"arn:{self.audited_partition}:waf:{self.region}:{self.audited_account}:rule/{rule_id}"
                     acl.rules.append(self.rules[rule_arn])
-
-        except Exception as error:
-            logger.error(
-                f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-            )
-
-    def _list_resources_for_web_acl(self, acl):
-        logger.info("WAF Global - Describing resources...")
-        try:
-            for resource in self.client.list_resources_for_web_acl(
-                WebACLId=acl.id, ResourceType="APPLICATION_LOAD_BALANCER"
-            ).get("ResourceArns", []):
-                acl.albs.append(resource)
 
         except Exception as error:
             logger.error(

--- a/tests/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions_test.py
+++ b/tests/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions_test.py
@@ -1,0 +1,167 @@
+from unittest import mock
+from unittest.mock import patch
+
+import botocore
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+RULE_ID = "test-rule-id"
+
+# Original botocore _make_api_call function
+orig = botocore.client.BaseClient._make_api_call
+
+
+# Mocked botocore _make_api_call function
+def mock_make_api_call_compliant_rule(self, operation_name, kwarg):
+    if operation_name == "ListRules":
+        return {
+            "Rules": [
+                {
+                    "RuleId": RULE_ID,
+                    "Name": RULE_ID,
+                },
+            ]
+        }
+    if operation_name == "GetRule":
+        return {
+            "Rule": {
+                "RuleId": RULE_ID,
+                "Predicates": [
+                    {
+                        "Negated": False,
+                        "Type": "IPMatch",
+                        "DataId": "IPSetId",
+                    },
+                ],
+            }
+        }
+    return orig(self, operation_name, kwarg)
+
+
+def mock_make_api_call_non_compliant_rule(self, operation_name, kwarg):
+    if operation_name == "ListRules":
+        return {
+            "Rules": [
+                {
+                    "RuleId": RULE_ID,
+                    "Name": RULE_ID,
+                },
+            ]
+        }
+    if operation_name == "GetRule":
+        return {
+            "Rule": {
+                "RuleId": RULE_ID,
+                "Predicates": [],
+            }
+        }
+    return orig(self, operation_name, kwarg)
+
+
+class Test_waf_global_rule_with_conditions:
+    @mock_aws
+    def test_no_rules(self):
+        from prowler.providers.aws.services.waf.waf_service import WAF
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.waf.waf_global_rule_with_conditions.waf_global_rule_with_conditions.waf_client",
+                new=WAF(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.waf.waf_global_rule_with_conditions.waf_global_rule_with_conditions import (
+                    waf_global_rule_with_conditions,
+                )
+
+                check = waf_global_rule_with_conditions()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_compliant_rule,
+    )
+    @mock_aws
+    def test_waf_rules_with_condition(self):
+        from prowler.providers.aws.services.waf.waf_service import WAF
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.waf.waf_global_rule_with_conditions.waf_global_rule_with_conditions.waf_client",
+                new=WAF(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.waf.waf_global_rule_with_conditions.waf_global_rule_with_conditions import (
+                    waf_global_rule_with_conditions,
+                )
+
+                check = waf_global_rule_with_conditions()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"AWS WAF Global Rule {RULE_ID} has at least one condition."
+                )
+                assert result[0].resource_id == RULE_ID
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:rule/{RULE_ID}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_non_compliant_rule,
+    )
+    @mock_aws
+    def test_waf_rules_without_condition(self):
+        from prowler.providers.aws.services.waf.waf_service import WAF
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.waf.waf_global_rule_with_conditions.waf_global_rule_with_conditions.waf_client",
+                new=WAF(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.waf.waf_global_rule_with_conditions.waf_global_rule_with_conditions import (
+                    waf_global_rule_with_conditions,
+                )
+
+                check = waf_global_rule_with_conditions()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"AWS WAF Global Rule {RULE_ID} does not have any conditions."
+                )
+                assert result[0].resource_id == RULE_ID
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:rule/{RULE_ID}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions_test.py
+++ b/tests/providers/aws/services/waf/waf_global_rule_with_conditions/waf_global_rule_with_conditions_test.py
@@ -123,7 +123,7 @@ class Test_waf_global_rule_with_conditions:
                 assert result[0].resource_id == RULE_ID
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:rule/{RULE_ID}"
+                    == f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/{RULE_ID}"
                 )
                 assert result[0].region == AWS_REGION_US_EAST_1
 
@@ -162,6 +162,6 @@ class Test_waf_global_rule_with_conditions:
                 assert result[0].resource_id == RULE_ID
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:rule/{RULE_ID}"
+                    == f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/{RULE_ID}"
                 )
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -9,7 +9,11 @@ from prowler.providers.aws.services.waf.waf_service import (
     RuleGroup,
     WAFRegional,
 )
-from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+from tests.providers.aws.utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
 
 # Mocking WAF Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -98,43 +102,170 @@ def mock_generate_regional_clients(provider, service):
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
-@patch(
-    "prowler.providers.aws.aws_provider.AwsProvider.generate_regional_clients",
-    new=mock_generate_regional_clients,
-)
 class Test_WAF_Service:
-    # Test WAF Service
-    def test_service(self):
+    # Test WAF Global Service
+    def test_service_global(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
         assert waf.service == "waf"
 
-    # Test WAF Client
-    def test_client(self):
+    # Test WAF Global Client
+    def test_client_global(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
         for regional_client in waf.regional_clients.values():
             assert regional_client.__class__.__name__ == "WAF"
 
-    # Test WAF Session
-    def test__get_session__(self):
+    # Test WAF Global Session
+    def test__get_session___global(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
         assert waf.session.__class__.__name__ == "Session"
 
-    # Test WAF Describe Web ACLs
-    def test_list_web_acls(self):
+    # Test WAF Global List Rules
+    def test_list_rules(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        assert waf.rules
+
+    # Test WAF Global Get Rule
+    def test_get_rule(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        rule_arn = "arn:aws:waf:123456789012:rule/my-rule-id"
+        assert waf.rules == {
+            rule_arn: Rule(
+                arn=rule_arn,
+                id="my-rule-id",
+                name="my-rule",
+                region=AWS_REGION_US_EAST_1,
+                predicates=[
+                    Predicate(negated=False, type="IPMatch", data_id="my-data-id")
+                ],
+            )
+        }
+
+    # Test WAF Global List Rule Groups
+    def test_list_rule_groups(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        assert waf.rule_groups
+
+    # Test WAF Global Get Rule Groups
+    def test_get_rule_groups(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        rule_arn = "arn:aws:waf:123456789012:rulegroup/my-rule-group-id"
+        assert waf.rule_groups == {
+            rule_arn: RuleGroup(
+                arn="arn:aws:waf:123456789012:rulegroup/my-rule-group-id",
+                id="my-rule-group-id",
+                region=AWS_REGION_US_EAST_1,
+                name="my-rule-group",
+                rules=[
+                    Rule(
+                        arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                        id="my-rule-id",
+                        region=AWS_REGION_US_EAST_1,
+                        name="my-rule",
+                        predicates=[
+                            Predicate(
+                                negated=False, type="IPMatch", data_id="my-data-id"
+                            )
+                        ],
+                        tags=[],
+                    )
+                ],
+            )
+        }
+
+    # Test WAF Global List Web ACLs
+    def test_list_web_acls_waf_global(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+
+    # Test WAF Global Get Web ACL
+    def test_get_web_acl(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules == [
+            Rule(
+                arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                id="my-rule-id",
+                region=AWS_REGION_US_EAST_1,
+                name="my-rule",
+                predicates=[
+                    Predicate(negated=False, type="IPMatch", data_id="my-data-id")
+                ],
+                tags=[],
+            )
+        ]
+        assert waf.web_acls[waf_arn].rule_groups == [
+            RuleGroup(
+                arn="arn:aws:waf:123456789012:rulegroup/my-rule-group-id",
+                id="my-rule-group-id",
+                region=AWS_REGION_US_EAST_1,
+                name="my-rule-group",
+                rules=[
+                    Rule(
+                        arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                        id="my-rule-id",
+                        region=AWS_REGION_US_EAST_1,
+                        name="my-rule",
+                        predicates=[
+                            Predicate(
+                                negated=False, type="IPMatch", data_id="my-data-id"
+                            )
+                        ],
+                        tags=[],
+                    )
+                ],
+            )
+        ]
 
     # Test WAFRegional Describe Web ACLs Resources
     def test_list_resources_for_web_acl(self):
@@ -169,7 +300,7 @@ class Test_WAF_Service:
         assert waf.session.__class__.__name__ == "Session"
 
     # Test WAFRegional List Rules
-    def test_list_rules(self):
+    def test_list_regional_rules(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -182,7 +313,7 @@ class Test_WAF_Service:
         assert waf.rules
 
     # Test WAFRegional Get Rule
-    def test_get_rule(self):
+    def test_get_regional_rule(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -206,7 +337,7 @@ class Test_WAF_Service:
         }
 
     # Test WAFRegional List Rule Groups
-    def test_list_rule_groups(self):
+    def test_list_regional_rule_groups(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -219,7 +350,7 @@ class Test_WAF_Service:
         assert waf.rule_groups
 
     # Test WAFRegional Get Rule Groups
-    def test_get_rule_groups(self):
+    def test_get_regional_rule_groups(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -256,7 +387,7 @@ class Test_WAF_Service:
         }
 
     # Test WAFRegional List Web ACLs
-    def test_list_web_acls_waf_regional(self):
+    def test_list__regionalweb_acls_waf(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -269,7 +400,7 @@ class Test_WAF_Service:
         assert waf.web_acls[waf_arn].rule_groups
 
     # Test WAFRegional Get Web ACL
-    def test_get_web_acl(self):
+    def test_get_regional_web_acl(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -10,7 +10,7 @@ from prowler.providers.aws.services.waf.waf_service import (
     WAFRegional,
 )
 from tests.providers.aws.utils import (
-    AWS_REGION_EU_WEST_1,
+    AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_provider,
 )
@@ -94,10 +94,10 @@ def mock_make_api_call(self, operation_name, kwarg):
 # Mock generate_regional_clients()
 def mock_generate_regional_clients(provider, service):
     regional_client = provider._session.current_session.client(
-        service, region_name=AWS_REGION_EU_WEST_1
+        service, region_name=AWS_REGION_US_EAST_1
     )
-    regional_client.region = AWS_REGION_EU_WEST_1
-    return {AWS_REGION_EU_WEST_1: regional_client}
+    regional_client.region = AWS_REGION_US_EAST_1
+    return {AWS_REGION_US_EAST_1: regional_client}
 
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
@@ -106,14 +106,14 @@ class Test_WAF_Service:
     # Test WAF Global Service
     def test_service_global(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
         assert waf.service == "waf"
 
     # Test WAF Global Client
     def test_client_global(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
         for regional_client in waf.regional_clients.values():
             assert regional_client.__class__.__name__ == "WAF"
@@ -121,16 +121,16 @@ class Test_WAF_Service:
     # Test WAF Global Session
     def test__get_session___global(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
         assert waf.session.__class__.__name__ == "Session"
 
     # Test WAF Global List Rules
     def test_list_rules(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
         assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
@@ -141,15 +141,17 @@ class Test_WAF_Service:
     # Test WAF Global Get Rule
     def test_get_rule(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
         assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules
         assert waf.web_acls[waf_arn].rule_groups
-        rule_arn = "arn:aws:waf:123456789012:rule/my-rule-id"
+        rule_arn = (
+            f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id"
+        )
         assert waf.rules == {
             rule_arn: Rule(
                 arn=rule_arn,
@@ -165,9 +167,9 @@ class Test_WAF_Service:
     # Test WAF Global List Rule Groups
     def test_list_rule_groups(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
         assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
@@ -178,24 +180,24 @@ class Test_WAF_Service:
     # Test WAF Global Get Rule Groups
     def test_get_rule_groups(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
         assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules
         assert waf.web_acls[waf_arn].rule_groups
-        rule_arn = "arn:aws:waf:123456789012:rulegroup/my-rule-group-id"
+        rule_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rulegroup/my-rule-group-id"
         assert waf.rule_groups == {
             rule_arn: RuleGroup(
-                arn="arn:aws:waf:123456789012:rulegroup/my-rule-group-id",
+                arn=f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rulegroup/my-rule-group-id",
                 id="my-rule-group-id",
                 region=AWS_REGION_US_EAST_1,
                 name="my-rule-group",
                 rules=[
                     Rule(
-                        arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                        arn=f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id",
                         id="my-rule-id",
                         region=AWS_REGION_US_EAST_1,
                         name="my-rule",
@@ -213,10 +215,11 @@ class Test_WAF_Service:
     # Test WAF Global List Web ACLs
     def test_list_web_acls_waf_global(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
+        print(waf.web_acls.keys())
         assert waf.web_acls[waf_arn].name == "my-web-acl"
         assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
@@ -226,15 +229,15 @@ class Test_WAF_Service:
     # Test WAF Global Get Web ACL
     def test_get_web_acl(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
         assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules == [
             Rule(
-                arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                arn=f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id",
                 id="my-rule-id",
                 region=AWS_REGION_US_EAST_1,
                 name="my-rule",
@@ -246,13 +249,13 @@ class Test_WAF_Service:
         ]
         assert waf.web_acls[waf_arn].rule_groups == [
             RuleGroup(
-                arn="arn:aws:waf:123456789012:rulegroup/my-rule-group-id",
+                arn=f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rulegroup/my-rule-group-id",
                 id="my-rule-group-id",
                 region=AWS_REGION_US_EAST_1,
                 name="my-rule-group",
                 rules=[
                     Rule(
-                        arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                        arn=f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id",
                         id="my-rule-id",
                         region=AWS_REGION_US_EAST_1,
                         name="my-rule",
@@ -270,9 +273,9 @@ class Test_WAF_Service:
     # Test WAFRegional Describe Web ACLs Resources
     def test_list_resources_for_web_acl(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
-        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
         assert len(waf.web_acls[waf_arn].albs) == 1
         assert "alb-arn" in waf.web_acls[waf_arn].albs
@@ -280,14 +283,14 @@ class Test_WAF_Service:
     # Test WAFRegional Service
     def test_service_regional(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
         assert waf.service == "waf-regional"
 
     # Test WAFRegional Client
     def test_client_regional(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
         for regional_client in waf.regional_clients.values():
             assert regional_client.__class__.__name__ == "WAFRegional"
@@ -295,18 +298,18 @@ class Test_WAF_Service:
     # Test WAFRegional Session
     def test__get_session___regional(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
         assert waf.session.__class__.__name__ == "Session"
 
     # Test WAFRegional List Rules
     def test_list_regional_rules(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
-        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules
         assert waf.web_acls[waf_arn].rule_groups
@@ -315,21 +318,21 @@ class Test_WAF_Service:
     # Test WAFRegional Get Rule
     def test_get_regional_rule(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
-        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules
         assert waf.web_acls[waf_arn].rule_groups
-        rule_arn = "arn:aws:waf-regional:eu-west-1:123456789012:rule/my-rule-id"
+        rule_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id"
         assert waf.rules == {
             rule_arn: Rule(
                 arn=rule_arn,
                 id="my-rule-id",
                 name="my-rule",
-                region=AWS_REGION_EU_WEST_1,
+                region=AWS_REGION_US_EAST_1,
                 predicates=[
                     Predicate(negated=False, type="IPMatch", data_id="my-data-id")
                 ],
@@ -339,11 +342,11 @@ class Test_WAF_Service:
     # Test WAFRegional List Rule Groups
     def test_list_regional_rule_groups(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
-        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules
         assert waf.web_acls[waf_arn].rule_groups
@@ -352,28 +355,26 @@ class Test_WAF_Service:
     # Test WAFRegional Get Rule Groups
     def test_get_regional_rule_groups(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
-        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules
         assert waf.web_acls[waf_arn].rule_groups
-        rule_arn = (
-            "arn:aws:waf-regional:eu-west-1:123456789012:rulegroup/my-rule-group-id"
-        )
+        rule_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rulegroup/my-rule-group-id"
         assert waf.rule_groups == {
             rule_arn: RuleGroup(
-                arn="arn:aws:waf-regional:eu-west-1:123456789012:rulegroup/my-rule-group-id",
+                arn=f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rulegroup/my-rule-group-id",
                 id="my-rule-group-id",
-                region=AWS_REGION_EU_WEST_1,
+                region=AWS_REGION_US_EAST_1,
                 name="my-rule-group",
                 rules=[
                     Rule(
-                        arn="arn:aws:waf-regional:eu-west-1:123456789012:rule/my-rule-id",
+                        arn=f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id",
                         id="my-rule-id",
-                        region=AWS_REGION_EU_WEST_1,
+                        region=AWS_REGION_US_EAST_1,
                         name="my-rule",
                         predicates=[
                             Predicate(
@@ -389,12 +390,12 @@ class Test_WAF_Service:
     # Test WAFRegional List Web ACLs
     def test_list__regionalweb_acls_waf(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
-        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules
         assert waf.web_acls[waf_arn].rule_groups
@@ -402,17 +403,17 @@ class Test_WAF_Service:
     # Test WAFRegional Get Web ACL
     def test_get_regional_web_acl(self):
         # WAF client for this test class
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         waf = WAFRegional(aws_provider)
-        waf_arn = "arn:aws:waf-regional:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
         assert waf.web_acls[waf_arn].rules == [
             Rule(
-                arn="arn:aws:waf-regional:eu-west-1:123456789012:rule/my-rule-id",
+                arn=f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id",
                 id="my-rule-id",
-                region=AWS_REGION_EU_WEST_1,
+                region=AWS_REGION_US_EAST_1,
                 name="my-rule",
                 predicates=[
                     Predicate(negated=False, type="IPMatch", data_id="my-data-id")
@@ -422,15 +423,15 @@ class Test_WAF_Service:
         ]
         assert waf.web_acls[waf_arn].rule_groups == [
             RuleGroup(
-                arn="arn:aws:waf-regional:eu-west-1:123456789012:rulegroup/my-rule-group-id",
+                arn=f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rulegroup/my-rule-group-id",
                 id="my-rule-group-id",
-                region=AWS_REGION_EU_WEST_1,
+                region=AWS_REGION_US_EAST_1,
                 name="my-rule-group",
                 rules=[
                     Rule(
-                        arn="arn:aws:waf-regional:eu-west-1:123456789012:rule/my-rule-id",
+                        arn=f"arn:aws:waf-regional:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rule/my-rule-id",
                         id="my-rule-id",
-                        region=AWS_REGION_EU_WEST_1,
+                        region=AWS_REGION_US_EAST_1,
                         name="my-rule",
                         predicates=[
                             Predicate(

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -219,7 +219,6 @@ class Test_WAF_Service:
         waf = WAF(aws_provider)
         waf_arn = f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
-        print(waf.web_acls.keys())
         assert waf.web_acls[waf_arn].name == "my-web-acl"
         assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"


### PR DESCRIPTION
### Context

`AWS WAF Classic global rules` are used to manage and control web traffic by specifying conditions that determine how the firewall handles requests. These conditions help identify, inspect, and mitigate potential security threats, such as malicious or suspicious traffic, thereby improving the overall security posture. Without any conditions in place, web traffic flows freely, which can lead to vulnerabilities being exploited, bypassing security policies.

### Description

This check ensures that `AWS WAF Classic global rules` contain at least one condition. If no conditions are present, the rule becomes ineffective, allowing all traffic to pass unchecked.

### Checklist

- Are there new checks included in this PR? Yes.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
