### PR TITLE
fix(k8s): do not raise error when unable to list roles

### DIFF
--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -366,17 +366,15 @@ class KubernetesProvider(Provider):
             logger.info("Context user roles retrieved successfully.")
             return roles
         except ApiException as api_error:
-            logger.critical(
+            logger.error(
                 f"ApiException[{api_error.__traceback__.tb_lineno}]: {api_error}"
             )
-            raise KubernetesAPIError(original_exception=api_error)
         except KubernetesError as error:
             raise error
         except Exception as error:
-            logger.critical(
+            logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
-            raise KubernetesError(original_exception=error)
 
     def get_all_namespaces(self) -> list[str]:
         """


### PR DESCRIPTION
### Context

When scanning from remote, the users don't have permissions to list all `clusterrolebindings`.

Fix https://github.com/prowler-cloud/prowler/discussions/5452#discussioncomment-11017518.

### Description

Low the error severity and do not raise an error when Prowler doesn't have permissions to list all `clusterrolebindings`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
