### PR TITLE
feat(mutelist): add mute_finding method

### DIFF
--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -12,7 +12,7 @@ from prowler.config.config import (
     default_output_directory,
 )
 from prowler.lib.check.models import Severity
-from prowler.lib.outputs.finding import Status
+from prowler.lib.outputs.common import Status
 from prowler.providers.common.arguments import (
     init_providers_parser,
     validate_provider_arguments,

--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -5,6 +5,7 @@ import yaml
 
 from prowler.lib.logger import logger
 from prowler.lib.mutelist.models import mutelist_schema
+from prowler.lib.outputs.utils import unroll_dict, unroll_tags
 
 
 class Mutelist(ABC):
@@ -237,7 +238,7 @@ class Mutelist(ABC):
             )
             return False
 
-    def mute_finding(self, finding: Finding) -> Finding:
+    def mute_finding(self, finding):
         """
         Check if the provided finding is muted
 
@@ -254,14 +255,13 @@ class Mutelist(ABC):
                 finding.metadata.CheckID,
                 finding.region,
                 finding.resource_id,
-                finding.resource_tags,
+                unroll_dict(unroll_tags(finding.resource_tags)),
             )
 
             if is_finding_muted:
-                finding.raw = finding.status
+                finding.raw["status"] = finding.status
                 finding.status = "MUTED"
                 finding.muted = True
-
             return finding
         except Exception as error:
             logger.error(

--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -237,6 +237,38 @@ class Mutelist(ABC):
             )
             return False
 
+    def mute_finding(self, finding: Finding) -> Finding:
+        """
+        Check if the provided finding is muted
+
+        Args:
+            finding (Finding): The finding to be evaluated for muting.
+
+        Returns:
+            Finding: The finding with the status updated if it is muted, otherwise the finding is returned
+
+        """
+        try:
+            is_finding_muted = self.is_muted(
+                finding.account_uid,
+                finding.metadata.CheckID,
+                finding.region,
+                finding.resource_id,
+                finding.resource_tags,
+            )
+
+            if is_finding_muted:
+                finding.raw = finding.status
+                finding.status = "MUTED"
+                finding.muted = True
+
+            return finding
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
+            )
+            return False
+
     def is_excepted(
         self,
         exceptions,

--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -5,6 +5,7 @@ import yaml
 
 from prowler.lib.logger import logger
 from prowler.lib.mutelist.models import mutelist_schema
+from prowler.lib.outputs.common import Status
 from prowler.lib.outputs.utils import unroll_dict, unroll_tags
 
 
@@ -250,24 +251,22 @@ class Mutelist(ABC):
 
         """
         try:
-            is_finding_muted = self.is_muted(
+            if self.is_muted(
                 finding.account_uid,
                 finding.metadata.CheckID,
                 finding.region,
                 finding.resource_id,
                 unroll_dict(unroll_tags(finding.resource_tags)),
-            )
-
-            if is_finding_muted:
+            ):
                 finding.raw["status"] = finding.status
-                finding.status = "MUTED"
+                finding.status = Status.MUTED
                 finding.muted = True
             return finding
         except Exception as error:
             logger.error(
                 f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
             )
-            return False
+            return finding
 
     def is_excepted(
         self,

--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -255,7 +255,7 @@ class Mutelist(ABC):
                 finding.account_uid,
                 finding.metadata.CheckID,
                 finding.region,
-                finding.resource_id,
+                finding.resource_uid,
                 unroll_dict(unroll_tags(finding.resource_tags)),
             ):
                 finding.raw["status"] = finding.status

--- a/prowler/lib/outputs/common.py
+++ b/prowler/lib/outputs/common.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from prowler.config.config import timestamp
 from prowler.lib.outputs.utils import unroll_tags
 from prowler.lib.utils.utils import outputs_unix_timestamp
