### PR TITLE
feat(s3): add new check `s3_bucket_event_notifications_enabled`

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_cross_region_replication/s3_bucket_cross_region_replication.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_cross_region_replication/s3_bucket_cross_region_replication.metadata.json
@@ -21,7 +21,7 @@
       "Terraform": "https://docs.prowler.com/checks/aws/general-policies/ensure-that-s3-bucket-has-cross-region-replication-enabled#terraform"
     },
     "Recommendation": {
-      "Text": "Ensure that S3 buckets have corss region replication.",
+      "Text": "Ensure that S3 buckets have cross region replication.",
       "Url": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-walkthrough1.html"
     }
   },

--- a/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.metadata.json
@@ -1,0 +1,32 @@
+{
+  "Provider": "aws",
+  "CheckID": "s3_bucket_event_notifications_enabled",
+  "CheckTitle": "Check if S3 buckets have event notifications enabled.",
+  "CheckType": [
+    "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
+  ],
+  "ServiceName": "s3",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:s3:::bucket_name",
+  "Severity": "medium",
+  "ResourceType": "AwsS3Bucket",
+  "Description": "Ensure whether S3 buckets have event notifications enabled.",
+  "Risk": "Without event notifications, important actions on S3 buckets may go unnoticed, leading to missed opportunities for timely response to critical changes, such as object creation, deletion, or updates that could impact data security and availability.",
+  "RelatedUrl": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-11",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable event notifications for all S3 general-purpose buckets to monitor important events such as object creation, deletion, tagging, and lifecycle events, ensuring visibility and quick action on relevant changes.",
+      "Url": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventNotifications.html"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.py
@@ -1,0 +1,30 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.s3.s3_client import s3_client
+
+
+class s3_bucket_event_notifications_enabled(Check):
+    def execute(self):
+        findings = []
+        for arn, bucket in s3_client.buckets.items():
+            report = Check_Report_AWS(self.metadata())
+            report.region = bucket.region
+            report.resource_id = bucket.name
+            report.resource_arn = arn
+            report.resource_tags = bucket.tags
+            report.status = "FAIL"
+            report.status_extended = (
+                f"S3 Bucket {bucket.name} does not have event notifications enabled."
+            )
+
+            logger.error("NOTIFICATION CONFIG:")
+            logger.error(bucket.notification_config)
+            if bucket.notification_config:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"S3 Bucket {bucket.name} does have event notifications enabled."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.py
@@ -4,7 +4,19 @@ from prowler.providers.aws.services.s3.s3_client import s3_client
 
 
 class s3_bucket_event_notifications_enabled(Check):
-    def execute(self):
+    """Ensure S3 Buckets have event notifications enabled
+
+    This check will return a FAIL if the S3 Bucket does not have event notifications enabled.
+    """
+
+    def execute(self) -> list[Check_Report_AWS]:
+        """Execute the s3_bucket_event_notifications_enabled check
+
+        Iterates over all S3 Buckets and checks if they have event notifications enabled.
+
+        Returns:
+            list[Check_Report_AWS]: List of Check_Report_AWS objects
+        """
         findings = []
         for arn, bucket in s3_client.buckets.items():
             report = Check_Report_AWS(self.metadata())

--- a/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled.py
@@ -1,5 +1,4 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
-from prowler.lib.logger import logger
 from prowler.providers.aws.services.s3.s3_client import s3_client
 
 
@@ -29,8 +28,6 @@ class s3_bucket_event_notifications_enabled(Check):
                 f"S3 Bucket {bucket.name} does not have event notifications enabled."
             )
 
-            logger.error("NOTIFICATION CONFIG:")
-            logger.error(bucket.notification_config)
             if bucket.notification_config:
                 report.status = "PASS"
                 report.status_extended = (

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -454,7 +454,6 @@ class S3(AWSService):
                     Bucket=bucket.name
                 )
             )
-            print(bucket_notification_config)
 
             if any(
                 key in bucket_notification_config
@@ -462,6 +461,7 @@ class S3(AWSService):
                     "TopicConfigurations",
                     "QueueConfigurations",
                     "LambdaFunctionConfigurations",
+                    "EventBridgeConfiguration",
                 )
             ):
                 bucket.notification_config = bucket_notification_config

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -469,9 +469,7 @@ class S3(AWSService):
                 bucket.notification_config = {}
 
         except ClientError as error:
-            if error.response["Error"]["Code"] == "NoSuchNotificationConfiguration":
-                bucket.notification_config = {}
-            elif error.response["Error"]["Code"] == "NoSuchBucket":
+            if error.response["Error"]["Code"] == "NoSuchBucket":
                 logger.warning(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -454,6 +454,7 @@ class S3(AWSService):
                     Bucket=bucket.name
                 )
             )
+            print(bucket_notification_config)
 
             if any(
                 key in bucket_notification_config
@@ -465,7 +466,7 @@ class S3(AWSService):
             ):
                 bucket.notification_config = bucket_notification_config
             else:
