### PR TITLE
feat(ec2): add new check `ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983`

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "aws",
+  "CheckID": "ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983",
+  "CheckTitle": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to Solr ports 7574 and 8983.",
+  "CheckType": [
+    "Infrastructure Security"
+  ],
+  "ServiceName": "ec2",
+  "SubServiceName": "securitygroup",
+  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "Severity": "high",
+  "ResourceType": "AwsEc2SecurityGroup",
+  "Description": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to Solr ports 7574 and 8983.",
+  "Risk": "If Security groups are not properly configured the attack surface is increased.",
+  "RelatedUrl": "",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Use a Zero Trust approach. Narrow ingress traffic as much as possible. Consider north-south as well as east-west traffic.",
+      "Url": "https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html"
+    }
+  },
+  "Categories": [
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983.py
@@ -1,0 +1,47 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
+    ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
+)
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+from prowler.providers.aws.services.vpc.vpc_client import vpc_client
+
+
+class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983(Check):
+    def execute(self):
+        findings = []
+        check_ports = [7574, 8983]
+        for security_group_arn, security_group in ec2_client.security_groups.items():
+            # Check if ignoring flag is set and if the VPC and the SG is in use
+            if ec2_client.provider.scan_unused_services or (
+                security_group.vpc_id in vpc_client.vpcs
+                and vpc_client.vpcs[security_group.vpc_id].in_use
+                and len(security_group.network_interfaces) > 0
+            ):
+                report = Check_Report_AWS(self.metadata())
+                report.region = security_group.region
+                report.resource_details = security_group.name
+                report.resource_id = security_group.id
+                report.resource_arn = security_group_arn
+                report.resource_tags = security_group.tags
+                report.status = "PASS"
+                report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Solr ports 7574 and 8983 open to the Internet."
+                # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice
+                if not ec2_client.is_failed_check(
+                    ec2_securitygroup_allow_ingress_from_internet_to_all_ports.__name__,
+                    security_group_arn,
+                ):
+                    # Loop through every security group's ingress rule and check it
+                    for ingress_rule in security_group.ingress_rules:
+                        if check_security_group(
+                            ingress_rule, "tcp", check_ports, any_address=True
+                        ):
+                            report.status = "FAIL"
+                            report.status_extended = f"Security group {security_group.name} ({security_group.id}) has Solr ports 7574 and 8983 open to the Internet."
+                            break
+                else:
+                    report.status_extended = f"Security group {security_group.name} ({security_group.id}) has all ports open to the Internet and therefore was not checked against the specific Solr ports 7574 and 8983."
+
+                findings.append(report)
+
+        return findings


### PR DESCRIPTION
### Context
Currently, Prowler rule cover Elasticsearch but lack specific validation for Solr ports (7574, 8983) in EC2 security groups. As Solr is a critical search platform like Elasticsearch, this gap in security validation needs to be addressed to prevent unauthorized access and potential vulnerabilities. This check complements existing security measures by adding dedicated Solr port validation.

### Description

Add new check `ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_solr_7574_8983` with respective unit tests and metadata.

### Checklist

- Are there new checks included in this PR? Yes 
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.