### PR TITLE
chore(aws): deprecate `glue_etl_jobs_logging_enabled` check

### DIFF
--- a/prowler/providers/aws/services/glue/glue_etl_jobs_logging_enabled/glue_etl_jobs_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/glue/glue_etl_jobs_logging_enabled/glue_etl_jobs_logging_enabled.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "glue_etl_jobs_logging_enabled",
-  "CheckTitle": "Check if Glue ETL Jobs have logging enabled.",
+  "CheckTitle": "[DEPRECATED] Check if Glue ETL Jobs have logging enabled.",
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
   ],
@@ -10,7 +10,7 @@
   "ResourceIdTemplate": "arn:partition:glue:region:account-id:job/job-name",
   "Severity": "medium",
   "ResourceType": "AwsGlueJob",
-  "Description": "Ensure that Glue ETL Jobs have CloudWatch logs enabled.",
+  "Description": "[DEPRECATED] Ensure that Glue ETL Jobs have CloudWatch logs enabled.",
   "Risk": "Without logging enabled, AWS Glue jobs lack visibility into job activities and failures, making it difficult to detect unauthorized access, troubleshoot issues, and ensure compliance. This may result in untracked security incidents or operational issues that affect data processing.",
   "RelatedUrl": "https://docs.aws.amazon.com/glue/latest/dg/monitor-continuous-logging.html",
   "Remediation": {
@@ -28,5 +28,5 @@
   "Categories": [],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": ""
+  "Notes": "This check is being removed since logs for all AWS Glue jobs are now always sent to Amazon CloudWatch."
 }


### PR DESCRIPTION
### Description

This check is deprecated since logs for all AWS Glue jobs are now always sent to Amazon CloudWatch.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
