### PR TITLE
fix(docs): provider typo

### DIFF
--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -190,18 +190,18 @@ from prowler.providers.common.models import Audit_Metadata
 from prowler.providers.common.provider import Provider
 from prowler.providers.<new_provider_name>.models import (
     # All providers models needed
-    ProvierSessionModel,
-    ProvierIdentityModel,
-    ProvierOutputOptionsModel
+    ProviderSessionModel,
+    ProviderIdentityModel,
+    ProviderOutputOptionsModel
 )
 
 class NewProvider(Provider):
     # All properties from the class, some of this are properties in the base class
     _type: str = "<provider_name>"
-    _session: <ProvierSessionModel>
-    _identity: <ProvierIdentityModel>
+    _session: <ProviderSessionModel>
+    _identity: <ProviderIdentityModel>
     _audit_config: dict
-    _output_options: ProvierOutputOptionsModel
+    _output_options: ProviderOutputOptionsModel
     _mutelist: dict
     audit_metadata: Audit_Metadata
 
@@ -218,7 +218,7 @@ class NewProvider(Provider):
         self._session = self.setup_session(credentials_file)
 
         # Set the Identity class normaly the provider class give by Python provider library
-        self._identity = <ProvierIdentityModel>()
+        self._identity = <ProviderIdentityModel>()
 
         # Set the provider configuration
         self._audit_config = load_and_validate_config_file(

--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -212,7 +212,7 @@ class NewProvider(Provider):
             arguments (dict): A dictionary containing configuration arguments.
         """
         logger.info("Setting <NewProviderName> provider ...")
-        # First get from arguments the necesary from the cloud acount (subscriptions or projects or whatever the provider use for storing services)
+        # First get from arguments the necessary from the cloud acount (subscriptions or projects or whatever the provider use for storing services)
 
         # Set the session with the method enforced by parent class
         self._session = self.setup_session(credentials_file)
@@ -254,7 +254,7 @@ class NewProvider(Provider):
             <all_needed_for_auth> Can include all necessary arguments to setup the session
 
         Returns:
-            Credentials necesary to communicate with the provider.
+            Credentials necessary to communicate with the provider.
         """
         pass
 

--- a/docs/developer-guide/provider.md
+++ b/docs/developer-guide/provider.md
@@ -212,7 +212,7 @@ class NewProvider(Provider):
             arguments (dict): A dictionary containing configuration arguments.
         """
         logger.info("Setting <NewProviderName> provider ...")
-        # First get from arguments the necessary from the cloud acount (subscriptions or projects or whatever the provider use for storing services)
+        # First get from arguments the necessary from the cloud account (subscriptions or projects or whatever the provider use for storing services)
 
         # Set the session with the method enforced by parent class
         self._session = self.setup_session(credentials_file)


### PR DESCRIPTION
### Context

I found a typo in the documentation that needs to be fixed. `Provier` was written instead of `Provider`.

### Description

All instances of `Provier` have been updated to `Provider` to ensure accuracy in the documentation.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
