### PR TITLE
Introducing Prowler Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   <a href="https://github.com/prowler-cloud/prowler"><img alt="License" src="https://img.shields.io/github/license/prowler-cloud/prowler"></a>
   <a href="https://twitter.com/ToniBlyx"><img alt="Twitter" src="https://img.shields.io/twitter/follow/toniblyx?style=social"></a>
   <a href="https://twitter.com/prowlercloud"><img alt="Twitter" src="https://img.shields.io/twitter/follow/prowlercloud?style=social"></a>
+  <a href="https://gurubase.io/g/prowler"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Prowler%20Guru-006BFF"></a>
 </p>
 <hr>
 <p align="center">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Prowler Guru](https://gurubase.io/g/prowler) to Gurubase. Prowler Guru uses the data from this repo and data from the [docs](https://docs.prowler.com/projects/prowler-open-source/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Prowler Guru", which highlights that Prowler now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Prowler Guru in Gurubase, just let me know that's totally fine.