### PR TITLE
chore(slack): add text argument by best practice

### DIFF
--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -43,6 +43,7 @@ class Slack:
                 username="Prowler",
                 icon_url=square_logo_img,
                 channel=f"#{self.channel}",
+                text="Prowler Scan Summary"
                 blocks=self.__create_message_blocks__(identity, logo, stats, args),
             )
             return response

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -43,7 +43,7 @@ class Slack:
                 username="Prowler",
                 icon_url=square_logo_img,
                 channel=f"#{self.channel}",
-                text="Prowler Scan Summary"
+                text="Prowler Scan Summary",
                 blocks=self.__create_message_blocks__(identity, logo, stats, args),
             )
             return response


### PR DESCRIPTION
### Context

The PR helps supressing a warning that comes up when prowler scan completes.

### Description

The slack sdk expects a argument `text` which was missing (best practice)

![image](https://github.com/user-attachments/assets/de229034-f03a-45dd-b901-ef821175f9ef)

because of this  missing argument prowler was throwing a warning 

![image](https://github.com/user-attachments/assets/5fa21b7f-1a95-40ad-89cc-19fe95e515ad)


Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
