### PR TITLE
fix(aws): review checks with wrong attributes

### DIFF
--- a/prowler/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check.py
+++ b/prowler/providers/aws/services/acm/acm_certificates_expiration_check/acm_certificates_expiration_check.py
@@ -1,4 +1,4 @@
-from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.check.models import Check, Check_Report_AWS, Severity
 from prowler.providers.aws.services.acm.acm_client import acm_client
 
 
@@ -22,10 +22,10 @@ class acm_certificates_expiration_check(Check):
                     report.status = "FAIL"
                     if certificate.expiration_days < 0:
                         report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} has expired ({abs(certificate.expiration_days)} days ago)."
-                        report.check_metadata.Severity = "high"
+                        report.check_metadata.Severity = Severity.high
                     else:
                         report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} is about to expire in {certificate.expiration_days} days."
-                        report.check_metadata.Severity = "medium"
+                        report.check_metadata.Severity = Severity.medium
 
                     report.resource_id = certificate.id
                     report.resource_details = certificate.name

--- a/prowler/providers/aws/services/codebuild/codebuild_project_no_secrets_in_variables/codebuild_project_no_secrets_in_variables.metadata.json
+++ b/prowler/providers/aws/services/codebuild/codebuild_project_no_secrets_in_variables/codebuild_project_no_secrets_in_variables.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "codebuild_project_no_secrets_in_variables",
-  "CheckTitle": "Ensure CodeBuild projects do not contain secrets on plaintext environmet variables",
+  "CheckTitle": "Ensure CodeBuild projects do not contain secrets on plaintext environment variables",
   "CheckType": [
     "Security Best Practices"
   ],
@@ -21,7 +21,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "",
+      "Text": "Do not store secrets in plaintext environment variables. Use AWS Secrets Manager or AWS Systems Manager Parameter Store to securely store and retrieve sensitive information.",
       "Url": "https://docs.aws.amazon.com/codebuild/latest/userguide/change-project.html"
     }
   },

--- a/prowler/providers/aws/services/documentdb/documentdb_cluster_backup_enabled/documentdb_cluster_backup_enabled.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_cluster_backup_enabled/documentdb_cluster_backup_enabled.py
@@ -1,4 +1,4 @@
-from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.check.models import Check, Check_Report_AWS, Severity
 from prowler.providers.aws.services.documentdb.documentdb_client import (
     documentdb_client,
 )
@@ -25,7 +25,7 @@ class documentdb_cluster_backup_enabled(Check):
             else:
                 if cluster.backup_retention_period > 0:
                     report.status = "FAIL"
-                    report.check_metadata.Severity = "low"
+                    report.check_metadata.Severity = Severity.low
                     report.status_extended = f"DocumentDB Cluster {cluster.id} has backup enabled with retention period {cluster.backup_retention_period} days. Recommended to increase the backup retention period to a minimum of 7 days."
 
             findings.append(report)

--- a/prowler/providers/aws/services/documentdb/documentdb_cluster_cloudwatch_log_export/documentdb_cluster_cloudwatch_log_export.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_cluster_cloudwatch_log_export/documentdb_cluster_cloudwatch_log_export.py
@@ -1,4 +1,4 @@
-from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.check.models import Check, Check_Report_AWS, Severity
 from prowler.providers.aws.services.documentdb.documentdb_client import (
     documentdb_client,
 )
@@ -27,7 +27,7 @@ class documentdb_cluster_cloudwatch_log_export(Check):
                     or "profiler" in cluster.cloudwatch_logs
                 ):
                     report.status = "FAIL"
-                    report.check_metadata.Severity = "low"
+                    report.check_metadata.Severity = Severity.low
                     report.status_extended = f"DocumentDB Cluster {cluster.id} is only shipping {' '.join(cluster.cloudwatch_logs)} to CloudWatch Logs. Recommended to ship both Audit and Profiler logs."
 
             findings.append(report)