@@ -15,3 +17,10 @@ def fill_common_finding_data(finding: dict, unix_timestamp: bool) -> dict:
         "resource_tags": unroll_tags(finding.resource_tags),
     }
     return finding_data
+
+
+class Status(str, Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    MANUAL = "MANUAL"
+    MUTED = "MUTED"

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from enum import Enum
 from typing import Optional, Union
 
 from pydantic import BaseModel, Field
@@ -7,16 +6,10 @@ from pydantic import BaseModel, Field
 from prowler.config.config import prowler_version
 from prowler.lib.check.models import Check_Report, CheckMetadata
 from prowler.lib.logger import logger
-from prowler.lib.outputs.common import fill_common_finding_data
+from prowler.lib.outputs.common import Status, fill_common_finding_data
 from prowler.lib.outputs.compliance.compliance import get_check_compliance
 from prowler.lib.utils.utils import dict_to_lowercase, get_nested_attribute
 from prowler.providers.common.provider import Provider
-
-
-class Status(str, Enum):
-    PASS = "PASS"
-    FAIL = "FAIL"
-    MANUAL = "MANUAL"
 
 
 class Finding(BaseModel):

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -49,6 +49,7 @@ class Finding(BaseModel):
     region: str
     compliance: dict
     prowler_version: str = prowler_version
+    raw: dict = Field(default_factory=dict)
 
     @property
     def provider(self) -> str:
@@ -84,13 +85,6 @@ class Finding(BaseModel):
         Returns the service name from the finding check's metadata.
         """
         return self.metadata.ServiceName
-
-    @property
-    def raw(self) -> dict:
-        """
-        Returns the raw (dict) finding without any post-processing.
-        """
-        return {}
 
     def get_metadata(self) -> dict:
         """

--- a/prowler/lib/scan/scan.py
+++ b/prowler/lib/scan/scan.py
@@ -12,7 +12,8 @@ from prowler.lib.check.compliance import update_checks_metadata_with_compliance
 from prowler.lib.check.compliance_models import Compliance
 from prowler.lib.check.models import CheckMetadata, Severity
 from prowler.lib.logger import logger
-from prowler.lib.outputs.finding import Finding, Status
+from prowler.lib.outputs.common import Status
+from prowler.lib.outputs.finding import Finding
 from prowler.lib.scan.exceptions.exceptions import (
     ScanInvalidCategoryError,
     ScanInvalidCheckError,

--- a/tests/lib/outputs/finding_test.py
+++ b/tests/lib/outputs/finding_test.py
@@ -8,7 +8,8 @@ from prowler.lib.check.models import (
     Remediation,
     Severity,
 )
-from prowler.lib.outputs.finding import Finding, Status
+from prowler.lib.outputs.common import Status
+from prowler.lib.outputs.finding import Finding
 from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 
 

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -1871,16 +1871,6 @@ class TestAWSMutelist:
             resource_tags=[],
             muted=False,
         )
-        # finding_1 = MagicMock
-        # finding_1.metadata = MagicMock
-        # finding_1.metadata.CheckID = "check_test"
-        # finding_1.status = "FAIL"
-        # finding_1.region = AWS_REGION_US_EAST_1
-        # finding_1.account_uid = AWS_ACCOUNT_NUMBER
-        # finding_1.resource_id = "prowler"
-        # finding_1.resource_tags = []
-        # finding_1.muted = False
-        # finding_1.raw = {}
 
         muted_finding = mutelist.mute_finding(finding_1)
 

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -10,6 +10,7 @@ from moto import mock_aws
 
 from prowler.config.config import encoding_format_utf_8
 from prowler.providers.aws.lib.mutelist.mutelist import AWSMutelist
+from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 from tests.providers.aws.services.awslambda.awslambda_service_test import (
     create_zip_file,
 )
@@ -1862,16 +1863,24 @@ class TestAWSMutelist:
         mutelist = AWSMutelist(mutelist_content=mutelist_content)
 
         # Finding
-        finding_1 = MagicMock
-        finding_1.metadata = MagicMock
-        finding_1.metadata.CheckID = "check_test"
-        finding_1.status = "FAIL"
-        finding_1.region = AWS_REGION_US_EAST_1
-        finding_1.account_uid = AWS_ACCOUNT_NUMBER
-        finding_1.resource_id = "prowler"
-        finding_1.resource_tags = []
-        finding_1.muted = False
-        finding_1.raw = {}
+        finding_1 = generate_finding_output(
+            check_id="check_test",
+            status="FAIL",
+            region=AWS_REGION_US_EAST_1,
+            resource_uid="prowler",
+            resource_tags=[],
+            muted=False,
+        )
+        # finding_1 = MagicMock
+        # finding_1.metadata = MagicMock
+        # finding_1.metadata.CheckID = "check_test"
+        # finding_1.status = "FAIL"
+        # finding_1.region = AWS_REGION_US_EAST_1
+        # finding_1.account_uid = AWS_ACCOUNT_NUMBER
+        # finding_1.resource_id = "prowler"
+        # finding_1.resource_tags = []
+        # finding_1.muted = False
+        # finding_1.raw = {}
 
         muted_finding = mutelist.mute_finding(finding_1)
 

--- a/tests/providers/azure/lib/mutelist/azure_mutelist_test.py
+++ b/tests/providers/azure/lib/mutelist/azure_mutelist_test.py
@@ -2,6 +2,7 @@ import yaml
 from mock import MagicMock
 
 from prowler.providers.azure.lib.mutelist.mutelist import AzureMutelist
+from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 
 MUTELIST_FIXTURE_PATH = (
     "tests/providers/azure/lib/mutelist/fixtures/azure_mutelist.yaml"
@@ -84,18 +85,17 @@ class TestAzureMutelist:
 
         mutelist = AzureMutelist(mutelist_content=mutelist_content)
 
-        finding = MagicMock
-        finding.metadata = MagicMock
-        finding.metadata.CheckID = "check_test"
-        finding.region = "West Europe"
-        finding.status = "FAIL"
-        finding.resource_id = "test_resource"
-        finding.resource_tags = []
-        finding.account_uid = "subscription_1"
-        finding.muted = False
-        finding.raw = {}
+        finding_1 = generate_finding_output(
+            check_id="check_test",
+            status="FAIL",
+            account_uid="subscription_1",
+            region="subscription_1",
+            resource_uid="test_resource",
+            resource_tags=[],
+            muted=False,
+        )
 
-        muted_finding = mutelist.mute_finding(finding=finding)
+        muted_finding = mutelist.mute_finding(finding=finding_1)
 
         assert muted_finding.status == "MUTED"
         assert muted_finding.muted is True

--- a/tests/providers/azure/lib/mutelist/azure_mutelist_test.py
+++ b/tests/providers/azure/lib/mutelist/azure_mutelist_test.py
@@ -66,3 +66,37 @@ class TestAzureMutelist:
         finding.subscription = "subscription_1"
 
         assert mutelist.is_finding_muted(finding)
+
+    def test_mute_finding(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "subscription_1": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": ["*"],
+                            "Resources": ["test_resource"],
+                        }
+                    }
+                }
+            }
+        }
+
+        mutelist = AzureMutelist(mutelist_content=mutelist_content)
+
+        finding = MagicMock
+        finding.metadata = MagicMock
+        finding.metadata.CheckID = "check_test"
+        finding.region = "West Europe"
+        finding.status = "FAIL"
+        finding.resource_id = "test_resource"
+        finding.resource_tags = []
+        finding.account_uid = "subscription_1"
+        finding.muted = False
+        finding.raw = {}
+
+        muted_finding = mutelist.mute_finding(finding=finding)
+
+        assert muted_finding.status == "MUTED"
+        assert muted_finding.muted is True
+        assert muted_finding.raw["status"] == "FAIL"

