### PR TITLE
fix(docker): add g++ to Dockerfile for presidio-analyzer compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.12-alpine
 
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 
-# Install essential tool to compile presidio-analyze library
-# hadolint ignore=DL3018
-RUN apk --no-cache add g++
+# Update system dependencies and install essential tools
+#hadolint ignore=DL3018
+RUN apk --no-cache upgrade && apk --no-cache add curl git g++
 
 # Create non-root user
 RUN mkdir -p /home/prowler && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM python:3.12-alpine
 
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 
-# Update system dependencies and install essential tools
-#hadolint ignore=DL3018
-RUN apk --no-cache upgrade && apk --no-cache add curl git
+# Install essential tool to compile presidio-analyze library
+# hadolint ignore=DL3018
+RUN apk --no-cache add g++
 
-# Create nonroot user
+# Create non-root user
 RUN mkdir -p /home/prowler && \
     echo 'prowler:x:1000:1000:prowler:/home/prowler:' > /etc/passwd && \
     echo 'prowler:x:1000:' > /etc/group && \


### PR DESCRIPTION
### Context
The absence of `g++` was causing docker build to fail due to compilation errors in dependencies like `cymem` and `murmurhash`. Adding `g++` ensures successful installation of presidio-analyzer and related packages.
### Description

Adds`g++` to the Dockerfile to resolve build issues with `presidio-analyzer,` which requires a C++ compiler for certain dependencies.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
