### PR TITLE
fix(aurora): Add default ports to the check of using non default ports 

### DIFF
--- a/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
+++ b/prowler/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port.py
@@ -6,8 +6,8 @@ class rds_cluster_non_default_port(Check):
     def execute(self):
         findings = []
         default_ports = {
-            3306: ["mysql", "mariadb"],
-            5432: ["postgres"],
+            3306: ["mysql", "mariadb", "aurora-mysql"],
+            5432: ["postgres", "aurora-postgresql"],
             1521: ["oracle"],
             1433: ["sqlserver"],
             50000: ["db2"],

--- a/prowler/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port.py
+++ b/prowler/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port.py
@@ -6,8 +6,8 @@ class rds_instance_non_default_port(Check):
     def execute(self):
         findings = []
         default_ports = {
-            3306: ["mysql", "mariadb"],
-            5432: ["postgres"],
+            3306: ["mysql", "mariadb", "aurora-mysql"],
+            5432: ["postgres", "aurora-postgresql"],
             1521: ["oracle"],
             1433: ["sqlserver"],
             50000: ["db2"],

--- a/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
@@ -321,6 +321,7 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].resource_tags == [
                     {"Key": "env", "Value": "production"}
                 ]
+
     @mock_aws
     def test_rds_cluster_mysql_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)

--- a/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
+++ b/tests/providers/aws/services/rds/rds_cluster_non_default_port/rds_cluster_non_default_port_test.py
@@ -35,7 +35,7 @@ class Test_rds_cluster_non_default_port:
                 assert len(result) == 0
 
     @mock_aws
-    def test_rds_cluster_using_default_port(self):
+    def test_rds_cluster_aurora_postgres_using_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
             DBClusterIdentifier="db-cluster-1",
@@ -82,10 +82,10 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]
 
     @mock_aws
-    def test_rds_cluster_using_non_default_port(self):
+    def test_rds_cluster_aurora_postgres_using_non_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
-            DBClusterIdentifier="db-cluster-1",
+            DBClusterIdentifier="db-cluster-2",
             Engine="aurora-postgresql",
             StorageEncrypted=True,
             DeletionProtection=True,
@@ -118,23 +118,214 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-cluster-1 is not using the default port 5433 for aurora-postgresql."
+                    == "RDS Cluster db-cluster-2 is not using the default port 5433 for aurora-postgresql."
                 )
-                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].resource_id == "db-cluster-2"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-2"
                 )
                 assert result[0].resource_tags == [
                     {"Key": "env", "Value": "production"}
                 ]
 
     @mock_aws
+    def test_rds_cluster_postgres_using_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-3",
+            Engine="postgres",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="cluster",
+            MasterUserPassword="password",
+            Port=5432,
+            Tags=[{"Key": "test", "Value": "test"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-3 is using the default port 5432 for postgres."
+                )
+                assert result[0].resource_id == "db-cluster-3"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-3"
+                )
+                assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]
+
+    @mock_aws
+    def test_rds_cluster_postgres_using_non_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-4",
+            Engine="postgres",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="cluster",
+            MasterUserPassword="password",
+            Port=5433,
+            Tags=[{"Key": "env", "Value": "production"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-4 is not using the default port 5433 for postgres."
+                )
+                assert result[0].resource_id == "db-cluster-4"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-4"
+                )
+                assert result[0].resource_tags == [
+                    {"Key": "env", "Value": "production"}
+                ]
+
+    @mock_aws
+    def test_rds_cluster_aurora_mysql_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-5",
+            Engine="aurora-mysql",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="cluster",
+            MasterUserPassword="password",
+            Port=3306,
+            Tags=[{"Key": "env", "Value": "staging"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-5 is using the default port 3306 for aurora-mysql."
+                )
+                assert result[0].resource_id == "db-cluster-5"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-5"
+                )
+                assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
+
+    @mock_aws
+    def test_rds_cluster_aurora_mysql_non_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_cluster(
+            DBClusterIdentifier="db-cluster-6",
+            Engine="aurora-mysql",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            MasterUsername="cluster",
+            MasterUserPassword="password",
+            Port=3307,
+            Tags=[{"Key": "env", "Value": "production"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_cluster_non_default_port.rds_cluster_non_default_port import (
+                    rds_cluster_non_default_port,
+                )
+
+                check = rds_cluster_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Cluster db-cluster-6 is not using the default port 3307 for aurora-mysql."
+                )
+                assert result[0].resource_id == "db-cluster-6"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-6"
+                )
+                assert result[0].resource_tags == [
+                    {"Key": "env", "Value": "production"}
+                ]
+    @mock_aws
     def test_rds_cluster_mysql_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
-            DBClusterIdentifier="db-cluster-1",
+            DBClusterIdentifier="db-cluster-7",
             Engine="mysql",
             StorageEncrypted=True,
             DeletionProtection=True,
@@ -167,13 +358,13 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-cluster-1 is using the default port 3306 for mysql."
+                    == "RDS Cluster db-cluster-7 is using the default port 3306 for mysql."
                 )
