### PR TITLE
fix(check): add .value to severity enum

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -273,7 +273,7 @@ def print_checks(
     for check in check_list:
         try:
             print(
-                f"[{bulk_checks_metadata[check].CheckID}] {bulk_checks_metadata[check].CheckTitle} - {Fore.MAGENTA}{bulk_checks_metadata[check].ServiceName} {Fore.YELLOW}[{bulk_checks_metadata[check].Severity}]{Style.RESET_ALL}"
+                f"[{bulk_checks_metadata[check].CheckID}] {bulk_checks_metadata[check].CheckTitle} - {Fore.MAGENTA}{bulk_checks_metadata[check].ServiceName} {Fore.YELLOW}[{bulk_checks_metadata[check].Severity.value}]{Style.RESET_ALL}"
             )
         except KeyError as error:
             logger.error(
@@ -442,7 +442,7 @@ def execute_checks(
                     continue
                 if verbose:
                     print(
-                        f"\nCheck ID: {check.CheckID} - {Fore.MAGENTA}{check.ServiceName}{Fore.YELLOW} [{check.Severity}]{Style.RESET_ALL}"
+                        f"\nCheck ID: {check.CheckID} - {Fore.MAGENTA}{check.ServiceName}{Fore.YELLOW} [{check.Severity.value}]{Style.RESET_ALL}"
                     )
                 check_findings = execute(
                     check,
@@ -522,7 +522,7 @@ def execute_checks(
                         continue
                     if verbose:
                         print(
-                            f"\nCheck ID: {check.CheckID} - {Fore.MAGENTA}{check.ServiceName}{Fore.YELLOW} [{check.Severity}]{Style.RESET_ALL}"
+                            f"\nCheck ID: {check.CheckID} - {Fore.MAGENTA}{check.ServiceName}{Fore.YELLOW} [{check.Severity.value}]{Style.RESET_ALL}"
                         )
                     check_findings = execute(
                         check,


### PR DESCRIPTION
### Description
This pull request includes changes to the `prowler/lib/check/check.py` file to improve the display of check severities. The main change is the modification of how the severity level is accessed and displayed in the output.

Changes to severity display:

* [`prowler/lib/check/check.py`](diffhunk://#diff-de419e9ab010fe89ab6587abcab136ee1cd17c82940e92db5500574e0f52d4e8L276-R276): Updated the severity display in the `print_checks` function to use `check.Severity.value` instead of `check.Severity`.
* [`prowler/lib/check/check.py`](diffhunk://#diff-de419e9ab010fe89ab6587abcab136ee1cd17c82940e92db5500574e0f52d4e8L445-R445): Updated the severity display in the `execute_checks` function to use `check.Severity.value` instead of `check.Severity` in two places. [[1]](diffhunk://#diff-de419e9ab010fe89ab6587abcab136ee1cd17c82940e92db5500574e0f52d4e8L445-R445) [[2]](diffhunk://#diff-de419e9ab010fe89ab6587abcab136ee1cd17c82940e92db5500574e0f52d4e8L525-R525)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
