### PR TITLE
feat(waf): add new check `waf_global_webacl_logging_enabled`

### DIFF
--- a/prowler/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "waf_global_webacl_logging_enabled",
+  "CheckTitle": "Check if AWS WAF Classic Global WebACL has logging enabled.",
+  "CheckType": [
+    "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
+  ],
+  "ServiceName": "waf",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:waf:account-id:webacl/web-acl-id",
+  "Severity": "medium",
+  "ResourceType": "AwsWafWebAcl",
+  "Description": "Ensure that every AWS WAF Classic Global WebACL has logging enabled.",
+  "Risk": "Without logging enabled, there is no visibility into traffic patterns or potential security threats, which limits the ability to troubleshoot and monitor web traffic effectively.",
+  "RelatedUrl": "https://docs.aws.amazon.com/waf/latest/developerguide/classic-waf-incident-response.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws waf put-logging-configuration --logging-configuration ResourceArn=<web-acl-arn>,LogDestinationConfigs=<log-destination-arn>",
+      "NativeIaC": "https://docs.prowler.com/checks/aws/logging-policies/bc_aws_logging_31/",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-1",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Ensure logging is enabled for AWS WAF Classic Global Web ACLs to capture traffic details and maintain compliance.",
+      "Url": "https://docs.aws.amazon.com/waf/latest/developerguide/classic-logging.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled.py
+++ b/prowler/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled.py
@@ -2,7 +2,7 @@ from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.waf.waf_client import waf_client
 
 
-class waf_regional_webacl_with_rules(Check):
+class waf_global_webacl_logging_enabled(Check):
     def execute(self):
         findings = []
         for acl in waf_client.web_acls.values():
@@ -13,13 +13,13 @@ class waf_regional_webacl_with_rules(Check):
             report.resource_tags = acl.tags
             report.status = "FAIL"
             report.status_extended = (
-                f"AWS WAF Regional Web ACL {acl.name} does not have logging enabled."
+                f"AWS WAF Global Web ACL {acl.name} does not have logging enabled."
             )
 
             if acl.logging_enabled:
                 report.status = "PASS"
                 report.status_extended = (
-                    f"AWS WAF Regional Web ACL {acl.name} has logging enabled."
+                    f"AWS WAF Global Web ACL {acl.name} does have logging enabled."
                 )
 
             findings.append(report)

