### PR TITLE
feat(sqs): add new fixer `sqs_queues_not_publicly_accessible_fixer`

### DIFF
--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
@@ -33,6 +33,8 @@ def fixer(resource_id: str, region: str) -> bool:
 
         regional_client = sqs_client.regional_clients[region]
 
+        queue_name = resource_id.split("/")[-1]
+
         trusted_policy = {
             "Version": "2012-10-17",
             "Statement": [
@@ -43,6 +45,7 @@ def fixer(resource_id: str, region: str) -> bool:
                         "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
                     },
                     "Action": "sqs:*",
+                    "Resource": f"arn:{audited_partition}:sqs:{region}:{queue_name}",
                 }
             ],
         }

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
@@ -42,10 +42,10 @@ def fixer(resource_id: str, region: str) -> bool:
                     "Sid": "ProwlerFixerStatement",
                     "Effect": "Allow",
                     "Principal": {
-                        "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
+                        "AWS": account_id,
                     },
                     "Action": "sqs:*",
-                    "Resource": account_id,
+                    "Resource": f"arn:{audited_partition}:sqs:{region}:{account_id}:{queue_name}",
                 }
             ],
         }

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
@@ -45,7 +45,7 @@ def fixer(resource_id: str, region: str) -> bool:
                         "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
                     },
                     "Action": "sqs:*",
