### PR TITLE
feat(mq): add new check `mq_broker_logging_enabled`

### DIFF
--- a/prowler/providers/aws/services/mq/mq_broker_active_deployment_mode/mq_broker_active_deployment_mode.py
+++ b/prowler/providers/aws/services/mq/mq_broker_active_deployment_mode/mq_broker_active_deployment_mode.py
@@ -14,10 +14,10 @@ class mq_broker_active_deployment_mode(Check):
                 report.resource_arn = broker.arn
                 report.resource_tags = broker.tags
                 report.status = "FAIL"
-                report.status_extended = f"MQ Broker {broker.name} does not have an active/standby deployment mode."
+                report.status_extended = f"MQ Apache ActiveMQ Broker {broker.name} does not have an active/standby deployment mode."
                 if broker.deployment_mode == DeploymentMode.ACTIVE_STANDBY_MULTI_AZ:
                     report.status = "PASS"
-                    report.status_extended = f"MQ Broker {broker.name} does have an active/standby deployment mode."
+                    report.status_extended = f"MQ Apache ActiveMQ Broker {broker.name} does have an active/standby deployment mode."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "mq_broker_logging_enabled",
-  "CheckTitle": "ActiveMQ brokers should stream audit logs to CloudWatch.",
+  "CheckTitle": "MQ brokers should stream audit logs to CloudWatch.",
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
   ],
@@ -10,18 +10,18 @@
   "ResourceIdTemplate": "arn:aws:mq:region:account-id:broker:broker-id",
   "Severity": "medium",
   "ResourceType": "AwsAmazonMQBroker",
-  "Description": "Ensure ActiveMQ brokers are configured to stream audit logs to CloudWatch to enhance monitoring and detect security-related issues.",
+  "Description": "Ensure MQ brokers are configured to stream audit logs to CloudWatch to enhance monitoring and detect security-related issues.",
   "Risk": "Without streaming audit logs to CloudWatch, monitoring and alerting on suspicious activity or security incidents is limited. This reduces visibility into the broker's operations and potential security breaches.",
-  "RelatedUrl": "https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/configure-logging-monitoring-activemq.html#security-logging-monitoring-configure-cloudwatch-structure",
+  "RelatedUrl": "https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/security-logging-monitoring.html",
   "Remediation": {
     "Code": {
-      "CLI": "aws mq update-broker --broker-id <broker-id> --logs 'audit=true, general=true'",
-      "NativeIaC": "https://docs.prowler.com/checks/aws/logging-policies/bc_aws_logging_10/",
+      "CLI": "aws mq update-broker --broker-id <broker-id> --logs 'audit=true'",
+      "NativeIaC": "https://docs.prowler.com/checks/aws/logging-policies/bc_aws_logging_10/#terraform",
       "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/mq-controls.html#mq-2",
       "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/MQ/log-exports.html"
     },
     "Recommendation": {
-      "Text": "Ensure ActiveMQ brokers are configured to stream audit logs to CloudWatch to enhance monitoring and detect security-related issues.",
+      "Text": "Ensure MQ brokers are configured to stream audit logs to CloudWatch to enhance monitoring and detect security-related issues.",
       "Url": "https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/configure-logging-monitoring-activemq.html"
     }
   },

--- a/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "mq_broker_logging_enabled",
+  "CheckTitle": "ActiveMQ brokers should stream audit logs to CloudWatch.",
+  "CheckType": [
+    "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
+  ],
+  "ServiceName": "mq",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:mq:region:account-id:broker:broker-id",
+  "Severity": "medium",
+  "ResourceType": "AwsAmazonMQBroker",
+  "Description": "Ensure ActiveMQ brokers are configured to stream audit logs to CloudWatch to enhance monitoring and detect security-related issues.",
+  "Risk": "Without streaming audit logs to CloudWatch, monitoring and alerting on suspicious activity or security incidents is limited. This reduces visibility into the broker's operations and potential security breaches.",
+  "RelatedUrl": "https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/configure-logging-monitoring-activemq.html#security-logging-monitoring-configure-cloudwatch-structure",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws mq update-broker --broker-id <broker-id> --logs 'audit=true, general=true'",
+      "NativeIaC": "https://docs.prowler.com/checks/aws/logging-policies/bc_aws_logging_10/",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/mq-controls.html#mq-2",
+      "Terraform": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/MQ/log-exports.html"
+    },
+    "Recommendation": {
+      "Text": "Ensure ActiveMQ brokers are configured to stream audit logs to CloudWatch to enhance monitoring and detect security-related issues.",
+      "Url": "https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/configure-logging-monitoring-activemq.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
+++ b/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
@@ -1,6 +1,5 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.mq.mq_client import mq_client
-from prowler.providers.aws.services.mq.mq_service import EngineType
 
 
 class mq_broker_logging_enabled(Check):
@@ -25,13 +24,11 @@ class mq_broker_logging_enabled(Check):
             report.status_extended = (
                 f"MQ Broker {broker.name} does not have logging enabled."
             )
-
-            if broker.engine_type == EngineType.ACTIVEMQ:
-                if broker.logging_enabled:
-                    report.status = "PASS"
-                    report.status_extended = (
-                        f"MQ Broker {broker.name} does have logging enabled."
-                    )
+            if broker.logging_enabled:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"MQ Broker {broker.name} have logging enabled."
+                )
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
+++ b/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
@@ -1,9 +1,19 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.mq.mq_client import mq_client
+from prowler.providers.aws.services.mq.mq_service import EngineType
 
 
 class mq_broker_logging_enabled(Check):
