### PR TITLE
feat(rds): add new fixer `rds_snapshots_public_access_fixer`

### DIFF
--- a/prowler/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer.py
+++ b/prowler/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer.py
@@ -1,0 +1,63 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.rds.rds_client import rds_client
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the attributes of an RDS DB snapshot or DB cluster snapshot to remove public access.
+    Specifically, this fixer removes the 'all' value from the 'restore' attribute to
+    prevent the snapshot from being publicly accessible for both DB snapshots and DB cluster snapshots.
+
+    Requires the rds:ModifyDBSnapshotAttribute or rds:ModifyDBClusterSnapshotAttribute permissions.
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "rds:ModifyDBSnapshotAttribute",
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": "rds:ModifyDBClusterSnapshotAttribute",
+                "Resource": "*"
+            }
+        ]
+    }
+
+    Args:
+        resource_id (str): The DB snapshot or DB cluster snapshot identifier.
+        region (str): AWS region where the snapshot exists.
+
+    Returns:
+        bool: True if the operation is successful (public access is removed), False otherwise.
+    """
+    try:
+        regional_client = rds_client.regional_clients[region]
+
+        # Check if the resource is a DB Cluster Snapshot or a DB Instance Snapshot
+        try:
+            regional_client.describe_db_cluster_snapshots(
+                DBClusterSnapshotIdentifier=resource_id
+            )
+            # If the describe call is successful, it's a DB cluster snapshot
+            regional_client.modify_db_cluster_snapshot_attribute(
+                DBClusterSnapshotIdentifier=resource_id,
+                AttributeName="restore",
+                ValuesToRemove=["all"],
+            )
+        except regional_client.exceptions.DBClusterSnapshotNotFoundFault:
+            # If the DB cluster snapshot doesn't exist, it's an instance snapshot
+            regional_client.modify_db_snapshot_attribute(
+                DBSnapshotIdentifier=resource_id,
+                AttributeName="restore",
+                ValuesToRemove=["all"],
+            )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer_test.py
+++ b/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer_test.py
@@ -1,0 +1,187 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+
+class Test_rds_snapshots_public_access:
+    @mock_aws
+    def test_rds_private_snapshot(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-primary-1",
+            AllocatedStorage=10,
+            Engine="postgres",
+            DBName="staging-postgres",
+            DBInstanceClass="db.m1.small",
+        )
+
+        conn.create_db_snapshot(
+            DBInstanceIdentifier="db-primary-1", DBSnapshotIdentifier="snapshot-1"
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer import (
+                    fixer,
+                )
+
+                assert fixer("snapshot-1", AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_rds_public_snapshot(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-primary-1",
+            AllocatedStorage=10,
+            Engine="postgres",
+            DBName="staging-postgres",
+            DBInstanceClass="db.m1.small",
+        )
+
+        conn.create_db_snapshot(
+            DBInstanceIdentifier="db-primary-1", DBSnapshotIdentifier="snapshot-1"
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer.rds_client",
+                new=RDS(aws_provider),
+            ) as service_client:
+
+                service_client.db_snapshots[0].public = True
+
+                # Test Fixer
+                from prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer import (
+                    fixer,
+                )
+
+                assert fixer("snapshot-1", AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_rds_cluster_private_snapshot(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-primary-1",
+            AllocatedStorage=10,
+            Engine="postgres",
+            DBClusterInstanceClass="db.m1.small",
+            MasterUsername="root",
+            MasterUserPassword="hunter2000",
+        )
+
+        conn.create_db_cluster_snapshot(
+            DBClusterIdentifier="db-primary-1", DBClusterSnapshotIdentifier="snapshot-1"
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer.rds_client",
+                new=RDS(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer import (
+                    fixer,
+                )
+
+                assert fixer("snapshot-1", AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_rds_cluster_public_snapshot(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-primary-1",
+            AllocatedStorage=10,
+            Engine="postgres",
+            DBClusterInstanceClass="db.m1.small",
+            MasterUsername="root",
+            MasterUserPassword="hunter2000",
+        )
+
+        conn.create_db_cluster_snapshot(
+            DBClusterIdentifier="db-primary-1", DBClusterSnapshotIdentifier="snapshot-1"
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer.rds_client",
+                new=RDS(aws_provider),
+            ) as service_client:
+
+                service_client.db_cluster_snapshots[0].public = True
+
+                # Test Fixer
+                from prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer import (
+                    fixer,
+                )
+
+                assert fixer("snapshot-1", AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_rds_cluster_public_snapshot_error(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-primary-1",
+            AllocatedStorage=10,
+            Engine="postgres",
+            DBClusterInstanceClass="db.m1.small",
+            MasterUsername="root",
+            MasterUserPassword="hunter2000",
+        )
+
+        conn.create_db_cluster_snapshot(
+            DBClusterIdentifier="db-primary-1", DBClusterSnapshotIdentifier="snapshot-1"
+        )
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer.rds_client",
+                new=RDS(aws_provider),
+            ) as service_client:
+
+                service_client.db_cluster_snapshots[0].public = True
+
+                # Test Fixer
+                from prowler.providers.aws.services.rds.rds_snapshots_public_access.rds_snapshots_public_access_fixer import (
+                    fixer,
+                )
+
+                assert not fixer("snapshot-2", AWS_REGION_US_EAST_1)


### PR DESCRIPTION
### Context

Develop a fixer that modifies the access permissions of RDS snapshots to ensure they are private and not accessible to the public. This will help prevent unauthorized access to sensitive data stored in database backups, enhancing the security of RDS resources.

As this fixer is executed when the `rds_snapshots_public_access` check fails and that check scans instances and clusters snapshots I've had to adapt a little bit the code of the fixer in order to know only with the ResourceID if what I'm trying to modify is an instance or a cluster.

### Description

Added new fixer `rds_snapshots_public_access_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
