### PR TITLE
chore(check): remove custom_report_interface

### DIFF
--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -556,19 +556,6 @@ def execute_checks(
                 bar()
             bar.title = f"-> {Fore.GREEN}Scan completed!{Style.RESET_ALL}"
 
-    # Custom report interface
-    if os.environ.get("PROWLER_REPORT_LIB_PATH"):
-        try:
-            logger.info("Using custom report interface ...")
-            lib = os.environ["PROWLER_REPORT_LIB_PATH"]
-            outputs_module = importlib.import_module(lib)
-            custom_report_interface = getattr(outputs_module, "report")
-
-            # TODO: review this call and see if we can remove the global_provider.output_options since it is contained in the global_provider
-            custom_report_interface(check_findings, output_options, global_provider)
-        except Exception:
-            sys.exit(1)
-
     return all_findings
 
 


### PR DESCRIPTION
### Description

Remove in order to deprecate custom report interface.

```python
# Custom report interface
    if os.environ.get("PROWLER_REPORT_LIB_PATH"):
        try:
            logger.info("Using custom report interface ...")
            lib = os.environ["PROWLER_REPORT_LIB_PATH"]
            outputs_module = importlib.import_module(lib)
            custom_report_interface = getattr(outputs_module, "report")

            # TODO: review this call and see if we can remove the global_provider.output_options since it is contained in the global_provider
            custom_report_interface(check_findings, output_options, global_provider)
        except Exception:
            sys.exit(1)
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.