### PR TITLE
fix(severity): add enum for severity values

### DIFF
--- a/prowler/providers/aws/services/ec2/lib/instance.py
+++ b/prowler/providers/aws/services/ec2/lib/instance.py
@@ -1,3 +1,4 @@
+from prowler.lib.check.models import Severity
 from prowler.providers.aws.services.ec2.ec2_service import Instance
 from prowler.providers.aws.services.vpc.vpc_service import VpcSubnet
 
@@ -15,13 +16,13 @@ def get_instance_public_status(
         tuple: The status and severity of the instance status.
     """
     status = f"Instance {instance.id} has {service} exposed to 0.0.0.0/0 but with no public IP address."
-    severity = "medium"
+    severity = Severity.medium
 
     if instance.public_ip:
         status = f"Instance {instance.id} has {service} exposed to 0.0.0.0/0 on public IP address {instance.public_ip} but it is placed in a private subnet {instance.subnet_id}."
-        severity = "high"
+        severity = Severity.high
         if vpc_subnets[instance.subnet_id].public:
             status = f"Instance {instance.id} has {service} exposed to 0.0.0.0/0 on public IP address {instance.public_ip} in public subnet {instance.subnet_id}."
-            severity = "critical"
+            severity = Severity.critical
 
     return status, severity


### PR DESCRIPTION
### Context

Fix #5854

### Description

This pull request includes changes to the `prowler/providers/aws/services/ec2/lib/instance.py` file to improve the handling of severity levels for instance statuses. The most important changes involve replacing string literals with the `Severity` enum for better code maintainability and clarity.

Codebase improvements:

* [`prowler/providers/aws/services/ec2/lib/instance.py`](diffhunk://#diff-e528668ffed1a7fe223d4d4eeb5e47407e617b01289830c046cc83a0b269cfcdR1): Imported the `Severity` enum from `prowler.lib.check.models`.
* [`prowler/providers/aws/services/ec2/lib/instance.py`](diffhunk://#diff-e528668ffed1a7fe223d4d4eeb5e47407e617b01289830c046cc83a0b269cfcdL18-R26): Replaced string literals for severity levels ("medium", "high", "critical") with the corresponding `Severity` enum values (`Severity.medium`, `Severity.high`, `Severity.critical`).

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