+    """Ensure that MQ Brokers have logging enabled
+
+    This check will return FAIL if the MQ Broker does not have logging enabled.
+    """
+
     def execute(self):
+        """Execute the check
+
+        Returns: List[Check_Report_AWS]: List of check reports
+        """
         findings = []
         for broker in mq_client.brokers.values():
             report = Check_Report_AWS(self.metadata())
@@ -16,12 +26,13 @@ class mq_broker_logging_enabled(Check):
                 f"MQ Broker {broker.name} does not have logging enabled."
             )
 
-            if broker.logging_enabled:
-                report.status = "PASS"
-                report.status_extended = (
-                    f"MQ Broker {broker.name} does have logging enabled."
-                )
+            if broker.engine_type == EngineType.ACTIVEMQ:
+                if broker.logging_enabled:
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"MQ Broker {broker.name} does have logging enabled."
+                    )
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
+++ b/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
@@ -1,0 +1,27 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.mq.mq_client import mq_client
+
+
+class mq_broker_logging_enabled(Check):
+    def execute(self):
+        findings = []
+        for broker in mq_client.brokers.values():
+            report = Check_Report_AWS(self.metadata())
+            report.region = broker.region
+            report.resource_id = broker.id
+            report.resource_arn = broker.arn
+            report.resource_tags = broker.tags
+            report.status = "FAIL"
+            report.status_extended = (
+                f"MQ Broker {broker.name} does not have logging enabled."
+            )
+
+            if broker.logging_enabled:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"MQ Broker {broker.name} does have logging enabled."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
+++ b/prowler/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled.py
@@ -22,7 +22,9 @@ class mq_broker_logging_enabled(Check):
             report.resource_arn = broker.arn
             report.resource_tags = broker.tags
             report.status = "FAIL"
-            report.status_extended = f"MQ {broker.engine_type.value} Broker {broker.name} does not have logging enabled."
+            report.status_extended = (
+                f"MQ Broker {broker.name} does not have logging enabled."
+            )
             logging_enabled = False
 
             if broker.engine_type == EngineType.ACTIVEMQ:
@@ -34,7 +36,9 @@ class mq_broker_logging_enabled(Check):
 
             if logging_enabled:
                 report.status = "PASS"
-                report.status_extended = f"MQ {broker.engine_type.value} Broker {broker.name} does have logging enabled."
+                report.status_extended = (
+                    f"MQ Broker {broker.name} does have logging enabled."
+                )
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/mq/mq_service.py
+++ b/prowler/providers/aws/services/mq/mq_service.py
@@ -56,12 +56,6 @@ class MQ(AWSService):
             broker.audit_logging_enabled = describe_broker.get("Logs", {}).get(
                 "Audit", False
             )
-            broker.engine_type = EngineType(
-                describe_broker.get("EngineType", "ACTIVEMQ").upper()
-            )
-            broker.deployment_mode = DeploymentMode(
-                describe_broker.get("DeploymentMode", "SINGLE_INSTANCE")
-            )
             broker.tags = [describe_broker.get("Tags", {})]
 
         except Exception as error:

--- a/prowler/providers/aws/services/mq/mq_service.py
+++ b/prowler/providers/aws/services/mq/mq_service.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
@@ -42,6 +42,9 @@ class MQ(AWSService):
             broker.auto_minor_version_upgrade = describe_broker.get(
                 "AutoMinorVersionUpgrade", False
             )