--- a/prowler/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled.py
+++ b/prowler/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled.py
@@ -1,0 +1,27 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.waf.waf_client import waf_client
+
+
+class waf_regional_webacl_with_rules(Check):
+    def execute(self):
+        findings = []
+        for acl in waf_client.web_acls.values():
+            report = Check_Report_AWS(self.metadata())
+            report.region = acl.region
+            report.resource_id = acl.id
+            report.resource_arn = acl.arn
+            report.resource_tags = acl.tags
+            report.status = "FAIL"
+            report.status_extended = (
+                f"AWS WAF Regional Web ACL {acl.name} does not have logging enabled."
+            )
+
+            if acl.logging_enabled:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"AWS WAF Regional Web ACL {acl.name} has logging enabled."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -1,6 +1,6 @@
-from typing import Optional
+from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
@@ -11,46 +11,139 @@ class WAF(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__
         super().__init__("waf", provider)
+        self.rules = {}
+        self.rule_groups = {}
         self.web_acls = {}
-        self.__threading_call__(self._list_web_acls)
+        self._list_rules()
+        self.__threading_call__(self._get_rule, self.rules.values())
+        self._list_rule_groups()
+        self.__threading_call__(
+            self._list_activated_rules_in_rule_group, self.rule_groups.values()
+        )
+        self._list_web_acls()
+        self.__threading_call__(self._get_web_acl, self.web_acls.values())
         self.__threading_call__(
             self._list_resources_for_web_acl, self.web_acls.values()
         )
 
-    def _list_web_acls(self, regional_client):
-        logger.info("WAF - Listing Regional Web ACLs...")
+    def _list_rules(self):
+        logger.info("WAF - Listing Global Rules...")
         try:
-            for waf in regional_client.list_web_acls()["WebACLs"]:
+            for rule in self.client.list_rules().get("Rules", []):
+                arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule['RuleId']}"
+                self.rules[arn] = Rule(
+                    arn=arn,
+                    id=rule.get("RuleId", ""),
+                    region="us-east-1",
+                    name=rule.get("Name", ""),
+                )
+
+        except Exception as error:
+            logger.error(
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _get_rule(self, rule):
+        logger.info(f"WAF - Getting Global Rule {rule.name}...")
+        try:
+            get_rule = self.client.get_rule(RuleId=rule.id)
+            for predicate in get_rule.get("Rule", {}).get("Predicates", []):
+                rule.predicates.append(
+                    Predicate(
+                        negated=predicate.get("Negated", False),
+                        type=predicate.get("Type", "IPMatch"),
+                        data_id=predicate.get("DataId", ""),
+                    )
+                )
+
+        except KeyError:
+            logger.error(f"Rule {rule.name} not found in {rule.region}.")
+
+    def _list_rule_groups(self):
+        logger.info("WAF - Listing Global Rule Groups...")
+        try:
+            for rule_group in self.client.list_rule_groups().get("RuleGroups", []):
+                arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rulegroup/{rule_group['RuleGroupId']}"
+                self.rule_groups[arn] = RuleGroup(
+                    arn=arn,
+                    region="us-east-1",
+                    id=rule_group.get("RuleGroupId", ""),
+                    name=rule_group.get("Name", ""),
+                )
+
+        except Exception as error:
+            logger.error(
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_activated_rules_in_rule_group(self, rule_group):
+        logger.info(
+            f"WAF - Listing activated rules in Global Rule Group {rule_group.name}..."
+        )
+        try:
+            for rule in self.client.list_activated_rules_in_rule_group(
+                RuleGroupId=rule_group.id
+            ).get("ActivatedRules", []):
+                rule_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule.get('RuleId', '')}"
+                rule_group.rules.append(self.rules[rule_arn])
+
+        except Exception as error:
+            logger.error(
+                f"{rule_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_web_acls(self):
+        logger.info("WAF - Listing Global Web ACLs...")
+        try:
+            for waf in self.client.list_web_acls()["WebACLs"]:
                 if not self.audit_resources or (
                     is_resource_filtered(waf["WebACLId"], self.audit_resources)
                 ):
-                    arn = f"arn:{self.audited_partition}:waf:{regional_client.region}:{self.audited_account}:webacl/{waf['WebACLId']}"
+                    arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:webacl/{waf['WebACLId']}"
                     self.web_acls[arn] = WebAcl(
                         arn=arn,
                         name=waf["Name"],
                         id=waf["WebACLId"],
                         albs=[],
-                        region=regional_client.region,
+                        region="us-east-1",
                     )
 
         except Exception as error:
             logger.error(
-                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def _list_resources_for_web_acl(self, regional_client):
-        logger.info("WAF - Describing resources...")
+    def _get_web_acl(self, acl):
+        logger.info(f"WAF - Getting Global Web ACL {acl.name}...")
+        try:
+            get_web_acl = self.client.get_web_acl(WebACLId=acl.id)
+            for rule in get_web_acl.get("WebACL", {}).get("Rules", []):
+                rule_id = rule.get("RuleId", "")
+                if rule.get("Type", "") == "GROUP":
+                    rule_group_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rulegroup/{rule_id}"
+                    acl.rule_groups.append(self.rule_groups[rule_group_arn])
+                else:
+                    rule_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule_id}"
+                    acl.rules.append(self.rules[rule_arn])
+
+        except Exception as error:
+            logger.error(
+                f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_resources_for_web_acl(self):
+        logger.info("WAF Global - Describing resources...")
         try:
             for acl in self.web_acls.values():
-                if acl.region == regional_client.region:
-                    for resource in regional_client.list_resources_for_web_acl(
+                if acl.region == "us-east-1":
+                    for resource in self.client.list_resources_for_web_acl(
                         WebACLId=acl.id, ResourceType="APPLICATION_LOAD_BALANCER"
-                    )["ResourceArns"]:
+                    ).get("ResourceArns", []):
                         acl.albs.append(resource)
 
         except Exception as error:
             logger.error(
-                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
 
@@ -159,7 +252,7 @@ class WAFRegional(AWSService):
             )
 
     def _get_web_acl(self, acl):
-        logger.info(f"WAFRegional - Getting Web ACL {acl.name}...")
+        logger.info(f"WAFRegional - Getting Regional Web ACL {acl.name}...")
         try:
             get_web_acl = self.regional_clients[acl.region].get_web_acl(WebACLId=acl.id)
             for rule in get_web_acl.get("WebACL", {}).get("Rules", []):
@@ -207,8 +300,8 @@ class Rule(BaseModel):
     id: str
     region: str
     name: str
-    predicates: list[Predicate] = []
-    tags: Optional[list] = []
+    predicates: Optional[List[Predicate]] = Field(default_factory=list)
+    tags: Optional[List[Dict[str, str]]] = Field(default_factory=list)
 
 
 class RuleGroup(BaseModel):
@@ -218,8 +311,8 @@ class RuleGroup(BaseModel):
     id: str
     region: str
     name: str
-    rules: list[Rule] = []
-    tags: Optional[list] = []
+    rules: List[Rule] = Field(default_factory=list)
+    tags: Optional[List[Dict[str, str]]] = Field(default_factory=list)
 
 
 class WebAcl(BaseModel):
@@ -228,8 +321,8 @@ class WebAcl(BaseModel):
     arn: str
     name: str
     id: str
-    albs: list[str]
+    albs: List[str] = Field(default_factory=list)
     region: str
-    rules: list[Rule] = []
-    rule_groups: list[RuleGroup] = []
-    tags: Optional[list] = []
+    rules: List[Rule] = Field(default_factory=list)
+    rule_groups: List[RuleGroup] = Field(default_factory=list)
+    tags: Optional[List[Dict[str, str]]] = Field(default_factory=list)

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -22,6 +22,7 @@ class WAF(AWSService):
         )
         self._list_web_acls()
         self.__threading_call__(self._get_web_acl, self.web_acls.values())
+        self.__threading_call__(self._get_logging_configuration, self.web_acls.values())
         self.__threading_call__(
             self._list_resources_for_web_acl, self.web_acls.values()
         )
@@ -125,6 +126,23 @@ class WAF(AWSService):
                 else:
                     rule_arn = f"arn:{self.audited_partition}:waf:{self.audited_account}:rule/{rule_id}"
                     acl.rules.append(self.rules[rule_arn])
+
+        except Exception as error:
+            logger.error(
+                f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _get_logging_configuration(self, acl):
+        logger.info(f"WAF - Getting Global Web ACL {acl.name} logging configuration...")
+        try:
+            get_logging_configuration = self.client.get_logging_configuration(
+                ResourceArn=acl.arn
+            )
+            acl.logging_enabled = bool(
+                get_logging_configuration.get("LoggingConfiguration", {}).get(
+                    "LogDestinationConfigs", []
+                )
+            )
 
         except Exception as error:
             logger.error(
@@ -325,4 +343,5 @@ class WebAcl(BaseModel):
     region: str
     rules: List[Rule] = Field(default_factory=list)
     rule_groups: List[RuleGroup] = Field(default_factory=list)
+    logging_enabled: bool = Field(default=False)
     tags: Optional[List[Dict[str, str]]] = Field(default_factory=list)

--- a/tests/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled_test.py
+++ b/tests/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled_test.py
@@ -76,10 +76,10 @@ def mock_make_api_call_logging_disabled(self, operation_name, kwarg):
     return orig(self, operation_name, kwarg)
 
 
-class Test_waf_regional_webacl_with_rules:
+class Test_waf_global_webacl_logging_enabled:
     @mock_aws
     def test_no_waf(self):
-        from prowler.providers.aws.services.waf.waf_service import WAFRegional
+        from prowler.providers.aws.services.waf.waf_service import WAF
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
@@ -88,15 +88,15 @@ class Test_waf_regional_webacl_with_rules:
             return_value=aws_provider,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules.waf_client",
-                new=WAFRegional(aws_provider),
+                "prowler.providers.aws.services.waf.waf_global_webacl_logging_enabled.waf_global_webacl_logging_enabled.waf_client",
+                new=WAF(aws_provider),
             ):
                 # Test Check
-                from prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules import (
-                    waf_regional_webacl_with_rules,
+                from prowler.providers.aws.services.waf.waf_global_webacl_logging_enabled.waf_global_webacl_logging_enabled import (
+                    waf_global_webacl_logging_enabled,
                 )
 
-                check = waf_regional_webacl_with_rules()
+                check = waf_global_webacl_logging_enabled()
                 result = check.execute()
 
                 assert len(result) == 0
@@ -106,8 +106,8 @@ class Test_waf_regional_webacl_with_rules:
         new=mock_make_api_call_logging_disabled,
     )
     @mock_aws
-    def test_waf_no_rules_and_no_rule_group(self):
-        from prowler.providers.aws.services.waf.waf_service import WAFRegional
+    def test_waf_webacl_logging_disabled(self):
+        from prowler.providers.aws.services.waf.waf_service import WAF
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
@@ -116,22 +116,61 @@ class Test_waf_regional_webacl_with_rules:
             return_value=aws_provider,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules.waf_client",
-                new=WAFRegional(aws_provider),
+                "prowler.providers.aws.services.waf.waf_global_webacl_logging_enabled.waf_global_webacl_logging_enabled.waf_client",
+                new=WAF(aws_provider),
             ):
                 # Test Check
-                from prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules import (
-                    waf_regional_webacl_with_rules,
+                from prowler.providers.aws.services.waf.waf_global_webacl_logging_enabled.waf_global_webacl_logging_enabled import (
+                    waf_global_webacl_logging_enabled,
                 )
 
-                check = waf_regional_webacl_with_rules()
+                check = waf_global_webacl_logging_enabled()
                 result = check.execute()
 
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"AWS WAF Global Web ACL {WEB_ACL_NAME} does not have any rules or rule groups."
+                    == f"AWS WAF Global Web ACL {WEB_ACL_NAME} does not have logging enabled."
+                )
+                assert result[0].resource_id == WEB_ACL_ID
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_logging_enabled,
+    )
+    @mock_aws
+    def test_waf_webacl_logging_enabled(self):
+        from prowler.providers.aws.services.waf.waf_service import WAF
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.waf.waf_global_webacl_logging_enabled.waf_global_webacl_logging_enabled.waf_client",
+                new=WAF(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.waf.waf_global_webacl_logging_enabled.waf_global_webacl_logging_enabled import (
+                    waf_global_webacl_logging_enabled,
+                )
+
+                check = waf_global_webacl_logging_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"AWS WAF Global Web ACL {WEB_ACL_NAME} does have logging enabled."
                 )
                 assert result[0].resource_id == WEB_ACL_ID
                 assert (

--- a/tests/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled_test.py
+++ b/tests/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled_test.py
@@ -36,7 +36,7 @@ def mock_make_api_call_logging_enabled(self, operation_name, kwarg):
     if operation_name == "GetLoggingConfiguration":
         return {
             "LoggingConfiguration": {
-                "ResourceArn": f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}",
+                "ResourceArn": f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}",
                 "LogDestinationConfigs": [
                     "arn:aws:firehose:us-east-1:123456789012:deliverystream/my-firehose"
                 ],
@@ -66,7 +66,7 @@ def mock_make_api_call_logging_disabled(self, operation_name, kwarg):
     if operation_name == "GetLoggingConfiguration":
         return {
             "LoggingConfiguration": {
-                "ResourceArn": f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}",
+                "ResourceArn": f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}",
                 "LogDestinationConfigs": [],
                 "RedactedFields": [],
                 "ManagedByFirewallManager": False,
@@ -136,7 +136,7 @@ class Test_waf_global_webacl_logging_enabled:
                 assert result[0].resource_id == WEB_ACL_ID
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}"
+                    == f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}"
                 )
                 assert result[0].region == AWS_REGION_US_EAST_1
 
