### PR TITLE
feat(azure): Add get_regions method for provider

### DIFF
--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -2,7 +2,9 @@ import asyncio
 import os
 import re
 from argparse import ArgumentTypeError
+from itertools import chain
 from os import getenv
+from typing import Union
 from uuid import UUID
 
 import requests
@@ -972,7 +974,32 @@ class AzureProvider(Provider):
                 locations[display_name].append(location.name)
 
         return locations
+    
+    def get_regions(self, subscription_ids: Union[list[str], None] = None) -> set:
+        """
+        Retrieves a set of regions available across all subscriptions or specific subscriptions if provided.
 
+        Args:
+            subscription_ids (List[str], optional): A list of subscription display names to filter the regions.
+                If None, regions from all subscriptions are returned.
+
+        Returns:
+            Set[str]: A set containing the unique regions available across the specified subscriptions.
+
+        Examples:
+            >>> provider = AzureProvider(...)
+            >>> provider.get_regions()
+            {'eastus', 'eastus2', 'westus', 'westus2'}
+
+            >>> provider.get_regions(subscription_ids=['Subscription 1'])
+            {'eastus', 'eastus2', 'westus', 'westus2'}
+        """
+        locations = self.get_locations()
+        if subscription_ids is not None:
+            locations = {sid: regions for sid, regions in locations.items() if sid in subscription_ids}
+
+        return set(chain.from_iterable(locations.values()))
+    
     @staticmethod
     def validate_static_credentials(
         tenant_id: str = None, client_id: str = None, client_secret: str = None

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -974,7 +974,7 @@ class AzureProvider(Provider):
                 locations[display_name].append(location.name)
 
         return locations
-    
+
     def get_regions(self, subscription_ids: Union[list[str], None] = None) -> set:
         """
         Retrieves a set of regions available across all subscriptions or specific subscriptions if provided.
@@ -996,10 +996,14 @@ class AzureProvider(Provider):
         """
         locations = self.get_locations()
         if subscription_ids is not None:
-            locations = {sid: regions for sid, regions in locations.items() if sid in subscription_ids}
+            locations = {
+                sid: regions
+                for sid, regions in locations.items()
+                if sid in subscription_ids
+            }
 
         return set(chain.from_iterable(locations.values()))
-    
+
     @staticmethod
     def validate_static_credentials(
         tenant_id: str = None, client_id: str = None, client_secret: str = None

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -456,7 +456,7 @@ class TestAzureProvider:
     )
     def test_get_regions(
         self,
-        azure_provider_init_mock,
+        azure_provider_init_mock,  # noqa: F841
         azure_get_locations_mock,
         subscription_ids,
         expected_regions,

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -439,3 +439,34 @@ class TestAzureProvider:
 
             assert exception.type == Exception
             assert exception.value.args[0] == "Simulated Exception"
+
+    @pytest.mark.parametrize(
+        "subscription_ids, expected_regions",
+        [
+            (None, {"region1", "region2", "region3"}),
+            (["sub1", "sub2"], {"region1", "region2", "region3"}),
+            ("sub1", {"region1", "region2"}),
+            ("not_exists", set()),
+        ],
+    )
+    @patch("prowler.providers.azure.azure_provider.AzureProvider.get_locations")
+    @patch(
+        "prowler.providers.azure.azure_provider.AzureProvider.__init__",
+        return_value=None,
+    )
+    def test_get_regions(
+        self,
+        azure_provider_init_mock,
+        azure_get_locations_mock,
+        subscription_ids,
+        expected_regions,
+    ):
+        azure_get_locations_mock.return_value = {
+            "sub1": ["region1", "region2"],
+            "sub2": ["region2", "region3"],
+        }
+
+        azure_provider = AzureProvider()
+        regions = azure_provider.get_regions(subscription_ids=subscription_ids)
+
+        assert regions == expected_regions


### PR DESCRIPTION
### Context

A method to retrieve the Azure provider regions was needed.

### Description

Added the method and unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
