### PR TITLE
fix(iam): use `get` to get the key

### DIFF
--- a/prowler/providers/gcp/services/iam/iam_service.py
+++ b/prowler/providers/gcp/services/iam/iam_service.py
@@ -34,7 +34,7 @@ class IAM(GCPService):
                             ServiceAccount(
                                 name=account["name"],
                                 email=account["email"],
-                                display_name=account["displayName"],
+                                display_name=account.get("displayName", ""),
                                 project_id=project_id,
                             )
                         )


### PR DESCRIPTION
### Description

This pull request includes a minor change to the `prowler/providers/gcp/services/iam/iam_service.py` file. The change modifies the `_get_service_accounts` method to handle cases where the `displayName` field might be missing from the account dictionary.

* [`prowler/providers/gcp/services/iam/iam_service.py`](diffhunk://#diff-d4b727016ad17e15629091e634befb1bc482ec5522fa2386656aae154e3558d8L37-R37): Updated the `display_name` assignment to use the `get` method with a default value of an empty string if `displayName` is not present in the account dictionary.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
