### PR TITLE
fix(kubernetes): handle input kube config file

### DIFF
--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -185,13 +185,12 @@ class KubernetesProvider(Provider):
                 )
 
             else:
+                kubeconfig_file = (
+                    kubeconfig_file if kubeconfig_file else "~/.kube/config"
+                )
                 try:
                     config.load_kube_config(
-                        config_file=(
-                            os.path.abspath(kubeconfig_file)
-                            if kubeconfig_file != "~/.kube/config"
-                            else os.path.expanduser(kubeconfig_file)
-                        ),
+                        config_file=kubeconfig_file,
                         context=context,
                     )
                 except ConfigException:
@@ -209,12 +208,16 @@ class KubernetesProvider(Provider):
                         api_client=client.ApiClient(), context=context
                     )
             if context:
-                contexts = config.list_kube_config_contexts()[0]
+                contexts = config.list_kube_config_contexts(
+                    config_file=kubeconfig_file
+                )[0]
                 for context_item in contexts:
                     if context_item["name"] == context:
                         context = context_item
             else:
-                context = config.list_kube_config_contexts()[1]
+                context = config.list_kube_config_contexts(config_file=kubeconfig_file)[
+                    1
+                ]
             return KubernetesSession(api_client=client.ApiClient(), context=context)
 
         except parser.ParserError as parser_error:


### PR DESCRIPTION
### Context

When a non-default kubeconfig file path is used, Prowler does not correctly utilize the provided kubeconfig in the `list_kube_config_contexts() `function. This causes issues when users specify a custom kubeconfig file and context, as Prowler defaults back to using `~/.kube/config`, leading to misconfigurations and potential errors.

Fix #5489.


### Description
This PR addresses the issue by explicitly ensuring that when a non-default kubeconfig path is passed to Prowler, it is correctly used in all Kubernetes-related operations, including `list_kube_config_contexts()`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
