### PR TITLE
feat(checks_loader): discard unneeded cloudwatch checks

### DIFF
--- a/prowler/lib/check/checks_loader.py
+++ b/prowler/lib/check/checks_loader.py
@@ -117,13 +117,15 @@ def load_checks_to_execute(
 
         # Exclude check cloudwatch_log_group_no_secrets_in_logs from the checks to execute if not in check_list
         if (
-            "cloudwatch_log_group_no_secrets_in_logs" not in check_list
+            check_list
+            and "cloudwatch_log_group_no_secrets_in_logs" not in check_list
             and "cloudwatch_log_group_no_secrets_in_logs" in checks_to_execute
         ):
             checks_to_execute.remove("cloudwatch_log_group_no_secrets_in_logs")
         # Exclude check cloudwatch_log_group_no_critical_pii_in_logs from the checks to execute if not in check_list
         if (
-            "cloudwatch_log_group_no_critical_pii_in_logs" not in check_list
+            check_list
+            and "cloudwatch_log_group_no_critical_pii_in_logs" not in check_list
             and "cloudwatch_log_group_no_critical_pii_in_logs" in checks_to_execute
         ):
             checks_to_execute.remove("cloudwatch_log_group_no_critical_pii_in_logs")

--- a/prowler/lib/check/checks_loader.py
+++ b/prowler/lib/check/checks_loader.py
@@ -115,6 +115,18 @@ def load_checks_to_execute(
             for threat_detection_check in check_categories.get("threat-detection", []):
                 checks_to_execute.discard(threat_detection_check)
 
+        # Exclude check cloudwatch_log_group_no_secrets_in_logs from the checks to execute if not in check_list
+        if (
+            "cloudwatch_log_group_no_secrets_in_logs" not in check_list
+            and "cloudwatch_log_group_no_secrets_in_logs" in checks_to_execute
+        ):
+            checks_to_execute.remove("cloudwatch_log_group_no_secrets_in_logs")
+        # Exclude check cloudwatch_log_group_no_critical_pii_in_logs from the checks to execute if not in check_list
+        if (
+            "cloudwatch_log_group_no_critical_pii_in_logs" not in check_list
+            and "cloudwatch_log_group_no_critical_pii_in_logs" in checks_to_execute
+        ):
+            checks_to_execute.remove("cloudwatch_log_group_no_critical_pii_in_logs")
         # Check Aliases
         checks_to_execute = update_checks_to_execute_with_aliases(
             checks_to_execute, check_aliases


### PR DESCRIPTION
### Description
This pull request includes updates to the `load_checks_to_execute` method in `prowler/lib/check/checks_loader.py` to enhance the filtering of checks to execute. The changes ensure that specific checks are excluded if they are not explicitly listed in the `check_list`.

Key changes include:

* Added logic to exclude the `cloudwatch_log_group_no_secrets_in_logs` check from the checks to execute if it is not present in the `check_list`.
* Added logic to exclude the `cloudwatch_log_group_no_critical_pii_in_logs` check from the checks to execute if it is not present in the `check_list`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