-                    "Resource": f"arn:{audited_partition}:sqs:{region}:{account_id}:{queue_name}",
+                    "Resource": account_id,
                 }
             ],
         }

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
@@ -1,0 +1,87 @@
+import json
+
+import boto3
+
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.sqs.sqs_client import sqs_client
+
+
+def get_account_id() -> str:
+    """
+    Retrieve the AWS account ID using STS get_caller_identity.
+    Returns:
+        str: The AWS account ID.
+    """
+    sts_client = boto3.client("sts")
+    identity = sts_client.get_caller_identity()
+    return identity["Account"]
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the SQS queue's resource-based policy to remove public access and replace with trusted account access.
+    Specifically, this fixer checks if any statement has a public Principal (e.g., "*" or "CanonicalUser")
+    and replaces it with the ARN of the trusted AWS account.
+    Requires the sqs:SetQueueAttributes permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "sqs:SetQueueAttributes",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The SQS queue name or ARN.
+        region (str): AWS region where the SQS queue exists.
+    Returns:
+        bool: True if the operation is successful (policy updated), False otherwise.
+    """
+    try:
+        account_id = get_account_id()
+
+        regional_client = sqs_client.regional_clients[region]
+
+        policy_response = regional_client.get_queue_attributes(
+            QueueUrl=resource_id, AttributeNames=["Policy"]
+        )
+
+        policy = policy_response.get("Attributes", {}).get("Policy")
+
+        if policy:
+            if isinstance(policy, str):
+                policy = json.loads(policy)
+
+            for statement in policy.get("Statement", []):
+                if "Principal" in statement and (
+                    "*" in statement["Principal"]
+                    or (
+                        "AWS" in statement["Principal"]
+                        and "*" in statement["Principal"]["AWS"]
+                    )
+                    or (
+                        "CanonicalUser" in statement["Principal"]
+                        and "*" in statement["Principal"]["CanonicalUser"]
+                    )
+                ):
+                    statement["Principal"] = {"AWS": f"arn:aws:iam::{account_id}:root"}
+                    statement["Action"] = "sqs:*"
+                    statement["Resource"] = (
+                        f"arn:aws:sqs:{region}:{account_id}:{resource_id}"
+                    )
+
+            regional_client.set_queue_attributes(
+                QueueUrl=resource_id,
+                Attributes={"Policy": json.dumps(policy)},
+            )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
@@ -45,7 +45,7 @@ def fixer(resource_id: str, region: str) -> bool:
                         "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
                     },
                     "Action": "sqs:*",
-                    "Resource": f"arn:{audited_partition}:sqs:{region}:{queue_name}",
+                    "Resource": f"arn:{audited_partition}:sqs:{region}:{account_id}:{queue_name}",
                 }
             ],
         }

--- a/tests/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer_test.py
+++ b/tests/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer_test.py
@@ -1,0 +1,130 @@
+from json import dumps
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+
+class Test_sqs_queues_not_publicly_accessible_fixer:
+    @mock_aws
+    def test_queue_public(self):
+        sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
+
+        queue_url = sqs_client.create_queue(QueueName="test-queue")["QueueUrl"]
+
+        sqs_client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={
+                "Policy": dumps({"Statement": [{"Effect": "Allow", "Principal": "*"}]})
+            },
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        from prowler.providers.aws.services.sqs.sqs_service import SQS
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer.sqs_client",
+            new=SQS(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert fixer(queue_url, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_queue_public_with_aws(self):
+        sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
+
+        queue_url = sqs_client.create_queue(QueueName="test-queue")["QueueUrl"]
+
+        sqs_client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={
+                "Policy": dumps(
+                    {"Statement": [{"Effect": "Allow", "Principal": {"AWS": "*"}}]}
+                )
+            },
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        from prowler.providers.aws.services.sqs.sqs_service import SQS
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer.sqs_client",
+            new=SQS(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert fixer(queue_url, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_queue_not_public(self):
+        sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
+
+        queue_url = sqs_client.create_queue(QueueName="test-queue")["QueueUrl"]
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        from prowler.providers.aws.services.sqs.sqs_service import SQS
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer.sqs_client",
+            new=SQS(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert fixer(queue_url, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_queue_public_error(self):
+        sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
+
+        queue_url = sqs_client.create_queue(QueueName="test-queue")["QueueUrl"]
+
+        sqs_client.set_queue_attributes(
+            QueueUrl=queue_url,
+            Attributes={
+                "Policy": dumps(
+                    {"Statement": [{"Effect": "Allow", "Principal": {"AWS": "*"}}]}
+                )
+            },
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        from prowler.providers.aws.services.sqs.sqs_service import SQS
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer.sqs_client",
+            new=SQS(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert not fixer("queue_url_non_existing", AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer_test.py
+++ b/tests/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer_test.py
@@ -73,30 +73,6 @@ class Test_sqs_queues_not_publicly_accessible_fixer:
             assert fixer(queue_url, AWS_REGION_EU_WEST_1)
 
     @mock_aws
-    def test_queue_not_public(self):
-        sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
-
-        queue_url = sqs_client.create_queue(QueueName="test-queue")["QueueUrl"]
-
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
-
-        from prowler.providers.aws.services.sqs.sqs_service import SQS
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer.sqs_client",
-            new=SQS(aws_provider),
-        ):
-            # Test Fixer
-            from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible_fixer import (
-                fixer,
-            )
-
-            assert fixer(queue_url, AWS_REGION_EU_WEST_1)
-
-    @mock_aws
     def test_queue_public_error(self):
         sqs_client = client("sqs", region_name=AWS_REGION_EU_WEST_1)
 

--- a/tests/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_test.py
@@ -110,7 +110,10 @@ class Test_sqs_queues_not_publicly_accessible:
         sqs_client.queues = []
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible import (
                 sqs_queues_not_publicly_accessible,
@@ -167,7 +170,10 @@ class Test_sqs_queues_not_publicly_accessible:
         )
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible import (
                 sqs_queues_not_publicly_accessible,
@@ -201,7 +207,10 @@ class Test_sqs_queues_not_publicly_accessible:
         )
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible import (
                 sqs_queues_not_publicly_accessible,
@@ -235,7 +244,10 @@ class Test_sqs_queues_not_publicly_accessible:
         )
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible import (
                 sqs_queues_not_publicly_accessible,
@@ -269,7 +281,10 @@ class Test_sqs_queues_not_publicly_accessible:
         )
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible import (
                 sqs_queues_not_publicly_accessible,
@@ -303,7 +318,10 @@ class Test_sqs_queues_not_publicly_accessible:
         )
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_not_publicly_accessible.sqs_queues_not_publicly_accessible import (
                 sqs_queues_not_publicly_accessible,

--- a/tests/providers/aws/services/sqs/sqs_queues_server_side_encryption_enabled/sqs_queues_server_side_encryption_enabled_test.py
+++ b/tests/providers/aws/services/sqs/sqs_queues_server_side_encryption_enabled/sqs_queues_server_side_encryption_enabled_test.py
@@ -18,7 +18,10 @@ class Test_sqs_queues_server_side_encryption_enabled:
         sqs_client.queues = []
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_server_side_encryption_enabled.sqs_queues_server_side_encryption_enabled import (
                 sqs_queues_server_side_encryption_enabled,
@@ -42,7 +45,10 @@ class Test_sqs_queues_server_side_encryption_enabled:
         )
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_server_side_encryption_enabled.sqs_queues_server_side_encryption_enabled import (
                 sqs_queues_server_side_encryption_enabled,
@@ -72,7 +78,10 @@ class Test_sqs_queues_server_side_encryption_enabled:
         )
         with mock.patch(
             "prowler.providers.aws.services.sqs.sqs_service.SQS",
-            sqs_client,
+            new=sqs_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.sqs.sqs_client.sqs_client",
+            new=sqs_client,
         ):
             from prowler.providers.aws.services.sqs.sqs_queues_server_side_encryption_enabled.sqs_queues_server_side_encryption_enabled import (
                 sqs_queues_server_side_encryption_enabled,


### PR DESCRIPTION
### Context

Developed a new fixer that restricts public access to SQS queues, ensuring that only authorized users and applications can interact with the queue. This includes modifying the queue's access policy to block any public access permissions and limit access to trusted IAM roles or specific AWS accounts.

The way to solve this is modifying the attributes of the failed queue, here we add a new policy which is the old one but changing the public statements to a trusted account.

### Description

Added new fixer `sqs_queues_not_publicly_accessible_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.