@@ -175,6 +175,6 @@ class Test_waf_global_webacl_logging_enabled:
                 assert result[0].resource_id == WEB_ACL_ID
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}"
+                    == f"arn:aws:waf:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}"
                 )
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled_test.py
+++ b/tests/providers/aws/services/waf/waf_global_webacl_logging_enabled/waf_global_webacl_logging_enabled_test.py
@@ -1,0 +1,141 @@
+from unittest import mock
+from unittest.mock import patch
+
+import botocore
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+WEB_ACL_ID = "test-web-acl-id"
+WEB_ACL_NAME = "test-web-acl-name"
+
+# Original botocore _make_api_call function
+orig = botocore.client.BaseClient._make_api_call
+
+
+# Mocked botocore _make_api_call function
+def mock_make_api_call_logging_enabled(self, operation_name, kwarg):
+    if operation_name == "GetChangeToken":
+        return {"ChangeToken": "my-change-token"}
+    if operation_name == "ListWebACLs":
+        return {
+            "WebACLs": [
+                {"WebACLId": WEB_ACL_ID, "Name": WEB_ACL_NAME},
+            ]
+        }
+    if operation_name == "GetWebACL":
+        return {
+            "WebACL": {
+                "Rules": [],
+            }
+        }
+    if operation_name == "GetLoggingConfiguration":
+        return {
+            "LoggingConfiguration": {
+                "ResourceArn": f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}",
+                "LogDestinationConfigs": [
+                    "arn:aws:firehose:us-east-1:123456789012:deliverystream/my-firehose"
+                ],
+                "RedactedFields": [],
+                "ManagedByFirewallManager": False,
+            }
+        }
+    # If we don't want to patch the API call
+    return orig(self, operation_name, kwarg)
+
+
+def mock_make_api_call_logging_disabled(self, operation_name, kwarg):
+    if operation_name == "GetChangeToken":
+        return {"ChangeToken": "my-change-token"}
+    if operation_name == "ListWebACLs":
+        return {
+            "WebACLs": [
+                {"WebACLId": WEB_ACL_ID, "Name": WEB_ACL_NAME},
+            ]
+        }
+    if operation_name == "GetWebACL":
+        return {
+            "WebACL": {
+                "Rules": [],
+            }
+        }
+    if operation_name == "GetLoggingConfiguration":
+        return {
+            "LoggingConfiguration": {
+                "ResourceArn": f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}",
+                "LogDestinationConfigs": [],
+                "RedactedFields": [],
+                "ManagedByFirewallManager": False,
+            }
+        }
+    # If we don't want to patch the API call
+    return orig(self, operation_name, kwarg)
+
+
+class Test_waf_regional_webacl_with_rules:
+    @mock_aws
+    def test_no_waf(self):
+        from prowler.providers.aws.services.waf.waf_service import WAFRegional
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules.waf_client",
+                new=WAFRegional(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules import (
+                    waf_regional_webacl_with_rules,
+                )
+
+                check = waf_regional_webacl_with_rules()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_logging_disabled,
+    )
+    @mock_aws
+    def test_waf_no_rules_and_no_rule_group(self):
+        from prowler.providers.aws.services.waf.waf_service import WAFRegional
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules.waf_client",
+                new=WAFRegional(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.waf.waf_regional_webacl_with_rules.waf_regional_webacl_with_rules import (
+                    waf_regional_webacl_with_rules,
+                )
+
+                check = waf_regional_webacl_with_rules()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"AWS WAF Global Web ACL {WEB_ACL_NAME} does not have any rules or rule groups."
+                )
+                assert result[0].resource_id == WEB_ACL_ID
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:waf:{AWS_ACCOUNT_NUMBER}:webacl/{WEB_ACL_ID}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/waf/waf_service_test.py
+++ b/tests/providers/aws/services/waf/waf_service_test.py
@@ -9,7 +9,11 @@ from prowler.providers.aws.services.waf.waf_service import (
     RuleGroup,
     WAFRegional,
 )
