### PR TITLE
fix(compliance): CIS details for new EFS Controls

### DIFF
--- a/prowler/compliance/aws/cis_1.5_aws.json
+++ b/prowler/compliance/aws/cis_1.5_aws.json
@@ -645,9 +645,9 @@
       ],
       "Attributes": [
         {
-          "Section": "2.4 Relational Database Service (RDS)",
+          "Section": "2.4 Elastic File System (EFS)",
           "Profile": "Level 1",
-          "AssessmentStatus": "Manual",
+          "AssessmentStatus": "Automated",
           "Description": "EFS data should be encrypted at rest using AWS KMS (Key Management Service).",
           "RationaleStatement": "Data should be encrypted at rest to reduce the risk of a data breach via direct access to the storage device.",
           "ImpactStatement": "",

--- a/prowler/compliance/aws/cis_1.5_aws.json
+++ b/prowler/compliance/aws/cis_1.5_aws.json
@@ -647,7 +647,7 @@
         {
           "Section": "2.4 Elastic File System (EFS)",
           "Profile": "Level 1",
-          "AssessmentStatus": "Automated",
+          "AssessmentStatus": "Manual",
           "Description": "EFS data should be encrypted at rest using AWS KMS (Key Management Service).",
           "RationaleStatement": "Data should be encrypted at rest to reduce the risk of a data breach via direct access to the storage device.",
           "ImpactStatement": "",

--- a/prowler/compliance/aws/cis_2.0_aws.json
+++ b/prowler/compliance/aws/cis_2.0_aws.json
@@ -645,7 +645,7 @@
         {
           "Section": "2.4 Elastic File System (EFS)",
           "Profile": "Level 1",
-          "AssessmentStatus": "Automated",
+          "AssessmentStatus": "Manual",
           "Description": "EFS data should be encrypted at rest using AWS KMS (Key Management Service).",
           "RationaleStatement": "Data should be encrypted at rest to reduce the risk of a data breach via direct access to the storage device.",
           "ImpactStatement": "",

--- a/prowler/compliance/aws/cis_2.0_aws.json
+++ b/prowler/compliance/aws/cis_2.0_aws.json
@@ -643,9 +643,9 @@
       ],
       "Attributes": [
         {
-          "Section": "2.4 Relational Database Service (RDS)",
+          "Section": "2.4 Elastic File System (EFS)",
           "Profile": "Level 1",
-          "AssessmentStatus": "Manual",
+          "AssessmentStatus": "Automated",
           "Description": "EFS data should be encrypted at rest using AWS KMS (Key Management Service).",
           "RationaleStatement": "Data should be encrypted at rest to reduce the risk of a data breach via direct access to the storage device.",
           "ImpactStatement": "",

--- a/prowler/compliance/aws/cis_3.0_aws.json
+++ b/prowler/compliance/aws/cis_3.0_aws.json
@@ -643,7 +643,7 @@
       ],
       "Attributes": [
         {
-          "Section": "2.4 Relational Database Service (RDS)",
+          "Section": "2.4 Elastic File System (EFS)",
           "Profile": "Level 1",
           "AssessmentStatus": "Automated",
           "Description": "EFS data should be encrypted at rest using AWS KMS (Key Management Service).",


### PR DESCRIPTION
### Context

The new EFS controls for CIS have incorrect information. EFS is not part of RDS (DATABASES)
EFS is elastic file system. Much like NFS and has no correlation to RDS

This is also an automated check and not manual.

I have updated the CIS Standards to reflect the correct information

### Description

Updated the Section to create a new EFS section as RDS is not related to this control
Updated Check on 2 of the controls to Automated as per efs_encryption_at_reset_enabled.py

### Checklist

- Are there new checks included in this PR? No
 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
