### PR TITLE
feat(documentdb): add new fixer `documentdb_cluster_public_snapshot_fixer`

### DIFF
--- a/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
@@ -1,0 +1,31 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.documentdb.documentdb_client import (
+    documentdb_client,
+)
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the attributes of a DocumentDB cluster snapshot to remove public access.
+    Specifically, this fixer removes the 'all' value from the 'restore' attribute to
+    prevent the snapshot from being publicly accessible.
+    Args:
+        resource_id (str): The DB cluster snapshot identifier.
+        region (str): AWS region where the snapshot exists.
+    Returns:
+        bool: True if the operation is successful (public access is removed), False otherwise.
+    """
+    try:
+        regional_client = documentdb_client.regional_clients[region]
+        regional_client.modify_db_cluster_snapshot_attribute(
+            DBClusterSnapshotIdentifier=resource_id,
+            AttributeName="restore",
+            ValuesToRemove=["all"],
+        )
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
@@ -9,6 +9,19 @@ def fixer(resource_id: str, region: str) -> bool:
     Modify the attributes of a DocumentDB cluster snapshot to remove public access.
     Specifically, this fixer removes the 'all' value from the 'restore' attribute to
     prevent the snapshot from being publicly accessible.
+
+    Requires the rds:ModifyDBClusterSnapshotAttribute permissions.
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "rds:ModifyDBClusterSnapshotAttribute",
+                "Resource": "*"
+            }
+        ]
+    }
+
     Args:
         resource_id (str): The DB cluster snapshot identifier.
         region (str): AWS region where the snapshot exists.

--- a/tests/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer_test.py
@@ -1,0 +1,93 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_public_snapshot(self, operation_name, kwarg):
+    if operation_name == "ModifyDBClusterSnapshotAttribute":
+        return {
+            "DBClusterSnapshotAttributesResult": {
+                "DBClusterSnapshotAttributes": [
+                    {
+                        "AttributeName": "restore",
+                        "DBClusterSnapshotIdentifier": "test-snapshot",
+                        "AttributeValues": [],
+                    }
+                ]
+            }
+        }
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+def mock_make_api_call_public_snapshot_error(self, operation_name, kwarg):
+    if operation_name == "ModifyDBClusterSnapshotAttribute":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "DBClusterSnapshotNotFoundFault",
+                    "Message": "DBClusterSnapshotNotFoundFault",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_documentdb_cluster_public_snapshot_fixer:
+    @mock_aws
+    def test_documentdb_cluster_public_snapshot_fixer(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_public_snapshot,
+        ):
+            from prowler.providers.aws.services.documentdb.documentdb_service import (
+                DocumentDB,
+            )
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.documentdb.documentdb_cluster_public_snapshot.documentdb_cluster_public_snapshot_fixer.documentdb_client",
+                new=DocumentDB(aws_provider),
+            ):
+                from prowler.providers.aws.services.documentdb.documentdb_cluster_public_snapshot.documentdb_cluster_public_snapshot_fixer import (
+                    fixer,
+                )
+
+                assert fixer(resource_id="test-snapshot", region=AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_documentdb_cluster_public_snapshot_fixer_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_public_snapshot_error,
+        ):
+            from prowler.providers.aws.services.documentdb.documentdb_service import (
+                DocumentDB,
+            )
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.documentdb.documentdb_cluster_public_snapshot.documentdb_cluster_public_snapshot_fixer.documentdb_client",
+                new=DocumentDB(aws_provider),
+            ):
+                from prowler.providers.aws.services.documentdb.documentdb_cluster_public_snapshot.documentdb_cluster_public_snapshot_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(
+                    resource_id="test-snapshot", region=AWS_REGION_EU_WEST_1
+                )


### PR DESCRIPTION
### Context

Developed a new fixer that modifies DocumentDB cluster snapshots to restrict public accessibility, ensuring that snapshots are private and only accessible within authorized accounts or VPCs. This fixer will prevent unauthorized access to DocumentDB backups and secure sensitive data stored in snapshots.

As moto does not cover this DocumentDB API calls I needed to use Botocore for the unit tests.

### Description

Added new fixer `documentdb_cluster_public_snapshot_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
