### PR TITLE
chore(providers): Remove `get_output_mapping`

### DIFF
--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -44,7 +44,6 @@ class Provider(ABC):
     Methods:
         print_credentials(): Displays the provider's credentials used for auditing in the command-line interface.
         setup_session(): Sets up the session for the provider.
-        get_output_mapping(): Returns the output mapping between the provider and the generic model.
         validate_arguments(): Validates the arguments for the provider.
         get_checks_to_execute_by_audit_resources(): Returns a set of checks based on the input resources to scan.
 
@@ -126,15 +125,6 @@ class Provider(ABC):
     def output_options(self, value: str) -> Any:
         """
         output_options.setter sets the provider's audit output configuration.
-
-        This method needs to be created in each provider.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_output_mapping(self) -> dict:
-        """
-        get_output_mapping returns the output mapping between the provider and the generic model.
 
         This method needs to be created in each provider.
         """

--- a/prowler/lib/outputs/common.py
+++ b/prowler/lib/outputs/common.py
@@ -1,24 +1,6 @@
-from operator import attrgetter
-
 from prowler.config.config import timestamp
-from prowler.lib.logger import logger
 from prowler.lib.outputs.utils import unroll_tags
 from prowler.lib.utils.utils import outputs_unix_timestamp
-
-
-def get_provider_data_mapping(provider) -> dict:
-    data = {}
-    for generic_field, provider_field in provider.get_output_mapping.items():
-        try:
-            provider_value = attrgetter(provider_field)(provider)
-            data[generic_field] = provider_value
-        except AttributeError:
-            data[generic_field] = ""
-        except Exception as error:
-            logger.error(
-                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-            )
-    return data
 
 
 # TODO: add test for outputs_unix_timestamp

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -159,7 +159,7 @@ class Finding(BaseModel):
 
                 # TODO: probably Organization UID is without the account id
                 output_data["auth_method"] = (
-                    f"profile: {get_nested_attribute(provider, "identity.profile")}"
+                    f"profile: {get_nested_attribute(provider, 'identity.profile')}"
                 )
                 output_data["resource_name"] = check_output.resource_id
                 output_data["resource_uid"] = check_output.resource_arn

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -200,7 +200,7 @@ class Finding(BaseModel):
 
             elif provider.type == "gcp":
                 output_data["auth_method"] = (
-                    f"Principal: {get_nested_attribute(provider, "identity.profile")}"
+                    f"Principal: {get_nested_attribute(provider, 'identity.profile')}"
                 )
                 output_data["account_uid"] = provider.projects[
                     check_output.project_id

--- a/prowler/lib/utils/utils.py
+++ b/prowler/lib/utils/utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+from operator import attrgetter
 
 try:
     import grp
@@ -16,7 +17,7 @@ from io import TextIOWrapper
 from ipaddress import ip_address
 from os.path import exists
 from time import mktime
-from typing import Optional
+from typing import Any, Optional
 
 from colorama import Style
 from detect_secrets import SecretsCollection
@@ -293,3 +294,23 @@ def dict_to_lowercase(d):
             v = dict_to_lowercase(v)
         new_dict[k.lower()] = v
     return new_dict
+
+
+def get_nested_attribute(obj: Any, attr: str) -> Any:
+    """
+    Get a nested attribute from an object.
+    Args:
+        obj (Any): The object to get the attribute from.
+        attr (str): The attribute to get.
+    Returns:
+        Any: The attribute value if present, otherwise "".
+    """
+    try:
+        return attrgetter(attr)(obj)
+    except AttributeError:
+        return ""
+    except Exception as error:
+        logger.error(
+            f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return ""

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -360,20 +360,6 @@ class AwsProvider(Provider):
         """
         return self._mutelist
 
