### PR TITLE
feat(aws): add new check `cloudwatch_log_group_not_publicly_accessible`

### DIFF
--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.metadata.json
@@ -5,7 +5,7 @@
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices"
   ],
-  "ServiceName": "ses",
+  "ServiceName": "cloudwatch",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:ses:region:account-id:identity/<IDENTITY-NAME>",
   "Severity": "high",

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.metadata.json
@@ -7,7 +7,7 @@
   ],
   "ServiceName": "cloudwatch",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:aws:ses:region:account-id:identity/<IDENTITY-NAME>",
+  "ResourceIdTemplate": "arn:aws:ses:region:account-id:log-group/log_group_name",
   "Severity": "high",
   "ResourceType": "Other",
   "Description": "This check ensures that no CloudWatch Log Groups are publicly accessible by checking for resource policies that allow access from any entity (Principal: '*'). Publicly exposed log groups pose a serious security risk as sensitive log data could be accessed by unauthorized parties.",

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "cloudwatch_log_group_not_publicly_accessible",
+  "CheckTitle": "Ensure that CloudWatch Log Groups are not publicly accessible",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "ses",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:ses:region:account-id:identity/<IDENTITY-NAME>",
+  "Severity": "high",
+  "ResourceType": "Other",
+  "Description": "This check ensures that no CloudWatch Log Groups are publicly accessible by checking for resource policies that allow access from any entity (Principal: '*'). Publicly exposed log groups pose a serious security risk as sensitive log data could be accessed by unauthorized parties.",
+  "Risk": "Publicly accessible CloudWatch Log Groups can expose sensitive information, leading to data breaches or unauthorized access. It is important to ensure that log groups are only accessible by trusted entities.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws logs delete-resource-policy --policy-name <policy-name>",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Ensure that CloudWatch Log Groups are not publicly accessible. Review and remove any resource policies that allow public access (Principal: '*') to log groups.",
+      "Url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html"
+    }
+  },
+  "Categories": [
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.py
@@ -1,0 +1,45 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.cloudwatch.logs_client import logs_client
+from prowler.providers.aws.services.iam.lib.policy import is_policy_public
+
+
+class cloudwatch_log_group_not_publicly_accessible(Check):
+    def execute(self):
+        findings = []
+        public_log_groups = []
+        if (
+            logs_client.resource_policies is not None
+            and logs_client.log_groups is not None
+        ):
+            for resource_policies in logs_client.resource_policies.values():
+                for resource_policy in resource_policies:
+                    if is_policy_public(
+                        resource_policy.policy, logs_client.audited_account
+                    ):
+                        for statement in resource_policy.policy.get("Statement", []):
+                            public_resources = statement.get("Resource", [])
+                            if isinstance(public_resources, str):
+                                public_resources = [public_resources]
+                            for resource in public_resources:
+                                for log_group in logs_client.log_groups.values():
+                                    if log_group.arn in resource or resource == "*":
+                                        public_log_groups.append(log_group.arn)
+            for log_group in logs_client.log_groups.values():
+                report = Check_Report_AWS(self.metadata())
+                report.region = log_group.region
+                report.resource_id = log_group.name
+                report.resource_arn = log_group.arn
+                report.resource_tags = log_group.tags
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Log Group {log_group.name} is not publicly accessible."
+                )
+                if log_group.arn in public_log_groups:
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"Log Group {log_group.name} is publicly accessible."
+                    )
+
+                findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible_test.py
@@ -1,0 +1,179 @@
+import json
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+
+class Test_cloudwatch_log_group_not_publicly_accessible:
+    @mock_aws
+    def test_no_log_groups(self):
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible.logs_client",
+            new=Logs(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible import (
+                cloudwatch_log_group_not_publicly_accessible,
+            )
+
+            check = cloudwatch_log_group_not_publicly_accessible()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_log_group_not_publicly_accessible(self):
+        # Generate Logs Client
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        # Create Log Group without a public policy
+        logs_client.create_log_group(
+            logGroupName="test-log-group", tags={"test": "test"}
+        )
+
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible.logs_client",
+            new=Logs(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible import (
+                cloudwatch_log_group_not_publicly_accessible,
+            )
+
+            check = cloudwatch_log_group_not_publicly_accessible()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Log Group test-log-group is not publicly accessible."
+            )
+            assert result[0].resource_id == "test-log-group"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:123456789012:log-group:test-log-group"
+            )
+
+    @mock_aws
+    def test_log_group_publicly_accessible(self):
+        # Generate Logs Client
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        # Create Log Group with a public policy
+        logs_client.create_log_group(
+            logGroupName="test-log-group", tags={"test": "test"}
+        )
+        logs_client.put_resource_policy(
+            policyName="PublicAccessPolicy",
+            policyDocument=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": "*",
+                            "Action": "logs:*",
+                            "Resource": "*",
+                        }
+                    ],
+                }
+            ),
+        )
+
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible.logs_client",
+            new=Logs(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible import (
+                cloudwatch_log_group_not_publicly_accessible,
+            )
+
+            check = cloudwatch_log_group_not_publicly_accessible()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Log Group test-log-group is publicly accessible."
+            )
+            assert result[0].resource_id == "test-log-group"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:123456789012:log-group:test-log-group"
+            )
+
+    @mock_aws
+    def test_log_group_empty_principal(self):
+        # Generate Logs Client
+        logs_client = client("logs", region_name=AWS_REGION_US_EAST_1)
+        # Create Log Group with a policy missing 'Principal'
+        logs_client.create_log_group(
+            logGroupName="test-log-group", tags={"test": "test"}
+        )
+        logs_client.put_resource_policy(
+            policyName="LimitedAccessPolicy",
+            policyDocument=json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {"Effect": "Allow", "Action": "logs:*", "Resource": "*"}
+                    ],
+                }
+            ),
+        )
+
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import Logs
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible.logs_client",
+            new=Logs(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.cloudwatch.cloudwatch_log_group_not_publicly_accessible.cloudwatch_log_group_not_publicly_accessible import (
+                cloudwatch_log_group_not_publicly_accessible,
+            )
+
+            check = cloudwatch_log_group_not_publicly_accessible()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Log Group test-log-group is not publicly accessible."
+            )
+            assert result[0].resource_id == "test-log-group"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:logs:{AWS_REGION_US_EAST_1}:123456789012:log-group:test-log-group"
+            )


### PR DESCRIPTION
### Context
This PR introduces a new check, cloudwatch_log_group_not_publicly_accessible, which ensures that CloudWatch Log Groups are not publicly accessible. Public access to log groups can expose sensitive log data and pose significant security risks. This check inspects the resource policies attached to CloudWatch logs and flags any that grant public access (i.e., when "Principal": "*" is used in the policy).

### Description
- New Check: The `cloudwatch_log_group_not_publicly_accessible` check evaluates CloudWatch log groups and identifies any that are publicly accessible due to permissive resource policies.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
