### PR TITLE
docs(aws): improve docstrings

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -125,7 +125,7 @@ class AwsProvider(Provider):
         """
         Initializes the AWS provider.
 
-        Arguments:
+        Args:
             - retries_max_attempts: The maximum number of retries for the AWS client.
             - role_arn: The ARN of the IAM role to assume.
             - session_duration: The duration of the session in seconds, between 900 and 43200.
@@ -171,7 +171,7 @@ class AwsProvider(Provider):
                     * Note: If you have MFA enabled you will be prompted to enter the MFA ARN and the MFA TOTP code.
                     * Note: Take into account that you can use static credentials or a profile, with the combination of MFA.
 
-                - Assume Role: You can use Prowler against multiple accounts using IAM Assume Role features depending on each use case:
+                - Assume Role: *You should be authenticated to use this method* Prowler can be used against multiple accounts using IAM Assume Role features depending on each use case:
                     - Set up a custom profile inside your AWS CLI configuration file:
                         - [profile profile_name]
                             role_arn = arn:aws:iam::123456789012:role/role_name
@@ -417,7 +417,7 @@ class AwsProvider(Provider):
         """
         get_organizations_info returns a AWSOrganizationsInfo object if the account to be audited is a delegated administrator for AWS Organizations or if the AWS Organizations Role ARN (--organizations-role) is passed.
 
-        Arguments:
+        Args:
         - organizations_session: needs to be a Session object with permissions to do organizations:DescribeAccount and organizations:ListTagsForResource.
         - aws_account_id: is the AWS Account ID from which we want to get the AWS Organizations account metadata
 
@@ -477,7 +477,7 @@ class AwsProvider(Provider):
         """
         set_identity sets the AWS provider identity information.
 
-        Arguments:
+        Args:
             - caller_identity: The AWS caller identity information.
             - profile: The AWS CLI profile name.
             - regions: A set of regions to audit.
@@ -515,7 +515,7 @@ class AwsProvider(Provider):
         """
         setup_session sets up an AWS session using the provided credentials.
 
-        Arguments:
+        Args:
             - mfa: A boolean indicating whether MFA is enabled.
             - profile: The name of the AWS CLI profile to use.
             - aws_access_key_id: The AWS access key ID.
@@ -755,7 +755,7 @@ class AwsProvider(Provider):
         """
         get_available_aws_service_regions returns the available regions for the given service and partition.
 
-        Arguments:
+        Args:
             - service: The AWS service name.
             - partition: The AWS partition name. Default is "aws".
             - audited_regions: A set of regions to audit. Default is None.
@@ -849,7 +849,7 @@ class AwsProvider(Provider):
     def get_regions_from_audit_resources(self, audit_resources: list) -> set:
         """get_regions_from_audit_resources gets the regions from the audit resources arns
 
-        Arguments:
+        Args:
             - audit_resources: list of ARNs of the resources to audit
 
         Returns:
@@ -920,7 +920,7 @@ class AwsProvider(Provider):
     def get_default_region(self, service: str) -> str:
         """get_default_region returns the default region based on the profile and audited service regions
 
-        Arguments:
+        Args:
             - service: The AWS service name
 
         Returns:
@@ -985,7 +985,7 @@ class AwsProvider(Provider):
         """
         set_session_config returns a botocore Config object with the Prowler user agent and the default retrier configuration if nothing is passed as argument
 
-        Arguments:
+        Args:
             - retries_max_attempts: The maximum number of retries for the standard retrier config
 
         Returns:
@@ -1017,7 +1017,7 @@ class AwsProvider(Provider):
         """
         assume_role assumes the IAM roles passed with the given session and returns AWSCredentials
 
-        Arguments:
+        Args:
             - session: The AWS session object
             - assumed_role_info: The AWSAssumeRoleInfo object
 
@@ -1076,7 +1076,7 @@ class AwsProvider(Provider):
     def get_aws_enabled_regions(self, current_session: Session) -> set:
         """get_aws_enabled_regions returns a set of enabled AWS regions
 
-        Arguments:
+        Args:
             - current_session: The AWS session object
 
         Returns:

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -154,26 +154,36 @@ class AwsProvider(Provider):
             - ArgumentTypeError: If the input role session name is invalid.
 
         Usage:
-            - Using static credentials:
-                provider = AwsProvider(
-                    aws_access_key_id="AWS_ACCESS_KEY_ID",
-                    aws_secret_access_key="AWS_SECRET_ACCESS_KEY",
-                    aws_session_token="AWS_SESSION_TOKEN",
-                )
-            - Using a profile:
-                provider = AwsProvider(profile="PROFILE_NAME")
-            - Using an IAM role:
-                provider = AwsProvider(role_arn="ROLE_ARN")
-            - Using an IAM role and setting session duration with external ID:
-                provider = AwsProvider(
-                    role_arn="ROLE_ARN",
-                    session_duration=3600,
-                    external_id="EXTERNAL_ID",
-                )
-            - Using an IAM role and MFA:
-                provider = AwsProvider(role_arn="ROLE_ARN", mfa=True)
-            - Using role session name:
-                provider = AwsProvider(role_arn="ROLE_ARN", role_session_name="ROLE_SESSION_NAME")
+            - Boto3 is used so we follow their credential setup process:
+                - Authentication: Make sure you have properly configured your AWS CLI with a valid Access Key and Region or declare the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables.
+                    - aws configure
+                    or
+                    - export AWS_ACCESS_KEY_ID="ASXXXXXXX"
+                      export AWS_SECRET_ACCESS_KEY="XXXXXXXXX"
+                      export AWS_SESSION_TOKEN="XXXXXXXXX"
+                    - To create a new aws object you can use:
+                        - aws = AwsProvider()
+                        - aws = AwsProvider(aws_access_key_id="ASXXXXXXX", aws_secret_access_key="XXXXXXXXX", aws_session_token="XXXXXXXXX")
+                    - Profile: If you have multiple profiles in your AWS CLI configuration, you can specify the profile to use:
+                        - aws = AwsProvider(profile="profile_name")
+                    - MFA: If you have MFA enabled you can specify it:
+                        - aws = AwsProvider(mfa=True)
+                    * Note: If you have MFA enabled you will be prompted to enter the MFA ARN and the MFA TOTP code.
+                    * Note: Take into account that you can use static credentials or a profile, with the combination of MFA.
+
+                - Assume Role: You can use Prowler against multiple accounts using IAM Assume Role features depending on each use case:
+                    - Set up a custom profile inside your AWS CLI configuration file:
+                        - [profile profile_name]
+                            role_arn = arn:aws:iam::123456789012:role/role_name
+                        - aws = AwsProvider(profile="profile_name")
+                    - Use role_arn directly:
+                        - aws = AwsProvider(role_arn="arn:aws:iam::123456789012:role/role_name")
+                        - Use role_arn with session duration(in seconds, by default 3600) and external ID:
+                            - aws = AwsProvider(role_arn="arn:aws:iam::123456789012:role/role_name", session_duration=3600, external_id="external_id")
+                    - Use custom role session name:
+                        - aws = AwsProvider(role_arn="arn:aws:iam::123456789012:role/role_name", role_session_name="custom_session_name")
+                    * Note: You can use the combination of MFA with Assume Role.
+                        - aws = AwsProvider(role_arn="arn:aws:iam::123456789012:role/role_name", mfa=True)
         """
 
         logger.info("Initializing AWS provider ...")

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -171,7 +171,7 @@ class AwsProvider(Provider):
                     * Note: If you have MFA enabled you will be prompted to enter the MFA ARN and the MFA TOTP code.
                     * Note: Take into account that you can use static credentials or a profile, with the combination of MFA.
 
-                - Assume Role: *You should be authenticated to use this method* Prowler can be used against multiple accounts using IAM Assume Role features depending on each use case:
+                - Assume Role: *Requires authentication.* Prowler can be used against multiple accounts using IAM Assume Role features depending on each use case:
                     - Set up a custom profile inside your AWS CLI configuration file:
                         - [profile profile_name]
                             role_arn = arn:aws:iam::123456789012:role/role_name


### PR DESCRIPTION
### Description

This pull request introduces comprehensive docstrings to the `AwsProvider` class and its methods in the `prowler/providers/aws/aws_provider.py` file. These changes aim to enhance code readability and provide clear documentation for future developers.

### Enhancements to Documentation:

* **Class-level docstring**:
  - Added a detailed description of the `AwsProvider` class, including its responsibilities and attributes.

* **Method-level docstrings**:
  - [`__init__`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L112-R131): Expanded the description of `session_duration` and provided usage examples for different initialization scenarios. [[1]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L112-R131) [[2]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R156-R176)
  - [`set_identity`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R467-R481): Added a comprehensive description of the method, including arguments, return type, and possible exceptions.
  - [`setup_session`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R505-R520): Documented the method's purpose, arguments, return type, and potential exceptions.
  - [`print_credentials`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R662-R676): Added a docstring to describe the method's functionality and provide an example output.
  - [`get_checks_from_input_arn`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R768-R773): Included a description, return type, and example usage.
  - [`get_regions_from_audit_resources`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L748-R851): Detailed the arguments, return type, and provided an example.
  - [`get_default_region`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L808-R922): Explained the method's purpose, arguments, return type, and provided an example.
  - [`get_global_region`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L829-R950): Clarified the method's functionality, return type, and provided an example.
  - [`input_role_mfa_token_and_code`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L841-R982): Added a description of the method, its return type, and an example.
  - [`set_session_config`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R1009-R1015): Included a description of the method's arguments and return type.
  - [`assume_role`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R1009-R1015): Provided a detailed description of the method, its arguments, and return type. [[1]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R1009-R1015) [[2]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L926-R1074)
  - [`get_aws_enabled_regions`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R1098-R1103): Added a comprehensive docstring detailing the method's arguments and return type.
  - [`get_checks_to_execute_by_audit_resources`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R1098-R1103): Documented the method's purpose and return type.
  - [`get_aws_region_for_sts`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371R1493-R1505): Included a description of the function, its arguments, return type, and an example.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