-                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].resource_id == "db-cluster-7"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-7"
                 )
                 assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
 
@@ -181,7 +372,7 @@ class Test_rds_cluster_non_default_port:
     def test_rds_cluster_mysql_non_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_cluster(
-            DBClusterIdentifier="db-cluster-1",
+            DBClusterIdentifier="db-cluster-8",
             Engine="mysql",
             StorageEncrypted=True,
             DeletionProtection=True,
@@ -214,13 +405,13 @@ class Test_rds_cluster_non_default_port:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Cluster db-cluster-1 is not using the default port 3307 for mysql."
+                    == "RDS Cluster db-cluster-8 is not using the default port 3307 for mysql."
                 )
-                assert result[0].resource_id == "db-cluster-1"
+                assert result[0].resource_id == "db-cluster-8"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:cluster:db-cluster-8"
                 )
                 assert result[0].resource_tags == [
                     {"Key": "env", "Value": "production"}

--- a/tests/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_non_default_port/rds_instance_non_default_port_test.py
@@ -35,10 +35,114 @@ class Test_rds_instance_non_default_port:
                 assert len(result) == 0
 
     @mock_aws
-    def test_rds_instance_using_default_port(self):
+    def test_rds_instance_aurora_postgres_using_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
             DBInstanceIdentifier="db-master-1",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="staging-postgres",
+            DBInstanceClass="db.m1.small",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            PubliclyAccessible=True,
+            AutoMinorVersionUpgrade=True,
+            BackupRetentionPeriod=10,
+            Port=5432,
+            Tags=[{"Key": "test", "Value": "test"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
+                    rds_instance_non_default_port,
+                )
+
+                check = rds_instance_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-1 is using the default port 5432 for aurora-postgresql."
+                )
+                assert result[0].resource_id == "db-master-1"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                )
+                assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]
+
+    @mock_aws
+    def test_rds_instance_aurora_postgres_using_non_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-2",
+            AllocatedStorage=10,
+            Engine="aurora-postgresql",
+            DBName="production-postgres",
+            DBInstanceClass="db.m1.small",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            PubliclyAccessible=True,
+            AutoMinorVersionUpgrade=True,
+            BackupRetentionPeriod=10,
+            Port=5433,
+            Tags=[{"Key": "env", "Value": "production"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
+                    rds_instance_non_default_port,
+                )
+
+                check = rds_instance_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-2 is not using the default port 5433 for aurora-postgresql."
+                )
+                assert result[0].resource_id == "db-master-2"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-2"
+                )
+                assert result[0].resource_tags == [
+                    {"Key": "env", "Value": "production"}
+                ]
+
+    @mock_aws
+    def test_rds_instance_postgres_using_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-3",
             AllocatedStorage=10,
             Engine="postgres",
             DBName="staging-postgres",
@@ -75,21 +179,21 @@ class Test_rds_instance_non_default_port:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-1 is using the default port 5432 for postgres."
+                    == "RDS Instance db-master-3 is using the default port 5432 for postgres."
                 )
-                assert result[0].resource_id == "db-master-1"
+                assert result[0].resource_id == "db-master-3"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-1"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-3"
                 )
                 assert result[0].resource_tags == [{"Key": "test", "Value": "test"}]
 
     @mock_aws
-    def test_rds_instance_using_non_default_port(self):
+    def test_rds_instance_postgres_using_non_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
-            DBInstanceIdentifier="db-master-2",
+            DBInstanceIdentifier="db-master-4",
             AllocatedStorage=10,
             Engine="postgres",
             DBName="production-postgres",
@@ -126,13 +230,221 @@ class Test_rds_instance_non_default_port:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-2 is not using the default port 5433 for postgres."
+                    == "RDS Instance db-master-4 is not using the default port 5433 for postgres."
                 )
