### PR TITLE
fix(aws): exclude member accounts in IAM Root Credentials check

### DIFF
--- a/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
+++ b/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
@@ -6,7 +6,10 @@ class iam_no_root_access_key(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
         # Check if the root credentials are managed by AWS Organizations
-        if "RootCredentialsManagement" not in iam_client.organization_features:
+        if (
+            iam_client.organization_features
+            and "RootCredentialsManagement" not in iam_client.organization_features
+        ):
             for user in iam_client.credential_report:
                 if user["user"] == "<root_account>":
                     report = Check_Report_AWS(self.metadata())

--- a/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
+++ b/prowler/providers/aws/services/iam/iam_no_root_access_key/iam_no_root_access_key.py
@@ -7,7 +7,7 @@ class iam_no_root_access_key(Check):
         findings = []
         # Check if the root credentials are managed by AWS Organizations
         if (
-            iam_client.organization_features
+            iam_client.organization_features is not None
             and "RootCredentialsManagement" not in iam_client.organization_features
         ):
             for user in iam_client.credential_report:

--- a/prowler/providers/aws/services/iam/iam_root_credentials_management_enabled/iam_root_credentials_management_enabled.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_root_credentials_management_enabled/iam_root_credentials_management_enabled.metadata.json
@@ -27,7 +27,8 @@
   "DependsOn": [],
   "RelatedTo": [
     "iam_root_hardware_mfa_enabled",
-    "iam_root_mfa_enabled"
+    "iam_root_mfa_enabled",
+    "iam_no_root_access_key"
   ],
-  "Notes": ""
+  "Notes": "This check skips findings for member accounts as they cannot execute the ListOrganizationsFeatures API call, which is restricted to the management account or delegated administrators."
 }

--- a/prowler/providers/aws/services/iam/iam_root_credentials_management_enabled/iam_root_credentials_management_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_credentials_management_enabled/iam_root_credentials_management_enabled.py
@@ -11,6 +11,7 @@ class iam_root_credentials_management_enabled(Check):
         if (
             organizations_client.organization
             and organizations_client.organization.status == "ACTIVE"
+            and iam_client.organization_features is not None
         ):
             report = Check_Report_AWS(self.metadata())
             report.region = iam_client.region

--- a/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
@@ -8,7 +8,10 @@ class iam_root_hardware_mfa_enabled(Check):
         # This check is only available in Commercial Partition
         if iam_client.audited_partition == "aws":
             # Check if the root credentials are managed by AWS Organizations
-            if "RootCredentialsManagement" not in iam_client.organization_features:
+            if (
+                iam_client.organization_features
+                and "RootCredentialsManagement" not in iam_client.organization_features
+            ):
                 if iam_client.account_summary:
                     virtual_mfa = False
                     report = Check_Report_AWS(self.metadata())

--- a/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_hardware_mfa_enabled/iam_root_hardware_mfa_enabled.py
@@ -9,7 +9,7 @@ class iam_root_hardware_mfa_enabled(Check):
         if iam_client.audited_partition == "aws":
             # Check if the root credentials are managed by AWS Organizations
             if (
-                iam_client.organization_features
+                iam_client.organization_features is not None
                 and "RootCredentialsManagement" not in iam_client.organization_features
             ):
                 if iam_client.account_summary:

--- a/prowler/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.py
@@ -7,7 +7,7 @@ class iam_root_mfa_enabled(Check):
         findings = []
         # Check if the root credentials are managed by AWS Organizations
         if (
-            iam_client.organization_features
+            iam_client.organization_features is not None
             and "RootCredentialsManagement" not in iam_client.organization_features
         ):
             if iam_client.credential_report:

--- a/prowler/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.py
+++ b/prowler/providers/aws/services/iam/iam_root_mfa_enabled/iam_root_mfa_enabled.py
@@ -6,7 +6,10 @@ class iam_root_mfa_enabled(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
         # Check if the root credentials are managed by AWS Organizations
-        if "RootCredentialsManagement" not in iam_client.organization_features:
+        if (
+            iam_client.organization_features
+            and "RootCredentialsManagement" not in iam_client.organization_features
+        ):
             if iam_client.credential_report:
                 for user in iam_client.credential_report:
                     if user["user"] == "<root_account>":

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -982,6 +982,21 @@ class IAM(AWSService):
                 logger.warning(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
+            elif (
+                error.response["Error"]["Code"]
+                == "OrganizationNotInAllFeaturesModeException"
+            ):
+                logger.warning(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+            elif (
+                error.response["Error"]["Code"]
+                == "AccountNotManagementOrDelegatedAdministratorException"
+            ):
+                logger.warning(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+                self.organization_features = None
             else:
                 logger.error(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Context

The recently added check `iam_root_credentials_management_enabled` uses the `ListOrganizationsFeatures` API to verify if centralized root credentials management is enabled. However, this API is restricted to the management account or delegated administrators. AWS Support confirmed that member accounts cannot access this information, resulting in the `AccountNotManagementOrDelegatedAdministratorException` error.

### Description

The check now skips findings for member accounts, as they are unable to retrieve the required data due to API restrictions. This ensures accurate results without unnecessary findings for member accounts.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
