### PR TITLE
chore(aws): update fixers docstring

### DIFF
--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_enabled/accessanalyzer_enabled_fixer.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_enabled/accessanalyzer_enabled_fixer.py
@@ -6,7 +6,8 @@ from prowler.providers.aws.services.accessanalyzer.accessanalyzer_client import 
 
 def fixer(region):
     """
-    Enable Access Analyzer in a region. Requires the access-analyzer:CreateAnalyzer permission:
+    Enable Access Analyzer in a region. Requires the access-analyzer:CreateAnalyzer permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_fixer.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_fixer.py
@@ -7,7 +7,8 @@ from prowler.providers.aws.services.cloudtrail.cloudtrail_client import (
 def fixer(region):
     """
     NOTE: Define the S3 bucket name in the fixer_config.yaml file.
-    Enable CloudTrail in a region. Requires the cloudtrail:CreateTrail permission:
+    Enable CloudTrail in a region. Requires the cloudtrail:CreateTrail permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
@@ -8,9 +8,8 @@ def fixer(resource_id: str, region: str) -> bool:
     """
     Modify the attributes of a DocumentDB cluster snapshot to remove public access.
     Specifically, this fixer removes the 'all' value from the 'restore' attribute to
-    prevent the snapshot from being publicly accessible.
-
-    Requires the rds:ModifyDBClusterSnapshotAttribute permissions.
+    prevent the snapshot from being publicly accessible. Requires the rds:ModifyDBClusterSnapshotAttribute permissions.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -21,7 +20,6 @@ def fixer(resource_id: str, region: str) -> bool:
             }
         ]
     }
-
     Args:
         resource_id (str): The DB cluster snapshot identifier.
         region (str): AWS region where the snapshot exists.

--- a/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 def fixer(region):
     """
     Enable EBS encryption by default in a region. NOTE: Custom KMS keys for EBS Default Encryption may be overwritten.
-    Requires the ec2:EnableEbsEncryptionByDefault permission:
+    Requires the ec2:EnableEbsEncryptionByDefault permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_fixer.py
@@ -6,8 +6,8 @@ def fixer(resource_id: str, region: str) -> bool:
     """
     Modify the attributes of an EBS snapshot to remove public access.
     Specifically, this fixer removes the 'all' value from the 'createVolumePermission' attribute to
-    prevent the snapshot from being publicly accessible.
-    Requires the ec2:ModifySnapshotAttribute permission.
+    prevent the snapshot from being publicly accessible. Requires the ec2:ModifySnapshotAttribute permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/ec2/ec2_ebs_snapshot_account_block_public_access/ec2_ebs_snapshot_account_block_public_access_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_snapshot_account_block_public_access/ec2_ebs_snapshot_account_block_public_access_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 def fixer(region):
     """
     Enable EBS snapshot block public access in a region.
-    Requires the ec2:EnableSnapshotBlockPublicAccess permission:
+    Requires the ec2:EnableSnapshotBlockPublicAccess permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 def fixer(region):
     """
     Enable IMDSv2 for EC2 instances in the specified region.
-    Requires the ec2:ModifyInstanceMetadataDefaults permission:
+    Requires the ec2:ModifyInstanceMetadataDefaults permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_fixer.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_fixer.py
@@ -4,7 +4,8 @@ from prowler.providers.aws.services.guardduty.guardduty_client import guardduty_
 
 def fixer(region):
     """
-    Enable GuardDuty in a region. Requires the guardduty:CreateDetector permission:
+    Enable GuardDuty in a region. Requires the guardduty:CreateDetector permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 def fixer(resource_id: str) -> bool:
     """
     Enable IAM password policy to expire passwords within 90 days or less or the configurable value in prowler/config/fixer_config.yaml.
-    Requires the iam:UpdateAccountPasswordPolicy permission:
+    Requires the iam:UpdateAccountPasswordPolicy permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): AWS account ID
     Returns:
         bool: True if IAM password policy is updated, False otherwise
     """

--- a/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 def fixer(resource_id: str) -> bool:
     """
     Enable IAM password policy to require lowercase characters or the configurable value in prowler/config/fixer_config.yaml.
-    Requires the iam:UpdateAccountPasswordPolicy permission:
+    Requires the iam:UpdateAccountPasswordPolicy permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): AWS account ID
     Returns:
         bool: True if IAM password policy is updated, False otherwise
     """

--- a/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 def fixer(resource_id: str) -> bool:
     """
     Enable IAM password policy to require a minimum password length of 14 characters or the configurable value in prowler/config/fixer_config.yaml.
-    Requires the iam:UpdateAccountPasswordPolicy permission:
+    Requires the iam:UpdateAccountPasswordPolicy permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): AWS account ID
     Returns:
         bool: True if IAM password policy is updated, False otherwise
     """

