### PR TITLE
feat(gcp): add get regions method

### DIFF
--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -680,4 +680,4 @@ class GcpProvider(Provider):
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
-            return []
+            return set()

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -653,3 +653,31 @@ class GcpProvider(Provider):
                 file=__file__,
                 message="The provider ID does not match with the expected project_id.",
             )
+
+    def get_regions(self) -> set:
+        """
+        Get the regions available in GCP for the given project IDs
+
+        Returns:
+            set of regions
+        """
+        try:
+            regions = set()
+            service = discovery.build("compute", "v1", credentials=self._session)
+            for project_id in self._project_ids:
+                try:
+                    request = service.regions().list(project=project_id)
+                    response = request.execute()
+                    for region in response.get("items", []):
+                        regions.add(region["name"])
+                except Exception as error:
+                    logger.error(
+                        f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
+                    continue
+            return regions
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+            return []


### PR DESCRIPTION
### Description

This pull request introduces a new method to the `prowler/providers/gcp/gcp_provider.py` file to enhance the functionality of the GCP provider class. The most important change is the addition of a method to retrieve available regions for the given project IDs.

New functionality:

* [`prowler/providers/gcp/gcp_provider.py`](diffhunk://#diff-c74b2d04012d4dfcb59ce5491bb4b391df5201a418264c255452de7aea2340f6R656-R683): Added the `get_regions` method to fetch and return the set of regions available in GCP for the specified project IDs. This method handles exceptions and logs errors if they occur during the process.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
