### PR TITLE
feat(s3): add new check `s3_multi_region_access_point_public_access_block`

### DIFF
--- a/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "s3_multi_region_access_point_public_access_block",
+  "CheckTitle": "Block Public Access Settings enabled on Multi Region Access Points.",
+  "CheckType": [
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+  ],
+  "ServiceName": "s3",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:aws:s3:region:account-id:accesspoint/access-point-name",
+  "Severity": "high",
+  "ResourceType": "AwsS3AccessPoint",
+  "Description": "Ensures that public access is blocked on S3 Access Points.",
+  "Risk": "Leaving S3 multi region access points open to the public in AWS can lead to data exposure, breaches, compliance violations, unauthorized access, and data integrity issues.",
+  "RelatedUrl": "https://aws.amazon.com/es/getting-started/hands-on/getting-started-with-amazon-s3-multi-region-access-points/",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-24",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Ensure S3 multi region access points are private by default, applying strict access controls, and regularly auditing permissions to prevent unauthorized public access.",
+      "Url": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/multi-region-access-point-block-public-access.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
+++ b/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
@@ -1,0 +1,27 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.s3.s3control_client import s3control_client
+
+
+class s3_multi_region_access_point_public_access_block(Check):
+    def execute(self):
+        findings = []
+        for arn, mr_access_point in s3control_client.multi_region_access_points.keys():
+            report = Check_Report_AWS(self.metadata())
+            report.region = mr_access_point.region
+            report.resource_id = mr_access_point.name
+            report.resource_arn = mr_access_point.arn
+            report.status = "PASS"
+            report.status_extended = f"Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does have Public Access Block enabled."
+
+            if not (
+                mr_access_point.public_access_block.block_public_acls
+                and mr_access_point.public_access_block.ignore_public_acls
+                and mr_access_point.public_access_block.block_public_policy
+                and mr_access_point.public_access_block.restrict_public_buckets
+            ):
+                report.status = "FAIL"
+                report.status_extended = f"Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does not have Public Access Block enabled."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
+++ b/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
@@ -25,7 +25,6 @@ class s3_multi_region_access_point_public_access_block(Check):
             report.status = "PASS"
             report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of buckets {', '.join(mr_access_point.buckets)} does have Public Access Block enabled."
 