--- a/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 def fixer(resource_id: str) -> bool:
     """
     Enable IAM password policy to require numbers or the configurable value in prowler/config/fixer_config.yaml.
-    Requires the iam:UpdateAccountPasswordPolicy permission:
+    Requires the iam:UpdateAccountPasswordPolicy permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): AWS account ID
     Returns:
         bool: True if IAM password policy is updated, False otherwise
     """

--- a/prowler/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 def fixer(resource_id: str) -> bool:
     """
     Enable IAM password policy to prevent reusing the 24 previous passwords or the configurable value in prowler/config/fixer_config.yaml.
-    Requires the iam:UpdateAccountPasswordPolicy permission:
+    Requires the iam:UpdateAccountPasswordPolicy permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): AWS account ID
     Returns:
         bool: True if IAM password policy is updated, False otherwise
     """

--- a/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 def fixer(resource_id: str) -> bool:
     """
     Enable IAM password policy to require symbols or the configurable value in prowler/config/fixer_config.yaml.
-    Requires the iam:UpdateAccountPasswordPolicy permission:
+    Requires the iam:UpdateAccountPasswordPolicy permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): AWS account ID
     Returns:
         bool: True if IAM password policy is updated, False otherwise
     """

--- a/prowler/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.iam.iam_client import iam_client
 def fixer(resource_id: str) -> bool:
     """
     Enable IAM password policy to require uppercase characters or the configurable value in prowler/config/fixer_config.yaml.
-    Requires the iam:UpdateAccountPasswordPolicy permission:
+    Requires the iam:UpdateAccountPasswordPolicy permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): AWS account ID
     Returns:
         bool: True if IAM password policy is updated, False otherwise
     """

--- a/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_fixer.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_fixer.py
@@ -7,7 +7,6 @@ def fixer(resource_id: str, region: str) -> bool:
     Cancel the scheduled deletion of a KMS key.
     Specifically, this fixer calls the 'cancel_key_deletion' method to restore the KMS key's availability if it is marked for deletion.
     Requires the kms:CancelKeyDeletion permission.
-
     Permissions:
     {
         "Version": "2012-10-17",
@@ -19,11 +18,9 @@ def fixer(resource_id: str, region: str) -> bool:
             }
         ]
     }
-
     Args:
         resource_id (str): The ID of the KMS key to cancel the deletion for.
         region (str): AWS region where the KMS key exists.
-
     Returns:
         bool: True if the operation is successful (deletion cancellation is completed), False otherwise.
     """

--- a/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_fixer.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_fixer.py
@@ -4,7 +4,8 @@ from prowler.providers.aws.services.kms.kms_client import kms_client
 
 def fixer(resource_id: str, region: str) -> bool:
     """
-    Enable CMK rotation. Requires the kms:EnableKeyRotation permission:
+    Enable CMK rotation. Requires the kms:EnableKeyRotation permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/prowler/providers/aws/services/neptune/neptune_cluster_public_snapshot/neptune_cluster_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/neptune/neptune_cluster_public_snapshot/neptune_cluster_public_snapshot_fixer.py
@@ -6,9 +6,8 @@ def fixer(resource_id: str, region: str) -> bool:
     """
     Modify the attributes of a Neptune DB cluster snapshot to remove public access.
     Specifically, this fixer removes the 'all' value from the 'restore' attribute to
-    prevent the snapshot from being publicly accessible.
-
-    Requires the rds:ModifyDBClusterSnapshotAttribute permissions.
+    prevent the snapshot from being publicly accessible. Requires the rds:ModifyDBClusterSnapshotAttribute permissions.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -19,11 +18,9 @@ def fixer(resource_id: str, region: str) -> bool:
             }
         ]
     }
-
     Args:
         resource_id (str): The DB cluster snapshot identifier.
         region (str): AWS region where the snapshot exists.
-
     Returns:
         bool: True if the operation is successful (public access is removed), False otherwise.
     """

--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_fixer.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_fixer.py
@@ -6,9 +6,8 @@ def fixer(resource_id: str, region: str) -> bool:
     """
     Modify the attributes of an RDS instance to disable public accessibility.
     Specifically, this fixer sets the 'PubliclyAccessible' attribute to False
-    to prevent the RDS instance from being publicly accessible.
-
-    Requires the rds:ModifyDBInstance permission:
+    to prevent the RDS instance from being publicly accessible. Requires the rds:ModifyDBInstance permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -19,11 +18,9 @@ def fixer(resource_id: str, region: str) -> bool:
             }
         ]
     }
-
     Args:
         resource_id (str): The DB instance identifier.
         region (str): AWS region where the DB instance exists.
-
     Returns:
         bool: True if the operation is successful (public access is disabled), False otherwise.
     """