--- a/prowler/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled.py
+++ b/prowler/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled.py
@@ -11,7 +11,7 @@ class ecr_registry_scan_images_on_push_enabled(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.region = registry.region
                 report.resource_id = registry.id
-                report.resource_arn = ecr_client.audited_account_arn
+                report.resource_arn = registry.arn
                 report.status = "FAIL"
                 report.status_extended = f"ECR registry {registry.id} has {registry.scan_type} scanning without scan on push enabled."
                 if registry.rules:

--- a/prowler/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled.py
+++ b/prowler/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled.py
@@ -11,8 +11,7 @@ class ecr_registry_scan_images_on_push_enabled(Check):
                 report = Check_Report_AWS(self.metadata())
                 report.region = registry.region
                 report.resource_id = registry.id
-                # A registry cannot have tags
-                report.resource_tags = []
+                report.resource_arn = ecr_client.audited_account_arn
                 report.status = "FAIL"
                 report.status_extended = f"ECR registry {registry.id} has {registry.scan_type} scanning without scan on push enabled."
                 if registry.rules:

--- a/prowler/providers/aws/services/ecr/ecr_service.py
+++ b/prowler/providers/aws/services/ecr/ecr_service.py
@@ -58,6 +58,7 @@ class ECR(AWSService):
             # The default ECR registry is assumed
             self.registries[regional_client.region] = Registry(
                 id=self.registry_id,
+                arn=f"arn:{self.audited_partition}:ecr:{regional_client.region}:registry/{self.registry_id}",
                 region=regional_client.region,
                 repositories=regional_registry_repositories,
             )
@@ -389,6 +390,7 @@ class ScanningRule(BaseModel):
 
 class Registry(BaseModel):
     id: str
+    arn: str
     region: str
     repositories: list[Repository]
     scan_type: Optional[str]

--- a/prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.py
+++ b/prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.py
@@ -1,4 +1,4 @@
-from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.check.models import Check, Check_Report_AWS, Severity
 from prowler.providers.aws.services.elasticache.elasticache_client import (
     elasticache_client,
 )
@@ -23,7 +23,7 @@ class elasticache_redis_cluster_backup_enabled(Check):
             else:
                 if repl_group.snapshot_retention > 0:
                     report.status = "FAIL"
-                    report.check_metadata.Severity = "low"
+                    report.check_metadata.Severity = Severity.low
                     report.status_extended = f"Elasticache Redis cache cluster {repl_group.id} has automated snapshot backups enabled with retention period {repl_group.snapshot_retention} days. Recommended to increase the snapshot retention period to a minimum of 7 days."
 
             findings.append(report)

--- a/prowler/providers/aws/services/guardduty/guardduty_lambda_protection_enabled/guardduty_lambda_protection_enabled.metadata.json
+++ b/prowler/providers/aws/services/guardduty/guardduty_lambda_protection_enabled/guardduty_lambda_protection_enabled.metadata.json
@@ -9,7 +9,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:guardduty:region:account-id/detector-id",
   "Severity": "high",
-  "ResourceType": "",
+  "ResourceType": "AwsGuardDutyDetector",
   "Description": "GuardDuty Lambda Protection helps you identify potential security threats when an AWS Lambda function gets invoked. After you enable Lambda Protection, GuardDuty starts monitoring Lambda network activity logs associated with the Lambda functions in your AWS account.",
   "Risk": "If Lambda Protection is not enabled, GuardDuty will not be able to monitor Lambda network activity logs and may miss potential security threats.",
   "RelatedUrl": "https://docs.aws.amazon.com/guardduty/latest/ug/lambda-protection.html",

--- a/prowler/providers/aws/services/neptune/neptune_cluster_backup_enabled/neptune_cluster_backup_enabled.py
+++ b/prowler/providers/aws/services/neptune/neptune_cluster_backup_enabled/neptune_cluster_backup_enabled.py
@@ -1,4 +1,4 @@
-from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.check.models import Check, Check_Report_AWS, Severity
 from prowler.providers.aws.services.neptune.neptune_client import neptune_client
 
 
@@ -23,7 +23,7 @@ class neptune_cluster_backup_enabled(Check):
             else:
                 if cluster.backup_retention_period > 0:
                     report.status = "FAIL"
-                    report.check_metadata.Severity = "low"
+                    report.check_metadata.Severity = Severity.low
                     report.status_extended = f"Neptune Cluster {cluster.name} has backup enabled with retention period {cluster.backup_retention_period} days. Recommended to increase the backup retention period to a minimum of 7 days."
 
             findings.append(report)

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -116,9 +116,13 @@ class Organizations(AWSService):
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
                 policies = None
-            logger.error(
-                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-            )
+                logger.warning(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+            else:
+                logger.error(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration.py
+++ b/prowler/providers/aws/services/rds/rds_instance_certificate_expiration/rds_instance_certificate_expiration.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from dateutil import relativedelta
 from pytz import utc
 
-from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.check.models import Check, Check_Report_AWS, Severity
 from prowler.providers.aws.services.rds.rds_client import rds_client
 
 
@@ -21,7 +21,7 @@ class rds_instance_certificate_expiration(Check):
             report.resource_arn = db_instance_arn
             report.resource_tags = db_instance.tags
             report.status = "FAIL"
-            report.check_metadata.Severity = "critical"
+            report.check_metadata.Severity = Severity.critical
             report.status_extended = (
                 f"RDS Instance {db_instance.id} certificate has expired."
             )
@@ -33,7 +33,7 @@ class rds_instance_certificate_expiration(Check):
                         utc
                     ) + relativedelta.relativedelta(months=6):
                         report.status = "PASS"
-                        report.check_metadata.Severity = "informational"
+                        report.check_metadata.Severity = Severity.informational
                         report.status_extended = f"RDS Instance {db_instance.id} certificate has over 6 months of validity left."
                     elif cert.valid_till < datetime.now(
                         utc
@@ -45,7 +45,7 @@ class rds_instance_certificate_expiration(Check):
                         months=3
                     ):
                         report.status = "PASS"
-                        report.check_metadata.Severity = "low"
+                        report.check_metadata.Severity = Severity.low
                         report.status_extended = f"RDS Instance {db_instance.id} certificate has between 3 and 6 months of validity."
                     elif cert.valid_till < datetime.now(
                         utc
@@ -57,7 +57,7 @@ class rds_instance_certificate_expiration(Check):
                         months=1
                     ):
                         report.status = "FAIL"
-                        report.check_metadata.Severity = "medium"
+                        report.check_metadata.Severity = Severity.medium
                         report.status_extended = f"RDS Instance {db_instance.id} certificate less than 3 months of validity."
                     elif cert.valid_till < datetime.now(
                         utc
@@ -67,11 +67,11 @@ class rds_instance_certificate_expiration(Check):
                         utc
                     ):
                         report.status = "FAIL"
-                        report.check_metadata.Severity = "high"
+                        report.check_metadata.Severity = Severity.high
                         report.status_extended = f"RDS Instance {db_instance.id} certificate less than 1 month of validity."
                     else:
                         report.status = "FAIL"
-                        report.check_metadata.Severity = "critical"
+                        report.check_metadata.Severity = Severity.critical
                         report.status_extended = (
                             f"RDS Instance {db_instance.id} certificate has expired."
                         )
@@ -80,7 +80,7 @@ class rds_instance_certificate_expiration(Check):
                         utc
                     ) + relativedelta.relativedelta(months=6):
                         report.status = "PASS"
-                        report.check_metadata.Severity = "informational"
+                        report.check_metadata.Severity = Severity.informational
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate has over 6 months of validity left."
                     elif cert.valid_till < datetime.now(
                         utc
@@ -92,7 +92,7 @@ class rds_instance_certificate_expiration(Check):
                         months=3
                     ):
                         report.status = "PASS"
-                        report.check_metadata.Severity = "low"
+                        report.check_metadata.Severity = Severity.low
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate has between 3 and 6 months of validity."
                     elif cert.valid_till < datetime.now(
                         utc
@@ -104,7 +104,7 @@ class rds_instance_certificate_expiration(Check):
                         months=1
                     ):
                         report.status = "FAIL"
-                        report.check_metadata.Severity = "medium"
+                        report.check_metadata.Severity = Severity.medium
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate less than 3 months of validity."
                     elif cert.valid_till < datetime.now(
                         utc
@@ -114,11 +114,11 @@ class rds_instance_certificate_expiration(Check):
                         utc
                     ):
                         report.status = "FAIL"
-                        report.check_metadata.Severity = "high"
+                        report.check_metadata.Severity = Severity.high
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate less than 1 month of validity."
                     else:
                         report.status = "FAIL"
-                        report.check_metadata.Severity = "critical"
+                        report.check_metadata.Severity = Severity.critical
                         report.status_extended = f"RDS Instance {db_instance.id} custom certificate has expired."
             findings.append(report)
 

--- a/prowler/providers/aws/services/rds/rds_instance_protected_by_backup_plan/rds_instance_protected_by_backup_plan.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_protected_by_backup_plan/rds_instance_protected_by_backup_plan.metadata.json
@@ -21,7 +21,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "",
+      "Text": "Create a backup plan for the RDS instance to protect it from data loss, accidental deletion, or corruption.",
       "Url": "https://docs.aws.amazon.com/aws-backup/latest/devguide/assigning-resources.html"
     }
   },