-            print(mr_access_point.public_access_block)
             if not (
                 mr_access_point.public_access_block.block_public_acls
                 and mr_access_point.public_access_block.ignore_public_acls

--- a/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
+++ b/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
@@ -25,6 +25,7 @@ class s3_multi_region_access_point_public_access_block(Check):
             report.status = "PASS"
             report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of buckets {', '.join(mr_access_point.buckets)} does have Public Access Block enabled."
 
+            print(mr_access_point.public_access_block)
             if not (
                 mr_access_point.public_access_block.block_public_acls
                 and mr_access_point.public_access_block.ignore_public_acls

--- a/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
+++ b/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
@@ -23,7 +23,7 @@ class s3_multi_region_access_point_public_access_block(Check):
             report.resource_id = mr_access_point.name
             report.resource_arn = mr_access_point.arn
             report.status = "PASS"
-            report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does have Public Access Block enabled."
+            report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of buckets {', '.join(mr_access_point.buckets)} does have Public Access Block enabled."
 
             if not (
                 mr_access_point.public_access_block.block_public_acls
@@ -32,7 +32,7 @@ class s3_multi_region_access_point_public_access_block(Check):
                 and mr_access_point.public_access_block.restrict_public_buckets
             ):
                 report.status = "FAIL"
-                report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does not have Public Access Block enabled."
+                report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of buckets {', '.join(mr_access_point.buckets)} does not have Public Access Block enabled."
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
+++ b/prowler/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block.py
@@ -3,15 +3,27 @@ from prowler.providers.aws.services.s3.s3control_client import s3control_client
 
 
 class s3_multi_region_access_point_public_access_block(Check):
+    """Ensure that Multi Region Access Points have Public Access Block enabled.
+
+    This check is useful to ensure that Multi Region Access Points have Public Access Block enabled.
+    """
+
     def execute(self):
+        """Execute the Multi Region Access Points have Public Access Block enabled check.
+
+        Iterates over all Multi Region Access Points and checks if they have Public Access Block enabled.
+
+        Returns:
+            List[Check_Report_AWS]: A list of reports for each Multi Region Access Point.
+        """
         findings = []
-        for arn, mr_access_point in s3control_client.multi_region_access_points.keys():
+        for mr_access_point in s3control_client.multi_region_access_points.values():
             report = Check_Report_AWS(self.metadata())
             report.region = mr_access_point.region
             report.resource_id = mr_access_point.name
             report.resource_arn = mr_access_point.arn
             report.status = "PASS"
-            report.status_extended = f"Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does have Public Access Block enabled."
+            report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does have Public Access Block enabled."
 
             if not (
                 mr_access_point.public_access_block.block_public_acls
@@ -20,7 +32,7 @@ class s3_multi_region_access_point_public_access_block(Check):
                 and mr_access_point.public_access_block.restrict_public_buckets
             ):
                 report.status = "FAIL"
-                report.status_extended = f"Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does not have Public Access Block enabled."
+                report.status_extended = f"S3 Multi Region Access Point {mr_access_point.name} of bucket {mr_access_point.bucket} does not have Public Access Block enabled."
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -543,7 +543,7 @@ class S3Control(AWSService):
                     account_id=self.audited_account,
                     name=mr_access_point["Name"],
                     bucket=mr_access_point["Bucket"],
-                    region="us-east-1",
+                    region=self.region,
                     public_access_block=PublicAccessBlock(
                         block_public_acls=mr_access_point.get(
                             "PublicAccessBlockConfiguration", {}
@@ -562,15 +562,15 @@ class S3Control(AWSService):
         except ClientError as error:
             if error.response["Error"]["Code"] == "NoSuchMultiRegionAccessPoint":
                 logger.warning(
-                    f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
                 logger.error(
-                    f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             logger.error(
-                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
     def _get_access_point(self, ap):

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -514,15 +514,6 @@ class S3Control(AWSService):
                     bucket=ap["Bucket"],
                     region=regional_client.region,
                 )
-        except ClientError as error:
-            if error.response["Error"]["Code"] == "NoSuchMultiRegionAccessPoint":
-                logger.warning(
-                    f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                )
-            else:
-                logger.error(
-                    f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                )
         except Exception as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -537,7 +528,7 @@ class S3Control(AWSService):
                 )["AccessPoints"]
             )
             for mr_access_point in list_multi_region_access_points:
-                mr_ap_arn = f"arn:{self.audited_partition}:s3:{self.audited_account}:accesspoint/{mr_access_point['Name']}"
+                mr_ap_arn = f"arn:{self.audited_partition}:s3::{self.audited_account}:accesspoint/{mr_access_point['Name']}"
                 self.multi_region_access_points[mr_ap_arn] = AccessPoint(
                     arn=mr_ap_arn,
                     account_id=self.audited_account,
@@ -558,15 +549,6 @@ class S3Control(AWSService):
                             "PublicAccessBlockConfiguration", {}
                         ).get("RestrictPublicBuckets", False),
                     ),
-                )
-        except ClientError as error:
-            if error.response["Error"]["Code"] == "NoSuchMultiRegionAccessPoint":
-                logger.warning(
-                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                )
-            else:
-                logger.error(
-                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -473,7 +473,10 @@ class S3Control(AWSService):
         self.multi_region_access_points = {}
         self.__threading_call__(self._list_access_points)
         self.__threading_call__(self._get_access_point, self.access_points.values())
-        self._list_multi_region_access_points()
+        if self.audited_partition == "aws":
+            self.region = "us-west-2"
+            self.client = self.session.client(self.service, self.region)
+            self._list_multi_region_access_points()
 
     def _get_public_access_block(self):
         logger.info("S3 - Get account public access block...")

--- a/tests/providers/aws/services/s3/s3_access_point_public_access_block/s3_access_point_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_access_point_public_access_block/s3_access_point_public_access_block_test.py
@@ -74,6 +74,7 @@ class Test_s3_access_point_public_access_block:
             s3control_client = mock.MagicMock()
             s3control_client.access_points = {
                 arn_us: AccessPoint(
+                    arn=arn_us,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_us,
                     bucket=bucket_name_us,
@@ -86,6 +87,7 @@ class Test_s3_access_point_public_access_block:
                     ),
                 ),
                 arn_eu: AccessPoint(
+                    arn=arn_eu,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_eu,
                     bucket=bucket_name_eu,
@@ -165,6 +167,7 @@ class Test_s3_access_point_public_access_block:
             s3control_client = mock.MagicMock()
             s3control_client.access_points = {
                 arn_us: AccessPoint(
+                    arn=arn_us,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_us,
                     bucket=bucket_name_us,
@@ -177,6 +180,7 @@ class Test_s3_access_point_public_access_block:
                     ),
                 ),
                 arn_eu: AccessPoint(
+                    arn=arn_eu,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_eu,
                     bucket=bucket_name_eu,
@@ -256,6 +260,7 @@ class Test_s3_access_point_public_access_block:
             s3control_client = mock.MagicMock()
             s3control_client.access_points = {
                 arn_us: AccessPoint(
+                    arn=arn_us,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_us,
                     bucket=bucket_name_us,
@@ -268,6 +273,7 @@ class Test_s3_access_point_public_access_block:
                     ),
                 ),
                 arn_eu: AccessPoint(
+                    arn=arn_eu,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_eu,
                     bucket=bucket_name_eu,
@@ -346,6 +352,7 @@ class Test_s3_access_point_public_access_block:
             s3control_client = mock.MagicMock()
             s3control_client.access_points = {
                 arn_us: AccessPoint(
+                    arn=arn_us,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_us,
                     bucket="bucket-us",
@@ -358,6 +365,7 @@ class Test_s3_access_point_public_access_block:
                     ),
                 ),
                 arn_eu: AccessPoint(
+                    arn=arn_eu,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_eu,
                     bucket="bucket-eu",
@@ -370,6 +378,7 @@ class Test_s3_access_point_public_access_block:
                     ),
                 ),
                 arn_ap: AccessPoint(
+                    arn=arn_ap,
                     account_id=AWS_ACCOUNT_NUMBER,
                     name=ap_name_ap,
                     bucket="bucket-ap",

--- a/tests/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block_test.py
@@ -1,0 +1,212 @@
+from unittest import mock
+from unittest.mock import patch
+
+import botocore
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+MRAP_NAME = "test-mrap"
+BUCKET_NAME = "test-bucket"
+
+# Original botocore _make_api_call function
+orig = botocore.client.BaseClient._make_api_call
+
+
+# Mocked botocore _make_api_call function
+def mock_make_api_call_pab_enabled(self, operation_name, kwarg):
+    if operation_name == "ListMultiRegionAccessPoints":
+        return {
+            "AccessPoints": [
+                {
+                    "Name": MRAP_NAME,
+                    "Bucket": BUCKET_NAME,
+                    "NetworkOrigin": "Internet",
+                    "PublicAccessBlockConfiguration": {
+                        "BlockPublicAcls": True,
+                        "IgnorePublicAcls": True,
+                        "BlockPublicPolicy": True,
+                        "RestrictPublicBuckets": True,
+                    },
+                }
+            ]
+        }
+    # If we don't want to patch the API call
+    return orig(self, operation_name, kwarg)
+
+
+def mock_make_api_call_pab_disabled(self, operation_name, kwarg):
+    if operation_name == "ListMultiRegionAccessPoints":
+        return {
+            "AccessPoints": [
+                {
+                    "Name": MRAP_NAME,
+                    "Bucket": BUCKET_NAME,
+                    "NetworkOrigin": "Internet",
+                    "PublicAccessBlockConfiguration": {
+                        "BlockPublicAcls": False,
+                        "IgnorePublicAcls": False,
+                        "BlockPublicPolicy": False,
+                        "RestrictPublicBuckets": False,
+                    },
+                }
+            ]
+        }
+    # If we don't want to patch the API call
+    return orig(self, operation_name, kwarg)
+
+
+def mock_make_api_call_pab_one_disabled(self, operation_name, kwarg):
+    if operation_name == "ListMultiRegionAccessPoints":
+        return {
+            "AccessPoints": [
+                {
+                    "Name": MRAP_NAME,
+                    "Bucket": BUCKET_NAME,
+                    "NetworkOrigin": "Internet",
+                    "PublicAccessBlockConfiguration": {
+                        "BlockPublicAcls": False,
+                        "IgnorePublicAcls": True,
+                        "BlockPublicPolicy": True,
+                        "RestrictPublicBuckets": True,
+                    },
+                }
+            ]
+        }
+    # If we don't want to patch the API call
+    return orig(self, operation_name, kwarg)
+
+
+class Test_s3_multi_region_access_point_public_access_block:
+    @mock_aws
+    def test_no_multi_region_access_points(self):
+        from prowler.providers.aws.services.s3.s3_service import S3Control
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block.s3control_client",
+                new=S3Control(aws_provider),
+            ):
+                from prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block import (
+                    s3_multi_region_access_point_public_access_block,
+                )
+
+                check = s3_multi_region_access_point_public_access_block()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @patch(
+        "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_pab_enabled
+    )
+    def test_multi_region_access_points_with_public_access_block(self):
+        from prowler.providers.aws.services.s3.s3_service import S3Control
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block.s3control_client",
+                new=S3Control(aws_provider),
+            ):
+                from prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block import (
+                    s3_multi_region_access_point_public_access_block,
+                )
+
+                check = s3_multi_region_access_point_public_access_block()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Multi Region Access Point {MRAP_NAME} of bucket {BUCKET_NAME} does have Public Access Block enabled."
+                )
+                assert result[0].resource_id == MRAP_NAME
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:s3:{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
+                )
+
+    @patch(
+        "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_pab_disabled
+    )
+    def test_multi_region_access_points_without_public_access_block(self):
+        from prowler.providers.aws.services.s3.s3_service import S3Control
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block.s3control_client",
+                new=S3Control(aws_provider),
+            ):
+                from prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block import (
+                    s3_multi_region_access_point_public_access_block,
+                )
+
+                check = s3_multi_region_access_point_public_access_block()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Multi Region Access Point {MRAP_NAME} of bucket {BUCKET_NAME} does not have Public Access Block enabled."
+                )
+                assert result[0].resource_id == MRAP_NAME
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:s3:{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
+                )
+
+    @patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_make_api_call_pab_one_disabled,
+    )
+    def test_multi_region_access_points_without_one_public_access_block(self):
+        from prowler.providers.aws.services.s3.s3_service import S3Control
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block.s3control_client",
+                new=S3Control(aws_provider),
+            ):
+                from prowler.providers.aws.services.s3.s3_multi_region_access_point_public_access_block.s3_multi_region_access_point_public_access_block import (
+                    s3_multi_region_access_point_public_access_block,
+                )
+
+                check = s3_multi_region_access_point_public_access_block()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Multi Region Access Point {MRAP_NAME} of bucket {BUCKET_NAME} does not have Public Access Block enabled."
+                )
+                assert result[0].resource_id == MRAP_NAME
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:s3:{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
+                )