--- a/prowler/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer.py
+++ b/prowler/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer.py
@@ -5,10 +5,9 @@ from prowler.providers.aws.services.rds.rds_client import rds_client
 def fixer(resource_id: str, region: str) -> bool:
     """
     Modify the attributes of an RDS DB snapshot or DB cluster snapshot to remove public access.
-    Specifically, this fixer removes the 'all' value from the 'restore' attribute to
-    prevent the snapshot from being publicly accessible for both DB snapshots and DB cluster snapshots.
-
-    Requires the rds:ModifyDBSnapshotAttribute or rds:ModifyDBClusterSnapshotAttribute permissions.
+    Specifically, this fixer removes the 'all' value from the 'restore' attribute to prevent the snapshot from being publicly accessible
+    for both DB snapshots and DB cluster snapshots. Requires the rds:ModifyDBSnapshotAttribute or rds:ModifyDBClusterSnapshotAttribute permissions.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -24,11 +23,9 @@ def fixer(resource_id: str, region: str) -> bool:
             }
         ]
     }
-
     Args:
         resource_id (str): The DB snapshot or DB cluster snapshot identifier.
         region (str): AWS region where the snapshot exists.
-
     Returns:
         bool: True if the operation is successful (public access is removed), False otherwise.
     """

--- a/prowler/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_fixer.py
@@ -5,7 +5,8 @@ from prowler.providers.aws.services.s3.s3control_client import s3control_client
 def fixer(resource_id: str) -> bool:
     """
     Enable S3 Block Public Access for the account. NOTE: By blocking all S3 public access you may break public S3 buckets.
-    Requires the s3:PutAccountPublicAccessBlock permission:
+    Requires the s3:PutAccountPublicAccessBlock permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
@@ -16,6 +17,8 @@ def fixer(resource_id: str) -> bool:
             }
         ]
     }
+    Args:
+        resource_id (str): The AWS account ID.
     Returns:
         bool: True if S3 Block Public Access is enabled, False otherwise
     """