--- a/prowler/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled.py
+++ b/prowler/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled.py
@@ -11,6 +11,7 @@ class route53_domains_privacy_protection_enabled(Check):
         for domain in route53domains_client.domains.values():
             report = Check_Report_AWS(self.metadata())
             report.resource_id = domain.name
+            report.resource_arn = route53domains_client.audited_account_arn
             report.region = domain.region
             report.resource_tags = domain.tags
             if domain.admin_privacy:

--- a/prowler/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled.py
+++ b/prowler/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled.py
@@ -11,7 +11,7 @@ class route53_domains_privacy_protection_enabled(Check):
         for domain in route53domains_client.domains.values():
             report = Check_Report_AWS(self.metadata())
             report.resource_id = domain.name
-            report.resource_arn = route53domains_client.audited_account_arn
+            report.resource_arn = domain.arn
             report.region = domain.region
             report.resource_tags = domain.tags
             if domain.admin_privacy:

--- a/prowler/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled.py
+++ b/prowler/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled.py
@@ -11,7 +11,7 @@ class route53_domains_transferlock_enabled(Check):
         for domain in route53domains_client.domains.values():
             report = Check_Report_AWS(self.metadata())
             report.resource_id = domain.name
-            report.resource_arn = route53domains_client.audited_account_arn
+            report.resource_arn = domain.arn
             report.region = domain.region
             report.resource_tags = domain.tags
             if domain.status_list and "clientTransferProhibited" in domain.status_list:

