### PR TITLE
feat(aws): get regions by partition

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -1298,7 +1298,8 @@ class AwsProvider(Provider):
             )
             raise error
 
-    def get_aws_available_regions(partition: str = None) -> set:
+    @staticmethod
+    def get_regions_by_partition(partition: str = None) -> set:
         """
         Get the available AWS regions from the AWS services JSON file with the ability of filtering by partition.
 

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -1313,9 +1313,12 @@ def read_aws_regions_file() -> dict:
     return data
 
 
-def get_aws_available_regions() -> set:
+def get_aws_available_regions(partition: str = None) -> set:
     """
     Get the available AWS regions from the AWS services JSON file.
+
+    Args:
+        - partition (str): The AWS partition name. Default is None.
 
     Returns:
         set: A set of available AWS regions.
@@ -1324,10 +1327,16 @@ def get_aws_available_regions() -> set:
         data = read_aws_regions_file()
 
         regions = set()
-        for service in data["services"].values():
-            for partition in service["regions"]:
-                for item in service["regions"][partition]:
-                    regions.add(item)
+        if partition is None:
+            for service in data["services"].values():
+                for partition in service["regions"]:
+                    for item in service["regions"][partition]:
+                        regions.add(item)
+        else:
+            for service in data["services"].values():
+                if partition in service["regions"]:
+                    for item in service["regions"][partition]:
+                        regions.add(item)
         return regions
     except Exception as error:
         logger.error(f"{error.__class__.__name__}: {error}")

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -39,6 +39,7 @@ from prowler.providers.aws.exceptions.exceptions import (
     AWSIAMRoleARNPartitionEmptyError,
     AWSIAMRoleARNRegionNotEmtpyError,
     AWSIAMRoleARNServiceNotIAMnorSTSError,
+    AWSInvalidPartitionError,
     AWSInvalidProviderIdError,
     AWSNoCredentialsError,
     AWSProfileNotFoundError,
@@ -1297,6 +1298,43 @@ class AwsProvider(Provider):
             )
             raise error
 
