### PR TITLE
feat(glacier): add new fixer `glacier_vaults_policy_public_access_fixer`

### DIFF
--- a/prowler/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer.py
+++ b/prowler/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer.py
@@ -1,0 +1,60 @@
+import json
+
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.glacier.glacier_client import glacier_client
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the Glacier vault's policy to remove public access and replace it with trusted account access.
+    Specifically, this fixer checks if any statement has a public Principal (e.g., "*" or "AWS": "*")
+    and replaces it with the ARN of the trusted AWS account. Requires the glacier:UpdateVaultConfig permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "glacier:UpdateVaultConfig",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The Glacier vault name.
+        region (str): AWS region where the Glacier vault exists.
+    Returns:
+        bool: True if the operation is successful (policy updated), False otherwise.
+    """
+    try:
+        account_id = glacier_client.audited_account
+        audited_partition = glacier_client.audited_partition
+
+        regional_client = glacier_client.regional_clients[region]
+
+        trusted_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
+                    },
+                    "Action": "glacier:*",
+                    "Resource": f"arn:{audited_partition}:glacier:{region}:{account_id}:vaults/{resource_id}",
+                }
+            ],
+        }
+
+        regional_client.set_vault_access_policy(
+            vaultName=resource_id,
+            policy={"Policy": json.dumps(trusted_policy)},
+        )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer.py
+++ b/prowler/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer.py
@@ -1,21 +1,19 @@
-import json
-
 from prowler.lib.logger import logger
 from prowler.providers.aws.services.glacier.glacier_client import glacier_client
 
 
 def fixer(resource_id: str, region: str) -> bool:
     """
-    Modify the Glacier vault's policy to remove public access and replace it with trusted account access.
-    Specifically, this fixer checks if any statement has a public Principal (e.g., "*" or "AWS": "*")
-    and replaces it with the ARN of the trusted AWS account. Requires the glacier:UpdateVaultConfig permission.
+    Modify the Glacier vault's policy to remove public access.
+    Specifically, this fixer delete the vault policy that has public access.
+    Requires the glacier:DeleteVaultAccessPolicy permission.
     Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": "glacier:UpdateVaultConfig",
+                "Action": "glacier:DeleteVaultAccessPolicy",
                 "Resource": "*"
             }
         ]