--- a/prowler/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled.py
+++ b/prowler/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled.py
@@ -11,6 +11,7 @@ class route53_domains_transferlock_enabled(Check):
         for domain in route53domains_client.domains.values():
             report = Check_Report_AWS(self.metadata())
             report.resource_id = domain.name
+            report.resource_arn = route53domains_client.audited_account_arn
             report.region = domain.region
             report.resource_tags = domain.tags
             if domain.status_list and "clientTransferProhibited" in domain.status_list:

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -161,7 +161,9 @@ class Route53Domains(AWSService):
                     domain_name = domain["DomainName"]
 
                     self.domains[domain_name] = Domain(
-                        name=domain_name, region=self.region
+                        name=domain_name,
+                        arn=f"arn:{self.audited_partition}:route53:::domain/{domain_name}",
+                        region=self.region,
                     )
 
         except Exception as error:
@@ -198,6 +200,7 @@ class Route53Domains(AWSService):
 
 class Domain(BaseModel):
     name: str
+    arn: str
     region: str
     admin_privacy: bool = False
     status_list: list[str] = None

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -14,15 +14,21 @@ class WAF(AWSService):
         self.rules = {}
         self.rule_groups = {}
         self.web_acls = {}
-        self._list_rules()
-        self.__threading_call__(self._get_rule, self.rules.values())
-        self._list_rule_groups()
-        self.__threading_call__(
-            self._list_activated_rules_in_rule_group, self.rule_groups.values()
-        )
-        self._list_web_acls()
-        self.__threading_call__(self._get_web_acl, self.web_acls.values())
-        self.__threading_call__(self._get_logging_configuration, self.web_acls.values())
+        if self.audited_partition == "aws":
+            # AWS WAF is available globally for CloudFront distributions, but you must use the Region US East (N. Virginia) to create your web ACL and any resources used in the web ACL, such as rule groups, IP sets, and regex pattern sets.
+            self.region = "us-east-1"
+            self.client = self.session.client(self.service, self.region)
+            self._list_rules()
+            self.__threading_call__(self._get_rule, self.rules.values())
+            self._list_rule_groups()
+            self.__threading_call__(
+                self._list_activated_rules_in_rule_group, self.rule_groups.values()
+            )
+            self._list_web_acls()
+            self.__threading_call__(self._get_web_acl, self.web_acls.values())
+            self.__threading_call__(
+                self._get_logging_configuration, self.web_acls.values()
+            )
 
     def _list_rules(self):
         logger.info("WAF - Listing Global Rules...")

