### PR TITLE
fix(rds): fix typo error in `rds_snapshots_public_access_fixer` test

### DIFF
--- a/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer_test.py
+++ b/tests/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer_test.py
@@ -6,7 +6,7 @@ from moto import mock_aws
 from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
 
 
-class Test_rds_snapshots_public_access:
+class Test_rds_snapshots_public_access_fixer:
     @mock_aws
     def test_rds_private_snapshot(self):
         conn = client("rds", region_name=AWS_REGION_US_EAST_1)


### PR DESCRIPTION
### Context

Creating a new fixer I realized that I had a typo error on the merged fixer so I’ll solve it now.

### Description

Fixed typo error.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
