### PR TITLE
feat(aws): add new check `bedrock_agent_guardrail_enabled`

### DIFF
--- a/permissions/create_role_to_assume_cfn.yaml
+++ b/permissions/create_role_to_assume_cfn.yaml
@@ -59,6 +59,8 @@ Resources:
                 - 'appstream:Describe*'
                 - 'appstream:List*'
                 - 'backup:List*'
+                - 'bedrock:List*'
+                - 'bedrock:Get*'
                 - 'cloudtrail:GetInsightSelectors'
                 - 'codeartifact:List*'
                 - 'codebuild:BatchGet*'

--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -7,6 +7,8 @@
         "appstream:Describe*",
         "appstream:List*",
         "backup:List*",
+        "bedrock:List*",
+        "bedrock:Get*",
         "cloudtrail:GetInsightSelectors",
         "codeartifact:List*",
         "codebuild:BatchGet*",

--- a/prowler/providers/aws/aws_regions_by_service.json
+++ b/prowler/providers/aws/aws_regions_by_service.json
@@ -1284,6 +1284,30 @@
         ]
       }
     },
+    "bedrock-agent": {
+      "regions": {
+        "aws": [
+          "ap-northeast-1",
+          "ap-northeast-2",
+          "ap-south-1",
+          "ap-southeast-1",
+          "ap-southeast-2",
+          "ca-central-1",
+          "eu-central-1",
+          "eu-west-1",
+          "eu-west-2",
+          "eu-west-3",
+          "sa-east-1",
+          "us-east-1",
+          "us-east-2",
+          "us-west-2"
+        ],
+        "aws-cn": [],
+        "aws-us-gov": [
+          "us-gov-west-1"
+        ]
+      }
+    },
     "bedrock-runtime": {
       "regions": {
         "aws": [
@@ -11302,6 +11326,7 @@
           "ap-southeast-2",
           "ca-central-1",
           "eu-central-1",
+          "eu-central-2",
           "eu-north-1",
           "eu-west-2",
           "us-east-1"

--- a/prowler/providers/aws/services/bedrock/bedrock_agent_client.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_agent_client.py
@@ -1,0 +1,4 @@
+from prowler.providers.aws.services.bedrock.bedrock_service import BedrockAgent
+from prowler.providers.common.provider import Provider
+
+bedrock_agent_client = BedrockAgent(Provider.get_global_provider())

--- a/prowler/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled.metadata.json
@@ -20,7 +20,7 @@
     },
     "Recommendation": {
       "Text": "Enable Guardrails for Amazon Bedrock agent sessions to protect against harmful inputs and outputs during interactions.",
-      "Url": "https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html#enabling-guardrails"
+      "Url": "https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-create.html"
     }
   },
   "Categories": [],

--- a/prowler/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "aws",
+  "CheckID": "bedrock_agent_guardrail_enabled",
+  "CheckTitle": "Ensure that Guardrails are enabled for Amazon Bedrock agent sessions.",
+  "CheckType": [],
+  "ServiceName": "bedrock",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:bedrock:region:account-id:agent/resource-id",
+  "Severity": "high",
+  "ResourceType": "Other",
+  "Description": "This check ensures that Guardrails are enabled to protect Amazon Bedrock agent sessions. Guardrails help mitigate security risks by filtering and blocking harmful or sensitive content during interactions with AI models.",
+  "Risk": "Without guardrails enabled, Amazon Bedrock agent sessions are vulnerable to harmful prompts or inputs that could expose sensitive information or generate inappropriate content. This could lead to privacy violations, data leaks, or other security risks.",
+  "RelatedUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Bedrock/protect-agent-sessions-with-guardrails.html",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable Guardrails for Amazon Bedrock agent sessions to protect against harmful inputs and outputs during interactions.",
+      "Url": "https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html#enabling-guardrails"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled.py
@@ -1,0 +1,24 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.bedrock.bedrock_agent_client import (
+    bedrock_agent_client,
+)
+
+
+class bedrock_agent_guardrail_enabled(Check):
+    def execute(self):
+        findings = []
+        for agent in bedrock_agent_client.agents.values():
+            report = Check_Report_AWS(self.metadata())
+            report.region = agent.region
+            report.resource_id = agent.id
+            report.resource_arn = agent.arn
+            report.resource_tags = agent.tags
+            report.status = "FAIL"
+            report.status_extended = f"Bedrock Agent {agent.name} is not using any guardrail to protect agent sessions."
+            if agent.guardrail_id:
+                report.status = "PASS"
+                report.status_extended = f"Bedrock Agent {agent.name} is using guardrail {agent.guardrail_id} to protect agent sessions."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/bedrock/bedrock_guardrail_prompt_attack_filter_enabled/bedrock_guardrail_prompt_attack_filter_enabled.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_guardrail_prompt_attack_filter_enabled/bedrock_guardrail_prompt_attack_filter_enabled.metadata.json
@@ -23,9 +23,7 @@
       "Url": "https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-injection.html"
     }
   },
