### PR TITLE
fix(guardduty): fix `guardduty_is_enabled_fixer` test

### DIFF
--- a/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_fixer_test.py
+++ b/tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_fixer_test.py
@@ -1,35 +1,93 @@
 from unittest import mock
 from uuid import uuid4
 
+import botocore
+import botocore.client
 from moto import mock_aws
 
 from tests.providers.aws.utils import (
-    AWS_ACCOUNT_ARN,
     AWS_ACCOUNT_NUMBER,
     AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
 )
 
 DETECTOR_ID = str(uuid4())
 DETECTOR_ARN = f"arn:aws:guardduty:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:detector/{DETECTOR_ID}"
 
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_create_detector_success(self, operation_name, kwarg):
+    if operation_name == "CreateDetector":
+        return {"DetectorId": DETECTOR_ID}
+    elif operation_name == "GetDetector":
+        return {"Status": "ENABLED"}
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+def mock_make_api_call_create_detector_failure(self, operation_name, kwarg):
+    if operation_name == "CreateDetector":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDeniedException",
+                    "Message": "User: arn:aws:iam::012345678901:user/test is not authorized to perform: guardduty:CreateDetector",
+                }
+            },
+            "CreateDetector",
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
 
 class Test_guardduty_is_enabled_fixer:
     @mock_aws
     def test_guardduty_is_enabled_fixer(self):
-        regional_client = mock.MagicMock()
-        guardduty_client = mock.MagicMock
-        guardduty_client.region = AWS_REGION_EU_WEST_1
-        guardduty_client.detectors = []
-        guardduty_client.audited_account_arn = AWS_ACCOUNT_ARN
-        regional_client.create_detector.return_value = None
-        guardduty_client.regional_clients = {AWS_REGION_EU_WEST_1: regional_client}
-
         with mock.patch(
-            "prowler.providers.aws.services.guardduty.guardduty_service.GuardDuty",
-            guardduty_client,
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_create_detector_success,
         ):
-            from prowler.providers.aws.services.guardduty.guardduty_is_enabled.guardduty_is_enabled_fixer import (
-                fixer,
+
+            from prowler.providers.aws.services.guardduty.guardduty_service import (
+                GuardDuty,
             )
 
-            assert fixer(AWS_REGION_EU_WEST_1)
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.guardduty.guardduty_is_enabled.guardduty_is_enabled_fixer.guardduty_client",
+                new=GuardDuty(aws_provider),
+            ):
+                from prowler.providers.aws.services.guardduty.guardduty_is_enabled.guardduty_is_enabled_fixer import (
+                    fixer,
+                )
+
+                assert fixer(AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_guardduty_is_enabled_fixer_failure(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_create_detector_failure,
+        ):
+
+            from prowler.providers.aws.services.guardduty.guardduty_service import (
+                GuardDuty,
+            )
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.guardduty.guardduty_is_enabled.guardduty_is_enabled_fixer.guardduty_client",
+                new=GuardDuty(aws_provider),
+            ):
+                from prowler.providers.aws.services.guardduty.guardduty_is_enabled.guardduty_is_enabled_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(AWS_REGION_EU_WEST_1)


### PR DESCRIPTION
### Context

There is a test for the fixer `guardduty_is_enabled` causing problems:

`FAILED tests/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_fixer_test.py::Test_guardduty_is_enabled_fixer::test_guardduty_is_enabled_fixer - AssertionError: assert False`


### Description

Changed from MagicMock to Botocore and add another unit test to verify the fixer failure.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