--- a/tests/providers/gcp/lib/mutelist/gcp_mutelist_test.py
+++ b/tests/providers/gcp/lib/mutelist/gcp_mutelist_test.py
@@ -2,6 +2,7 @@ import yaml
 from mock import MagicMock
 
 from prowler.providers.gcp.lib.mutelist.mutelist import GCPMutelist
+from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 
 MUTELIST_FIXTURE_PATH = "tests/providers/gcp/lib/mutelist/fixtures/gcp_mutelist.yaml"
 
@@ -82,18 +83,17 @@ class TestGCPMutelist:
 
         mutelist = GCPMutelist(mutelist_content=mutelist_content)
 
-        finding = MagicMock
-        finding.metadata = MagicMock
-        finding.metadata.CheckID = "check_test"
-        finding.status = "FAIL"
-        finding.region = "test-location"
-        finding.resource_tags = []
-        finding.resource_id = "test_resource"
-        finding.account_uid = "project_1"
-        finding.muted = False
-        finding.raw = {}
+        finding_1 = generate_finding_output(
+            check_id="check_test",
+            status="FAIL",
+            account_uid="project_1",
+            region="test-region",
+            resource_uid="test_resource",
+            resource_tags=[],
+            muted=False,
+        )
 
-        muted_finding = mutelist.mute_finding(finding=finding)
+        muted_finding = mutelist.mute_finding(finding=finding_1)
 
         assert muted_finding.status == "MUTED"
         assert muted_finding.muted

