### PR TITLE
feat(gcp): add `--organization-id` flag

### DIFF
--- a/docs/tutorials/gcp/organization.md
+++ b/docs/tutorials/gcp/organization.md
@@ -1,9 +1,12 @@
 # GCP Organization
 
-By default, Prowler will scan all the Google Cloud projects that the authenticated user has access to.
+By default, Prowler scans all Google Cloud projects accessible to the authenticated user.
 
-If you want to scan only projects from a specific organization, you can use the `--organization-id` argument.
+To limit the scan to projects within a specific Google Cloud organization, use the `--organization-id` option with the GCP organization ID:
 
 ```console
 prowler gcp --organization-id organization-id
 ```
+
+???+ note
+    With this option, Prowler retrieves all projects within the specified organization, including those organized in folders and nested subfolders. This ensures that every project under the organization’s hierarchy is scanned, providing full visibility across the entire organization.

--- a/docs/tutorials/gcp/organization.md
+++ b/docs/tutorials/gcp/organization.md
@@ -8,5 +8,15 @@ To limit the scan to projects within a specific Google Cloud organization, use t
 prowler gcp --organization-id organization-id
 ```
 
+???+ warning
+    Make sure that the used credentials have the role Cloud Asset Viewer (`roles/cloudasset.viewer`) or Cloud Asset Owner (`roles/cloudasset.owner`) on the organization level.
+
 ???+ note
     With this option, Prowler retrieves all projects within the specified organization, including those organized in folders and nested subfolders. This ensures that every project under the organization’s hierarchy is scanned, providing full visibility across the entire organization.
+
+???+ note
+    To find the organization ID, use the following command:
+
+    ```console
+    gcloud organizations list
+    ```

--- a/docs/tutorials/gcp/organization.md
+++ b/docs/tutorials/gcp/organization.md
@@ -1,0 +1,9 @@
+# GCP Organization
+
+By default, Prowler will scan all the Google Cloud projects that the authenticated user has access to.
+
+If you want to scan only projects from a specific organization, you can use the `--organization-id` argument.
+
+```console
+prowler gcp --organization-id organization-id
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
       - Google Cloud:
           - Authentication: tutorials/gcp/authentication.md
           - Projects: tutorials/gcp/projects.md
+          - Organization: tutorials/gcp/organization.md
       - Kubernetes:
           - In-Cluster Execution: tutorials/kubernetes/in-cluster.md
           - Non In-Cluster Execution: tutorials/kubernetes/outside-cluster.md

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -202,6 +202,7 @@ class Provider(ABC):
                     )
                 elif "gcp" in provider_class_name.lower():
                     provider_class(
+                        arguments.organization_id,
                         arguments.project_id,
                         arguments.excluded_project_id,
                         arguments.credentials_file,

--- a/prowler/providers/gcp/exceptions/exceptions.py
+++ b/prowler/providers/gcp/exceptions/exceptions.py
@@ -42,6 +42,10 @@ class GCPBaseException(ProwlerException):
             "message": "Provider does not match with the expected project_id",
             "remediation": "Check the provider and ensure it matches the expected project_id.",
         },
+        (3009, "GCPCloudAssetAPINotUsedError"): {
+            "message": "Cloud Asset API not used",
+            "remediation": "Enable the Cloud Asset API for the project.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -125,4 +129,11 @@ class GCPInvalidProviderIdError(GCPBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             3008, file=file, original_exception=original_exception, message=message
+        )
+
+
+class GCPCloudAssetAPINotUsedError(GCPBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            3009, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/gcp/lib/arguments/arguments.py
+++ b/prowler/providers/gcp/lib/arguments/arguments.py
@@ -18,6 +18,14 @@ def init_parser(self):
         metavar="SERVICE_ACCOUNT",
         help="Impersonate a Google Service Account",
     )
+    # Organizations
+    gcp_organization_subparser = gcp_parser.add_argument_group("Organization")
+    gcp_organization_subparser.add_argument(
+        "--organization-id",
+        nargs="?",
+        metavar="ORGANIZATION_ID",
+        help="GCP Organization ID to be scanned by Prowler",
+    )
     # Projects
     gcp_projects_subparser = gcp_parser.add_argument_group("Projects")
     gcp_projects_subparser.add_argument(

--- a/tests/lib/cli/parser_test.py
+++ b/tests/lib/cli/parser_test.py
@@ -1212,6 +1212,14 @@ class Test_Parser:
         assert parsed.provider == "gcp"
         assert parsed.credentials_file == file
 
+    def test_parser_gcp_organization_id(self):
+        argument = "--organization-id"
+        organization = "test_organization"
+        command = [prowler_command, "gcp", argument, organization]
+        parsed = self.parser.parse(command)
+        assert parsed.provider == "gcp"
+        assert parsed.organization_id == organization
+
     def test_parser_gcp_project_id(self):
         argument = "--project-id"
         project_1 = "test_project_1"


### PR DESCRIPTION
### Context

Fix #5478 

### Description

Add new flag `--organization-id` flag to scan only GCP projects from a specific organization.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