--- a/tests/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled_test.py
@@ -7,6 +7,7 @@ from prowler.providers.aws.services.ecr.ecr_service import (
     ScanningRule,
 )
 from tests.providers.aws.utils import (
+    AWS_ACCOUNT_ARN,
     AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_provider,
@@ -66,6 +67,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
 
     def test_registry_scan_on_push_enabled(self):
         ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
@@ -107,10 +109,12 @@ class Test_ecr_registry_scan_images_on_push_enabled:
             assert result[0].status == "PASS"
             assert search("with scan on push", result[0].status_extended)
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_scan_on_push_enabled_with_filters(self):
         ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
@@ -155,10 +159,12 @@ class Test_ecr_registry_scan_images_on_push_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_scan_on_push_disabled(self):
         ecr_client = mock.MagicMock
+        ecr_client.audited_account_arn = AWS_ACCOUNT_ARN
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
@@ -195,4 +201,5 @@ class Test_ecr_registry_scan_images_on_push_enabled:
             assert result[0].status == "FAIL"
             assert search("scanning without scan on push", result[0].status_extended)
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_registry_scan_images_on_push_enabled/ecr_registry_scan_images_on_push_enabled_test.py
@@ -44,6 +44,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
@@ -71,6 +72,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -109,7 +111,10 @@ class Test_ecr_registry_scan_images_on_push_enabled:
             assert result[0].status == "PASS"
             assert search("with scan on push", result[0].status_extended)
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
-            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}"
+            )
             assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_scan_on_push_enabled_with_filters(self):
@@ -118,6 +123,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -159,7 +165,10 @@ class Test_ecr_registry_scan_images_on_push_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
-            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}"
+            )
             assert result[0].region == AWS_REGION_EU_WEST_1
 
     def test_scan_on_push_disabled(self):
@@ -168,6 +177,7 @@ class Test_ecr_registry_scan_images_on_push_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -201,5 +211,8 @@ class Test_ecr_registry_scan_images_on_push_enabled:
             assert result[0].status == "FAIL"
             assert search("scanning without scan on push", result[0].status_extended)
             assert result[0].resource_id == AWS_ACCOUNT_NUMBER
-            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}"
+            )
             assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/ecr/ecr_repositories_lifecycle_policy_enabled/ecr_repositories_lifecycle_policy_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_lifecycle_policy_enabled/ecr_repositories_lifecycle_policy_enabled_test.py
@@ -51,6 +51,7 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
@@ -77,6 +78,7 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             rules=[],
@@ -121,6 +123,7 @@ class Test_ecr_repositories_lifecycle_policy_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             rules=[],