+            broker.logging_enabled = describe_broker.get("Logs", {}).get(
+                "General", False
+            )
             broker.tags = [describe_broker.get("Tags", {})]
         except Exception as error:
             logger.error(
@@ -56,5 +59,6 @@ class Broker(BaseModel):
     name: str
     id: str
     region: str
-    auto_minor_version_upgrade: bool = False
+    auto_minor_version_upgrade: bool = Field(default=False)
+    logging_enabled: bool = Field(default=False)
     tags: Optional[List[Dict[str, str]]]

--- a/prowler/providers/aws/services/mq/mq_service.py
+++ b/prowler/providers/aws/services/mq/mq_service.py
@@ -47,7 +47,7 @@ class MQ(AWSService):
                 "General", False
             )
             broker.engine_type = EngineType(
-                describe_broker.get("EngineType", "ACTIVEMQ")
+                describe_broker.get("EngineType", "ACTIVEMQ").upper()
             )
             broker.deployment_mode = DeploymentMode(
                 describe_broker.get("DeploymentMode", "SINGLE_INSTANCE")

--- a/tests/providers/aws/services/mq/mq_broker_active_deployment_mode/mq_broker_active_deployment_mode_test.py
+++ b/tests/providers/aws/services/mq/mq_broker_active_deployment_mode/mq_broker_active_deployment_mode_test.py
@@ -120,7 +120,7 @@ class Test_mq_activemq_broker_active_standby_mode:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == f"MQ Broker {broker_name} does have an active/standby deployment mode."
+                    == f"MQ Apache ActiveMQ Broker {broker_name} does have an active/standby deployment mode."
                 )
                 assert result[0].resource_id == broker_id
                 assert (
@@ -173,7 +173,7 @@ class Test_mq_activemq_broker_active_standby_mode:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"MQ Broker {broker_name} does not have an active/standby deployment mode."
+                    == f"MQ Apache ActiveMQ Broker {broker_name} does not have an active/standby deployment mode."
                 )
                 assert result[0].resource_id == broker_id
                 assert (

--- a/tests/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled_test.py
+++ b/tests/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled_test.py
@@ -1,0 +1,145 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_mq_broker_logging_enabled:
+    @mock_aws
+    def test_no_brokers(self):
+        from prowler.providers.aws.services.mq.mq_service import MQ
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.mq.mq_broker_logging_enabled.mq_broker_logging_enabled.mq_client",
+            new=MQ(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.mq.mq_broker_logging_enabled.mq_broker_logging_enabled import (
+                mq_broker_logging_enabled,
+            )
+
+            check = mq_broker_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_broker_logging_enabled(self):
+        mq_client = client("mq", region_name=AWS_REGION_US_EAST_1)
+        broker_name = "test-broker"
+        broker_id = mq_client.create_broker(
+            BrokerName=broker_name,
+            EngineType="ACTIVEMQ",
+            EngineVersion="5.15.0",
+            HostInstanceType="mq.t2.micro",
+            Users=[
+                {
+                    "Username": "admin",
+                    "Password": "admin",
+                },
+            ],
+            DeploymentMode="SINGLE_INSTANCE",
+            PubliclyAccessible=False,
+            AutoMinorVersionUpgrade=True,
+            Logs={
+                "General": True,
+            },
+        )["BrokerId"]
+
+        from prowler.providers.aws.services.mq.mq_service import MQ
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.mq.mq_broker_logging_enabled.mq_broker_logging_enabled.mq_client",
+            new=MQ(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.mq.mq_broker_logging_enabled.mq_broker_logging_enabled import (
+                mq_broker_logging_enabled,
+            )
+
+            check = mq_broker_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"MQ Broker {broker_name} does have logging enabled."
+            )
+            assert result[0].resource_id == broker_id
+            assert (
+                result[0].resource_arn
+                == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_broker_logging_disabled(self):
+        mq_client = client("mq", region_name=AWS_REGION_US_EAST_1)
+        broker_name = "test-broker"
+        broker_id = mq_client.create_broker(
+            BrokerName=broker_name,
+            EngineType="ACTIVEMQ",
+            EngineVersion="5.15.0",
+            HostInstanceType="mq.t2.micro",
+            Users=[
+                {
+                    "Username": "admin",
+                    "Password": "admin",
+                },
+            ],
+            DeploymentMode="SINGLE_INSTANCE",
+            PubliclyAccessible=False,
+            AutoMinorVersionUpgrade=True,
+            Logs={
+                "General": False,
+            },
+        )["BrokerId"]
+
+        from prowler.providers.aws.services.mq.mq_service import MQ
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.mq.mq_broker_logging_enabled.mq_broker_logging_enabled.mq_client",
+            new=MQ(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.mq.mq_broker_logging_enabled.mq_broker_logging_enabled import (
+                mq_broker_logging_enabled,
+            )
+
+            check = mq_broker_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"MQ Broker {broker_name} does not have logging enabled."
+            )
+            assert result[0].resource_id == broker_id
+            assert (
+                result[0].resource_arn
+                == f"arn:{aws_provider.identity.partition}:mq:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:broker:{broker_id}"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled_test.py
+++ b/tests/providers/aws/services/mq/mq_broker_logging_enabled/mq_broker_logging_enabled_test.py
@@ -81,7 +81,7 @@ class Test_mq_broker_logging_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"MQ {engine_type} Broker {broker_name} does have logging enabled."
+                == f"MQ Broker {broker_name} does have logging enabled."
             )
             assert result[0].resource_id == broker_id
             assert (
@@ -137,7 +137,7 @@ class Test_mq_broker_logging_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"MQ {engine_type} Broker {broker_name} does not have logging enabled."
+                == f"MQ Broker {broker_name} does not have logging enabled."
             )
             assert result[0].resource_id == broker_id
             assert (
@@ -194,7 +194,7 @@ class Test_mq_broker_logging_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"MQ {engine_type} Broker {broker_name} does have logging enabled."
+                == f"MQ Broker {broker_name} does have logging enabled."
             )
             assert result[0].resource_id == broker_id
             assert (
@@ -251,7 +251,7 @@ class Test_mq_broker_logging_enabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"MQ {engine_type} Broker {broker_name} does not have logging enabled."
+                == f"MQ Broker {broker_name} does not have logging enabled."
             )
             assert result[0].resource_id == broker_id
             assert (

--- a/tests/providers/aws/services/mq/mq_service_test.py
+++ b/tests/providers/aws/services/mq/mq_service_test.py
@@ -1,7 +1,7 @@
 from boto3 import client
 from moto import mock_aws
 
-from prowler.providers.aws.services.mq.mq_service import MQ
+from prowler.providers.aws.services.mq.mq_service import MQ, DeploymentMode, EngineType
 from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
 
 
@@ -34,7 +34,7 @@ class Test_MQ_Service:
     # Test MQ List Brokers
     @mock_aws
     def test_list_brokers(self):
-        # Generate moto MQ client
+        # Generate MQ client
         mq_client = client("mq", region_name=AWS_REGION_EU_WEST_1)
         broker = mq_client.create_broker(
             AutoMinorVersionUpgrade=True,
@@ -55,7 +55,7 @@ class Test_MQ_Service:
         )
         broker_arn = broker["BrokerArn"]
 
-        # MQ client for this test class
+        # MQ Client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         mq = MQ(aws_provider)
 
@@ -68,7 +68,7 @@ class Test_MQ_Service:
     # Test MQ Describe Broker
     @mock_aws
     def test_describe_broker(self):
-        # Generate moto MQ client
+        # Generate MQ client
         mq_client = client("mq", region_name=AWS_REGION_EU_WEST_1)
         broker = mq_client.create_broker(
             AutoMinorVersionUpgrade=True,
@@ -86,12 +86,11 @@ class Test_MQ_Service:
                     "Username": "user",
                 }
             ],
-            Tags={"key": "value"},
         )
         broker_arn = broker["BrokerArn"]
         broker["BrokerId"]
 
-        # MQ client for this test class
+        # MQ Client for this test class
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
         mq = MQ(aws_provider)
 
@@ -100,5 +99,5 @@ class Test_MQ_Service:
         assert mq.brokers[broker_arn].name == "my-broker"
         assert mq.brokers[broker_arn].region == AWS_REGION_EU_WEST_1
         assert mq.brokers[broker_arn].id == broker["BrokerId"]
-        assert mq.brokers[broker_arn].auto_minor_version_upgrade
-        assert mq.brokers[broker_arn].tags == [{"key": "value"}]
+        assert mq.brokers[broker_arn].engine_type == EngineType.ACTIVEMQ
+        assert mq.brokers[broker_arn].deployment_mode == DeploymentMode.SINGLE_INSTANCE


### PR DESCRIPTION
### Context

`Amazon MQ ActiveMQ brokers` can stream audit logs to Amazon `CloudWatch Logs` to provide better visibility into security events and broker activities. Streaming logs to `CloudWatch` allows for the creation of alarms and metrics to monitor for suspicious activity or operational issues, enhancing security and compliance.

### Description

This check ensures that an `Amazon MQ ActiveMQ broker` is streaming audit logs to Amazon `CloudWatch Logs`. The check will fail if the broker is not configured to stream these logs.

### Checklist

- Are there new checks included in this PR? Yes.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
