### PR TITLE
fix(gcp): enforce correct severity levels in CloudSQL PostgreSQL `log_min_messages`

### DIFF
--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag.py
@@ -4,7 +4,17 @@ from prowler.providers.gcp.services.cloudsql.cloudsql_client import cloudsql_cli
 
 class cloudsql_instance_postgres_log_min_messages_flag(Check):
     def execute(self) -> Check_Report_GCP:
-        desired_log_min_messages = "error"
+        failing_log_levels = [
+            "DEBUG5",
+            "DEBUG4",
+            "DEBUG3",
+            "DEBUG2",
+            "DEBUG1",
+            "INFO",
+            "NOTICE",
+            "WARNING",
+        ]
+
         findings = []
         for instance in cloudsql_client.instances:
             if "POSTGRES" in instance.version:
@@ -14,15 +24,17 @@ class cloudsql_instance_postgres_log_min_messages_flag(Check):
                 report.resource_name = instance.name
                 report.location = instance.region
                 report.status = "FAIL"
-                report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_min_messages' flag set minimum to '{desired_log_min_messages}'."
+                report.status_extended = f"PostgreSQL Instance {instance.name} does not have 'log_min_messages' flag set."
+
                 for flag in instance.flags:
-                    if (
-                        flag.get("name", "") == "log_min_messages"
-                        and flag.get("value", "warning") == desired_log_min_messages
-                    ):
-                        report.status = "PASS"
-                        report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_messages' flag set minimum to '{desired_log_min_messages}'."
-                        break
+                    if flag.get("name", "") == "log_min_messages":
+                        current_level = flag.get("value", "").upper()
+                        if current_level in failing_log_levels:
+                            report.status = "FAIL"
+                            report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_messages' flag set to '{current_level}', which is below the recommended minimum of 'ERROR'."
+                        else:
+                            report.status = "PASS"
+                            report.status_extended = f"PostgreSQL Instance {instance.name} has 'log_min_messages' flag set to an acceptable severity level: '{current_level}'."
                 findings.append(report)
 
         return findings

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag.py
@@ -12,7 +12,6 @@ class cloudsql_instance_postgres_log_min_messages_flag(Check):
             "DEBUG1",
             "INFO",
             "NOTICE",
-            "WARNING",
         ]
 
         findings = []

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_postgres_log_min_messages_flag/cloudsql_instance_postgres_log_min_messages_flag_test.py
@@ -104,7 +104,7 @@ class Test_cloudsql_instance_postgres_log_min_messages_flag:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "PostgreSQL Instance instance1 does not have 'log_min_messages' flag set minimum to 'error'."
+                == "PostgreSQL Instance instance1 does not have 'log_min_messages' flag set."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"
@@ -139,7 +139,7 @@ class Test_cloudsql_instance_postgres_log_min_messages_flag:
                     ssl_mode="ENCRYPTED_ONLY",
                     automated_backups=True,
                     authorized_networks=[],
-                    flags=[{"name": "log_min_messages", "value": "debug"}],
+                    flags=[{"name": "log_min_messages", "value": "debug1"}],
                     project_id=GCP_PROJECT_ID,
                 )
             ]
@@ -150,7 +150,7 @@ class Test_cloudsql_instance_postgres_log_min_messages_flag:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "PostgreSQL Instance instance1 does not have 'log_min_messages' flag set minimum to 'error'."
+                == "PostgreSQL Instance instance1 has 'log_min_messages' flag set to 'DEBUG1', which is below the recommended minimum of 'ERROR'."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"
@@ -196,7 +196,7 @@ class Test_cloudsql_instance_postgres_log_min_messages_flag:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "PostgreSQL Instance instance1 has 'log_min_messages' flag set minimum to 'error'."
+                == "PostgreSQL Instance instance1 has 'log_min_messages' flag set to an acceptable severity level: 'ERROR'."
             )
             assert result[0].resource_id == "instance1"
             assert result[0].resource_name == "instance1"


### PR DESCRIPTION
### Context
This update aligns the `cloudsql_instance_postgres_log_min_messages_flag` check with CIS GCP framework recommendations, which specify that log_min_messages should be set to ERROR or higher (e.g., ERROR, LOG, FATAL, PANIC). Configurations below ERROR do not meet the recommended standards.

Description:
The check now fails only if `log_min_messages` is set to any level below ERROR, ensuring compliance and accuracy in flagging only non-compliant configurations.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
