### PR TITLE
feat(Provider): add soft deletion for providers and related resources

### DIFF
--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -103,7 +103,7 @@ def batch_delete(queryset, batch_size=5000):
     total_deleted = 0
     deletion_summary = {}
 
-    paginator = Paginator(queryset.only("id"), batch_size)
+    paginator = Paginator(queryset.order_by("id").only("id"), batch_size)
 
     for page_num in paginator.page_range:
         batch_ids = [obj.id for obj in paginator.page(page_num).object_list]

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -1,12 +1,13 @@
 import secrets
 from contextlib import contextmanager
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 from django.conf import settings
 from django.contrib.auth.models import BaseUserManager
-from django.db import models, transaction, connection
+from django.core.paginator import Paginator
+from django.db import connection, models, transaction
 from psycopg2 import connect as psycopg2_connect
-from psycopg2.extensions import new_type, register_type, register_adapter, AsIs
+from psycopg2.extensions import AsIs, new_type, register_adapter, register_type
 
 DB_USER = settings.DATABASES["default"]["USER"] if not settings.TESTING else "test"
 DB_PASSWORD = (
@@ -86,6 +87,35 @@ def generate_random_token(length: int = 14, symbols: str | None = None) -> str:
     """
     _symbols = "23456789ABCDEFGHJKMNPQRSTVWXYZ"
     return "".join(secrets.choice(symbols or _symbols) for _ in range(length))
+
+
+def batch_delete(queryset, batch_size=5000):
+    """
+    Deletes objects in batches and returns the total number of deletions and a summary.
+
+    Args:
+        queryset (QuerySet): The queryset of objects to delete.
+        batch_size (int): The number of objects to delete in each batch.
+
+    Returns:
+        tuple: (total_deleted, deletion_summary)
+    """
+    total_deleted = 0
+    deletion_summary = {}
+
+    paginator = Paginator(queryset.only("id"), batch_size)
+
+    for page_num in paginator.page_range:
+        batch_ids = [obj.id for obj in paginator.page(page_num).object_list]
+
+        deleted_count, deleted_info = queryset.filter(id__in=batch_ids).delete()
+
+        total_deleted += deleted_count
+
+        for model_label, count in deleted_info.items():
+            deletion_summary[model_label] = deletion_summary.get(model_label, 0) + count
+
+    return total_deleted, deletion_summary
 
 
 # Postgres Enums

--- a/api/src/backend/api/migrations/0001_initial.py
+++ b/api/src/backend/api/migrations/0001_initial.py
@@ -387,6 +387,7 @@ class Migration(migrations.Migration):
                 ),
                 ("inserted_at", models.DateTimeField(auto_now_add=True)),
                 ("updated_at", models.DateTimeField(auto_now=True)),
+                ("is_deleted", models.BooleanField(default=False)),
                 (
                     "provider",
                     ProviderEnumField(
@@ -1093,7 +1094,7 @@ class Migration(migrations.Migration):
             },
             bases=(PostgresPartitionedModel,),
             managers=[
-                ("objects", PostgresManager()),
+                ("objects", api.models.ActiveProviderPartitionedManager()),
             ],
         ),
         migrations.RunSQL(

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -167,7 +167,6 @@ class Membership(models.Model):
 
 
 class Provider(RowLevelSecurityProtectedModel):
-
     objects = ActiveProviderManager()
     all_objects = models.Manager()
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -702,7 +702,10 @@ class ProviderViewSet(BaseRLSViewSet):
         )
 
     def destroy(self, request, *args, pk=None, **kwargs):
-        get_object_or_404(Provider, pk=pk)
+        provider = get_object_or_404(Provider, pk=pk)
+        provider.is_deleted = True
+        provider.save()
+
         with transaction.atomic():
             task = delete_provider_task.delay(
                 provider_id=pk, tenant_id=request.tenant_id

--- a/api/src/backend/tasks/jobs/deletion.py
+++ b/api/src/backend/tasks/jobs/deletion.py
@@ -1,25 +1,46 @@
 from celery.utils.log import get_task_logger
+from django.db import transaction
+
+from api.db_utils import batch_delete
+from api.models import Finding, Provider, Resource, Scan
 
 logger = get_task_logger(__name__)
 
 
-def delete_instance(model, pk: str):
+def delete_provider(pk: str):
     """
-    Deletes an instance of the specified model.
-
-    This function retrieves an instance of the provided model using its primary key
-    and deletes it from the database.
+    Gracefully deletes an instance of a provider along with its related data.
 
     Args:
-        model (Model): The Django model class from which to delete an instance.
-        pk (str): The primary key of the instance to delete.
+        pk (str): The primary key of the Provider instance to delete.
 
     Returns:
-        tuple: A tuple containing the number of objects deleted and a dictionary
-               with the count of deleted objects per model,
-               including related models if applicable.
+        dict: A dictionary with the count of deleted objects per model,
+              including related models.
 
     Raises:
-        model.DoesNotExist: If no instance with the provided primary key exists.
+        Provider.DoesNotExist: If no instance with the provided primary key exists.
     """
-    return model.objects.get(pk=pk).delete()
+    instance = Provider.all_objects.get(pk=pk)
+    deletion_summary = {}
+
+    with transaction.atomic():
+        # Delete Findings
+        findings_qs = Finding.all_objects.filter(scan__provider=instance)
+        _, findings_summary = batch_delete(findings_qs)
+        deletion_summary.update(findings_summary)
+
+        # Delete Resources
+        resources_qs = Resource.all_objects.filter(provider=instance)
+        _, resources_summary = batch_delete(resources_qs)
+        deletion_summary.update(resources_summary)
+
+        # Delete Scans
+        scans_qs = Scan.all_objects.filter(provider=instance)
+        _, scans_summary = batch_delete(scans_qs)
+        deletion_summary.update(scans_summary)
+
+        provider_deleted_count, provider_summary = instance.delete()
+        deletion_summary.update(provider_summary)
+
+    return deletion_summary

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from config.celery import RLSTask
 from tasks.jobs.connection import check_provider_connection
-from tasks.jobs.deletion import delete_instance
+from tasks.jobs.deletion import delete_provider
 from tasks.jobs.scan import aggregate_findings, perform_prowler_scan
 
 from api.db_utils import tenant_transaction
@@ -32,6 +32,8 @@ def delete_provider_task(provider_id: str):
     """
     Task to delete a specific Provider instance.
 
+    It will delete in batches all the related resources first.
+
     Args:
         provider_id (str): The primary key of the `Provider` instance to be deleted.
 
@@ -41,7 +43,7 @@ def delete_provider_task(provider_id: str):
             - A dictionary with the count of deleted instances per model,
               including related models if cascading deletes were triggered.
     """
-    return delete_instance(model=Provider, pk=provider_id)
+    return delete_provider(pk=provider_id)
 
 
 @shared_task(base=RLSTask, name="scan-perform", queue="scans")

--- a/api/src/backend/tasks/tests/test_deletion.py
+++ b/api/src/backend/tasks/tests/test_deletion.py
@@ -1,15 +1,15 @@
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
+from tasks.jobs.deletion import delete_provider
 
 from api.models import Provider
-from tasks.jobs.deletion import delete_instance
 
 
 @pytest.mark.django_db
 class TestDeleteInstance:
     def test_delete_instance_success(self, providers_fixture):
         instance = providers_fixture[0]
-        result = delete_instance(Provider, instance.id)
+        result = delete_provider(instance.id)
 
         assert result
         with pytest.raises(ObjectDoesNotExist):
@@ -19,4 +19,4 @@ class TestDeleteInstance:
         non_existent_pk = "babf6796-cfcc-4fd3-9dcf-88d012247645"
 
         with pytest.raises(ObjectDoesNotExist):
-            delete_instance(Provider, non_existent_pk)
+            delete_provider(non_existent_pk)


### PR DESCRIPTION
### Context

To prevent database performance issues and errors, we needed to implement a soft delete method for Providers.

### Description

When deleting a Provider through the API, a new column in providers called `is_deleted` is set to `True`. All related resources will be returned if the related Provider is NOT deleted.

Then, the Celery task will try to delete related resources first in batches, to reduce overhead in the database.

```
prowler_db=# \d providers
                                Table "public.providers"
           Column           |           Type           | Collation | Nullable | Default
----------------------------+--------------------------+-----------+----------+---------
 id                         | uuid                     |           | not null |
 inserted_at                | timestamp with time zone |           | not null |
 updated_at                 | timestamp with time zone |           | not null |
 is_deleted                 | boolean                  |           | not null |
 provider                   | provider                 |           | not null |
 uid                        | character varying(63)    |           | not null |
 alias                      | character varying(100)   |           |          |
 connected                  | boolean                  |           |          |
 connection_last_checked_at | timestamp with time zone |           |          |
 metadata                   | jsonb                    |           | not null |
 scanner_args               | jsonb                    |           | not null |
 tenant_id                  | uuid                     |           | not null |
Indexes:
    "providers_pkey" PRIMARY KEY, btree (id)
    "providers_tenant_id_b06669a6" btree (tenant_id)
    "unique_provider_uids" UNIQUE CONSTRAINT, btree (tenant_id, provider, uid)
Foreign-key constraints:
    "providers_tenant_id_b06669a6_fk_tenants_id" FOREIGN KEY (tenant_id) REFERENCES tenants(id) DEFERRABLE INITIALLY DEFERRED
Referenced by:
    TABLE "provider_group_memberships" CONSTRAINT "provider_group_memberships_provider_id_0cf5a7d2_fk_providers_id" FOREIGN KEY (provider_id) REFERENCES providers(id) DEFERRABLE INITIALLY DEFERRED
    TABLE "provider_secrets" CONSTRAINT "provider_secrets_provider_id_5276da4f_fk_providers_id" FOREIGN KEY (provider_id) REFERENCES providers(id) DEFERRABLE INITIALLY DEFERRED
    TABLE "resources" CONSTRAINT "resources_provider_id_84da0f6e_fk_providers_id" FOREIGN KEY (provider_id) REFERENCES providers(id) DEFERRABLE INITIALLY DEFERRED
    TABLE "scans" CONSTRAINT "scans_provider_id_6e3ed3b6_fk_providers_id" FOREIGN KEY (provider_id) REFERENCES providers(id) DEFERRABLE INITIALLY DEFERRED
Policies (forced row security enabled):
    POLICY "prowler_user_providers_delete" FOR DELETE
      TO prowler_user
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_user_providers_insert" FOR INSERT
      TO prowler_user
      WITH CHECK (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_user_providers_select" FOR SELECT
      TO prowler_user
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_user_providers_update" FOR UPDATE
      TO prowler_user
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)

prowler_db=#
```

![image](https://github.com/user-attachments/assets/36d0c85b-4ad7-4b30-bd5f-bcd2032ba139)



### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.