### PR TITLE
fix(aws): findings in IAM policies were not reported

### DIFF
--- a/prowler/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges.py
@@ -20,6 +20,5 @@ class iam_aws_attached_policy_no_administrative_privileges(Check):
                     if check_admin_access(policy.document):
                         report.status = "FAIL"
                         report.status_extended = f"{policy.type} policy {policy.name} is attached and allows '*:*' administrative privileges."
-                        break
                 findings.append(report)
         return findings

--- a/prowler/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges.py
@@ -20,6 +20,5 @@ class iam_customer_attached_policy_no_administrative_privileges(Check):
                     if check_admin_access(policy.document):
                         report.status = "FAIL"
                         report.status_extended = f"{policy.type} policy {policy.name} is attached and allows '*:*' administrative privileges."
-                        break
                 findings.append(report)
         return findings

--- a/prowler/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges.py
@@ -20,6 +20,5 @@ class iam_customer_unattached_policy_no_administrative_privileges(Check):
                     if check_admin_access(policy.document):
                         report.status = "FAIL"
                         report.status_extended = f"{policy.type} policy {policy.name} is unattached and allows '*:*' administrative privileges."
-                        break
                 findings.append(report)
         return findings

--- a/tests/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges_test.py
@@ -34,6 +34,7 @@ class Test_iam_aws_attached_policy_no_administrative_privileges_test:
 
             check = iam_aws_attached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 1, f"Expected 1 result, but got {len(results)}"
             for result in results:
                 if result.resource_id == "AdministratorAccess":
                     assert result.status == "FAIL"
@@ -73,6 +74,7 @@ class Test_iam_aws_attached_policy_no_administrative_privileges_test:
 
             check = iam_aws_attached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 1, f"Expected 1 result, but got {len(results)}"
             for result in results:
                 if result.resource_id == "IAMUserChangePassword":
                     assert result.status == "PASS"
@@ -115,6 +117,7 @@ class Test_iam_aws_attached_policy_no_administrative_privileges_test:
 
             check = iam_aws_attached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 2, f"Expected 2 results, but got {len(results)}"
             for result in results:
                 if result.resource_id == "IAMUserChangePassword":
                     assert result.status == "PASS"

--- a/tests/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges_test.py
@@ -42,6 +42,7 @@ class Test_iam_customer_attached_policy_no_administrative_privileges_test:
 
             check = iam_customer_attached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 1, f"Expected 1 result, but got {len(results)}"
             for result in results:
                 if result.resource_id == "policy1":
                     assert result.status == "FAIL"
@@ -84,6 +85,7 @@ class Test_iam_customer_attached_policy_no_administrative_privileges_test:
 
             check = iam_customer_attached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 1, f"Expected 1 result, but got {len(results)}"
             for result in results:
                 if result.resource_id == "policy1":
                     assert result.status == "PASS"
@@ -141,6 +143,7 @@ class Test_iam_customer_attached_policy_no_administrative_privileges_test:
 
             check = iam_customer_attached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 2, f"Expected 2 results, but got {len(results)}"
             for result in results:
                 if result.resource_id == "policy1":
                     assert result.status == "PASS"

--- a/tests/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges_test.py
@@ -39,6 +39,7 @@ class Test_iam_customer_unattached_policy_no_administrative_privileges_test:
 
             check = iam_customer_unattached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 1, f"Expected 1 result, but got {len(results)}"
             for result in results:
                 if result.resource_id == "policy1":
                     assert result.status == "FAIL"
@@ -78,6 +79,7 @@ class Test_iam_customer_unattached_policy_no_administrative_privileges_test:
 
             check = iam_customer_unattached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 1, f"Expected 1 result, but got {len(results)}"
             for result in results:
                 if result.resource_id == "policy1":
                     assert result.status == "PASS"
@@ -129,6 +131,7 @@ class Test_iam_customer_unattached_policy_no_administrative_privileges_test:
 
             check = iam_customer_unattached_policy_no_administrative_privileges()
             results = check.execute()
+            assert len(results) == 2, f"Expected 2 results, but got {len(results)}"
             for result in results:
                 if result.resource_id == "policy1":
                     assert result.status == "PASS"


### PR DESCRIPTION
### Context

The refactoring done in PR #5035 introduced a bug so that findings in IAM policies were not reported anymore. Furthermore, the corresponding unit tests did not cover theses cases.
These bugs were first released in prowler v4.4.0 and are still present.

### Description

The bug consists of a wrong `break` statement which ends the loop as soon as the first finding was found. All the following IAM policies were wrongly disregarded.
Furthermore, the report is not added to the findings because this is done within the `for` loop which the `break` statement left already.
I fixed this by removing the `break` statement. 
I also added code to the unit tests to cover these cases.

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
