### PR TITLE
fix(gcp): scan only ACTIVE projects

### DIFF
--- a/prowler/providers/gcp/exceptions/exceptions.py
+++ b/prowler/providers/gcp/exceptions/exceptions.py
@@ -15,8 +15,8 @@ class GCPBaseException(ProwlerException):
             "remediation": "Check the HTTP error and ensure the request is properly formatted.",
         },
         (3002, "GCPNoAccesibleProjectsError"): {
-            "message": "No Project IDs can be accessed via Google Credentials",
-            "remediation": "Ensure the project is accessible and properly set up.",
+            "message": "No Project IDs are active or can be accessed via Google Credentials",
+            "remediation": "Ensure the project is active and accessible.",
         },
         (3003, "GCPSetUpSessionError"): {
             "message": "Error setting up session",


### PR DESCRIPTION
### Description

Ensure that Prowler scans only ACTIVE GCP projects, as projects scheduled for deletion are inaccessible and their resources cannot be listed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
