### PR TITLE
feat(opensearch): add new fixer `opensearch_service_domains_not_publicly_accessible_fixer`

### DIFF
--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
@@ -1,0 +1,68 @@
+import json
+
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.opensearch.opensearch_client import (
+    opensearch_client,
+)
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the OpenSearch domain's resource-based policy to remove public access and replace it with trusted account access.
+    Specifically, this fixer checks if any statement has a public Principal (e.g., "*" or "AWS": "*")
+    and replaces it with the ARN of the trusted AWS account. Requires the es:UpdateDomainConfig permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "es:UpdateDomainConfig",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The OpenSearch domain name or ARN.
+        region (str): AWS region where the OpenSearch domain exists.
+    Returns:
+        bool: True if the operation is successful (policy updated), False otherwise.
+    """
+    try:
+        account_id = opensearch_client.audited_account
+
+        regional_client = opensearch_client.regional_clients[region]
+
+        domain_config = regional_client.describe_domain_config(DomainName=resource_id)
+        policy = json.loads(domain_config["DomainConfig"]["AccessPolicies"]["Options"])
+
+        for statement in policy.get("Statement", []):
+            if "Principal" in statement and (
+                "*" in statement["Principal"]
+                or (
+                    "AWS" in statement["Principal"]
+                    and "*" in statement["Principal"]["AWS"]
+                )
+                or (
+                    "CanonicalUser" in statement["Principal"]
+                    and "*" in statement["Principal"]["CanonicalUser"]
+                )
+            ):
+                statement["Principal"] = {"AWS": f"arn:aws:iam::{account_id}:root"}
+                statement["Action"] = "es:*"
+                statement["Resource"] = (
+                    f"arn:aws:es:{region}:{account_id}:domain/{resource_id}/*"
+                )
+
+        regional_client.update_domain_config(
+            DomainName=resource_id,
+            AccessPolicies=json.dumps(policy),
+        )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
@@ -1,5 +1,3 @@
-import json
-
 from prowler.lib.logger import logger
 from prowler.providers.aws.services.opensearch.opensearch_client import (
     opensearch_client,
@@ -8,9 +6,9 @@ from prowler.providers.aws.services.opensearch.opensearch_client import (
 
 def fixer(resource_id: str, region: str) -> bool:
     """