+    def get_aws_available_regions(partition: str = None) -> set:
+        """
+        Get the available AWS regions from the AWS services JSON file with the ability of filtering by partition.
+
+        Args:
+            - partition (str): The AWS partition name. Default is None.
+
+        Returns:
+            set: A set of available AWS regions. All if no `partition` is especified.
+        """
+        try:
+            data = read_aws_regions_file()
+
+            regions = set()
+            if partition is None:
+                for service in data["services"].values():
+                    for partition in service["regions"]:
+                        for item in service["regions"][partition]:
+                            regions.add(item)
+            else:
+                for service in data["services"].values():
+                    try:
+                        for item in service["regions"][partition]:
+                            regions.add(item)
+                    except KeyError as key_error:
+                        logger.error(
+                            f"{key_error.__class__.__name__}[{key_error.__traceback__.tb_lineno}]: {key_error}"
+                        )
+                        raise AWSInvalidPartitionError(
+                            message=f"Invalid partition name: {partition}",
+                            file=os.path.basename(__file__),
+                        )
+            return regions
+        except Exception as error:
+            logger.error(f"{error.__class__.__name__}: {error}")
+            return set()
+
 
 def read_aws_regions_file() -> dict:
     """
@@ -1311,36 +1349,6 @@ def read_aws_regions_file() -> dict:
         data = parse_json_file(f)
 
     return data
-
-
-def get_aws_available_regions(partition: str = None) -> set:
-    """
-    Get the available AWS regions from the AWS services JSON file.
-
-    Args:
-        - partition (str): The AWS partition name. Default is None.
-
-    Returns:
-        set: A set of available AWS regions.
-    """
-    try:
-        data = read_aws_regions_file()
-
-        regions = set()
-        if partition is None:
-            for service in data["services"].values():
-                for partition in service["regions"]:
-                    for item in service["regions"][partition]:
-                        regions.add(item)
-        else:
-            for service in data["services"].values():
-                if partition in service["regions"]:
-                    for item in service["regions"][partition]:
-                        regions.add(item)
-        return regions
-    except Exception as error:
-        logger.error(f"{error.__class__.__name__}: {error}")
-        return set()
 
 
 # TODO: This can be moved to another class since it doesn't need self

--- a/prowler/providers/aws/exceptions/exceptions.py
+++ b/prowler/providers/aws/exceptions/exceptions.py
@@ -74,6 +74,10 @@ class AWSBaseException(ProwlerException):
             "message": "The provided AWS Session Token is expired",
             "remediation": "Get a new AWS Session Token and configure it for the provider.",
         },
+        (1917, "AWSInvalidPartitionError"): {
+            "message": "The provided AWS partition is invalid",
+            "remediation": "Check the provided AWS partition and ensure it is valid.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -219,4 +223,11 @@ class AWSSessionTokenExpiredError(AWSCredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             1016, file=file, original_exception=original_exception, message=message
+        )
+
+
+class AWSInvalidPartitionError(AWSBaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            1917, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentTypeError, Namespace
 from re import fullmatch, search
 
-from prowler.providers.aws.aws_provider import get_aws_available_regions
+from prowler.providers.aws.aws_provider import AwsProvider
 from prowler.providers.aws.config import ROLE_SESSION_NAME
 from prowler.providers.aws.lib.arn.arn import arn_type
 
@@ -64,7 +64,7 @@ def init_parser(self):
         "-f",
         nargs="+",
         help="AWS region names to run Prowler against",
-        choices=get_aws_available_regions(),
+        choices=AwsProvider.get_aws_available_regions(),
     )
     # AWS Organizations
     aws_orgs_subparser = aws_parser.add_argument_group("AWS Organizations")

--- a/prowler/providers/aws/lib/arguments/arguments.py
+++ b/prowler/providers/aws/lib/arguments/arguments.py
@@ -64,7 +64,7 @@ def init_parser(self):
         "-f",
         nargs="+",
         help="AWS region names to run Prowler against",
-        choices=AwsProvider.get_aws_available_regions(),
+        choices=AwsProvider.get_regions_by_partition(),
     )
     # AWS Organizations
     aws_orgs_subparser = aws_parser.add_argument_group("AWS Organizations")

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -11,7 +11,7 @@ from prowler.config.config import (
     load_and_validate_config_file,
     load_and_validate_fixer_config_file,
 )
-from prowler.providers.aws.aws_provider import get_aws_available_regions
+from prowler.providers.aws.aws_provider import AwsProvider
 
 MOCK_PROWLER_VERSION = "3.3.0"
 MOCK_OLD_PROWLER_VERSION = "0.0.0"
@@ -347,13 +347,13 @@ config_kubernetes = {
 
 class Test_Config:
     def test_get_aws_available_regions(self):
-        assert len(get_aws_available_regions()) == 34
+        assert len(AwsProvider.get_aws_available_regions()) == 34
 
     def test_get_aws_available_regions_with_partition(self):
-        assert len(get_aws_available_regions("aws-cn")) == 2
+        assert len(AwsProvider.get_aws_available_regions("aws-cn")) == 2
 
     def test_get_aws_available_regions_with_unknown_partition(self):
-        assert len(get_aws_available_regions("unknown")) == 0
+        assert len(AwsProvider.get_aws_available_regions("unknown")) == 0
 
     @mock.patch(
         "prowler.config.config.requests.get", new=mock_prowler_get_latest_release

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -349,6 +349,12 @@ class Test_Config:
     def test_get_aws_available_regions(self):
         assert len(get_aws_available_regions()) == 34
 
+    def test_get_aws_available_regions_with_partition(self):
+        assert len(get_aws_available_regions("aws-cn")) == 2
+
+    def test_get_aws_available_regions_with_unknown_partition(self):
+        assert len(get_aws_available_regions("unknown")) == 0
+
     @mock.patch(
         "prowler.config.config.requests.get", new=mock_prowler_get_latest_release
     )

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -346,14 +346,14 @@ config_kubernetes = {
 
 
 class Test_Config:
-    def test_get_aws_available_regions(self):
-        assert len(AwsProvider.get_aws_available_regions()) == 34
+    def test_get_regions_by_partition(self):
+        assert len(AwsProvider.get_regions_by_partition()) == 34
 
-    def test_get_aws_available_regions_with_partition(self):
-        assert len(AwsProvider.get_aws_available_regions("aws-cn")) == 2
+    def test_get_regions_by_partition_with_partition(self):
+        assert len(AwsProvider.get_regions_by_partition("aws-cn")) == 2
 
-    def test_get_aws_available_regions_with_unknown_partition(self):
-        assert len(AwsProvider.get_aws_available_regions("unknown")) == 0
+    def test_get_regions_by_partition_with_unknown_partition(self):
+        assert len(AwsProvider.get_regions_by_partition("unknown")) == 0
 
     @mock.patch(
         "prowler.config.config.requests.get", new=mock_prowler_get_latest_release

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1716,7 +1716,7 @@ aws:
         )
         assert not recovered_regions
 
-    def test_get_aws_available_regions(self):
+    def test_get_regions_by_partition(self):
         with patch(
             "prowler.providers.aws.aws_provider.read_aws_regions_file",
             return_value={
@@ -1737,13 +1737,13 @@ aws:
                 }
             },
         ):
-            assert AwsProvider.get_aws_available_regions() == {
+            assert AwsProvider.get_regions_by_partition() == {
                 "af-south-1",
                 "cn-north-1",
                 "us-gov-west-1",
             }
 
-    def test_get_aws_available_regions_with_partition(self):
+    def test_get_regions_by_partition_with_partition(self):
         with patch(
             "prowler.providers.aws.aws_provider.read_aws_regions_file",
             return_value={
@@ -1764,11 +1764,11 @@ aws:
                 }
             },
         ):
-            assert AwsProvider.get_aws_available_regions("aws-cn") == {
+            assert AwsProvider.get_regions_by_partition("aws-cn") == {
                 "cn-north-1",
             }
 
-    def test_get_aws_available_regions_with_unknown_partition(self):
+    def test_get_regions_by_partition_with_unknown_partition(self):
         with patch(
             "prowler.providers.aws.aws_provider.read_aws_regions_file",
             return_value={
@@ -1789,7 +1789,7 @@ aws:
                 }
             },
         ):
-            assert AwsProvider.get_aws_available_regions("unknown") == set()
+            assert AwsProvider.get_regions_by_partition("unknown") == set()
 
     def test_get_aws_region_for_sts_input_regions_none_session_region_none(self):
         input_regions = None

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -1747,6 +1747,54 @@ aws:
                 "us-gov-west-1",
             }
 
+    def test_get_aws_available_regions_with_partition(self):
+        with patch(
+            "prowler.providers.aws.aws_provider.read_aws_regions_file",
+            return_value={
+                "services": {
+                    "acm": {
+                        "regions": {
+                            "aws": [
+                                "af-south-1",
+                            ],
+                            "aws-cn": [
+                                "cn-north-1",
+                            ],
+                            "aws-us-gov": [
+                                "us-gov-west-1",
+                            ],
+                        }
+                    }
+                }
+            },
+        ):
+            assert get_aws_available_regions("aws-cn") == {
+                "cn-north-1",
+            }
+
+    def test_get_aws_available_regions_with_unknown_partition(self):
+        with patch(
+            "prowler.providers.aws.aws_provider.read_aws_regions_file",
+            return_value={
+                "services": {
+                    "acm": {
+                        "regions": {
+                            "aws": [
+                                "af-south-1",
+                            ],
+                            "aws-cn": [
+                                "cn-north-1",
+                            ],
+                            "aws-us-gov": [
+                                "us-gov-west-1",
+                            ],
+                        }
+                    }
+                }
+            },
+        ):
+            assert get_aws_available_regions("unknown") == set()
+
     def test_get_aws_region_for_sts_input_regions_none_session_region_none(self):
         input_regions = None
         session_region = None

--- a/tests/providers/aws/aws_provider_test.py
+++ b/tests/providers/aws/aws_provider_test.py
@@ -15,11 +15,7 @@ from moto import mock_aws
 from pytest import raises
 from tzlocal import get_localzone
 
-from prowler.providers.aws.aws_provider import (
-    AwsProvider,
-    get_aws_available_regions,
-    get_aws_region_for_sts,
-)
+from prowler.providers.aws.aws_provider import AwsProvider, get_aws_region_for_sts
 from prowler.providers.aws.config import (
     AWS_STS_GLOBAL_ENDPOINT_REGION,
     BOTO3_USER_AGENT_EXTRA,
@@ -1741,7 +1737,7 @@ aws:
                 }
             },
         ):
-            assert get_aws_available_regions() == {
+            assert AwsProvider.get_aws_available_regions() == {
                 "af-south-1",
                 "cn-north-1",
                 "us-gov-west-1",
@@ -1768,7 +1764,7 @@ aws:
                 }
             },
         ):
-            assert get_aws_available_regions("aws-cn") == {
+            assert AwsProvider.get_aws_available_regions("aws-cn") == {
                 "cn-north-1",
             }
 
@@ -1793,7 +1789,7 @@ aws:
                 }
             },
         ):
-            assert get_aws_available_regions("unknown") == set()
+            assert AwsProvider.get_aws_available_regions("unknown") == set()
 
     def test_get_aws_region_for_sts_input_regions_none_session_region_none(self):
         input_regions = None


### PR DESCRIPTION
### Description

This pull request introduces improvements to the `get_aws_available_regions` function in the `prowler/providers/aws/aws_provider.py` file, adding support for filtering by AWS partition. Additionally, it includes new tests to verify the functionality of this enhancement.

Enhancements to `get_aws_available_regions` function:

* [`prowler/providers/aws/aws_provider.py`](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L1316-R1339): Modified `get_aws_available_regions` to accept an optional `partition` parameter, allowing the function to filter available regions by the specified AWS partition.

New tests for partition filtering:

* [`tests/config/config_test.py`](diffhunk://#diff-ea516ccdbe20e60f16488aa15a37a1c6ac214de78194803c90f9dc71517f0918R352-R357): Added `test_get_aws_available_regions_with_partition` and `test_get_aws_available_regions_with_unknown_partition` to verify the function's behavior when a specific partition is provided and when an unknown partition is provided.
* [`tests/providers/aws/aws_provider_test.py`](diffhunk://#diff-931c013c745cc0394611a60a1a3264232e1d299bf9015af4319725f4b3280fb5R1750-R1797): Added `test_get_aws_available_regions_with_partition` and `test_get_aws_available_regions_with_unknown_partition` to ensure the function correctly handles known and unknown partitions, using mocked data for testing.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
