### PR TITLE
fix(wafv2): only list resources for regional Web ACLs

### DIFF
--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -99,7 +99,7 @@ class WAFv2(AWSService):
     def _list_resources_for_web_acl(self, acl):
         logger.info("WAFv2 - Describing resources...")
         try:
-            if acl.scope == Scope.REGIONAL or acl.region in self.regional_clients:
+            if acl.scope == Scope.REGIONAL:
                 for resource in self.regional_clients[
                     acl.region
                 ].list_resources_for_web_acl(


### PR DESCRIPTION
### Context

An `WAFInvalidParameterException` error message was appearing while listing resources due to global ACLs being included in the call, which isn't supported by `boto3`.

Fix #5805

### Description

Logic behind this error has been corrected and `_list_resources_for_web_acl` only lists regional ACLs.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