-                bucket.notification_config = {}  # No hay notificaciones configuradas
+                bucket.notification_config = {}
 
         except ClientError as error:
             if error.response["Error"]["Code"] == "NoSuchNotificationConfiguration":
@@ -474,6 +475,14 @@ class S3(AWSService):
                 logger.warning(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
+            else:
+                logger.error(
+                    f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
 
     def _head_bucket(self, bucket_name):
         logger.info("S3 - Checking if bucket exists...")

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -1,8 +1,8 @@
 import json
-from typing import Optional
+from typing import Dict, List, Optional
 
 from botocore.client import ClientError
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from prowler.lib.logger import logger
 from prowler.lib.scan_filters.scan_filters import is_resource_filtered
@@ -623,15 +623,15 @@ class Bucket(BaseModel):
     versioning: bool = False
     logging: bool = False
     public_access_block: Optional[PublicAccessBlock]
-    acl_grantees: list[ACL_Grantee] = []
-    policy: dict = {}
+    acl_grantees: List[ACL_Grantee] = Field(default_factory=list)
+    policy: Dict = Field(default_factory=dict)
     encryption: Optional[str]
     region: str
     logging_target_bucket: Optional[str]
     ownership: Optional[str]
     object_lock: bool = False
     mfa_delete: bool = False
-    tags: Optional[list] = []
-    lifecycle: Optional[list[LifeCycleRule]] = []
-    replication_rules: Optional[list[ReplicationRule]] = []
-    notification_config: Optional[dict] = {}
+    tags: List[Dict[str, str]] = Field(default_factory=list)
+    lifecycle: List[LifeCycleRule] = Field(default_factory=list)
+    replication_rules: List[ReplicationRule] = Field(default_factory=list)
+    notification_config: Dict = Field(default_factory=dict)

--- a/tests/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_event_notifications_enabled/s3_bucket_event_notifications_enabled_test.py
@@ -1,0 +1,143 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+
+class Test_s3_bucket_event_notifications_enabled:
+    # No Buckets
+    @mock_aws
+    def test_no_buckets(self):
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_event_notifications_enabled.s3_bucket_event_notifications_enabled.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.s3.s3_bucket_event_notifications_enabled.s3_bucket_event_notifications_enabled import (
+                    s3_bucket_event_notifications_enabled,
+                )
+
+                check = s3_bucket_event_notifications_enabled()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_bucket_event_notifications_disabled(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "test-bucket"
+        s3_client.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_event_notifications_enabled.s3_bucket_event_notifications_enabled.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.s3.s3_bucket_event_notifications_enabled.s3_bucket_event_notifications_enabled import (
+                    s3_bucket_event_notifications_enabled,
+                )
+
+                check = s3_bucket_event_notifications_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+
+                # US-EAST-1 Source Bucket
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} does not have event notifications enabled."
+                )
+                assert result[0].resource_id == bucket_name
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:s3:::{bucket_name}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bucket_event_notifications_enabled(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name = "test-bucket"
+        s3_client.create_bucket(
+            Bucket=bucket_name, ObjectOwnership="BucketOwnerEnforced"
+        )
+
+        s3_client.put_bucket_notification_configuration(
+            Bucket=bucket_name,
+            NotificationConfiguration={
+                "LambdaFunctionConfigurations": [
+                    {
+                        "LambdaFunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+                        "Events": ["s3:ObjectCreated:*"],
+                    }
+                ],
+                "QueueConfigurations": [
+                    {
+                        "QueueArn": "arn:aws:sqs:us-east-1:123456789012:my-queue",
+                        "Events": ["s3:ObjectCreated:*"],
+                    }
+                ],
+                "TopicConfigurations": [
+                    {
+                        "TopicArn": "arn:aws:sns:us-east-1:123456789012:my-topic",
+                        "Events": ["s3:ObjectCreated:*"],
+                    }
+                ],
+            },
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_event_notifications_enabled.s3_bucket_event_notifications_enabled.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.s3.s3_bucket_event_notifications_enabled.s3_bucket_event_notifications_enabled import (
+                    s3_bucket_event_notifications_enabled,
+                )
+
+                check = s3_bucket_event_notifications_enabled()
+                result = check.execute()
+
+                assert len(result) == 1
+
+                # US-EAST-1 Source Bucket
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"S3 Bucket {bucket_name} does have event notifications enabled."
+                )
+                assert result[0].resource_id == bucket_name
+                assert (
+                    result[0].resource_arn
+                    == f"arn:{aws_provider.identity.partition}:s3:::{bucket_name}"
+                )
+                assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

`Amazon S3 Event Notifications` provide a way to receive alerts when specific actions occur within `S3 buckets`, helping monitor bucket activity. These notifications support various AWS services (like `Lambda`, `SNS` or `SQS`), alerting on events like object creation, deletion, or modification. Enabling event notifications is a proactive measure that supports visibility and response to potential security events in real-time.

### Description

This check ensures that `S3 Event Notifications` are enabled for `Amazon S3 general-purpose buckets`. The check fails if no event notifications are set, indicating a lack of real-time monitoring for bucket events.

### Checklist

- Are there new checks included in this PR? Yes.
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