--- a/tests/providers/gcp/lib/mutelist/gcp_mutelist_test.py
+++ b/tests/providers/gcp/lib/mutelist/gcp_mutelist_test.py
@@ -64,3 +64,37 @@ class TestGCPMutelist:
         finding.project_id = "project_1"
 
         assert mutelist.is_finding_muted(finding)
+
+    def test_mute_finding(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "project_1": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": ["*"],
+                            "Resources": ["test_resource"],
+                        }
+                    }
+                }
+            }
+        }
+
+        mutelist = GCPMutelist(mutelist_content=mutelist_content)
+
+        finding = MagicMock
+        finding.metadata = MagicMock
+        finding.metadata.CheckID = "check_test"
+        finding.status = "FAIL"
+        finding.region = "test-location"
+        finding.resource_tags = []
+        finding.resource_id = "test_resource"
+        finding.account_uid = "project_1"
+        finding.muted = False
+        finding.raw = {}
+
+        muted_finding = mutelist.mute_finding(finding=finding)
+
+        assert muted_finding.status == "MUTED"
+        assert muted_finding.muted
+        assert muted_finding.raw["status"] == "FAIL"

--- a/tests/providers/kubernetes/lib/mutelist/kubernetes_mutelist_test.py
+++ b/tests/providers/kubernetes/lib/mutelist/kubernetes_mutelist_test.py
@@ -2,6 +2,7 @@ import yaml
 from mock import MagicMock
 
 from prowler.providers.kubernetes.lib.mutelist.mutelist import KubernetesMutelist