-    @property
-    def get_output_mapping(self):
-        return {
-            "auth_method": "identity.profile",
-            "provider": "type",
-            "account_uid": "identity.account",
-            "account_name": "organizations_metadata.account_name",
-            "account_email": "organizations_metadata.account_email",
-            "account_organization_uid": "organizations_metadata.organization_arn",
-            "account_organization_name": "organizations_metadata.organization_id",
-            "account_tags": "organizations_metadata.account_tags",
-            "partition": "identity.partition",
-        }
-
     # TODO: This can be moved to another class since it doesn't need self
     def get_organizations_info(
         self, organizations_session: Session, aws_account_id: str

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -87,7 +87,6 @@ class AzureProvider(Provider):
         fixer_config(self): Returns the fixer configuration.
         output_options(self, options: tuple): Sets the output options for the Azure provider.
         mutelist(self) -> AzureMutelist: Returns the mutelist object associated with the Azure provider.
-        get_output_mapping(self): Returns a dictionary that maps output keys to their corresponding values.
         validate_arguments(cls, az_cli_auth, sp_env_auth, browser_auth, managed_identity_auth, tenant_id): Validates the authentication arguments for the Azure provider.
         setup_region_config(cls, region): Sets up the region configuration for the Azure provider.
         print_credentials(self): Prints the Azure credentials information.
@@ -265,26 +264,6 @@ class AzureProvider(Provider):
     def mutelist(self) -> AzureMutelist:
         """Mutelist object associated with this Azure provider."""
         return self._mutelist
-
-    @property
-    def get_output_mapping(self):
-        """Dictionary that maps output keys to their corresponding values."""
-        return {
-            # identity_type: identity_id
-            # "auth_method": "identity.profile",
-            "provider": "type",
-            # "account_uid": "identity.account",
-            # TODO: store subscription_name + id pairs
-            # "account_name": "organizations_metadata.account_details_name",
-            # "account_email": "organizations_metadata.account_details_email",
-            # TODO: check the tenant_ids
-            # TODO: we have to get the account organization, the tenant is not that
-            "account_organization_uid": "identity.tenant_ids",
-            "account_organization_name": "identity.tenant_domain",
-            # TODO: pending to get the subscription tags
-            # "account_tags": "organizations_metadata.account_details_tags",
-            "partition": "region_config.name",
-        }
 
     # TODO: this should be moved to the argparse, if not we need to enforce it from the Provider
     # previously was using the AzureException

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -41,7 +41,6 @@ class Provider(ABC):
     Methods:
         print_credentials(): Displays the provider's credentials used for auditing in the command-line interface.
         setup_session(): Sets up the session for the provider.
-        get_output_mapping(): Returns the output mapping between the provider and the generic model.
         validate_arguments(): Validates the arguments for the provider.
         get_checks_to_execute_by_audit_resources(): Returns a set of checks based on the input resources to scan.
 
@@ -103,15 +102,6 @@ class Provider(ABC):
     def print_credentials(self) -> None:
         """
         print_credentials is used to display in the CLI the provider's credentials used to audit.
-
-        This method needs to be created in each provider.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_output_mapping(self) -> dict:
-        """
-        get_output_mapping returns the output mapping between the provider and the generic model.
 
         This method needs to be created in each provider.
         """

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -224,27 +224,6 @@ class GcpProvider(Provider):
         """
         return self._mutelist
 
-    @property
-    def get_output_mapping(self):
-        return {
-            # Account: identity.profile
-            "auth_method": "identity.profile",
-            "provider": "type",
-            # TODO: comes from finding, finding.project_id
-            # "account_uid": "",
-            # TODO: get project name from GCP
-            # "account_name": "organizations_metadata.account_details_name",
-            # There is no concept as project email in GCP
-            # "account_email": "organizations_metadata.account_details_email",
-            # TODO: get project organization ID from GCP
-            # "account_organization_uid": "organizations_metadata.account_details_arn",
-            # TODO: get project organization from GCP
-            # "account_organization": "",
-            # TODO: get project tags organization from GCP
-            # "account_tags": "organizations_metadata.account_details_tags",
-            # "partition": "identity.partition",
-        }
-
     @staticmethod
     def setup_session(
         credentials_file: str, service_account: str, gcp_credentials: dict = None

--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -144,22 +144,6 @@ class KubernetesProvider(Provider):
         """
         return self._mutelist
 
-    @property
-    def get_output_mapping(self):
-        return {
-            # "in-cluster/kubeconfig"
-            # "auth_method": "identity.profile",
-            "provider": "type",
-            # cluster: <context>
-            "account_uid": "identity.cluster",
-            # "account_name": "organizations_metadata.account_details_name",
-            # "account_email": "organizations_metadata.account_details_email",
-            # "account_organization_uid": "organizations_metadata.account_details_arn",
-            # "account_organization": "organizations_metadata.account_details_org",
-            # "account_tags": "organizations_metadata.account_details_tags",
-            # "partition": "identity.partition",
-        }
-
     @staticmethod
     def setup_session(
         kubeconfig_file: str = None,

--- a/tests/lib/outputs/finding_test.py
+++ b/tests/lib/outputs/finding_test.py
@@ -47,52 +47,11 @@ def mock_check_metadata(provider):
     )
 
 
-def mock_get_provider_data_mapping_aws(_):
-    return {
-        "auth_method": "mock_auth",
-        "provider": "aws",
-        "account_uid": "mock_account_uid",
-        "account_name": "mock_account_name",
-        "account_email": "mock_account_email",
-        "account_organization_uid": "mock_account_org_uid",
-        "account_organization_name": "mock_account_org_name",
-        "account_tags": {"tag1": "value1"},
-        "partition": "aws",
-    }
-
-
-def mock_get_provider_data_mapping_azure(_):
-    return {
-        "provider": "azure",
-        "account_organization_uid": "mock_account_org_uid",
-        "account_organization_name": "mock_account_org_name",
-        "partition": "AzureCloud",
-    }
-
-
-def mock_get_provider_data_mapping_gcp(_):
-    return {
-        "auth_method": "mock_auth",
-        "provider": "gcp",
-    }
-
-
-def mock_get_provider_data_mapping_kubernetes(_):
-    return {
-        "provider": "kubernetes",
-        "account_uid": "test_cluster",
-    }
-
-
 def mock_get_check_compliance(*_):
     return {"mock_compliance_key": "mock_compliance_value"}
 
 
 class TestFinding:
-    @patch(
-        "prowler.lib.outputs.finding.get_provider_data_mapping",
-        new=mock_get_provider_data_mapping_aws,
-    )
     @patch(
         "prowler.lib.outputs.finding.get_check_compliance",
         new=mock_get_check_compliance,
@@ -101,6 +60,14 @@ class TestFinding:
         # Mock provider
         provider = MagicMock()
         provider.type = "aws"
+        provider.identity.profile = "mock_auth"
+        provider.identity.account = "mock_account_uid"
+        provider.identity.partition = "aws"
+        provider.organizations_metadata.account_name = "mock_account_name"
+        provider.organizations_metadata.account_email = "mock_account_email"
+        provider.organizations_metadata.organization_arn = "mock_account_org_uid"
+        provider.organizations_metadata.organization_id = "mock_account_org_name"
+        provider.organizations_metadata.account_tags = {"tag1": "value1"}
 
         # Mock check result
         check_output = MagicMock()
@@ -123,7 +90,7 @@ class TestFinding:
         finding_output = Finding.generate_output(provider, check_output, output_options)
 
         # Finding
-        assert finding_output is not None
+        assert isinstance(finding_output, Finding)
         assert finding_output.auth_method == "profile: mock_auth"
         assert finding_output.resource_name == "test_resource_id"
         assert finding_output.resource_uid == "test_resource_arn"
@@ -171,10 +138,6 @@ class TestFinding:
         assert finding_output.metadata.Compliance == []
 
     @patch(
-        "prowler.lib.outputs.finding.get_provider_data_mapping",
-        new=mock_get_provider_data_mapping_azure,
-    )
-    @patch(
         "prowler.lib.outputs.finding.get_check_compliance",
         new=mock_get_check_compliance,
     )
@@ -187,6 +150,9 @@ class TestFinding:
         provider.identity.subscriptions = {
             "mock_subscription_id": "mock_subscription_name"
         }
+        provider.identity.tenant_ids = ["mock_tenant_id_1", "mock_tenant_id_2"]
+        provider.identity.tenant_domain = "mock_tenant_domain"
+        provider.region_config.name = "AzureCloud"
 
         # Mock check result
         check_output = MagicMock()
@@ -211,8 +177,12 @@ class TestFinding:
         finding_output = Finding.generate_output(provider, check_output, output_options)
 
         # Finding
-        assert finding_output is not None
+        assert isinstance(finding_output, Finding)
         assert finding_output.auth_method == "mock_identity_type: mock_identity_id"
+        assert finding_output.account_organization_uid == "mock_tenant_id_1"
+        assert finding_output.account_organization_name == "mock_tenant_domain"
+        assert finding_output.account_uid == "mock_subscription_name"
+        assert finding_output.account_name == "mock_subscription_id"
         assert finding_output.resource_name == "test_resource_name"
         assert finding_output.resource_uid == "test_resource_id"
         assert finding_output.region == "us-west-1"
@@ -224,6 +194,7 @@ class TestFinding:
         assert finding_output.muted is False
         assert finding_output.resource_tags == {}
         assert finding_output.partition == "AzureCloud"
+
         assert isinstance(finding_output.timestamp, int)
 
         # Metadata
@@ -253,10 +224,6 @@ class TestFinding:
         assert finding_output.metadata.Compliance == []
 
     @patch(
-        "prowler.lib.outputs.finding.get_provider_data_mapping",
-        new=mock_get_provider_data_mapping_gcp,
-    )
-    @patch(
         "prowler.lib.outputs.finding.get_check_compliance",
         new=mock_get_check_compliance,
     )
@@ -264,9 +231,12 @@ class TestFinding:
         # Mock provider
         provider = MagicMock()
         provider.type = "gcp"
+        provider.identity.profile = "mock_auth"
+        # Organization
         organization = MagicMock()
         organization.id = "mock_organization_id"
         organization.display_name = "mock_organization_name"
+        # Project
         project = MagicMock()
         project.id = "mock_project_id"
         project.name = "mock_project_name"
@@ -295,7 +265,7 @@ class TestFinding:
         finding_output = Finding.generate_output(provider, check_output, output_options)
 
         # Finding
-        assert finding_output is not None
+        assert isinstance(finding_output, Finding)
         assert finding_output.auth_method == "Principal: mock_auth"
         assert finding_output.resource_name == "test_resource_name"
         assert finding_output.resource_uid == "test_resource_id"
@@ -343,10 +313,6 @@ class TestFinding:
         assert finding_output.metadata.Compliance == []
 
     @patch(
-        "prowler.lib.outputs.finding.get_provider_data_mapping",
-        new=mock_get_provider_data_mapping_kubernetes,
-    )
-    @patch(
         "prowler.lib.outputs.finding.get_check_compliance",
         new=mock_get_check_compliance,
     )
@@ -354,9 +320,8 @@ class TestFinding:
         # Mock provider
         provider = MagicMock()
         provider.type = "kubernetes"
-        identity = MagicMock()
-        identity.context = "In-Cluster"
-        provider.identity = identity
+        provider.identity.context = "In-Cluster"
+        provider.identity.cluster = "test_cluster"
 
         # Mock check result
         check_output = MagicMock()
@@ -378,11 +343,12 @@ class TestFinding:
         finding_output = Finding.generate_output(provider, check_output, output_options)
 
         # Finding
-        assert finding_output is not None
+        assert isinstance(finding_output, Finding)
         assert finding_output.auth_method == "in-cluster"
         assert finding_output.resource_name == "test_resource_name"
         assert finding_output.resource_uid == "test_resource_id"
         assert finding_output.region == "namespace: test_namespace"
+        assert finding_output.account_name == "context: In-Cluster"
         assert finding_output.compliance == {
             "mock_compliance_key": "mock_compliance_value"
         }

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -460,22 +460,6 @@ class TestAWSProvider:
             )
 
     @mock_aws
-    def test_aws_provider_get_output_mapping(self):
-        aws_provider = AwsProvider()
-
-        assert aws_provider.get_output_mapping == {
-            "auth_method": "identity.profile",
-            "provider": "type",
-            "account_uid": "identity.account",
-            "account_name": "organizations_metadata.account_name",
-            "account_email": "organizations_metadata.account_email",
-            "account_organization_uid": "organizations_metadata.organization_arn",
-            "account_organization_name": "organizations_metadata.organization_id",
-            "account_tags": "organizations_metadata.account_tags",
-            "partition": "identity.partition",
-        }
-
-    @mock_aws
     def test_aws_provider_assume_role_with_mfa(self):
         # Variables
         mfa = True


### PR DESCRIPTION
### Description

Remove the method `get_output_mapping` from providers since almost everything was done in the Finding class.

### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