-  "Categories": [
-    "security"
-  ],
+  "Categories": [],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": "Ensure that prompt attack protection is set to the highest strength to minimize the risk of prompt injection attacks."

--- a/prowler/providers/aws/services/bedrock/bedrock_guardrail_sensitive_information_filter_enabled/bedrock_guardrail_sensitive_information_filter_enabled.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_guardrail_sensitive_information_filter_enabled/bedrock_guardrail_sensitive_information_filter_enabled.metadata.json
@@ -23,9 +23,7 @@
       "Url": "https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-sensitive-filters.html"
     }
   },
-  "Categories": [
-    "security"
-  ],
+  "Categories": [],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": ""

--- a/prowler/providers/aws/services/bedrock/bedrock_model_invocation_logs_encryption_enabled/bedrock_model_invocation_logs_encryption_enabled.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_model_invocation_logs_encryption_enabled/bedrock_model_invocation_logs_encryption_enabled.metadata.json
@@ -25,8 +25,7 @@
   },
   "Categories": [
     "encryption",
-    "logging",
-    "security"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/bedrock/bedrock_service.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_service.py
@@ -142,19 +142,19 @@ class BedrockAgent(AWSService):
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
-    def _list_tags_for_resource(self, agent):
+    def _list_tags_for_resource(self, resource):
         logger.info("Bedrock Agent - Listing Tags for Resource...")
         try:
             agent_tags = (
-                self.regional_clients[agent.region]
-                .list_tags_for_resource(resourceArn=agent.arn)
+                self.regional_clients[resource.region]
+                .list_tags_for_resource(resourceArn=resource.arn)
                 .get("tags", {})
             )
             if agent_tags:
-                agent.tags = [agent_tags]
+                resource.tags = [agent_tags]
         except Exception as error:
             logger.error(
-                f"{agent.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
 

--- a/prowler/providers/aws/services/bedrock/bedrock_service.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_service.py
@@ -110,3 +110,58 @@ class Guardrail(BaseModel):
     tags: Optional[list] = []
     sensitive_information_filter: bool = False
     prompt_attack_filter_strength: Optional[str]
+
+
+class BedrockAgent(AWSService):
+    def __init__(self, provider):
+        # Call AWSService's __init__
+        super().__init__("bedrock-agent", provider)
+        self.agents = {}
+        self.__threading_call__(self._list_agents)
+        self.__threading_call__(self._list_tags_for_resource, self.agents.values())
+
+    def _list_agents(self, regional_client):
+        logger.info("Bedrock Agent - Listing Agents...")
+        try:
+            for agent in regional_client.list_agents().get("agentSummaries", []):
+                agent_arn = f"arn:aws:bedrock:{regional_client.region}:{self.audited_account}:agent/{agent['agentId']}"
+                if not self.audit_resources or (
+                    is_resource_filtered(agent_arn, self.audit_resources)
+                ):
+                    self.agents[agent_arn] = Agent(
+                        id=agent["agentId"],
+                        name=agent["agentName"],
+                        arn=agent_arn,
+                        guardrail_id=agent.get("guardrailConfiguration", {}).get(
+                            "guardrailIdentifier"
+                        ),
+                        region=regional_client.region,
+                    )
+        except Exception as error:
+            logger.error(
+                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+    def _list_tags_for_resource(self, agent):
+        logger.info("Bedrock Agent - Listing Tags for Resource...")
+        try:
+            agent_tags = (
+                self.regional_clients[agent.region]
+                .list_tags_for_resource(resourceArn=agent.arn)
+                .get("tags", {})
+            )
+            if agent_tags:
+                agent.tags = [agent_tags]
+        except Exception as error:
+            logger.error(
+                f"{agent.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
+
+class Agent(BaseModel):
+    id: str
+    name: str
+    arn: str
+    guardrail_id: Optional[str]
+    region: str
+    tags: Optional[list] = []

--- a/tests/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled_test.py
+++ b/tests/providers/aws/services/bedrock/bedrock_agent_guardrail_enabled/bedrock_agent_guardrail_enabled_test.py
@@ -1,0 +1,136 @@
+from unittest import mock
+
+import botocore
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_no_guardrail(self, operation_name, kwarg):
+    if operation_name == "ListAgents":
+        return {
+            "agentSummaries": [
+                {
+                    "agentId": "test-agent-id",
+                    "agentName": "test-agent-name",
+                    "guardrailConfiguration": {
+                        "guardrailIdentifier": "test-guardrail-id",
+                        "guardrailVersion": "test-guardrail-version",
+                    },
+                },
+            ],
+        }
+    return make_api_call(self, operation_name, kwarg)
+
+
+class Test_bedrock_agent_guardrail_enabled:
+    @mock_aws
+    def test_no_agents(self):
+        from prowler.providers.aws.services.bedrock.bedrock_service import BedrockAgent
+
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.bedrock.bedrock_agent_guardrail_enabled.bedrock_agent_guardrail_enabled.bedrock_agent_client",
+            new=BedrockAgent(aws_provider),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_agent_guardrail_enabled.bedrock_agent_guardrail_enabled import (
+                bedrock_agent_guardrail_enabled,
+            )
+
+            check = bedrock_agent_guardrail_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_agent_without_guardrail(self):
+        bedrock_agent_client = client("bedrock-agent", region_name=AWS_REGION_US_EAST_1)
+        agent = bedrock_agent_client.create_agent(
+            agentName="agent_name",
+            agentResourceRoleArn="test-agent-arn",
+            tags={
+                "Key": "test-tag-key",
+            },
+        )["agent"]
+        agent_id = agent["agentId"]
+        agent_arn = agent["agentArn"]
+        agent_name = agent["agentName"]
+        from prowler.providers.aws.services.bedrock.bedrock_service import BedrockAgent
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.bedrock.bedrock_agent_guardrail_enabled.bedrock_agent_guardrail_enabled.bedrock_agent_client",
+            new=BedrockAgent(aws_provider),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_agent_guardrail_enabled.bedrock_agent_guardrail_enabled import (
+                bedrock_agent_guardrail_enabled,
+            )
+
+            check = bedrock_agent_guardrail_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Bedrock Agent {agent_name} is not using any guardrail to protect agent sessions."
+            )
+            assert result[0].resource_id == agent_id
+            assert result[0].resource_arn == agent_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == [{"Key": "test-tag-key"}]
+
+    @mock.patch(
+        "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_no_guardrail
+    )
+    @mock_aws
+    def test_agent_with_guardrail(self):
+        from prowler.providers.aws.services.bedrock.bedrock_service import BedrockAgent
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.bedrock.bedrock_agent_guardrail_enabled.bedrock_agent_guardrail_enabled.bedrock_agent_client",
+            new=BedrockAgent(aws_provider),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_agent_guardrail_enabled.bedrock_agent_guardrail_enabled import (
+                bedrock_agent_guardrail_enabled,
+            )
+
+            check = bedrock_agent_guardrail_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Bedrock Agent test-agent-name is using guardrail test-guardrail-id to protect agent sessions."
+            )
+            assert result[0].resource_id == "test-agent-id"
+            assert (
+                result[0].resource_arn
+                == f"arn:aws:bedrock:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:agent/test-agent-id"
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []

--- a/util/update_aws_services_regions.py
+++ b/util/update_aws_services_regions.py
@@ -48,6 +48,10 @@ for page in get_parameters_by_path_paginator.paginate(
 logging.info("Updating subservices and the services not present in the original matrix")
 # macie2 --> macie
 regions_by_service["services"]["macie2"] = regions_by_service["services"]["macie"]
+# bedrock-agent --> bedrock
+regions_by_service["services"]["bedrock-agent"] = regions_by_service["services"][
+    "bedrock"
+]
 # cognito --> cognito-idp
 regions_by_service["services"]["cognito"] = regions_by_service["services"][
     "cognito-idp"


### PR DESCRIPTION
### Context

This PR adds a new security check for Amazon Bedrock to ensure Guardrails are enabled for agent sessions. Guardrails help filter harmful or sensitive content during interactions with AI models, enhancing security and data protection.

### Description

- Check Name: `bedrock_agent_guardrail_enabled`
- Purpose: Verifies that Guardrails are enabled to prevent exposure of sensitive or inappropriate content in Bedrock agent sessions.
- Severity: High
- Remediation: Enable Guardrails in the Bedrock Console or via API to filter sensitive content during model interactions.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
