### PR TITLE
fix(ec2): add default value to Name key for image information

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -357,7 +357,7 @@ class EC2(AWSService):
                         Image(
                             id=image["ImageId"],
                             arn=arn,
-                            name=image["Name"],
+                            name=image.get("Name", None),
                             public=image.get("Public", False),
                             region=regional_client.region,
                             tags=image.get("Tags"),


### PR DESCRIPTION
### Context

If EC2 image does not have a name the function return an exception with KeyError.

### Description

Add default None value to not return the exception and continue with code execution.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
