### PR TITLE
docs(azure): improve docstrings

### DIFF
--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -152,45 +152,66 @@ class AzureProvider(Provider):
             AzureHTTPResponseError: If there is an HTTP response error.
 
         Usage:
-            - Using static credentials:
-                >>> AzureProvider(
-                ...     az_cli_auth=False,
-                ...     sp_env_auth=False,
-                ...     browser_auth=False,
-                ...     managed_identity_auth=False,
-                ...     tenant_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-                ...     client_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-                ...     client_secret="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-                ... )
-            - Using Azure CLI authentication:
-                >>> AzureProvider(
-                ...     az_cli_auth=True,
-                ...     sp_env_auth=False,
-                ...     browser_auth=False,
-                ...     managed_identity_auth=False,
-                ... )
-            - Using Service Principal environment authentication:
+            - Authentication: By default Prowler uses Azure Python SDK identity package authentication methods using the classes DefaultAzureCredential and InteractiveBrowserCredential.
+                - Using static credentials:
+                    >>> AzureProvider(
+                    ...     az_cli_auth=False,
+                    ...     sp_env_auth=False,
+                    ...     browser_auth=False,
+                    ...     managed_identity_auth=False,
+                    ...     tenant_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+                    ...     client_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+                    ...     client_secret="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                    ... )
+                - Using Azure CLI authentication:
+                    >>> AzureProvider(
+                    ...     az_cli_auth=True,
+                    ...     sp_env_auth=False,
+                    ...     browser_auth=False,
+                    ...     managed_identity_auth=False,
+                    ... )
+                - Using Service Principal environment authentication:
+                    >>> AzureProvider(
+                    ...     az_cli_auth=False,
+                    ...     sp_env_auth=True,
+                    ...     browser_auth=False,
+                    ...     managed_identity_auth=False,
+                    ... )
+                - Using interactive browser authentication:
+                    >>> AzureProvider(
+                    ...     az_cli_auth=False,
+                    ...     sp_env_auth=False,
+                    ...     browser_auth=True,
+                    ...     managed_identity_auth=False,
+                    ...     tenant_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+                    ... )
+                    * Note: Azure Tenant ID is required for browser authentication mode.
+                - Using managed identity authentication:
+                    >>> AzureProvider(
+                    ...     az_cli_auth=False,
+                    ...     sp_env_auth=False,
+                    ...     browser_auth=False,
+                    ...     managed_identity_auth=True,
+                    ... )
+            - Non default azure region: Microsoft provides clouds for compliance with regional laws, which are available for your use. By default, Prowler uses AzureCloud cloud which is the comercial one.
+              If you want to use a different one, you can specify it using the region parameter.
                 >>> AzureProvider(
                 ...     az_cli_auth=False,
                 ...     sp_env_auth=True,
                 ...     browser_auth=False,
                 ...     managed_identity_auth=False,
+                ...     region="AzureUSGovernment",
                 ... )
-            - Using interactive browser authentication:
+            - Subscriptions: rowler is multisubscription, which means that is going to scan all the subscriptions is able to list. If you only assign permissions to one subscription, it is going to scan a single one.
+              Prowler also allows you to specify the subscriptions you want to scan by passing a list of subscription IDs.
                 >>> AzureProvider(
                 ...     az_cli_auth=False,
-                ...     sp_env_auth=False,
-                ...     browser_auth=True,
-                ...     managed_identity_auth=False,
-                ...     tenant_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
-                ... )
-            - Using managed identity authentication:
-                >>> AzureProvider(
-                ...     az_cli_auth=False,
-                ...     sp_env_auth=False,
+                ...     sp_env_auth=True,
                 ...     browser_auth=False,
-                ...     managed_identity_auth=True,
+                ...     managed_identity_auth=False,
+                ...     subscription_ids=["XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"],
                 ... )
+
         """
         logger.info("Setting Azure provider ...")
 

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -150,6 +150,47 @@ class AzureProvider(Provider):
             AzureConfigCredentialsError: If there is an error in configuring the Azure credentials from a dictionary.
             AzureGetTokenIdentityError: If there is an error in getting the token from the Azure identity.
             AzureHTTPResponseError: If there is an HTTP response error.
+
+        Usage:
+            - Using static credentials:
+                >>> AzureProvider(
+                ...     az_cli_auth=False,
+                ...     sp_env_auth=False,
+                ...     browser_auth=False,
+                ...     managed_identity_auth=False,
+                ...     tenant_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+                ...     client_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+                ...     client_secret="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                ... )
+            - Using Azure CLI authentication:
+                >>> AzureProvider(
+                ...     az_cli_auth=True,
+                ...     sp_env_auth=False,
+                ...     browser_auth=False,
+                ...     managed_identity_auth=False,
+                ... )
+            - Using Service Principal environment authentication:
+                >>> AzureProvider(
+                ...     az_cli_auth=False,
+                ...     sp_env_auth=True,
+                ...     browser_auth=False,
+                ...     managed_identity_auth=False,
+                ... )
+            - Using interactive browser authentication:
+                >>> AzureProvider(
+                ...     az_cli_auth=False,
+                ...     sp_env_auth=False,
+                ...     browser_auth=True,
+                ...     managed_identity_auth=False,
+                ...     tenant_id="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+                ... )
+            - Using managed identity authentication:
+                >>> AzureProvider(
+                ...     az_cli_auth=False,
+                ...     sp_env_auth=False,
+                ...     browser_auth=False,
+                ...     managed_identity_auth=True,
+                ... )
         """
         logger.info("Setting Azure provider ...")
 


### PR DESCRIPTION
### Description

This pull request includes an enhancement to the `AzureProvider` class in the `prowler/providers/azure/azure_provider.py` file. The main change is the addition of usage examples to the `__init__` method's docstring, demonstrating various ways to instantiate the `AzureProvider` class.

Enhancements to documentation:

* [`prowler/providers/azure/azure_provider.py`](diffhunk://#diff-0a754230230caeff53e9974aeac407d2306193e1f8eba138a3d628b175ba747fR153-R193): Added detailed usage examples for different authentication methods (static credentials, Azure CLI, Service Principal environment, interactive browser, and managed identity) to the `__init__` method's docstring.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