--- a/tests/providers/aws/services/ecr/ecr_repositories_not_publicly_accessible/ecr_repositories_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_not_publicly_accessible/ecr_repositories_not_publicly_accessible_test.py
@@ -63,6 +63,7 @@ class Test_ecr_repositories_not_publicly_accessible:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
@@ -91,6 +92,7 @@ class Test_ecr_repositories_not_publicly_accessible:
         ecr_client.audited_account = AWS_ACCOUNT_NUMBER
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -134,6 +136,7 @@ class Test_ecr_repositories_not_publicly_accessible:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -179,6 +182,7 @@ class Test_ecr_repositories_not_publicly_accessible:
         ecr_client.audited_account = AWS_ACCOUNT_NUMBER
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[

--- a/tests/providers/aws/services/ecr/ecr_repositories_scan_images_on_push_enabled/ecr_repositories_scan_images_on_push_enabled_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_scan_images_on_push_enabled/ecr_repositories_scan_images_on_push_enabled_test.py
@@ -51,6 +51,7 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
@@ -77,6 +78,7 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -120,6 +122,7 @@ class Test_ecr_repositories_scan_images_on_push_enabled:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[

--- a/tests/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_scan_vulnerabilities_in_latest_image/ecr_repositories_scan_vulnerabilities_in_latest_image_test.py
@@ -62,6 +62,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
@@ -89,6 +90,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -126,6 +128,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -184,6 +187,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -242,6 +246,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -304,6 +309,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -366,6 +372,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -428,6 +435,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -490,6 +498,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -552,6 +561,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[
@@ -610,6 +620,7 @@ class Test_ecr_repositories_scan_vulnerabilities_in_latest_image:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[

--- a/tests/providers/aws/services/ecr/ecr_repositories_tag_immutability/ecr_repositories_tag_immutability_test.py
+++ b/tests/providers/aws/services/ecr/ecr_repositories_tag_immutability/ecr_repositories_tag_immutability_test.py
@@ -51,6 +51,7 @@ class Test_ecr_repositories_tag_immutability:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             repositories=[],
@@ -77,6 +78,7 @@ class Test_ecr_repositories_tag_immutability:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             rules=[],
@@ -122,6 +124,7 @@ class Test_ecr_repositories_tag_immutability:
         ecr_client.registries = {}
         ecr_client.registries[AWS_REGION_EU_WEST_1] = Registry(
             id=AWS_ACCOUNT_NUMBER,
+            arn=f"arn:aws:ecr:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:registry/{AWS_ACCOUNT_NUMBER}",
             region=AWS_REGION_EU_WEST_1,
             scan_type="BASIC",
             rules=[],

--- a/tests/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from prowler.providers.aws.services.route53.route53_service import Domain
-from tests.providers.aws.utils import AWS_REGION_US_EAST_1
+from tests.providers.aws.utils import AWS_ACCOUNT_ARN, AWS_REGION_US_EAST_1
 
 
 class Test_route53_domains_privacy_protection_enabled:
@@ -25,6 +25,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
     def test_domain_privacy_protection_disabled(self):
         route53domains = mock.MagicMock
+        route53domains.audited_account_arn = AWS_ACCOUNT_ARN
         domain_name = "test-domain.com"
         route53domains.domains = {
             domain_name: Domain(
@@ -46,6 +47,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
@@ -55,6 +57,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
     def test_domain_privacy_protection_enabled(self):
         route53domains = mock.MagicMock
+        route53domains.audited_account_arn = AWS_ACCOUNT_ARN
         domain_name = "test-domain.com"
         route53domains.domains = {
             domain_name: Domain(
@@ -76,6 +79,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "PASS"
             assert (

--- a/tests/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_domains_privacy_protection_enabled/route53_domains_privacy_protection_enabled_test.py
@@ -29,7 +29,10 @@ class Test_route53_domains_privacy_protection_enabled:
         domain_name = "test-domain.com"
         route53domains.domains = {
             domain_name: Domain(
-                name=domain_name, region=AWS_REGION_US_EAST_1, admin_privacy=False
+                name=domain_name,
+                arn=f"arn:aws:route53:::domain/{domain_name}",
+                region=AWS_REGION_US_EAST_1,
+                admin_privacy=False,
             )
         }
 
@@ -47,7 +50,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].resource_arn == f"arn:aws:route53:::domain/{domain_name}"
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
@@ -61,7 +64,10 @@ class Test_route53_domains_privacy_protection_enabled:
         domain_name = "test-domain.com"
         route53domains.domains = {
             domain_name: Domain(
-                name=domain_name, region=AWS_REGION_US_EAST_1, admin_privacy=True
+                name=domain_name,
+                arn=f"arn:aws:route53:::domain/{domain_name}",
+                region=AWS_REGION_US_EAST_1,
+                admin_privacy=True,
             )
         }
 
@@ -79,7 +85,7 @@ class Test_route53_domains_privacy_protection_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].resource_arn == f"arn:aws:route53:::domain/{domain_name}"
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "PASS"
             assert (

--- a/tests/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled_test.py
@@ -30,6 +30,7 @@ class Test_route53_domains_transferlock_enabled:
         route53domains.domains = {
             domain_name: Domain(
                 name=domain_name,
+                arn=f"arn:aws:route53:::domain/{domain_name}",
                 region=AWS_REGION_US_EAST_1,
                 admin_privacy=False,
                 status_list=[""],
@@ -50,7 +51,7 @@ class Test_route53_domains_transferlock_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].resource_arn == f"arn:aws:route53:::domain/{domain_name}"
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
@@ -65,6 +66,7 @@ class Test_route53_domains_transferlock_enabled:
         route53domains.domains = {
             domain_name: Domain(
                 name=domain_name,
+                arn=f"arn:aws:route53:::domain/{domain_name}",
                 region=AWS_REGION_US_EAST_1,
                 admin_privacy=False,
                 status_list=["clientTransferProhibited"],
@@ -85,7 +87,7 @@ class Test_route53_domains_transferlock_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
-            assert result[0].resource_arn == AWS_ACCOUNT_ARN
+            assert result[0].resource_arn == f"arn:aws:route53:::domain/{domain_name}"
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "PASS"
             assert (

--- a/tests/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_domains_transferlock_enabled/route53_domains_transferlock_enabled_test.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from prowler.providers.aws.services.route53.route53_service import Domain
-from tests.providers.aws.utils import AWS_REGION_US_EAST_1
+from tests.providers.aws.utils import AWS_ACCOUNT_ARN, AWS_REGION_US_EAST_1
 
 
 class Test_route53_domains_transferlock_enabled:
@@ -25,6 +25,7 @@ class Test_route53_domains_transferlock_enabled:
 
     def test_domain_transfer_lock_disabled(self):
         route53domains = mock.MagicMock
+        route53domains.audited_account_arn = AWS_ACCOUNT_ARN
         domain_name = "test-domain.com"
         route53domains.domains = {
             domain_name: Domain(
@@ -49,6 +50,7 @@ class Test_route53_domains_transferlock_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "FAIL"
             assert (
@@ -58,6 +60,7 @@ class Test_route53_domains_transferlock_enabled:
 
     def test_domain_transfer_lock_enabled(self):
         route53domains = mock.MagicMock
+        route53domains.audited_account_arn = AWS_ACCOUNT_ARN
         domain_name = "test-domain.com"
         route53domains.domains = {
             domain_name: Domain(
@@ -82,6 +85,7 @@ class Test_route53_domains_transferlock_enabled:
 
             assert len(result) == 1
             assert result[0].resource_id == domain_name
+            assert result[0].resource_arn == AWS_ACCOUNT_ARN
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].status == "PASS"
             assert (


### PR DESCRIPTION
### Context

Some checks did not have ARN, Resource Type or `Recommendation.Text`, which was making SecurityHub failing when sending findings.

Fix #5498.

### Description

- Review checks to complete wrong or empty values.
- Use the Severity Enum values when changing it within the checks.
- Improve WAF and Organizations service.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
