### PR TITLE
feat(wafv2): set `us-east-1` region for `global acls`

### DIFF
--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -14,7 +14,11 @@ class WAFv2(AWSService):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
         self.web_acls = {}
-        self._list_web_acls_global()
+        if self.audited_partition == "aws":
+            # AWS WAFv2 is available globally for CloudFront distributions, but you must use the Region US East (N. Virginia) to create your web ACL.
+            self.region = "us-east-1"
+            self.client = self.session.client(self.service, self.region)
+            self._list_web_acls_global()
         self.__threading_call__(self._list_web_acls_regional)
         self.__threading_call__(self._get_web_acl, self.web_acls.values())
         self.__threading_call__(

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -29,29 +29,25 @@ class WAFv2(AWSService):
 
     def _list_web_acls_global(self):
         logger.info("WAFv2 - Listing Global Web ACLs...")
-        if "us-east-1" in self.regional_clients:
-            try:
-                regional_client = self.regional_clients["us-east-1"]
-                for wafv2 in regional_client.list_web_acls(Scope="CLOUDFRONT")[
-                    "WebACLs"
-                ]:
-                    if not self.audit_resources or (
-                        is_resource_filtered(wafv2["ARN"], self.audit_resources)
-                    ):
-                        arn = wafv2["ARN"]
-                        self.web_acls[arn] = WebAclv2(
-                            arn=arn,
-                            name=wafv2["Name"],
-                            id=wafv2["Id"],
-                            albs=[],
-                            user_pools=[],
-                            scope=Scope.CLOUDFRONT,
-                            region="us-east-1",
-                        )
-            except Exception as error:
-                logger.error(
-                    f"us-east-1 -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                )
+        try:
+            for wafv2 in self.client.list_web_acls(Scope="CLOUDFRONT")["WebACLs"]:
+                if not self.audit_resources or (
+                    is_resource_filtered(wafv2["ARN"], self.audit_resources)
+                ):
+                    arn = wafv2["ARN"]
+                    self.web_acls[arn] = WebAclv2(
+                        arn=arn,
+                        name=wafv2["Name"],
+                        id=wafv2["Id"],
+                        albs=[],
+                        user_pools=[],
+                        scope=Scope.CLOUDFRONT,
+                        region=self.region,
+                    )
+        except Exception as error:
+            logger.error(
+                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
 
     def _list_web_acls_regional(self, regional_client):
         logger.info("WAFv2 - Listing Regional Web ACLs...")


### PR DESCRIPTION
### Context

Global resources need to have a region, and we should give them one, that will be `us-east-1`.

### Description

Added a explicit `region` and `client` for `global ACLs`, set to `us-east-1`.

### Checklist

- Are there new checks included in this PR? No.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