-                assert result[0].resource_id == "db-master-2"
+                assert result[0].resource_id == "db-master-4"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-2"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-4"
+                )
+                assert result[0].resource_tags == [
+                    {"Key": "env", "Value": "production"}
+                ]
+
+    @mock_aws
+    def test_rds_instance_mysql_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-5",
+            AllocatedStorage=10,
+            Engine="mysql",
+            DBName="staging-mariadb",
+            DBInstanceClass="db.m1.small",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            PubliclyAccessible=True,
+            AutoMinorVersionUpgrade=True,
+            BackupRetentionPeriod=10,
+            Port=3306,
+            Tags=[{"Key": "env", "Value": "staging"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
+                    rds_instance_non_default_port,
+                )
+
+                check = rds_instance_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-5 is using the default port 3306 for mysql."
+                )
+                assert result[0].resource_id == "db-master-5"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-5"
+                )
+                assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
+
+    @mock_aws
+    def test_rds_instance_mysql_non_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-6",
+            AllocatedStorage=10,
+            Engine="mysql",
+            DBName="production-mariadb",
+            DBInstanceClass="db.m1.small",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            PubliclyAccessible=True,
+            AutoMinorVersionUpgrade=True,
+            BackupRetentionPeriod=10,
+            Port=3307,
+            Tags=[{"Key": "env", "Value": "production"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
+                    rds_instance_non_default_port,
+                )
+
+                check = rds_instance_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-6 is not using the default port 3307 for mysql."
+                )
+                assert result[0].resource_id == "db-master-6"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-6"
+                )
+                assert result[0].resource_tags == [
+                    {"Key": "env", "Value": "production"}
+                ]
+
+    @mock_aws
+    def test_rds_instance_aurora_mysql_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-7",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DBName="staging-mariadb",
+            DBInstanceClass="db.m1.small",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            PubliclyAccessible=True,
+            AutoMinorVersionUpgrade=True,
+            BackupRetentionPeriod=10,
+            Port=3306,
+            Tags=[{"Key": "env", "Value": "staging"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
+                    rds_instance_non_default_port,
+                )
+
+                check = rds_instance_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-7 is using the default port 3306 for aurora-mysql."
+                )
+                assert result[0].resource_id == "db-master-7"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-7"
+                )
+                assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
+
+    @mock_aws
+    def test_rds_instance_aurora_mysql_non_default_port(self):
+        conn = client("rds", region_name=AWS_REGION_US_EAST_1)
+        conn.create_db_instance(
+            DBInstanceIdentifier="db-master-8",
+            AllocatedStorage=10,
+            Engine="aurora-mysql",
+            DBName="production-mariadb",
+            DBInstanceClass="db.m1.small",
+            StorageEncrypted=True,
+            DeletionProtection=True,
+            PubliclyAccessible=True,
+            AutoMinorVersionUpgrade=True,
+            BackupRetentionPeriod=10,
+            Port=3307,
+            Tags=[{"Key": "env", "Value": "production"}],
+        )
+
+        from prowler.providers.aws.services.rds.rds_service import RDS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port.rds_client",
+                new=RDS(aws_provider),
+            ):
+                from prowler.providers.aws.services.rds.rds_instance_non_default_port.rds_instance_non_default_port import (
+                    rds_instance_non_default_port,
+                )
+
+                check = rds_instance_non_default_port()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == "RDS Instance db-master-8 is not using the default port 3307 for aurora-mysql."
+                )
+                assert result[0].resource_id == "db-master-8"
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-8"
                 )
                 assert result[0].resource_tags == [
                     {"Key": "env", "Value": "production"}
@@ -142,7 +454,7 @@ class Test_rds_instance_non_default_port:
     def test_rds_instance_mariadb_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
-            DBInstanceIdentifier="db-master-3",
+            DBInstanceIdentifier="db-master-9",
             AllocatedStorage=10,
             Engine="mariadb",
             DBName="staging-mariadb",
@@ -179,13 +491,13 @@ class Test_rds_instance_non_default_port:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-3 is using the default port 3306 for mariadb."
+                    == "RDS Instance db-master-9 is using the default port 3306 for mariadb."
                 )
-                assert result[0].resource_id == "db-master-3"
+                assert result[0].resource_id == "db-master-9"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-3"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-9"
                 )
                 assert result[0].resource_tags == [{"Key": "env", "Value": "staging"}]
 
@@ -193,7 +505,7 @@ class Test_rds_instance_non_default_port:
     def test_rds_instance_mariadb_non_default_port(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)
         conn.create_db_instance(
-            DBInstanceIdentifier="db-master-4",
+            DBInstanceIdentifier="db-master-10",
             AllocatedStorage=10,
             Engine="mariadb",
             DBName="production-mariadb",
@@ -230,13 +542,13 @@ class Test_rds_instance_non_default_port:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "RDS Instance db-master-4 is not using the default port 3307 for mariadb."
+                    == "RDS Instance db-master-10 is not using the default port 3307 for mariadb."
                 )
-                assert result[0].resource_id == "db-master-4"
+                assert result[0].resource_id == "db-master-10"
                 assert result[0].region == AWS_REGION_US_EAST_1
                 assert (
                     result[0].resource_arn
-                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-4"
+                    == f"arn:aws:rds:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:db:db-master-10"
                 )
                 assert result[0].resource_tags == [
                     {"Key": "env", "Value": "production"}


### PR DESCRIPTION
### Context

When using Aurora RDS clusters/instances, they are marked as using non-default port, even though the default port are in use.

### Description

The Aurora engines has been added to the list of default ports to the respective default port.

### Checklist

- [x] Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
  If you find tests necessary, please let me know and I will add some tests. 
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. No needed

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
