### PR TITLE
fix(ec2): unique finding per Security Group in high risk ports check

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.py
@@ -17,34 +17,38 @@ class ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports(Check
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                check_ports = ec2_client.audit_config.get(
-                    "ec2_high_risk_ports",
-                    [25, 110, 135, 143, 445, 3000, 4333, 5000, 5500, 8080, 8088],
-                )
-                for port in check_ports:
-                    report = Check_Report_AWS(self.metadata())
-                    report.region = security_group.region
-                    report.resource_details = security_group.name
-                    report.resource_id = security_group.id
-                    report.resource_arn = security_group_arn
-                    report.resource_tags = security_group.tags
-                    report.status = "PASS"
-                    report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have port {port} open to the Internet."
-                    # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice
-                    if not ec2_client.is_failed_check(
-                        ec2_securitygroup_allow_ingress_from_internet_to_all_ports.__name__,
-                        security_group_arn,
-                    ):
-                        # Loop through every security group's ingress rule and check it
-                        for ingress_rule in security_group.ingress_rules:
+                report = Check_Report_AWS(self.metadata())
+                report.region = security_group.region
+                report.resource_details = security_group.name
+                report.resource_id = security_group.id
+                report.resource_arn = security_group_arn
+                report.resource_tags = security_group.tags
+                report.status = "PASS"
+                report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have any high-risk port open to the Internet."
+                # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice
+                if not ec2_client.is_failed_check(
+                    ec2_securitygroup_allow_ingress_from_internet_to_all_ports.__name__,
+                    security_group_arn,
+                ):
+                    check_ports = ec2_client.audit_config.get(
+                        "ec2_high_risk_ports",
+                        [25, 110, 135, 143, 445, 3000, 4333, 5000, 5500, 8080, 8088],
+                    )
+                    # Loop through every security group's ingress rule and check it
+                    open_ports = []
+                    for ingress_rule in security_group.ingress_rules:
+                        for port in check_ports:
                             if check_security_group(
                                 ingress_rule, "tcp", [port], any_address=True
                             ):
-                                report.status = "FAIL"
-                                report.status_extended = f"Security group {security_group.name} ({security_group.id}) has port {port} (high risk port) open to the Internet."
-                                break
-                    else:
-                        report.status_extended = f"Security group {security_group.name} ({security_group.id}) has all ports open to the Internet and therefore was not checked against port {port}."
-                    findings.append(report)
+                                open_ports.append(port)
+
+                    if open_ports:
+                        report.status = "FAIL"
+                        open_ports_str = ", ".join(map(str, open_ports))
+                        report.status_extended = f"Security group {security_group.name} ({security_group.id}) has the following high-risk ports open to the Internet: {open_ports_str}."
+                else:
+                    report.status_extended = f"Security group {security_group.name} ({security_group.id}) has all ports open to the Internet and therefore was not checked against high-risk ports."
+                findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

An issue was detected within `ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports` check because it loops over a list of ports and all the findings are generated with the same finding.uid which can’t be a possibility.

### Description

Changed `ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports` logic to create one finding per security group instead of one finding per high risk port.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
