### PR TITLE
fix(aws): handle global WAFv2 ACLs in service

### DIFF
--- a/prowler/providers/aws/services/autoscaling/autoscaling_group_capacity_rebalance_enabled/autoscaling_group_capacity_rebalance_enabled.metadata.json
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_group_capacity_rebalance_enabled/autoscaling_group_capacity_rebalance_enabled.metadata.json
@@ -3,7 +3,7 @@
   "CheckID": "autoscaling_group_capacity_rebalance_enabled",
   "CheckTitle": "Check if Amazon EC2 Auto Scaling groups have capacity rebalance enabled.",
   "CheckType": [
-    "Resiliance"
+    "Resilience"
   ],
   "ServiceName": "autoscaling",
   "SubServiceName": "",

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_logging_block_mode/ecs_task_definitions_logging_block_mode.metadata.json
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_logging_block_mode/ecs_task_definitions_logging_block_mode.metadata.json
@@ -3,7 +3,7 @@
   "CheckID": "ecs_task_definitions_logging_block_mode",
   "CheckTitle": "ECS task definitions containers should have a logging configured with non blocking mode",
   "CheckType": [
-    "Resiliance"
+    "Resilience"
   ],
   "ServiceName": "ecs",
   "SubServiceName": "",


### PR DESCRIPTION
### Description

Handle global WAFv2 ACLs in service to avoid key errors when the global region is not present in the audited regions.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
