### PR TITLE
feat(dms): add new check `dms_endpoint_neptune_iam_authorization_enabled`

### DIFF
--- a/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.metadata.json
+++ b/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "dms_endpoint_neptune_iam_authorization_enabled",
+  "CheckTitle": "Check if DMS endpoints for Neptune databases have IAM authorization enabled.",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices"
+  ],
+  "ServiceName": "dms",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:dms:region:account-id:endpoint/endpoint-id",
+  "Severity": "medium",
+  "ResourceType": "AwsDmsEndpoint",
+  "Description": "This control checks whether an AWS DMS endpoint for an Amazon Neptune database is configured with IAM authorization. The control fails if the DMS endpoint doesn't have IAM authorization enabled.",
+  "Risk": "Without IAM authorization, DMS endpoints for Neptune databases may lack granular access control, increasing the risk of unauthorized access to sensitive data.",
+  "RelatedUrl": "https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Neptune.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws dms modify-endpoint --endpoint-arn <endpoint-arn> --service-access-role-arn <iam-role-arn>",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/dms-controls.html#dms-10",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable IAM authorization on DMS endpoints for Neptune databases by specifying a service role in the ServiceAccessRoleARN parameter.",
+      "Url": "https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Neptune.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.py
+++ b/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.py
@@ -24,17 +24,18 @@ class dms_endpoint_neptune_iam_authorization_enabled(Check):
         """
         findings = []
         for endpoint_arn, endpoint in dms_client.endpoints.items():
-            report = Check_Report_AWS(self.metadata())
-            report.resource_id = endpoint.id
-            report.resource_arn = endpoint_arn
-            report.region = endpoint.region
-            report.resource_tags = endpoint.tags
-            report.status = "FAIL"
-            report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database does not have IAM authorization enabled."
-            if endpoint.neptune_iam_auth_enabled:
-                report.status = "PASS"
-                report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database has IAM authorization enabled."
+            if endpoint.engine_name == "neptune":
+                report = Check_Report_AWS(self.metadata())
+                report.resource_id = endpoint.id
+                report.resource_arn = endpoint_arn
+                report.region = endpoint.region
+                report.resource_tags = endpoint.tags
+                report.status = "FAIL"
+                report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database does not have IAM authorization enabled."
+                if endpoint.neptune_iam_auth_enabled:
+                    report.status = "PASS"
+                    report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database has IAM authorization enabled."
 
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.py
+++ b/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.py
@@ -1,0 +1,40 @@
+from typing import List
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.dms.dms_client import dms_client
+
+
+class dms_endpoint_neptune_iam_authorization_enabled(Check):
+    """
+    Check if AWS DMS Endpoints for Neptune have IAM authorization enabled.
+
+    This class verifies whether each AWS DMS Endpoint configured for Neptune has IAM authorization enabled
+    by checking the `NeptuneSettings.IamAuthEnabled` property in the endpoint's configuration.
+    """
+
+    def execute(self) -> List[Check_Report_AWS]:
+        """
+        Execute the DMS Neptune IAM authorization enabled check.
+
+        Iterates over all DMS Endpoints and generates a report indicating whether
+        each Neptune endpoint has IAM authorization enabled.
+
+        Returns:
+            List[Check_Report_AWS]: A list of report objects with the results of the check.
+        """
+        findings = []
+        for endpoint_arn, endpoint in dms_client.endpoints.items():
+            report = Check_Report_AWS(self.metadata())
+            report.resource_id = endpoint.id
+            report.resource_arn = endpoint_arn
+            report.region = endpoint.region
+            report.resource_tags = endpoint.tags
+            report.status = "FAIL"
+            report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database does not have IAM authorization enabled."
+            if endpoint.neptune_iam_auth_enabled:
+                report.status = "PASS"
+                report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database has IAM authorization enabled."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.py
+++ b/prowler/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled.py
@@ -31,10 +31,10 @@ class dms_endpoint_neptune_iam_authorization_enabled(Check):
                 report.region = endpoint.region
                 report.resource_tags = endpoint.tags
                 report.status = "FAIL"
-                report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database does not have IAM authorization enabled."
+                report.status_extended = f"DMS Endpoint {endpoint.id} for Neptune databases does not have IAM authorization enabled."
                 if endpoint.neptune_iam_auth_enabled:
                     report.status = "PASS"
-                    report.status_extended = f"DMS Endpoint '{endpoint.id}' for Neptune database has IAM authorization enabled."
+                    report.status_extended = f"DMS Endpoint {endpoint.id} for Neptune databases has IAM authorization enabled."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/dms/dms_service.py
+++ b/prowler/providers/aws/services/dms/dms_service.py
@@ -112,4 +112,4 @@ class RepInstance(BaseModel):
     security_groups: list[str] = []
     multi_az: bool
     region: str
-    tags: Optional[list]
+    tags: Optional[list] = []

--- a/prowler/providers/aws/services/dms/dms_service.py
+++ b/prowler/providers/aws/services/dms/dms_service.py
@@ -74,6 +74,7 @@ class DMS(AWSService):
                             neptune_iam_auth_enabled=endpoint.get(
                                 "NeptuneSettings", {}
                             ).get("IamAuthEnabled", False),
+                            engine_name=endpoint["EngineName"],
                         )
         except Exception as error:
             logger.error(
@@ -98,6 +99,7 @@ class Endpoint(BaseModel):
     ssl_mode: str
     tags: Optional[list]
     neptune_iam_auth_enabled: Optional[bool]
+    engine_name: Optional[str]
 
 
 class RepInstance(BaseModel):

--- a/prowler/providers/aws/services/dms/dms_service.py
+++ b/prowler/providers/aws/services/dms/dms_service.py
@@ -98,8 +98,8 @@ class Endpoint(BaseModel):
     region: str
     ssl_mode: str
     tags: Optional[list]
-    neptune_iam_auth_enabled: Optional[bool]
-    engine_name: Optional[str]
+    neptune_iam_auth_enabled: bool = False
+    engine_name: str
 
 
 class RepInstance(BaseModel):

--- a/prowler/providers/aws/services/dms/dms_service.py
+++ b/prowler/providers/aws/services/dms/dms_service.py
@@ -71,6 +71,9 @@ class DMS(AWSService):
                             id=endpoint["EndpointIdentifier"],
                             region=regional_client.region,
                             ssl_mode=endpoint.get("SslMode", False),
+                            neptune_iam_auth_enabled=endpoint.get(
+                                "NeptuneSettings", {}
+                            ).get("IamAuthEnabled", False),
                         )
         except Exception as error:
             logger.error(
@@ -94,6 +97,7 @@ class Endpoint(BaseModel):
     region: str
     ssl_mode: str
     tags: Optional[list]
+    neptune_iam_auth_enabled: Optional[bool]
 
 
 class RepInstance(BaseModel):

--- a/tests/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled_test.py
+++ b/tests/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled_test.py
@@ -1,0 +1,208 @@
+from unittest import mock
+
+import botocore
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+make_api_call = botocore.client.BaseClient._make_api_call
+
+DMS_ENDPOINT_NAME = "dms-endpoint"
+DMS_ENDPOINT_ARN = f"arn:aws:dms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:endpoint:{DMS_ENDPOINT_NAME}"
+DMS_INSTANCE_NAME = "rep-instance"
+DMS_INSTANCE_ARN = (
+    f"arn:aws:dms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:rep:{DMS_INSTANCE_NAME}"
+)
+
+
+def mock_make_api_call_enabled(self, operation_name, kwarg):
+    if operation_name == "DescribeEndpoints":
+        return {
+            "Endpoints": [
+                {
+                    "EndpointIdentifier": DMS_ENDPOINT_NAME,
+                    "EndpointArn": DMS_ENDPOINT_ARN,
+                    "SslMode": "require",
+                    "NeptuneSettings": {
+                        "IamAuthEnabled": True,
+                    },
+                }
+            ]
+        }
+    elif operation_name == "ListTagsForResource":
+        if kwarg["ResourceArn"] == DMS_INSTANCE_ARN:
+            return {
+                "TagList": [
+                    {"Key": "Name", "Value": "rep-instance"},
+                    {"Key": "Owner", "Value": "admin"},
+                ]
+            }
+        elif kwarg["ResourceArn"] == DMS_ENDPOINT_ARN:
+            return {
+                "TagList": [
+                    {"Key": "Name", "Value": "dms-endpoint"},
+                    {"Key": "Owner", "Value": "admin"},
+                ]
+            }
+    return make_api_call(self, operation_name, kwarg)
+
+
+def mock_make_api_call_not_enabled(self, operation_name, kwarg):
+    if operation_name == "DescribeEndpoints":
+        return {
+            "Endpoints": [
+                {
+                    "EndpointIdentifier": DMS_ENDPOINT_NAME,
+                    "EndpointArn": DMS_ENDPOINT_ARN,
+                    "SslMode": "require",
+                    "NeptuneSettings": {
+                        "IamAuthEnabled": False,
+                    },
+                }
+            ]
+        }
+    elif operation_name == "ListTagsForResource":
+        if kwarg["ResourceArn"] == DMS_INSTANCE_ARN:
+            return {
+                "TagList": [
+                    {"Key": "Name", "Value": "rep-instance"},
+                    {"Key": "Owner", "Value": "admin"},
+                ]
+            }
+        elif kwarg["ResourceArn"] == DMS_ENDPOINT_ARN:
+            return {
+                "TagList": [
+                    {"Key": "Name", "Value": "dms-endpoint"},
+                    {"Key": "Owner", "Value": "admin"},
+                ]
+            }
+    return make_api_call(self, operation_name, kwarg)
+
+
+class Test_dms_endpoint_neptune_iam_authorization_enabled:
+    @mock_aws
+    def test_no_dms_endpoints(self):
+        dms_client = client("dms", region_name=AWS_REGION_US_EAST_1)
+        dms_client.endpoints = {}
+
+        from prowler.providers.aws.services.dms.dms_service import DMS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_endpoint_neptune_iam_authorization_enabled.dms_endpoint_neptune_iam_authorization_enabled.dms_client",
+            new=DMS(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.dms.dms_endpoint_neptune_iam_authorization_enabled.dms_endpoint_neptune_iam_authorization_enabled import (
+                dms_endpoint_neptune_iam_authorization_enabled,
+            )
+
+            check = dms_endpoint_neptune_iam_authorization_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_dms_neptune_iam_auth_not_enabled(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_not_enabled,
+        ):
+
+            from prowler.providers.aws.services.dms.dms_service import DMS
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.dms.dms_endpoint_neptune_iam_authorization_enabled.dms_endpoint_neptune_iam_authorization_enabled.dms_client",
+                new=DMS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.dms.dms_endpoint_neptune_iam_authorization_enabled.dms_endpoint_neptune_iam_authorization_enabled import (
+                    dms_endpoint_neptune_iam_authorization_enabled,
+                )
+
+                check = dms_endpoint_neptune_iam_authorization_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert result[0].status_extended == (
+                    "DMS Endpoint 'dms-endpoint' for Neptune database does not have IAM authorization enabled."
+                )
+                assert result[0].resource_id == "dms-endpoint"
+                assert (
+                    result[0].resource_arn
+                    == "arn:aws:dms:us-east-1:123456789012:endpoint:dms-endpoint"
+                )
+                assert result[0].resource_tags == [
+                    {
+                        "Key": "Name",
+                        "Value": "dms-endpoint",
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": "admin",
+                    },
+                ]
+                assert result[0].region == "us-east-1"
+
+    @mock_aws
+    def test_dms_neptune_iam_auth_enabled(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_enabled,
+        ):
+
+            from prowler.providers.aws.services.dms.dms_service import DMS
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.dms.dms_endpoint_neptune_iam_authorization_enabled.dms_endpoint_neptune_iam_authorization_enabled.dms_client",
+                new=DMS(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.dms.dms_endpoint_neptune_iam_authorization_enabled.dms_endpoint_neptune_iam_authorization_enabled import (
+                    dms_endpoint_neptune_iam_authorization_enabled,
+                )
+
+                check = dms_endpoint_neptune_iam_authorization_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert result[0].status_extended == (
+                    "DMS Endpoint 'dms-endpoint' for Neptune database has IAM authorization enabled."
+                )
+                assert result[0].resource_id == "dms-endpoint"
+                assert (
+                    result[0].resource_arn
+                    == "arn:aws:dms:us-east-1:123456789012:endpoint:dms-endpoint"
+                )
+                assert result[0].resource_tags == [
+                    {
+                        "Key": "Name",
+                        "Value": "dms-endpoint",
+                    },
+                    {
+                        "Key": "Owner",
+                        "Value": "admin",
+                    },
+                ]
+                assert result[0].region == "us-east-1"

--- a/tests/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled_test.py
+++ b/tests/providers/aws/services/dms/dms_endpoint_neptune_iam_authorization_enabled/dms_endpoint_neptune_iam_authorization_enabled_test.py
@@ -203,7 +203,7 @@ class Test_dms_endpoint_neptune_iam_authorization_enabled:
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
                 assert result[0].status_extended == (
-                    "DMS Endpoint 'dms-endpoint' for Neptune database does not have IAM authorization enabled."
+                    "DMS Endpoint dms-endpoint for Neptune databases does not have IAM authorization enabled."
                 )
                 assert result[0].resource_id == "dms-endpoint"
                 assert (
@@ -251,7 +251,7 @@ class Test_dms_endpoint_neptune_iam_authorization_enabled:
                 assert len(result) == 1
                 assert result[0].status == "PASS"
                 assert result[0].status_extended == (
-                    "DMS Endpoint 'dms-endpoint' for Neptune database has IAM authorization enabled."
+                    "DMS Endpoint dms-endpoint for Neptune databases has IAM authorization enabled."
                 )
                 assert result[0].resource_id == "dms-endpoint"
                 assert (

--- a/tests/providers/aws/services/dms/dms_endpoint_ssl_enabled_test/dms_endpoint_ssl_enabled_test.py
+++ b/tests/providers/aws/services/dms/dms_endpoint_ssl_enabled_test/dms_endpoint_ssl_enabled_test.py
@@ -12,6 +12,9 @@ class Test_dms_endpoint_ssl_enabled:
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
             new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
+            new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_endpoint_ssl_enabled.dms_endpoint_ssl_enabled import (
                 dms_endpoint_ssl_enabled,
@@ -40,6 +43,9 @@ class Test_dms_endpoint_ssl_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
+            new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
             new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_endpoint_ssl_enabled.dms_endpoint_ssl_enabled import (
@@ -85,6 +91,9 @@ class Test_dms_endpoint_ssl_enabled:
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
             new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
+            new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_endpoint_ssl_enabled.dms_endpoint_ssl_enabled import (
                 dms_endpoint_ssl_enabled,
@@ -126,6 +135,9 @@ class Test_dms_endpoint_ssl_enabled:
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
             new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
+            new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_endpoint_ssl_enabled.dms_endpoint_ssl_enabled import (
                 dms_endpoint_ssl_enabled,
@@ -166,6 +178,9 @@ class Test_dms_endpoint_ssl_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
+            new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
             new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_endpoint_ssl_enabled.dms_endpoint_ssl_enabled import (

--- a/tests/providers/aws/services/dms/dms_endpoint_ssl_enabled_test/dms_endpoint_ssl_enabled_test.py
+++ b/tests/providers/aws/services/dms/dms_endpoint_ssl_enabled_test/dms_endpoint_ssl_enabled_test.py
@@ -28,6 +28,7 @@ class Test_dms_endpoint_ssl_enabled:
             endpoint_arn: Endpoint(
                 arn=endpoint_arn,
                 id="test-endpoint-no-ssl",
+                engine_name="test-engine",
                 region=AWS_REGION_US_EAST_1,
                 ssl_mode="none",
                 tags=[{"Key": "Name", "Value": "test-endpoint-no-ssl"}],
@@ -71,6 +72,7 @@ class Test_dms_endpoint_ssl_enabled:
             endpoint_arn: Endpoint(
                 arn=endpoint_arn,
                 id="test-endpoint-ssl-require",
+                engine_name="test-engine",
                 region=AWS_REGION_US_EAST_1,
                 ssl_mode="require",
                 tags=[{"Key": "Name", "Value": "test-endpoint-ssl-require"}],
@@ -111,6 +113,7 @@ class Test_dms_endpoint_ssl_enabled:
             endpoint_arn: Endpoint(
                 arn=endpoint_arn,
                 id="test-endpoint-ssl-verify-ca",
+                engine_name="test-engine",
                 region=AWS_REGION_US_EAST_1,
                 ssl_mode="verify-ca",
                 tags=[{"Key": "Name", "Value": "test-endpoint-ssl-verify-ca"}],
@@ -151,6 +154,7 @@ class Test_dms_endpoint_ssl_enabled:
             endpoint_arn: Endpoint(
                 arn=endpoint_arn,
                 id="test-endpoint-ssl-verify-full",
+                engine_name="test-engine",
                 region=AWS_REGION_US_EAST_1,
                 ssl_mode="verify-full",
                 tags=[{"Key": "Name", "Value": "test-endpoint-ssl-verify-full"}],

--- a/tests/providers/aws/services/dms/dms_instance_minor_version_upgrade_enabled/dms_instance_minor_version_upgrade_enabled_test.py
+++ b/tests/providers/aws/services/dms/dms_instance_minor_version_upgrade_enabled/dms_instance_minor_version_upgrade_enabled_test.py
@@ -18,6 +18,9 @@ class Test_dms_instance_minor_version_upgrade_enabled:
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
             new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
+            new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_instance_minor_version_upgrade_enabled.dms_instance_minor_version_upgrade_enabled import (
                 dms_instance_minor_version_upgrade_enabled,
@@ -46,6 +49,9 @@ class Test_dms_instance_minor_version_upgrade_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
+            new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
             new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_instance_minor_version_upgrade_enabled.dms_instance_minor_version_upgrade_enabled import (
@@ -86,6 +92,9 @@ class Test_dms_instance_minor_version_upgrade_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
+            new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
             new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_instance_minor_version_upgrade_enabled.dms_instance_minor_version_upgrade_enabled import (

--- a/tests/providers/aws/services/dms/dms_instance_multi_az/dms_instance_multi_az_test.py
+++ b/tests/providers/aws/services/dms/dms_instance_multi_az/dms_instance_multi_az_test.py
@@ -18,6 +18,9 @@ class Test_dms_instance_multi_az:
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
             new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
+            new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_instance_multi_az_enabled.dms_instance_multi_az_enabled import (
                 dms_instance_multi_az_enabled,
@@ -46,6 +49,9 @@ class Test_dms_instance_multi_az:
 
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
+            new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
             new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_instance_multi_az_enabled.dms_instance_multi_az_enabled import (
@@ -86,6 +92,9 @@ class Test_dms_instance_multi_az:
 
         with mock.patch(
             "prowler.providers.aws.services.dms.dms_service.DMS",
+            new=dms_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_client.dms_client",
             new=dms_client,
         ):
             from prowler.providers.aws.services.dms.dms_instance_multi_az_enabled.dms_instance_multi_az_enabled import (

--- a/tests/providers/aws/services/dms/dms_instance_no_public_access/dms_no_public_access_test.py
+++ b/tests/providers/aws/services/dms/dms_instance_no_public_access/dms_no_public_access_test.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import botocore
 from boto3 import client
 from moto import mock_aws
 
@@ -16,59 +17,91 @@ DMS_INSTANCE_ARN = (
 )
 KMS_KEY_ID = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/abcdabcd-1234-abcd-1234-abcdabcdabcd"
 
+make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_public(self, operation_name, kwargs):
+    if operation_name == "DescribeReplicationInstances":
+        return {
+            "ReplicationInstances": [
+                {
+                    "ReplicationInstanceIdentifier": DMS_INSTANCE_NAME,
+                    "ReplicationInstanceStatus": "available",
+                    "AutoMinorVersionUpgrade": True,
+                    "PubliclyAccessible": True,
+                    "ReplicationInstanceArn": DMS_INSTANCE_ARN,
+                    "MultiAZ": True,
+                    "VpcSecurityGroups": [],
+                    "KmsKeyId": KMS_KEY_ID,
+                },
+            ]
+        }
+
+    return make_api_call(self, operation_name, kwargs)
+
+
+def mock_make_api_call_private(self, operation_name, kwargs):
+    if operation_name == "DescribeReplicationInstances":
+        return {
+            "ReplicationInstances": [
+                {
+                    "ReplicationInstanceIdentifier": DMS_INSTANCE_NAME,
+                    "ReplicationInstanceStatus": "available",
+                    "AutoMinorVersionUpgrade": True,
+                    "PubliclyAccessible": False,
+                    "ReplicationInstanceArn": DMS_INSTANCE_ARN,
+                    "MultiAZ": True,
+                    "VpcSecurityGroups": [],
+                    "KmsKeyId": KMS_KEY_ID,
+                },
+            ]
+        }
+
+    return make_api_call(self, operation_name, kwargs)
+
 
 class Test_dms_instance_no_public_access:
+    @mock_aws
     def test_dms_no_instances(self):
-        dms_client = mock.MagicMock()
+        dms_client = client("dms", region_name=AWS_REGION_US_EAST_1)
         dms_client.instances = []
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        from prowler.providers.aws.services.dms.dms_service import DMS
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
+            new=DMS(aws_provider),
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.dms.dms_service.DMS",
-                new=dms_client,
-            ), mock.patch(
-                "prowler.providers.aws.services.dms.dms_client.dms_client",
-                new=dms_client,
-            ):
-                from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
-                    dms_instance_no_public_access,
-                )
-
-                check = dms_instance_no_public_access()
-                result = check.execute()
-                assert len(result) == 0
-
-    def test_dms_private(self):
-        dms_client = mock.MagicMock()
-        dms_client.instances = []
-        dms_client.instances.append(
-            RepInstance(
-                id=DMS_INSTANCE_NAME,
-                arn=DMS_INSTANCE_ARN,
-                status="available",
-                public=False,
-                security_groups=[],
-                kms_key=KMS_KEY_ID,
-                auto_minor_version_upgrade=False,
-                multi_az=False,
-                region=AWS_REGION_US_EAST_1,
-                tags=[{"Key": "Name", "Value": DMS_INSTANCE_NAME}],
+            from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
+                dms_instance_no_public_access,
             )
-        )
 
+            check = dms_instance_no_public_access()
+            result = check.execute()
+            assert len(result) == 0
+
+    @mock_aws
+    def test_dms_private(self):
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_private,
         ):
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+            from prowler.providers.aws.services.dms.dms_service import DMS
+
             with mock.patch(
-                "prowler.providers.aws.services.dms.dms_service.DMS",
-                new=dms_client,
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
             ), mock.patch(
-                "prowler.providers.aws.services.dms.dms_client.dms_client",
-                new=dms_client,
+                "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
+                new=DMS(aws_provider),
             ):
                 from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
                     dms_instance_no_public_access,
@@ -85,41 +118,25 @@ class Test_dms_instance_no_public_access:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == DMS_INSTANCE_NAME
                 assert result[0].resource_arn == DMS_INSTANCE_ARN
-                assert result[0].resource_tags == [
-                    {
-                        "Key": "Name",
-                        "Value": DMS_INSTANCE_NAME,
-                    }
-                ]
+                assert result[0].resource_tags == []
 
+    @mock_aws
     def test_dms_public(self):
-        dms_client = mock.MagicMock()
-        dms_client.instances = []
-        dms_client.instances.append(
-            RepInstance(
-                id=DMS_INSTANCE_NAME,
-                arn=DMS_INSTANCE_ARN,
-                status="available",
-                public=True,
-                security_groups=[],
-                kms_key=KMS_KEY_ID,
-                auto_minor_version_upgrade=False,
-                multi_az=False,
-                region=AWS_REGION_US_EAST_1,
-                tags=[{"Key": "Name", "Value": DMS_INSTANCE_NAME}],
-            )
-        )
-
         with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_public,
         ):
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+            from prowler.providers.aws.services.dms.dms_service import DMS
+
             with mock.patch(
-                "prowler.providers.aws.services.dms.dms_service.DMS",
-                new=dms_client,
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
             ), mock.patch(
-                "prowler.providers.aws.services.dms.dms_client.dms_client",
-                new=dms_client,
+                "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
+                new=DMS(aws_provider),
             ):
                 from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
                     dms_instance_no_public_access,
@@ -136,12 +153,7 @@ class Test_dms_instance_no_public_access:
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert result[0].resource_id == DMS_INSTANCE_NAME
                 assert result[0].resource_arn == DMS_INSTANCE_ARN
-                assert result[0].resource_tags == [
-                    {
-                        "Key": "Name",
-                        "Value": DMS_INSTANCE_NAME,
-                    }
-                ]
+                assert result[0].resource_tags == []
 
     @mock_aws
     def test_dms_public_with_public_sg(self):
@@ -160,6 +172,7 @@ class Test_dms_instance_no_public_access:
                 }
             ],
         )
+        dms_client = mock.MagicMock
         dms_client = mock.MagicMock()
         dms_client.instances = []
         dms_client.instances.append(
@@ -176,14 +189,12 @@ class Test_dms_instance_no_public_access:
                 tags=[{"Key": "Name", "Value": DMS_INSTANCE_NAME}],
             )
         )
-
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         aws_provider.audit_metadata.expected_checks = [
             "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
         ]
-
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
@@ -205,7 +216,6 @@ class Test_dms_instance_no_public_access:
 
                 check = dms_instance_no_public_access()
                 result = check.execute()
-
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
                 assert (
@@ -255,14 +265,12 @@ class Test_dms_instance_no_public_access:
                 tags=[{"Key": "Name", "Value": DMS_INSTANCE_NAME}],
             )
         )
-
         from prowler.providers.aws.services.ec2.ec2_service import EC2
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         aws_provider.audit_metadata.expected_checks = [
             "ec2_securitygroup_allow_ingress_from_internet_to_any_port"
         ]
-
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
@@ -284,7 +292,6 @@ class Test_dms_instance_no_public_access:
 
                 check = dms_instance_no_public_access()
                 result = check.execute()
-
                 assert len(result) == 1
                 assert result[0].status == "PASS"
                 assert (

--- a/tests/providers/aws/services/dms/dms_instance_no_public_access/dms_no_public_access_test.py
+++ b/tests/providers/aws/services/dms/dms_instance_no_public_access/dms_no_public_access_test.py
@@ -19,23 +19,19 @@ KMS_KEY_ID = f"arn:aws:kms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:key/abcda
 
 class Test_dms_instance_no_public_access:
     def test_dms_no_instances(self):
-        dms_client = mock.MagicMock
+        dms_client = mock.MagicMock()
         dms_client.instances = []
-
-        from prowler.providers.aws.services.ec2.ec2_service import EC2
-
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ):
             with mock.patch(
                 "prowler.providers.aws.services.dms.dms_service.DMS",
                 new=dms_client,
             ), mock.patch(
-                "prowler.providers.aws.services.rds.rds_instance_no_public_access.rds_instance_no_public_access.ec2_client",
-                new=EC2(aws_provider),
+                "prowler.providers.aws.services.dms.dms_client.dms_client",
+                new=dms_client,
             ):
                 from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
                     dms_instance_no_public_access,
@@ -46,7 +42,7 @@ class Test_dms_instance_no_public_access:
                 assert len(result) == 0
 
     def test_dms_private(self):
-        dms_client = mock.MagicMock
+        dms_client = mock.MagicMock()
         dms_client.instances = []
         dms_client.instances.append(
             RepInstance(
@@ -63,14 +59,15 @@ class Test_dms_instance_no_public_access:
             )
         )
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ):
             with mock.patch(
                 "prowler.providers.aws.services.dms.dms_service.DMS",
+                new=dms_client,
+            ), mock.patch(
+                "prowler.providers.aws.services.dms.dms_client.dms_client",
                 new=dms_client,
             ):
                 from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
@@ -96,7 +93,7 @@ class Test_dms_instance_no_public_access:
                 ]
 
     def test_dms_public(self):
-        dms_client = mock.MagicMock
+        dms_client = mock.MagicMock()
         dms_client.instances = []
         dms_client.instances.append(
             RepInstance(
@@ -113,14 +110,15 @@ class Test_dms_instance_no_public_access:
             )
         )
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
-
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
         ):
             with mock.patch(
                 "prowler.providers.aws.services.dms.dms_service.DMS",
+                new=dms_client,
+            ), mock.patch(
+                "prowler.providers.aws.services.dms.dms_client.dms_client",
                 new=dms_client,
             ):
                 from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
@@ -162,7 +160,7 @@ class Test_dms_instance_no_public_access:
                 }
             ],
         )
-        dms_client = mock.MagicMock
+        dms_client = mock.MagicMock()
         dms_client.instances = []
         dms_client.instances.append(
             RepInstance(
@@ -191,7 +189,10 @@ class Test_dms_instance_no_public_access:
             return_value=aws_provider,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.dms.dms_service.DMS",
+                "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
+                new=dms_client,
+            ), mock.patch(
+                "prowler.providers.aws.services.dms.dms_client.dms_client",
                 new=dms_client,
             ), mock.patch(
                 "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.ec2_client",
@@ -267,7 +268,10 @@ class Test_dms_instance_no_public_access:
             return_value=aws_provider,
         ):
             with mock.patch(
-                "prowler.providers.aws.services.dms.dms_service.DMS",
+                "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
+                new=dms_client,
+            ), mock.patch(
+                "prowler.providers.aws.services.dms.dms_client.dms_client",
                 new=dms_client,
             ), mock.patch(
                 "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.ec2_client",

--- a/tests/providers/aws/services/dms/dms_service_test.py
+++ b/tests/providers/aws/services/dms/dms_service_test.py
@@ -47,6 +47,7 @@ def mock_make_api_call(self, operation_name, kwargs):
                     "NeptuneSettings": {
                         "IamAuthEnabled": True,
                     },
+                    "EngineName": "neptune",
                 }
             ]
         }
@@ -125,6 +126,7 @@ class Test_DMS_Service:
         assert dms.endpoints[DMS_ENDPOINT_ARN].id == DMS_ENDPOINT_NAME
         assert dms.endpoints[DMS_ENDPOINT_ARN].ssl_mode == "require"
         assert dms.endpoints[DMS_ENDPOINT_ARN].neptune_iam_auth_enabled
+        assert dms.endpoints[DMS_ENDPOINT_ARN].engine_name == "neptune"
 
     def test_list_tags(self):
         aws_provider = set_mocked_aws_provider()

--- a/tests/providers/aws/services/dms/dms_service_test.py
+++ b/tests/providers/aws/services/dms/dms_service_test.py
@@ -44,6 +44,9 @@ def mock_make_api_call(self, operation_name, kwargs):
                     "EndpointIdentifier": DMS_ENDPOINT_NAME,
                     "EndpointArn": DMS_ENDPOINT_ARN,
                     "SslMode": "require",
+                    "NeptuneSettings": {
+                        "IamAuthEnabled": True,
+                    },
                 }
             ]
         }
@@ -121,6 +124,7 @@ class Test_DMS_Service:
         assert len(dms.endpoints) == 1
         assert dms.endpoints[DMS_ENDPOINT_ARN].id == DMS_ENDPOINT_NAME
         assert dms.endpoints[DMS_ENDPOINT_ARN].ssl_mode == "require"
+        assert dms.endpoints[DMS_ENDPOINT_ARN].neptune_iam_auth_enabled
 
     def test_list_tags(self):
         aws_provider = set_mocked_aws_provider()


### PR DESCRIPTION
### Context

This new check verifies whether AWS Database Migration Service (DMS) endpoints for Amazon Neptune databases are configured with IAM authorization. The control fails if IAM authorization is not enabled for these endpoints.

IAM authorization enables fine-grained access control and passwordless authentication, enhancing security by ensuring that only authorized IAM users and roles can access the Neptune database through DMS. Using IAM policies allows you to enforce least-privilege access and manage permissions effectively.

### Description

Added new check `dms_endpoint_neptune_iam_authorization_enabled` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