-from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+from tests.providers.aws.utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
 
 # Mocking WAF Calls
 make_api_call = botocore.client.BaseClient._make_api_call
@@ -98,43 +102,170 @@ def mock_generate_regional_clients(provider, service):
 
 # Patch every AWS call using Boto3 and generate_regional_clients to have 1 client
 @patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
-@patch(
-    "prowler.providers.aws.aws_provider.AwsProvider.generate_regional_clients",
-    new=mock_generate_regional_clients,
-)
 class Test_WAF_Service:
-    # Test WAF Service
-    def test_service(self):
+    # Test WAF Global Service
+    def test_service_global(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
         assert waf.service == "waf"
 
-    # Test WAF Client
-    def test_client(self):
+    # Test WAF Global Client
+    def test_client_global(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
         for regional_client in waf.regional_clients.values():
             assert regional_client.__class__.__name__ == "WAF"
 
-    # Test WAF Session
-    def test__get_session__(self):
+    # Test WAF Global Session
+    def test__get_session___global(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
         assert waf.session.__class__.__name__ == "Session"
 
-    # Test WAF Describe Web ACLs
-    def test_list_web_acls(self):
+    # Test WAF Global List Rules
+    def test_list_rules(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAF(aws_provider)
-        waf_arn = "arn:aws:waf:eu-west-1:123456789012:webacl/my-web-acl-id"
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        assert waf.rules
+
+    # Test WAF Global Get Rule
+    def test_get_rule(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        rule_arn = "arn:aws:waf:123456789012:rule/my-rule-id"
+        assert waf.rules == {
+            rule_arn: Rule(
+                arn=rule_arn,
+                id="my-rule-id",
+                name="my-rule",
+                region=AWS_REGION_US_EAST_1,
+                predicates=[
+                    Predicate(negated=False, type="IPMatch", data_id="my-data-id")
+                ],
+            )
+        }
+
+    # Test WAF Global List Rule Groups
+    def test_list_rule_groups(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        assert waf.rule_groups
+
+    # Test WAF Global Get Rule Groups
+    def test_get_rule_groups(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+        rule_arn = "arn:aws:waf:123456789012:rulegroup/my-rule-group-id"
+        assert waf.rule_groups == {
+            rule_arn: RuleGroup(
+                arn="arn:aws:waf:123456789012:rulegroup/my-rule-group-id",
+                id="my-rule-group-id",
+                region=AWS_REGION_US_EAST_1,
+                name="my-rule-group",
+                rules=[
+                    Rule(
+                        arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                        id="my-rule-id",
+                        region=AWS_REGION_US_EAST_1,
+                        name="my-rule",
+                        predicates=[
+                            Predicate(
+                                negated=False, type="IPMatch", data_id="my-data-id"
+                            )
+                        ],
+                        tags=[],
+                    )
+                ],
+            )
+        }
+
+    # Test WAF Global List Web ACLs
+    def test_list_web_acls_waf_global(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
         assert len(waf.web_acls) == 1
         assert waf.web_acls[waf_arn].name == "my-web-acl"
-        assert waf.web_acls[waf_arn].region == AWS_REGION_EU_WEST_1
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
         assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules
+        assert waf.web_acls[waf_arn].rule_groups
+
+    # Test WAF Global Get Web ACL
+    def test_get_web_acl(self):
+        # WAF client for this test class
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        waf = WAF(aws_provider)
+        waf_arn = "arn:aws:waf:123456789012:webacl/my-web-acl-id"
+        assert waf.web_acls[waf_arn].name == "my-web-acl"
+        assert waf.web_acls[waf_arn].region == AWS_REGION_US_EAST_1
+        assert waf.web_acls[waf_arn].id == "my-web-acl-id"
+        assert waf.web_acls[waf_arn].rules == [
+            Rule(
+                arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                id="my-rule-id",
+                region=AWS_REGION_US_EAST_1,
+                name="my-rule",
+                predicates=[
+                    Predicate(negated=False, type="IPMatch", data_id="my-data-id")
+                ],
+                tags=[],
+            )
+        ]
+        assert waf.web_acls[waf_arn].rule_groups == [
+            RuleGroup(
+                arn="arn:aws:waf:123456789012:rulegroup/my-rule-group-id",
+                id="my-rule-group-id",
+                region=AWS_REGION_US_EAST_1,
+                name="my-rule-group",
+                rules=[
+                    Rule(
+                        arn="arn:aws:waf:123456789012:rule/my-rule-id",
+                        id="my-rule-id",
+                        region=AWS_REGION_US_EAST_1,
+                        name="my-rule",
+                        predicates=[
+                            Predicate(
+                                negated=False, type="IPMatch", data_id="my-data-id"
+                            )
+                        ],
+                        tags=[],
+                    )
+                ],
+            )
+        ]
 
     # Test WAFRegional Describe Web ACLs Resources
     def test_list_resources_for_web_acl(self):
@@ -169,7 +300,7 @@ class Test_WAF_Service:
         assert waf.session.__class__.__name__ == "Session"
 
     # Test WAFRegional List Rules
-    def test_list_rules(self):
+    def test_list_regional_rules(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -182,7 +313,7 @@ class Test_WAF_Service:
         assert waf.rules
 
     # Test WAFRegional Get Rule
-    def test_get_rule(self):
+    def test_get_regional_rule(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -206,7 +337,7 @@ class Test_WAF_Service:
         }
 
     # Test WAFRegional List Rule Groups
-    def test_list_rule_groups(self):
+    def test_list_regional_rule_groups(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -219,7 +350,7 @@ class Test_WAF_Service:
         assert waf.rule_groups
 
     # Test WAFRegional Get Rule Groups
-    def test_get_rule_groups(self):
+    def test_get_regional_rule_groups(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -256,7 +387,7 @@ class Test_WAF_Service:
         }
 
     # Test WAFRegional List Web ACLs
-    def test_list_web_acls_waf_regional(self):
+    def test_list__regionalweb_acls_waf(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)
@@ -269,7 +400,7 @@ class Test_WAF_Service:
         assert waf.web_acls[waf_arn].rule_groups
 
     # Test WAFRegional Get Web ACL
-    def test_get_web_acl(self):
+    def test_get_regional_web_acl(self):
         # WAF client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         waf = WAFRegional(aws_provider)


### PR DESCRIPTION
### Context


`AWS WAF Classic Global Web ACL logging` helps track detailed information about the traffic that passes through your web `ACL`. Enabling logging ensures that you have a record of all requests analyzed by `AWS WAF`, which is critical for monitoring, troubleshooting, and meeting compliance requirements. Logging data can help identify trends, detect anomalous activity, and provide insights into how web ACLs perform.

### Description

This check verifies if `logging` is enabled for an` AWS WAF global web ACL`. The check will fail if `logging` is not activated.

### Checklist

- Are there new checks included in this PR? Yes.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
