### PR TITLE
fix(docs): Update misc tutorial categories example

### DIFF
--- a/docs/tutorials/misc.md
+++ b/docs/tutorials/misc.md
@@ -125,5 +125,5 @@ prowler <provider> --list-categories
 ```
 - Execute specific category(s):
 ```console
-prowler  <provider> --categories
+prowler  <provider> --categories secrets
 ```


### PR DESCRIPTION
### Context

The misc tutorial in the documentation has an incorrect command in the categories section.

### Description

- `prowler <provider> --categories` -> `prowler <provider> --categories secrets`

### Checklist

- Are there new checks included in this PR? No
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
