### PR TITLE
refactor(azure): get locations with self session

### DIFF
--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -198,7 +198,7 @@ class AzureProvider(Provider):
         )
 
         # TODO: should we keep this here or within the identity?
-        self._locations = self.get_locations(self.session)
+        self._locations = self.get_locations()
 
         # Audit Config
         if config_content:
@@ -942,33 +942,29 @@ class AzureProvider(Provider):
 
         return identity
 
-    def get_locations(self, credentials) -> dict[str, list[str]]:
+    def get_locations(self) -> dict[str, list[str]]:
         """
         Retrieves the locations available for each subscription using the provided credentials.
-
-        Args:
-            credentials: The credentials object used to authenticate the request.
 
         Returns:
             A dictionary containing the locations available for each subscription. The dictionary
             has subscription display names as keys and lists of location names as values.
         """
-        locations = None
-        if credentials:
-            locations = {}
-            token = credentials.get_token("https://management.azure.com/.default").token
-            for display_name, subscription_id in self._identity.subscriptions.items():
-                locations.update({display_name: []})
-                url = f"https://management.azure.com/subscriptions/{subscription_id}/locations?api-version=2022-12-01"
-                headers = {
-                    "Authorization": f"Bearer {token}",
-                    "Content-Type": "application/json",
-                }
-                response = requests.get(url, headers=headers)
-                if response.status_code == 200:
-                    data = response.json()
-                    for location in data["value"]:
-                        locations[display_name].append(location["name"])
+        credentials = self.session
+        locations = {}
+        token = credentials.get_token("https://management.azure.com/.default").token
+        for display_name, subscription_id in self._identity.subscriptions.items():
+            locations.update({display_name: []})
+            url = f"https://management.azure.com/subscriptions/{subscription_id}/locations?api-version=2022-12-01"
+            headers = {
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            }
+            response = requests.get(url, headers=headers)
+            if response.status_code == 200:
+                data = response.json()
+                for location in data["value"]:
+                    locations[display_name].append(location["name"])
         return locations
 
     @staticmethod

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
@@ -9,7 +9,7 @@ class network_watcher_enabled(Check):
             report = Check_Report_Azure(self.metadata())
             report.subscription = subscription
             report.resource_name = "Network Watcher"
-            report.location = "Global"
+            report.location = "global"
             report.resource_id = f"/subscriptions/{network_client.subscriptions[subscription]}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
 
             missing_locations = set(network_client.locations[subscription]) - set(

--- a/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
+++ b/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
@@ -78,7 +78,7 @@ class Test_network_watcher_enabled:
             assert result[0].subscription == AZURE_SUBSCRIPTION_NAME
             assert result[0].resource_name == network_watcher_name
             assert result[0].resource_id == network_watcher_id
-            assert result[0].location == "Global"
+            assert result[0].location == "global"
 
     def test_network_valid_network_watchers(self):
         network_client = mock.MagicMock
@@ -124,4 +124,4 @@ class Test_network_watcher_enabled:
             assert result[0].subscription == AZURE_SUBSCRIPTION_NAME
             assert result[0].resource_name == network_watcher_name
             assert result[0].resource_id == network_watcher_id
-            assert result[0].location == "Global"
+            assert result[0].location == "global"


### PR DESCRIPTION
### Description

This pull request includes changes to the `azure_provider.py` file within the `prowler/providers/azure` directory. The main focus of these changes is to simplify the `get_locations` method by removing the need to pass credentials as an argument and instead using the session directly.

Key changes include:

* Simplification of the `__init__` method by removing the credentials argument from the `get_locations` method call.
* Modification of the `get_locations` method to no longer require credentials as an argument and directly use the session for authentication.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
