### PR TITLE
fix(gcp): use session credentials to check if API is active

### DIFF
--- a/prowler/providers/gcp/lib/service/service.py
+++ b/prowler/providers/gcp/lib/service/service.py
@@ -55,7 +55,9 @@ class GCPService:
         project_ids = []
         for project_id in audited_project_ids:
             try:
-                client = discovery.build("serviceusage", "v1")
+                client = discovery.build(
+                    "serviceusage", "v1", credentials=self.credentials
+                )
                 request = client.services().get(
                     name=f"projects/{project_id}/services/{self.service}.googleapis.com"
                 )


### PR DESCRIPTION
### Description

Use the session credentials to check if a GCP API is active, instead of the default ones.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.