### PR TITLE
fix(checks_loader): solve issue related with checks from compliance

### DIFF
--- a/prowler/lib/check/checks_loader.py
+++ b/prowler/lib/check/checks_loader.py
@@ -7,15 +7,15 @@ from prowler.lib.logger import logger
 
 # Generate the list of checks to execute
 def load_checks_to_execute(
-    bulk_checks_metadata: dict,
-    bulk_compliance_frameworks: dict,
-    checks_file: str,
-    check_list: list,
-    service_list: list,
-    severities: list,
-    compliance_frameworks: list,
-    categories: set,
-    provider: str,
+    bulk_checks_metadata: dict = None,
+    bulk_compliance_frameworks: dict = None,
+    checks_file: str = None,
+    check_list: list = None,
+    service_list: list = None,
+    severities: list = None,
+    compliance_frameworks: list = None,
+    categories: set = None,
+    provider: str = None,
 ) -> set:
     """Generate the list of checks to execute based on the cloud provider and the input arguments given"""
     try:
@@ -25,28 +25,29 @@ def load_checks_to_execute(
         check_categories = {}
         check_severities = {severity.value: [] for severity in Severity}
 
-        # First, loop over the bulk_checks_metadata to extract the needed subsets
-        for check, metadata in bulk_checks_metadata.items():
-            try:
-                # Aliases
-                for alias in metadata.CheckAliases:
-                    if alias not in check_aliases:
-                        check_aliases[alias] = []
-                    check_aliases[alias].append(check)
+        if bulk_checks_metadata:
+            # First, loop over the bulk_checks_metadata to extract the needed subsets
+            for check, metadata in bulk_checks_metadata.items():
+                try:
+                    # Aliases
+                    for alias in metadata.CheckAliases:
+                        if alias not in check_aliases:
+                            check_aliases[alias] = []
+                        check_aliases[alias].append(check)
 
-                # Severities
-                if metadata.Severity:
-                    check_severities[metadata.Severity].append(check)
+                    # Severities
+                    if metadata.Severity:
+                        check_severities[metadata.Severity].append(check)
 
-                # Categories
-                for category in metadata.Categories:
-                    if category not in check_categories:
-                        check_categories[category] = []
-                    check_categories[category].append(check)
-            except Exception as error:
-                logger.error(
-                    f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
-                )
+                    # Categories
+                    for category in metadata.Categories:
+                        if category not in check_categories:
+                            check_categories[category] = []
+                        check_categories[category].append(check)
+                except Exception as error:
+                    logger.error(
+                        f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
+                    )
 
         # Handle if there are checks passed using -c/--checks
         if check_list:
@@ -88,7 +89,7 @@ def load_checks_to_execute(
             for compliance_framework in compliance_frameworks:
                 checks_to_execute.update(
                     CheckMetadata.list(
-                        bulk_checks_metadata=bulk_compliance_frameworks,
+                        bulk_compliance_frameworks=bulk_compliance_frameworks,
                         compliance_framework=compliance_framework,
                     )
                 )

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -187,11 +187,11 @@ class CheckMetadata(BaseModel):
         Returns:
             set: A set of checks.
         """
-        checks_from_provider = {}
-        checks_from_severity = {}
-        checks_from_category = {}
-        checks_from_service = {}
-        checks_from_compliance_framework = {}
+        checks_from_provider = set()
+        checks_from_severity = set()
+        checks_from_category = set()
+        checks_from_service = set()
+        checks_from_compliance_framework = set()
         # If the bulk checks metadata is not provided, get it
         if not bulk_checks_metadata:
             bulk_checks_metadata = {}
@@ -223,7 +223,7 @@ class CheckMetadata(BaseModel):
                 available_providers = [p.value for p in Provider]
                 for provider in available_providers:
                     bulk_compliance_frameworks = Compliance.get_bulk(provider=provider)
-            checks_from_compliance_framework = set(
+            checks_from_compliance_framework = (
                 CheckMetadata.list_by_compliance_framework(
                     bulk_compliance_frameworks=bulk_compliance_frameworks,
                     compliance_framework=compliance_framework,

--- a/tests/lib/check/check_loader_test.py
+++ b/tests/lib/check/check_loader_test.py
@@ -56,96 +56,48 @@ class TestCheckLoader:
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
-        checks_file = None
-        check_list = None
-        service_list = None
-        severities = None
-        compliance_frameworks = None
-        categories = None
 
         assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_checks_metadata=bulk_checks_metatada,
+            provider=self.provider,
         )
 
     def test_load_checks_to_execute_with_check_list(self):
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
-        checks_file = None
         check_list = [S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME]
-        service_list = None
-        severities = None
-        compliance_frameworks = None
-        categories = None
 
         assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_checks_metadata=bulk_checks_metatada,
+            check_list=check_list,
+            provider=self.provider,
         )
 
     def test_load_checks_to_execute_with_severities(self):
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
-        checks_file = None
-        check_list = []
-        service_list = None
         severities = [S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_SEVERITY]
-        compliance_frameworks = None
-        categories = None
 
         assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_checks_metadata=bulk_checks_metatada,
+            severities=severities,
+            provider=self.provider,
         )
 
     def test_load_checks_to_execute_with_severities_and_services(self):
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
-        checks_file = None
-        check_list = []
         service_list = [S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME_SERVICE]
         severities = [S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_SEVERITY]
-        compliance_frameworks = None
-        categories = None
 
         assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_checks_metadata=bulk_checks_metatada,
+            service_list=service_list,
+            severities=severities,
+            provider=self.provider,
         )
 
     def test_load_checks_to_execute_with_severities_and_services_not_within_severity(
@@ -154,24 +106,14 @@ class TestCheckLoader:
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
-        checks_file = None
-        check_list = []
         service_list = ["ec2"]
         severities = [S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_SEVERITY]
-        compliance_frameworks = None
-        categories = None
 
         assert set() == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_checks_metadata=bulk_checks_metatada,
+            service_list=service_list,
+            severities=severities,
+            provider=self.provider,
         )
 
     def test_load_checks_to_execute_with_checks_file(
@@ -180,27 +122,15 @@ class TestCheckLoader:
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
         checks_file = "path/to/test_file"
-        check_list = []
-        service_list = []
-        severities = []
-        compliance_frameworks = None
-        categories = None
         with patch(
             "prowler.lib.check.checks_loader.parse_checks_from_file",
             return_value={S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME},
         ):
             assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-                bulk_checks_metatada,
-                bulk_compliance_frameworks,
-                checks_file,
-                check_list,
-                service_list,
-                severities,
-                compliance_frameworks,
-                categories,
-                self.provider,
+                bulk_checks_metadata=bulk_checks_metatada,
+                checks_file=checks_file,
+                provider=self.provider,
             )
 
     def test_load_checks_to_execute_with_service_list(
@@ -209,24 +139,12 @@ class TestCheckLoader:
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
-        checks_file = None
-        check_list = []
         service_list = [S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME_SERVICE]
-        severities = []
-        compliance_frameworks = None
-        categories = None
 
         assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_checks_metadata=bulk_checks_metatada,
+            service_list=service_list,
+            provider=self.provider,
         )
 
     def test_load_checks_to_execute_with_compliance_frameworks(
@@ -248,24 +166,12 @@ class TestCheckLoader:
                 ],
             ),
         }
-        bulk_checks_metatada = None
-        checks_file = None
-        check_list = []
-        service_list = []
-        severities = []
         compliance_frameworks = ["soc2_aws"]
-        categories = None
 
         assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_compliance_frameworks=bulk_compliance_frameworks,
+            compliance_frameworks=compliance_frameworks,
+            provider=self.provider,
         )
 
     def test_load_checks_to_execute_with_categories(
@@ -274,25 +180,60 @@ class TestCheckLoader:
         bulk_checks_metatada = {
             S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
         }
-        bulk_compliance_frameworks = None
-        checks_file = None
-        check_list = []
-        service_list = []
-        severities = []
-        compliance_frameworks = []
         categories = {"internet-exposed"}
 
         assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-            bulk_checks_metatada,
-            bulk_compliance_frameworks,
-            checks_file,
-            check_list,
-            service_list,
-            severities,
-            compliance_frameworks,
-            categories,
-            self.provider,
+            bulk_checks_metadata=bulk_checks_metatada,
+            categories=categories,
+            provider=self.provider,
         )
+
+    def test_load_checks_to_execute_no_bulk_checks_metadata(self):
+        bulk_checks_metatada = {
+            S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
+        }
+        with patch(
+            "prowler.lib.check.checks_loader.CheckMetadata.get_bulk",
+            return_value=bulk_checks_metatada,
+        ):
+            assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
+                provider=self.provider,
+            )
+
+    def test_load_checks_to_execute_no_bulk_compliance_frameworks(self):
+        bulk_compliance_frameworks = {
+            "soc2_aws": Compliance(
+                Framework="SOC2",
+                Provider="aws",
+                Version="2.0",
+                Description="This CIS Benchmark is the product of a community consensus process and consists of secure configuration guidelines developed for Azuee Platform",
+                Requirements=[
+                    Compliance_Requirement(
+                        Checks=[S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME],
+                        Id="",
+                        Description="",
+                        Attributes=[],
+                    )
+                ],
+            ),
+        }
+
+        compliance_frameworks = ["soc2_aws"]
+
+        bulk_checks_metatada = {
+            S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
+        }
+        with patch(
+            "prowler.lib.check.checks_loader.CheckMetadata.get_bulk",
+            return_value=bulk_checks_metatada,
+        ), patch(
+            "prowler.lib.check.checks_loader.Compliance.get_bulk",
+            return_value=bulk_compliance_frameworks,
+        ):
+            assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
+                compliance_frameworks=compliance_frameworks,
+                provider=self.provider,
+            )
 
     def test_update_checks_to_execute_with_aliases(self):
         checks_to_execute = {"renamed_check"}

--- a/tests/lib/check/check_loader_test.py
+++ b/tests/lib/check/check_loader_test.py
@@ -4,6 +4,7 @@ from prowler.lib.check.checks_loader import (
     load_checks_to_execute,
     update_checks_to_execute_with_aliases,
 )
+from prowler.lib.check.compliance_models import Compliance, Compliance_Requirement
 from prowler.lib.check.models import CheckMetadata, Code, Recommendation, Remediation
 
 S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME = "s3_bucket_level_public_access_block"
@@ -63,21 +64,17 @@ class TestCheckLoader:
         compliance_frameworks = None
         categories = None
 
-        with patch(
-            "prowler.lib.check.checks_loader.CheckMetadata.list",
-            return_value={S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME},
-        ):
-            assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-                bulk_checks_metatada,
-                bulk_compliance_frameworks,
-                checks_file,
-                check_list,
-                service_list,
-                severities,
-                compliance_frameworks,
-                categories,
-                self.provider,
-            )
+        assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
+            bulk_checks_metatada,
+            bulk_compliance_frameworks,
+            checks_file,
+            check_list,
+            service_list,
+            severities,
+            compliance_frameworks,
+            categories,
+            self.provider,
+        )
 
     def test_load_checks_to_execute_with_check_list(self):
         bulk_checks_metatada = {
@@ -139,21 +136,17 @@ class TestCheckLoader:
         compliance_frameworks = None
         categories = None
 
-        with patch(
-            "prowler.lib.check.checks_loader.CheckMetadata.list_by_service",
-            return_value={S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME},
-        ):
-            assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-                bulk_checks_metatada,
-                bulk_compliance_frameworks,
-                checks_file,
-                check_list,
-                service_list,
-                severities,
-                compliance_frameworks,
-                categories,
-                self.provider,
-            )
+        assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
+            bulk_checks_metatada,
+            bulk_compliance_frameworks,
+            checks_file,
+            check_list,
+            service_list,
+            severities,
+            compliance_frameworks,
+            categories,
+            self.provider,
+        )
 
     def test_load_checks_to_execute_with_severities_and_services_not_within_severity(
         self,
@@ -169,24 +162,17 @@ class TestCheckLoader:
         compliance_frameworks = None
         categories = None
 
-        with patch(
-            "prowler.lib.check.checks_loader.CheckMetadata.list_by_severity",
-            return_value={S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME},
-        ), patch(
-            "prowler.lib.check.checks_loader.CheckMetadata.list_by_service",
-            return_value={"ec2_ami_public"},
-        ):
-            assert set() == load_checks_to_execute(
-                bulk_checks_metatada,
-                bulk_compliance_frameworks,
-                checks_file,
-                check_list,
-                service_list,
-                severities,
-                compliance_frameworks,
-                categories,
-                self.provider,
-            )
+        assert set() == load_checks_to_execute(
+            bulk_checks_metatada,
+            bulk_compliance_frameworks,
+            checks_file,
+            check_list,
+            service_list,
+            severities,
+            compliance_frameworks,
+            categories,
+            self.provider,
+        )
 
     def test_load_checks_to_execute_with_checks_file(
         self,
@@ -201,7 +187,6 @@ class TestCheckLoader:
         severities = []
         compliance_frameworks = None
         categories = None
-
         with patch(
             "prowler.lib.check.checks_loader.parse_checks_from_file",
             return_value={S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME},
@@ -232,51 +217,56 @@ class TestCheckLoader:
         compliance_frameworks = None
         categories = None
 
-        with patch(
-            "prowler.lib.check.checks_loader.CheckMetadata.list_by_service",
-            return_value={S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME},
-        ):
-            assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-                bulk_checks_metatada,
-                bulk_compliance_frameworks,
-                checks_file,
-                check_list,
-                service_list,
-                severities,
-                compliance_frameworks,
-                categories,
-                self.provider,
-            )
+        assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
+            bulk_checks_metatada,
+            bulk_compliance_frameworks,
+            checks_file,
+            check_list,
+            service_list,
+            severities,
+            compliance_frameworks,
+            categories,
+            self.provider,
+        )
 
     def test_load_checks_to_execute_with_compliance_frameworks(
         self,
     ):
-        bulk_checks_metatada = {
-            S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME: self.get_custom_check_metadata()
+        bulk_compliance_frameworks = {
+            "soc2_aws": Compliance(
+                Framework="SOC2",
+                Provider="aws",
+                Version="2.0",
+                Description="This CIS Benchmark is the product of a community consensus process and consists of secure configuration guidelines developed for Azuee Platform",
+                Requirements=[
+                    Compliance_Requirement(
+                        Checks=[S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME],
+                        Id="",
+                        Description="",
+                        Attributes=[],
+                    )
+                ],
+            ),
         }
-        bulk_compliance_frameworks = None
+        bulk_checks_metatada = None
         checks_file = None
         check_list = []
         service_list = []
         severities = []
-        compliance_frameworks = ["test-compliance-framework"]
+        compliance_frameworks = ["soc2_aws"]
         categories = None
 
-        with patch(
-            "prowler.lib.check.checks_loader.CheckMetadata.list",
-            return_value={S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME},
-        ):
-            assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
-                bulk_checks_metatada,
-                bulk_compliance_frameworks,
-                checks_file,
-                check_list,
-                service_list,
-                severities,
-                compliance_frameworks,
-                categories,
-                self.provider,
-            )
+        assert {S3_BUCKET_LEVEL_PUBLIC_ACCESS_BLOCK_NAME} == load_checks_to_execute(
+            bulk_checks_metatada,
+            bulk_compliance_frameworks,
+            checks_file,
+            check_list,
+            service_list,
+            severities,
+            compliance_frameworks,
+            categories,
+            self.provider,
+        )
 
     def test_load_checks_to_execute_with_categories(
         self,


### PR DESCRIPTION
### Context
Fix #5595 

### Description
This pull request includes several changes to the `prowler` library, focusing on improving the flexibility and robustness of the `load_checks_to_execute` function and its related tests. The most important changes include making function parameters optional, updating the handling of compliance frameworks, and removing unnecessary test patches.

### Functionality Improvements:

* [`prowler/lib/check/checks_loader.py`](diffhunk://#diff-32e2ec5bfdd5944707b7ea1197ae3c7312a3696e9a203ee35639479f9558eccfL10-R18): Made parameters of the `load_checks_to_execute` function optional to enhance flexibility.
* [`prowler/lib/check/checks_loader.py`](diffhunk://#diff-32e2ec5bfdd5944707b7ea1197ae3c7312a3696e9a203ee35639479f9558eccfR28): Added a conditional check for `bulk_checks_metadata` to prevent errors when it is not provided.
* [`prowler/lib/check/checks_loader.py`](diffhunk://#diff-32e2ec5bfdd5944707b7ea1197ae3c7312a3696e9a203ee35639479f9558eccfL91-R92): Corrected a parameter name in the call to `CheckMetadata.list` to ensure the correct metadata is used.

### Codebase Simplification:

* [`prowler/lib/check/models.py`](diffhunk://#diff-8f998b586c18e08a5fa76f7508cf19c71088a5b28b392989c46882ad5c853eeaL190-R194): Changed the initialization of several dictionaries to sets to simplify the storage and retrieval of checks. [[1]](diffhunk://#diff-8f998b586c18e08a5fa76f7508cf19c71088a5b28b392989c46882ad5c853eeaL190-R194) [[2]](diffhunk://#diff-8f998b586c18e08a5fa76f7508cf19c71088a5b28b392989c46882ad5c853eeaL226-R226)

### Test Improvements:

* [`tests/lib/check/check_loader_test.py`](diffhunk://#diff-843325f3001b1e7e7c0768499b8c1568764c8d903b831308d316dc13657a7f21L66-L69): Removed unnecessary patches in multiple test cases to streamline the tests and ensure they accurately reflect the updated function behavior. [[1]](diffhunk://#diff-843325f3001b1e7e7c0768499b8c1568764c8d903b831308d316dc13657a7f21L66-L69) [[2]](diffhunk://#diff-843325f3001b1e7e7c0768499b8c1568764c8d903b831308d316dc13657a7f21L142-L145) [[3]](diffhunk://#diff-843325f3001b1e7e7c0768499b8c1568764c8d903b831308d316dc13657a7f21L172-L178) [[4]](diffhunk://#diff-843325f3001b1e7e7c0768499b8c1568764c8d903b831308d316dc13657a7f21L204) [[5]](diffhunk://#diff-843325f3001b1e7e7c0768499b8c1568764c8d903b831308d316dc13657a7f21L235-L238) [[6]](diffhunk://#diff-843325f3001b1e7e7c0768499b8c1568764c8d903b831308d316dc13657a7f21L254-L268)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