+from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 
 MUTELIST_FIXTURE_PATH = (
     "tests/providers/kubernetes/lib/mutelist/fixtures/kubernetes_mutelist.yaml"
@@ -146,18 +147,17 @@ class TestKubernetesMutelist:
 
         mutelist = KubernetesMutelist(mutelist_content=mutelist_content)
 
-        finding = MagicMock
-        finding.metadata = MagicMock
-        finding.metadata.CheckID = "check_test"
-        finding.status = "FAIL"
-        finding.resource_id = "test_resource"
-        finding.account_uid = "cluster_1"
-        finding.region = "test-location"
-        finding.resource_tags = []
-        finding.raw = {}
-        finding.muted = False
+        finding_1 = generate_finding_output(
+            check_id="check_test",
+            status="FAIL",
+            account_uid="cluster_1",
+            region="test-region",
+            resource_uid="test_resource",
+            resource_tags=[],
+            muted=False,
+        )
 
-        muted_finding = mutelist.mute_finding(finding)
+        muted_finding = mutelist.mute_finding(finding_1)
 
         assert muted_finding.status == "MUTED"
         assert muted_finding.muted is True

--- a/tests/providers/kubernetes/lib/mutelist/kubernetes_mutelist_test.py
+++ b/tests/providers/kubernetes/lib/mutelist/kubernetes_mutelist_test.py
@@ -128,3 +128,37 @@ class TestKubernetesMutelist:
         finding.resource_tags = []
 
         assert mutelist.is_finding_muted(finding, "cluster_1")
+
+    def test_mute_finding(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "cluster_1": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": ["*"],
+                            "Resources": ["test_resource"],
+                        }
+                    }
+                }
+            }
+        }
+
+        mutelist = KubernetesMutelist(mutelist_content=mutelist_content)
+
+        finding = MagicMock
+        finding.metadata = MagicMock
+        finding.metadata.CheckID = "check_test"
+        finding.status = "FAIL"
+        finding.resource_id = "test_resource"
+        finding.account_uid = "cluster_1"
+        finding.region = "test-location"
+        finding.resource_tags = []
+        finding.raw = {}
+        finding.muted = False
+
+        muted_finding = mutelist.mute_finding(finding)
+
+        assert muted_finding.status == "MUTED"
+        assert muted_finding.muted is True
+        assert muted_finding.raw["status"] == "FAIL"


### PR DESCRIPTION
### Description
This pull request introduces a new method `mute_finding` to the `Mutelist` class and adds corresponding unit tests for various cloud providers. The main changes include the addition of the method itself, which checks if a finding should be muted, and the implementation of tests to ensure this functionality works correctly across AWS, Azure, GCP, and Kubernetes.

### New Method Addition:
* Added `mute_finding` method to `Mutelist` class in `prowler/lib/mutelist/mutelist.py` to check and update the status of a finding based on muting conditions. (`[prowler/lib/mutelist/mutelist.pyR241-R271](diffhunk://#diff-09b4cefd150351713ac7e94d472eb048baf9cc26b2d9672b14159e1b6d8cd522R241-R271)`)

### Unit Tests:
* Added `test_mute_finding` for AWS in `tests/providers/aws/lib/mutelist/aws_mutelist_test.py` to verify the `mute_finding` method. (`[tests/providers/aws/lib/mutelist/aws_mutelist_test.pyR1847-R1880](diffhunk://#diff-a2ee83f49b2b18e5c8290d2289239c2abc8c0d0c2b7d2c46833517daf4f07f17R1847-R1880)`)
* Added `test_mute_finding` for Azure in `tests/providers/azure/lib/mutelist/azure_mutelist_test.py` to verify the `mute_finding` method. (`[tests/providers/azure/lib/mutelist/azure_mutelist_test.pyR69-R102](diffhunk://#diff-63327ab7d6943494eca0591588ec8396a503556da00a9ebc8e64f672ab97cba7R69-R102)`)
* Added `test_mute_finding` for GCP in `tests/providers/gcp/lib/mutelist/gcp_mutelist_test.py` to verify the `mute_finding` method. (`[tests/providers/gcp/lib/mutelist/gcp_mutelist_test.pyR67-R100](diffhunk://#diff-7db0a0db7d0cb555eb4e03dac8415eb978bea40c1bc3186bac714326cb46e292R67-R100)`)
* Added `test_mute_finding` for Kubernetes in `tests/providers/kubernetes/lib/mutelist/kubernetes_mutelist_test.py` to verify the `mute_finding` method. (`[tests/providers/kubernetes/lib/mutelist/kubernetes_mutelist_test.pyR131-R164](diffhunk://#diff-c3e8768eecca04e9e042d229c49331423bba0e9fe54c624c2f04f03049c3886fR131-R164)`)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
