### PR TITLE
fix(aws): review checks in compliance frameworks

### DIFF
--- a/prowler/compliance/aws/aws_account_security_onboarding_aws.json
+++ b/prowler/compliance/aws/aws_account_security_onboarding_aws.json
@@ -557,7 +557,7 @@
         }
       ],
       "Checks": [
-        "inspector2_findings_exist"
+        "inspector2_is_enabled"
       ]
     },
     {
@@ -587,7 +587,8 @@
         }
       ],
       "Checks": [
-        "inspector2_findings_exist",
+        "inspector2_active_findings_exist",
+        "inspector2_is_enabled",
         "ecr_registry_scan_images_on_push_enabled",
         "ecr_repositories_scan_vulnerabilities_in_latest_image",
         "ecr_repositories_scan_images_on_push_enabled"

--- a/prowler/compliance/aws/kisa_isms_p_2023_aws.json
+++ b/prowler/compliance/aws/kisa_isms_p_2023_aws.json
@@ -1192,7 +1192,6 @@
       "Checks": [
         "organizations_scp_check_deny_regions",
         "cognito_user_pool_self_registration_disabled",
-        "cloudtrail_threat_detection_privilege_escalation",
         "iam_user_administrator_access_policy",
         "iam_customer_unattached_policy_no_administrative_privileges",
         "iam_inline_policy_allows_privilege_escalation",
@@ -2654,7 +2653,6 @@
         "accessanalyzer_enabled_without_findings",
         "cloudtrail_insights_exist",
         "cloudtrail_threat_detection_enumeration",
-        "cloudtrail_threat_detection_privilege_escalation",
         "guardduty_no_high_severity_findings",
         "trustedadvisor_errors_and_warnings"
       ],

--- a/prowler/compliance/aws/kisa_isms_p_2023_korean_aws.json
+++ b/prowler/compliance/aws/kisa_isms_p_2023_korean_aws.json
@@ -1192,7 +1192,6 @@
       "Checks": [
         "organizations_scp_check_deny_regions",
         "cognito_user_pool_self_registration_disabled",
-        "cloudtrail_threat_detection_privilege_escalation",
         "iam_user_administrator_access_policy",
         "iam_customer_unattached_policy_no_administrative_privileges",
         "iam_inline_policy_allows_privilege_escalation",
@@ -2654,7 +2653,6 @@
         "accessanalyzer_enabled_without_findings",
         "cloudtrail_insights_exist",
         "cloudtrail_threat_detection_enumeration",
-        "cloudtrail_threat_detection_privilege_escalation",
         "guardduty_no_high_severity_findings",
         "trustedadvisor_errors_and_warnings"
       ],


### PR DESCRIPTION
### Context

Some checks were wrongly included in some compliance frameworks.

### Description

- Remove threat detection checks from KISA-ISMS-P framework.
- Replace old check `inspector2_findings_exist` from AWS-Account-Security-Onboarding framework.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
