### PR TITLE
docs: Update `contact.md` with new Slack join URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 </p>
 
 <p align="center">
-<a href="https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog"><img width="30" height="30" alt="Prowler community on Slack" src="https://github.com/prowler-cloud/prowler/assets/38561120/3c8b4ec5-6849-41a5-b5e1-52bbb94af73a"></a>
+<a href="https://goto.prowler.com/slack"><img width="30" height="30" alt="Prowler community on Slack" src="https://github.com/prowler-cloud/prowler/assets/38561120/3c8b4ec5-6849-41a5-b5e1-52bbb94af73a"></a>
   <br>
-  <a href="https://join.slack.com/t/prowler-workspace/shared_invite/zt-2oinmgmw6-cl7gOrljSEqo_aoripVPFA">Join our Prowler community!</a>
+  <a href="https://goto.prowler.com/slack">Join our Prowler community!</a>
 </p>
 <hr>
 <p align="center">
-  <a href="https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog"><img alt="Slack Shield" src="https://img.shields.io/badge/slack-prowler-brightgreen.svg?logo=slack"></a>
+  <a href="https://goto.prowler.com/slack"><img alt="Slack Shield" src="https://img.shields.io/badge/slack-prowler-brightgreen.svg?logo=slack"></a>
   <a href="https://pypi.org/project/prowler/"><img alt="Python Version" src="https://img.shields.io/pypi/v/prowler.svg"></a>
   <a href="https://pypi.python.org/pypi/prowler/"><img alt="Python Version" src="https://img.shields.io/pypi/pyversions/prowler.svg"></a>
   <a href="https://pypistats.org/packages/prowler"><img alt="PyPI Prowler Downloads" src="https://img.shields.io/pypi/dw/prowler.svg?label=prowler%20downloads"></a>

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -2,7 +2,7 @@
 
 For technical support or any type of inquiries, you are very welcome to:
 
-- Reach out to community members on the [**Prowler Slack channel**](https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog)
+- Reach out to community members on the [**Prowler Slack channel**](https://goto.prowler.com/slack)
 
 - Open an Issue or a Pull Request in our [**GitHub repository**](https://github.com/prowler-cloud/prowler).
 

--- a/docs/developer-guide/introduction.md
+++ b/docs/developer-guide/introduction.md
@@ -67,4 +67,4 @@ If you create or review a PR in https://github.com/prowler-cloud/prowler please 
 
 ## Want some swag as appreciation for your contribution?
 
-If you are like us and you love swag, we are happy to thank you for your contribution with some laptop stickers or whatever other swag we may have at that time. Please, tell us more details and your pull request link in our [Slack workspace here](https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog). You can also reach out to Toni de la Fuente on Twitter [here](https://twitter.com/ToniBlyx), his DMs are open.
+If you are like us and you love swag, we are happy to thank you for your contribution with some laptop stickers or whatever other swag we may have at that time. Please, tell us more details and your pull request link in our [Slack workspace here](https://goto.prowler.com/slack). You can also reach out to Toni de la Fuente on Twitter [here](https://twitter.com/ToniBlyx), his DMs are open.

--- a/prowler/lib/outputs/slack/slack.py
+++ b/prowler/lib/outputs/slack/slack.py
@@ -185,7 +185,7 @@ class Slack:
                     "accessory": {
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Prowler :slack:"},
-                        "url": "https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog",
+                        "url": "https://goto.prowler.com/slack",
                     },
                 },
                 {

--- a/tests/lib/outputs/slack/slack_test.py
+++ b/tests/lib/outputs/slack/slack_test.py
@@ -176,7 +176,7 @@ class TestSlackIntegration:
                 "accessory": {
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Prowler :slack:"},
-                    "url": "https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog",
+                    "url": "https://goto.prowler.com/slack",
                 },
             },
             {
@@ -305,7 +305,7 @@ class TestSlackIntegration:
                 "accessory": {
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Prowler :slack:"},
-                    "url": "https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog",
+                    "url": "https://goto.prowler.com/slack",
                 },
             },
             {
@@ -432,7 +432,7 @@ class TestSlackIntegration:
                 "accessory": {
                     "type": "button",
                     "text": {"type": "plain_text", "text": "Prowler :slack:"},
-                    "url": "https://join.slack.com/t/prowler-workspace/shared_invite/zt-1hix76xsl-2uq222JIXrC7Q8It~9ZNog",
+                    "url": "https://goto.prowler.com/slack",
                 },
             },
             {


### PR DESCRIPTION
### Context

Update the community slack link to the new slack invitation url https://goto.prowler.com/slack 

Does not fix a raised issue, just housekeeping.

### Description

Single Docs URL change for the contact.md page.

### Checklist

- Are there new checks included in this PR?  No
- [N/A] Review if the code is being covered by tests.
- [N/A] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [N/A] Review if backport is needed.

### License
No licence changes.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