-    Modify the OpenSearch domain's resource-based policy to remove public access and replace it with trusted account access.
-    Specifically, this fixer checks if any statement has a public Principal (e.g., "*" or "AWS": "*")
-    and replaces it with the ARN of the trusted AWS account. Requires the es:UpdateDomainConfig permission.
+    Modify the OpenSearch domain's resource-based policy to remove public access.
+    Specifically, this fixer update the domain config and add an empty policy to remove the old one.
+    Requires the es:UpdateDomainConfig permission.
     Permissions:
     {
         "Version": "2012-10-17",
@@ -29,28 +27,11 @@ def fixer(resource_id: str, region: str) -> bool:
         bool: True if the operation is successful (policy updated), False otherwise.
     """
     try:
-        account_id = opensearch_client.audited_account
-        audited_partition = opensearch_client.audited_partition
-
         regional_client = opensearch_client.regional_clients[region]
-
-        trusted_policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {
-                        "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
-                    },
-                    "Action": "es:*",
-                    "Resource": f"arn:{audited_partition}:es:{region}:{account_id}:domain/{resource_id}/*",
-                }
-            ],
-        }
 
         regional_client.update_domain_config(
             DomainName=resource_id,
-            AccessPolicies=json.dumps(trusted_policy),
+            AccessPolicies="",
         )
 
     except Exception as error:

--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
@@ -23,7 +23,7 @@ def fixer(resource_id: str, region: str) -> bool:
         ]
     }
     Args:
-        resource_id (str): The OpenSearch domain name or ARN.
+        resource_id (str): The OpenSearch domain name.
         region (str): AWS region where the OpenSearch domain exists.
     Returns:
         bool: True if the operation is successful (policy updated), False otherwise.
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                         "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
                     },
                     "Action": "es:*",
-                    "Resource": f"arn:aws:es:{region}:{account_id}:domain/{resource_id}/*",
+                    "Resource": f"arn:{audited_partition}:es:{region}:{account_id}:domain/{resource_id}/*",
                 }
             ],
         }

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer_test.py
@@ -1,0 +1,135 @@
+from json import dumps
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_WEST_2,
+    set_mocked_aws_provider,
+)
+
+domain_name = "test-domain"
+
+policy_data_restricted = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"AWS": [f"{AWS_ACCOUNT_NUMBER}"]},
+            "Action": ["es:*"],
+            "Resource": f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}/*",
+        }
+    ],
+}
+
+policy_data_not_restricted = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"AWS": ["*"]},
+            "Action": ["es:*"],
+            "Resource": f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}/*",
+        }
+    ],
+}
+
+policy_data_not_restricted_principal = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": ["es:*"],
+            "Resource": f"arn:aws:es:us-west-2:{AWS_ACCOUNT_NUMBER}:domain/{domain_name}/*",
+        }
+    ],
+}
+
+
+class Test_opensearch_service_domains_not_publicly_accessible:
+    @mock_aws
+    def test_policy_data_restricted_error(self):
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
+        opensearch_client.create_domain(DomainName=domain_name)["DomainStatus"]["ARN"]
+        opensearch_client.update_domain_config(
+            DomainName=domain_name,
+            AccessPolicies=str(policy_data_restricted),
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
+
+        from prowler.providers.aws.services.opensearch.opensearch_service import (
+            OpenSearchService,
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible_fixer.opensearch_client",
+            new=OpenSearchService(aws_provider),
+        ):
+            from prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert not fixer("domain_name_non_existing", AWS_REGION_US_WEST_2)
+
+    @mock_aws
+    def test_policy_data_not_restricted_with_principal_AWS(self):
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
+        opensearch_client.create_domain(DomainName=domain_name)["DomainStatus"]["ARN"]
+        opensearch_client.update_domain_config(
+            DomainName=domain_name,
+            AccessPolicies=dumps(policy_data_not_restricted),
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
+
+        from prowler.providers.aws.services.opensearch.opensearch_service import (
+            OpenSearchService,
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible_fixer.opensearch_client",
+            new=OpenSearchService(aws_provider),
+        ):
+            from prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert fixer(domain_name, AWS_REGION_US_WEST_2)
+
+    @mock_aws
+    def test_policy_data_not_restricted_with_principal_no_AWS(self):
+        opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)
+        opensearch_client.create_domain(DomainName=domain_name)["DomainStatus"]["ARN"]
+        opensearch_client.update_domain_config(
+            DomainName=domain_name,
+            AccessPolicies=dumps(policy_data_not_restricted_principal),
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_WEST_2])
+
+        from prowler.providers.aws.services.opensearch.opensearch_service import (
+            OpenSearchService,
+        )
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible_fixer.opensearch_client",
+            new=OpenSearchService(aws_provider),
+        ):
+            from prowler.providers.aws.services.opensearch.opensearch_service_domains_not_publicly_accessible.opensearch_service_domains_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert fixer(domain_name, AWS_REGION_US_WEST_2)

--- a/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer_test.py
+++ b/tests/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer_test.py
@@ -49,7 +49,7 @@ policy_data_not_restricted_principal = {
 }
 
 
-class Test_opensearch_service_domains_not_publicly_accessible:
+class Test_opensearch_service_domains_not_publicly_accessible_fixer:
     @mock_aws
     def test_policy_data_restricted_error(self):
         opensearch_client = client("opensearch", region_name=AWS_REGION_US_WEST_2)


### PR DESCRIPTION
### Context

Developed a new fixer that restricts public access to OpenSearch Service domains, ensuring they are only accessible from within the VPC or specific, authorized IP ranges. This will enhance security by preventing unauthorized users from accessing sensitive data stored in OpenSearch domains.

### Description

Added new fixer `opensearch_service_domains_not_publicly_accessible_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.