### PR TITLE
fix: added s3 origin comprobation in `cloudfront_distributions_s3_origin_non_existent_bucket`

### DIFF
--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket.metadata.json
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "cloudfront_distributions_s3_origin_non_existent_bucket",
-  "CheckTitle": "CloudFront distributions should not point to non-existent S3 origins.",
+  "CheckTitle": "CloudFront distributions should not point to non-existent S3 origins without static website hosting.",
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
   ],
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:partition:cloudfront:region:account-id:distribution/resource-id",
   "Severity": "high",
   "ResourceType": "AwsCloudFrontDistribution",
-  "Description": "This control checks whether Amazon CloudFront distributions are pointing to non-existent Amazon S3 origins. The control fails if the origin is configured to point to a non-existent bucket.",
+  "Description": "This control checks whether Amazon CloudFront distributions are pointing to non-existent Amazon S3 origins without static website hosting. The control fails if the origin is configured to point to a non-existent bucket.",
   "Risk": "Pointing a CloudFront distribution to a non-existent S3 bucket can allow malicious actors to create the bucket and potentially serve unauthorized content through your distribution, leading to security and integrity issues.",
   "RelatedUrl": "https://docs.aws.amazon.com/whitepapers/latest/secure-content-delivery-amazon-cloudfront/s3-origin-with-cloudfront.html",
   "Remediation": {

--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket.py
@@ -19,9 +19,10 @@ class cloudfront_distributions_s3_origin_non_existent_bucket(Check):
             non_existent_buckets = []
 
             for origin in distribution.origins:
-                bucket_name = origin.domain_name.split(".")[0]
-                if not s3_client._head_bucket(bucket_name):
-                    non_existent_buckets.append(bucket_name)
+                if origin.s3_origin_config:
+                    bucket_name = origin.domain_name.split(".")[0]
+                    if not s3_client._head_bucket(bucket_name):
+                        non_existent_buckets.append(bucket_name)
 
             if non_existent_buckets:
                 report.status = "FAIL"

--- a/tests/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket_test.py
+++ b/tests/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket_test.py
@@ -58,6 +58,7 @@ class Test_cloudfront_s3_origin_non_existent_bucket:
                         id="S3-ORIGIN",
                         origin_protocol_policy="",
                         origin_ssl_protocols=[],
+                        s3_origin_config={"OriginAccessIdentity": ""},
                     ),
                 ],
             )


### PR DESCRIPTION
### Context

In the `cloudfront_distributions_s3_origin_non_existent_bucket` check, we initially didn't verify if the origin was a `S3 bucket`, which resulted in numerous false positives.

It fixes issue: fix #5532

### Description

A comprobation has been added to confirm that the origin is a `S3 bucket`.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
