### PR TITLE
chore(iam): add missing service catalog permissions

### DIFF
--- a/permissions/create_role_to_assume_cfn.yaml
+++ b/permissions/create_role_to_assume_cfn.yaml
@@ -91,6 +91,8 @@ Resources:
                 - 'shield:GetSubscriptionState'
                 - 'securityhub:BatchImportFindings'
                 - 'securityhub:GetFindings'
+                - 'servicecatalog:Describe*'
+                - 'servicecatalog:List*'
                 - 'ssm:GetDocument'
                 - 'ssm-incidents:List*'
                 - 'support:Describe*'

--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -39,6 +39,8 @@
         "shield:GetSubscriptionState",
         "securityhub:BatchImportFindings",
         "securityhub:GetFindings",
+        "servicecatalog:Describe*",
+        "servicecatalog:List*",
         "ssm:GetDocument",
         "ssm-incidents:List*",
         "support:Describe*",


### PR DESCRIPTION
### Context

With the recently added check of Service Catalog, some additional permissions are needed for Prowler.

### Description

Include List and Describe permissions for Service Catalog checks.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