@@ -27,29 +25,9 @@ def fixer(resource_id: str, region: str) -> bool:
         bool: True if the operation is successful (policy updated), False otherwise.
     """
     try:
-        account_id = glacier_client.audited_account
-        audited_partition = glacier_client.audited_partition
-
         regional_client = glacier_client.regional_clients[region]
 
-        trusted_policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Effect": "Allow",
-                    "Principal": {
-                        "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
-                    },
-                    "Action": "glacier:*",
-                    "Resource": f"arn:{audited_partition}:glacier:{region}:{account_id}:vaults/{resource_id}",
-                }
-            ],
-        }
-
-        regional_client.set_vault_access_policy(
-            vaultName=resource_id,
-            policy={"Policy": json.dumps(trusted_policy)},
-        )
+        regional_client.delete_vault_access_policy(vaultName=resource_id)
 
     except Exception as error:
         logger.error(

--- a/tests/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer_test.py
+++ b/tests/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer_test.py
@@ -9,27 +9,18 @@ mock_make_api_call = botocore.client.BaseClient._make_api_call
 
 
 def mock_make_api_call_public_vault(self, operation_name, kwarg):
-    if operation_name == "SetVaultAccessPolicy":
+    if operation_name == "DeleteVaultAccessPolicy":
         return {
-            "VaultAccessPolicy": {
-                "Policy": {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {"AWS": "arn:aws:iam::106908755756:root"},
-                            "Action": "glacier:InitiateJob",
-                            "Resource": "arn:aws:glacier:eu-west-1:106908755756:vaults/test-vault",
-                        }
-                    ],
-                }
+            "ResponseMetadata": {
+                "HTTPStatusCode": 204,
+                "RequestId": "test-request-id",
             }
         }
     return mock_make_api_call(self, operation_name, kwarg)
 
 
 def mock_make_api_call_public_vault_error(self, operation_name, kwarg):
-    if operation_name == "SetVaultAccessPolicy":
+    if operation_name == "DeleteVaultAccessPolicy":
         raise botocore.exceptions.ClientError(
             {
                 "Error": {

--- a/tests/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer_test.py
+++ b/tests/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer_test.py
@@ -1,0 +1,90 @@
+from unittest import mock
+
+import botocore
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_public_vault(self, operation_name, kwarg):
+    if operation_name == "SetVaultAccessPolicy":
+        return {
+            "VaultAccessPolicy": {
+                "Policy": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"AWS": "arn:aws:iam::106908755756:root"},
+                            "Action": "glacier:InitiateJob",
+                            "Resource": "arn:aws:glacier:eu-west-1:106908755756:vaults/test-vault",
+                        }
+                    ],
+                }
+            }
+        }
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+def mock_make_api_call_public_vault_error(self, operation_name, kwarg):
+    if operation_name == "SetVaultAccessPolicy":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "VaultNotFound",
+                    "Message": "VaultNotFound",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_glacier_vaults_policy_public_access_fixer:
+    @mock_aws
+    def test_glacier_vault_public(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_public_vault,
+        ):
+            from prowler.providers.aws.services.glacier.glacier_service import Glacier
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.glacier.glacier_vaults_policy_public_access.glacier_vaults_policy_public_access_fixer.glacier_client",
+                new=Glacier(aws_provider),
+            ):
+                from prowler.providers.aws.services.glacier.glacier_vaults_policy_public_access.glacier_vaults_policy_public_access_fixer import (
+                    fixer,
+                )
+
+                assert fixer(resource_id="test-vault", region=AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_glacier_vault_public_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_public_vault_error,
+        ):
+            from prowler.providers.aws.services.glacier.glacier_service import Glacier
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.glacier.glacier_vaults_policy_public_access.glacier_vaults_policy_public_access_fixer.glacier_client",
+                new=Glacier(aws_provider),
+            ):
+                from prowler.providers.aws.services.glacier.glacier_vaults_policy_public_access.glacier_vaults_policy_public_access_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(resource_id="test-vault", region=AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_test.py
+++ b/tests/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_test.py
@@ -11,6 +11,9 @@ class Test_glacier_vaults_policy_public_access:
         with mock.patch(
             "prowler.providers.aws.services.glacier.glacier_service.Glacier",
             new=glacier_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.glacier.glacier_client.glacier_client",
+            new=glacier_client,
         ):
             # Test Check
             from prowler.providers.aws.services.glacier.glacier_vaults_policy_public_access.glacier_vaults_policy_public_access import (
@@ -36,6 +39,9 @@ class Test_glacier_vaults_policy_public_access:
         }
         with mock.patch(
             "prowler.providers.aws.services.glacier.glacier_service.Glacier",
+            new=glacier_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.glacier.glacier_client.glacier_client",
             new=glacier_client,
         ):
             # Test Check
@@ -89,6 +95,9 @@ class Test_glacier_vaults_policy_public_access:
         with mock.patch(
             "prowler.providers.aws.services.glacier.glacier_service.Glacier",
             new=glacier_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.glacier.glacier_client.glacier_client",
+            new=glacier_client,
         ):
             # Test Check
             from prowler.providers.aws.services.glacier.glacier_vaults_policy_public_access.glacier_vaults_policy_public_access import (
@@ -141,6 +150,9 @@ class Test_glacier_vaults_policy_public_access:
         with mock.patch(
             "prowler.providers.aws.services.glacier.glacier_service.Glacier",
             new=glacier_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.glacier.glacier_client.glacier_client",
+            new=glacier_client,
         ):
             # Test Check
             from prowler.providers.aws.services.glacier.glacier_vaults_policy_public_access.glacier_vaults_policy_public_access import (
@@ -192,6 +204,9 @@ class Test_glacier_vaults_policy_public_access:
         }
         with mock.patch(
             "prowler.providers.aws.services.glacier.glacier_service.Glacier",
+            new=glacier_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.glacier.glacier_client.glacier_client",
             new=glacier_client,
         ):
             # Test Check
@@ -248,6 +263,9 @@ class Test_glacier_vaults_policy_public_access:
         }
         with mock.patch(
             "prowler.providers.aws.services.glacier.glacier_service.Glacier",
+            new=glacier_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.glacier.glacier_client.glacier_client",
             new=glacier_client,
         ):
             # Test Check


### PR DESCRIPTION
### Context

Developed a new fixer that updates the access policies for Glacier vaults to restrict public access, ensuring they are only accessible to authorized AWS accounts and trusted IAM roles. This will help prevent unauthorized access to archived data and improve the security of Glacier vault resources.

Also, while testing, I noticed that the unit tests from the check `glacier_vaults_policy_public_access` did not have the right patch in order to work without problems with MagicMock so I've fixed them. 

Aditionally, as Moto does not cover the `set_vault_access_policy` API call I needed to use Botocore.

### Description

Added new fixer `glacier_vaults_policy_public_access_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.