### PR TITLE
fix(aws): do not flag cross-service confused deputy as public

### DIFF
--- a/prowler/providers/aws/services/iam/iam_role_cross_service_confused_deputy_prevention/iam_role_cross_service_confused_deputy_prevention.py
+++ b/prowler/providers/aws/services/iam/iam_role_cross_service_confused_deputy_prevention/iam_role_cross_service_confused_deputy_prevention.py
@@ -20,6 +20,7 @@ class iam_role_cross_service_confused_deputy_prevention(Check):
                     if not is_policy_public(
                         role.assume_role_policy,
                         iam_client.audited_account,
+                        check_cross_service_confused_deputy=True,
                         not_allowed_actions=["sts:AssumeRole", "sts:*"],
                     ):
                         report.status = "PASS"

--- a/tests/providers/aws/services/iam/lib/policy_test.py
+++ b/tests/providers/aws/services/iam/lib/policy_test.py
@@ -1923,6 +1923,44 @@ class Test_Policy:
         }
         assert not is_policy_public(policy, TRUSTED_AWS_ACCOUNT_NUMBER)
 
+    def test_is_policy_public_cross_cross_service_confused_deputy(
+        self,
+    ):
+        policy = {
+            "Statement": [
+                {
+                    "Sid": "test",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                    "Action": "lambda:InvokeFunction",
+                    "Resource": "*",
+                }
+            ]
+        }
+        assert is_policy_public(
+            policy, TRUSTED_AWS_ACCOUNT_NUMBER, check_cross_service_confused_deputy=True
+        )
+
+    def test_is_policy_public_cross_cross_service_confused_deputy_ignored(
+        self,
+    ):
+        policy = {
+            "Statement": [
+                {
+                    "Sid": "test",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "ec2.amazonaws.com"},
+                    "Action": "lambda:InvokeFunction",
+                    "Resource": "*",
+                }
+            ]
+        }
+        assert not is_policy_public(
+            policy,
+            TRUSTED_AWS_ACCOUNT_NUMBER,
+            check_cross_service_confused_deputy=False,
+        )
+
     def test_is_policy_public_alexa_condition(
         self,
     ):


### PR DESCRIPTION
### Context

Fix #5454.

### Description

Do not flag IAM policies with cross service confused deputy as public unless the argument `check_cross_service_confused_deputy` is passed to the `is_policy_public` function.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