--- a/prowler/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_fixer.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_fixer.py
@@ -6,7 +6,8 @@ from prowler.providers.aws.services.securityhub.securityhub_client import (
 
 def fixer(region):
     """
-    Enable Security Hub in a region. Requires the securityhub:EnableSecurityHub permission:
+    Enable Security Hub in a region. Requires the securityhub:EnableSecurityHub permission.
+    Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [

--- a/tests/providers/aws/services/documentdb/documentdb_cluster_backup_enabled/documentdb_cluster_backup_enabled_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_cluster_backup_enabled/documentdb_cluster_backup_enabled_test.py
@@ -21,6 +21,9 @@ class Test_documentdb_cluster_backup_enabled:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_backup_enabled.documentdb_cluster_backup_enabled import (
                 documentdb_cluster_backup_enabled,
@@ -51,6 +54,9 @@ class Test_documentdb_cluster_backup_enabled:
         documentdb_client.audit_config = {"minimum_backup_retention_period": 7}
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_backup_enabled.documentdb_cluster_backup_enabled import (
@@ -92,6 +98,9 @@ class Test_documentdb_cluster_backup_enabled:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_backup_enabled.documentdb_cluster_backup_enabled import (
                 documentdb_cluster_backup_enabled,
@@ -129,6 +138,9 @@ class Test_documentdb_cluster_backup_enabled:
         documentdb_client.audit_config = {"minimum_backup_retention_period": 7}
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_backup_enabled.documentdb_cluster_backup_enabled import (
@@ -168,6 +180,9 @@ class Test_documentdb_cluster_backup_enabled:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_backup_enabled.documentdb_cluster_backup_enabled import (
                 documentdb_cluster_backup_enabled,
@@ -206,6 +221,9 @@ class Test_documentdb_cluster_backup_enabled:
         documentdb_client.audit_config = {"minimum_backup_retention_period": 1}
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_backup_enabled.documentdb_cluster_backup_enabled import (

--- a/tests/providers/aws/services/documentdb/documentdb_cluster_cloudwatch_log_export/documentdb_cluster_cloudwatch_log_export_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_cluster_cloudwatch_log_export/documentdb_cluster_cloudwatch_log_export_test.py
@@ -20,6 +20,9 @@ class Test_documentdb_cluster_cloudwatch_log_export:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_cloudwatch_log_export.documentdb_cluster_cloudwatch_log_export import (
                 documentdb_cluster_cloudwatch_log_export,
@@ -50,6 +53,9 @@ class Test_documentdb_cluster_cloudwatch_log_export:
 
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_cloudwatch_log_export.documentdb_cluster_cloudwatch_log_export import (
@@ -90,6 +96,9 @@ class Test_documentdb_cluster_cloudwatch_log_export:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_cloudwatch_log_export.documentdb_cluster_cloudwatch_log_export import (
                 documentdb_cluster_cloudwatch_log_export,
@@ -127,6 +136,9 @@ class Test_documentdb_cluster_cloudwatch_log_export:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_cloudwatch_log_export.documentdb_cluster_cloudwatch_log_export import (
                 documentdb_cluster_cloudwatch_log_export,
@@ -163,6 +175,9 @@ class Test_documentdb_cluster_cloudwatch_log_export:
         }
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_cloudwatch_log_export.documentdb_cluster_cloudwatch_log_export import (

--- a/tests/providers/aws/services/documentdb/documentdb_cluster_deletion_protection/documentdb_cluster_deletion_protection_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_cluster_deletion_protection/documentdb_cluster_deletion_protection_test.py
@@ -20,6 +20,9 @@ class Test_documentdb_cluster_deletion_protection:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_deletion_protection.documentdb_cluster_deletion_protection import (
                 documentdb_cluster_deletion_protection,
@@ -50,6 +53,9 @@ class Test_documentdb_cluster_deletion_protection:
 
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_deletion_protection.documentdb_cluster_deletion_protection import (
@@ -89,6 +95,9 @@ class Test_documentdb_cluster_deletion_protection:
         }
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_deletion_protection.documentdb_cluster_deletion_protection import (

--- a/tests/providers/aws/services/documentdb/documentdb_cluster_multi_az_enabled/documentdb_cluster_multi_az_enabled_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_cluster_multi_az_enabled/documentdb_cluster_multi_az_enabled_test.py
@@ -20,6 +20,9 @@ class Test_documentdb_cluster_multi_az_enabled:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_multi_az_enabled.documentdb_cluster_multi_az_enabled import (
                 documentdb_cluster_multi_az_enabled,
@@ -50,6 +53,9 @@ class Test_documentdb_cluster_multi_az_enabled:
 
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_multi_az_enabled.documentdb_cluster_multi_az_enabled import (
@@ -88,6 +94,9 @@ class Test_documentdb_cluster_multi_az_enabled:
         }
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_multi_az_enabled.documentdb_cluster_multi_az_enabled import (

--- a/tests/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_test.py
@@ -22,6 +22,9 @@ class Test_documentdb_cluster_public_snapshot:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_public_snapshot.documentdb_cluster_public_snapshot import (
                 documentdb_cluster_public_snapshot,
@@ -62,6 +65,9 @@ class Test_documentdb_cluster_public_snapshot:
 
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_public_snapshot.documentdb_cluster_public_snapshot import (
@@ -115,6 +121,9 @@ class Test_documentdb_cluster_public_snapshot:
         ]
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_public_snapshot.documentdb_cluster_public_snapshot import (

--- a/tests/providers/aws/services/documentdb/documentdb_cluster_storage_encrypted/documentdb_cluster_storage_encrypted_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_cluster_storage_encrypted/documentdb_cluster_storage_encrypted_test.py
@@ -20,6 +20,9 @@ class Test_documentdb_cluster_storage_encrypted:
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
             new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
+            new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_storage_encrypted.documentdb_cluster_storage_encrypted import (
                 documentdb_cluster_storage_encrypted,
@@ -50,6 +53,9 @@ class Test_documentdb_cluster_storage_encrypted:
 
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_storage_encrypted.documentdb_cluster_storage_encrypted import (
@@ -88,6 +94,9 @@ class Test_documentdb_cluster_storage_encrypted:
         }
         with mock.patch(
             "prowler.providers.aws.services.documentdb.documentdb_service.DocumentDB",
+            new=documentdb_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.documentdb.documentdb_client.documentdb_client",
             new=documentdb_client,
         ):
             from prowler.providers.aws.services.documentdb.documentdb_cluster_storage_encrypted.documentdb_cluster_storage_encrypted import (


### PR DESCRIPTION
### Context

In order to follow the same criteria in all fixers and to simplify the way to handle permissions needed for each one, we’ve decided to modify the docstrings and add Permissions above the code block of the IAM permissions needed, so while this information is not yet included in the metadata, having it formatted this way will make it easier to locate by searching for the code between Permissions and Args.

### Description

Modified docstring of the 22 fixers available.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