--- a/tests/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block_test.py
@@ -30,7 +30,7 @@ def mock_make_api_call_pab_enabled(self, operation_name, kwarg):
                             "Region": "us-west-2",
                         }
                     ],
-                    "PublicAccessBlockConfiguration": {
+                    "PublicAccessBlock": {
                         "BlockPublicAcls": True,
                         "IgnorePublicAcls": True,
                         "BlockPublicPolicy": True,
@@ -55,7 +55,7 @@ def mock_make_api_call_pab_disabled(self, operation_name, kwarg):
                             "Region": "us-west-2",
                         }
                     ],
-                    "PublicAccessBlockConfiguration": {
+                    "PublicAccessBlock": {
                         "BlockPublicAcls": False,
                         "IgnorePublicAcls": False,
                         "BlockPublicPolicy": False,
@@ -80,7 +80,7 @@ def mock_make_api_call_pab_one_disabled(self, operation_name, kwarg):
                             "Region": "us-west-2",
                         }
                     ],
-                    "PublicAccessBlockConfiguration": {
+                    "PublicAccessBlock": {
                         "BlockPublicAcls": False,
                         "IgnorePublicAcls": True,
                         "BlockPublicPolicy": True,

--- a/tests/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block_test.py
+++ b/tests/providers/aws/services/s3/s3_multi_region_access_point_public_access_block/s3_multi_region_access_point_public_access_block_test.py
@@ -6,7 +6,7 @@ from moto import mock_aws
 
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
-    AWS_REGION_US_EAST_1,
+    AWS_REGION_US_WEST_2,
     set_mocked_aws_provider,
 )
 
@@ -24,8 +24,12 @@ def mock_make_api_call_pab_enabled(self, operation_name, kwarg):
             "AccessPoints": [
                 {
                     "Name": MRAP_NAME,
-                    "Bucket": BUCKET_NAME,
-                    "NetworkOrigin": "Internet",
+                    "Regions": [
+                        {
+                            "Bucket": BUCKET_NAME,
+                            "Region": "us-west-2",
+                        }
+                    ],
                     "PublicAccessBlockConfiguration": {
                         "BlockPublicAcls": True,
                         "IgnorePublicAcls": True,
@@ -45,8 +49,12 @@ def mock_make_api_call_pab_disabled(self, operation_name, kwarg):
             "AccessPoints": [
                 {
                     "Name": MRAP_NAME,
-                    "Bucket": BUCKET_NAME,
-                    "NetworkOrigin": "Internet",
+                    "Regions": [
+                        {
+                            "Bucket": BUCKET_NAME,
+                            "Region": "us-west-2",
+                        }
+                    ],
                     "PublicAccessBlockConfiguration": {
                         "BlockPublicAcls": False,
                         "IgnorePublicAcls": False,
@@ -66,8 +74,12 @@ def mock_make_api_call_pab_one_disabled(self, operation_name, kwarg):
             "AccessPoints": [
                 {
                     "Name": MRAP_NAME,
-                    "Bucket": BUCKET_NAME,
-                    "NetworkOrigin": "Internet",
+                    "Regions": [
+                        {
+                            "Bucket": BUCKET_NAME,
+                            "Region": "us-west-2",
+                        }
+                    ],
                     "PublicAccessBlockConfiguration": {
                         "BlockPublicAcls": False,
                         "IgnorePublicAcls": True,
@@ -86,7 +98,7 @@ class Test_s3_multi_region_access_point_public_access_block:
     def test_no_multi_region_access_points(self):
         from prowler.providers.aws.services.s3.s3_service import S3Control
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -111,7 +123,7 @@ class Test_s3_multi_region_access_point_public_access_block:
     def test_multi_region_access_points_with_public_access_block(self):
         from prowler.providers.aws.services.s3.s3_service import S3Control
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -132,12 +144,12 @@ class Test_s3_multi_region_access_point_public_access_block:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == f"S3 Multi Region Access Point {MRAP_NAME} of bucket {BUCKET_NAME} does have Public Access Block enabled."
+                    == f"S3 Multi Region Access Point {MRAP_NAME} of buckets {BUCKET_NAME} does have Public Access Block enabled."
                 )
                 assert result[0].resource_id == MRAP_NAME
                 assert (
                     result[0].resource_arn
-                    == f"arn:{aws_provider.identity.partition}:s3:{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
+                    == f"arn:{aws_provider.identity.partition}:s3::{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
                 )
 
     @patch(
@@ -146,7 +158,7 @@ class Test_s3_multi_region_access_point_public_access_block:
     def test_multi_region_access_points_without_public_access_block(self):
         from prowler.providers.aws.services.s3.s3_service import S3Control
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -167,12 +179,12 @@ class Test_s3_multi_region_access_point_public_access_block:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Multi Region Access Point {MRAP_NAME} of bucket {BUCKET_NAME} does not have Public Access Block enabled."
+                    == f"S3 Multi Region Access Point {MRAP_NAME} of buckets {BUCKET_NAME} does not have Public Access Block enabled."
                 )
                 assert result[0].resource_id == MRAP_NAME
                 assert (
                     result[0].resource_arn
-                    == f"arn:{aws_provider.identity.partition}:s3:{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
+                    == f"arn:{aws_provider.identity.partition}:s3::{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
                 )
 
     @patch(
@@ -182,7 +194,7 @@ class Test_s3_multi_region_access_point_public_access_block:
     def test_multi_region_access_points_without_one_public_access_block(self):
         from prowler.providers.aws.services.s3.s3_service import S3Control
 
-        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -203,10 +215,10 @@ class Test_s3_multi_region_access_point_public_access_block:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"S3 Multi Region Access Point {MRAP_NAME} of bucket {BUCKET_NAME} does not have Public Access Block enabled."
+                    == f"S3 Multi Region Access Point {MRAP_NAME} of buckets {BUCKET_NAME} does not have Public Access Block enabled."
                 )
                 assert result[0].resource_id == MRAP_NAME
                 assert (
                     result[0].resource_arn
-                    == f"arn:{aws_provider.identity.partition}:s3:{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
+                    == f"arn:{aws_provider.identity.partition}:s3::{AWS_ACCOUNT_NUMBER}:accesspoint/{MRAP_NAME}"
                 )


### PR DESCRIPTION
### Context

Amazon `S3 Multi-Region Access Points` facilitate data access across multiple `AWS regions` for globally distributed applications. By enabling `Block Public Access` settings for these `Access Points`, AWS helps prevent unauthorized public access to the data stored in `S3 buckets`. Without these settings, resources could be inadvertently exposed to the public internet, increasing risks of data breaches and unauthorized access.

### Description

This check ensures that `S3 Multi-Region Access Points` have `Block Public Access` settings enabled. If these settings are disabled, the check fails, indicating potential public exposure of data.

### Checklist

- Are there new checks included in this PR? Yes.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
