### PR TITLE
feat(dynamic_filters): add dynamic filters system

### DIFF
--- a/api/src/backend/api/filters.py
+++ b/api/src/backend/api/filters.py
@@ -426,6 +426,16 @@ class FindingFilter(FilterSet):
         return dt
 
 
+class FindingDynamicFilter(FilterSet):
+    updated_at = DateFilter(field_name="updated_at", lookup_expr="date")
+
+    class Meta:
+        model = Finding
+        fields = {
+            "updated_at": ["exact"],
+        }
+
+
 class ProviderSecretFilter(FilterSet):
     inserted_at = DateFilter(field_name="inserted_at", lookup_expr="date")
     updated_at = DateFilter(field_name="updated_at", lookup_expr="date")

--- a/api/src/backend/api/filters.py
+++ b/api/src/backend/api/filters.py
@@ -426,31 +426,6 @@ class FindingFilter(FilterSet):
         return dt
 
 
-class FindingDynamicFilter(FilterSet):
-    inserted_at = DateFilter(
-        method="filter_inserted_at", lookup_expr="date", required=True
-    )
-
-    class Meta:
-        model = Finding
-        fields = {
-            "inserted_at": ["exact"],
-        }
-
-    def filter_inserted_at(self, queryset, name, value):
-        value = self.maybe_date_to_datetime(value)
-        start = uuid7_start(datetime_to_uuid7(value))
-
-        return queryset.filter(id__gte=start).filter(inserted_at__date=value)
-
-    @staticmethod
-    def maybe_date_to_datetime(value):
-        dt = value
-        if isinstance(value, date):
-            dt = datetime.combine(value, datetime.min.time(), tzinfo=timezone.utc)
-        return dt
-
-
 class ProviderSecretFilter(FilterSet):
     inserted_at = DateFilter(field_name="inserted_at", lookup_expr="date")
     updated_at = DateFilter(field_name="updated_at", lookup_expr="date")

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -754,12 +754,12 @@ paths:
   /api/v1/findings/findings_services_regions:
     get:
       operationId: findings_findings_services_regions_retrieve
-      description: Fetch services and regions affected in a finding by date.
-      summary: Retrieve the services and regions that are impacted by a finding in
+      description: Fetch services and regions affected in findings by date.
+      summary: Retrieve the services and regions that are impacted by findings in
         a specific date
       parameters:
       - in: query
-        name: fields[findings-services-regions]
+        name: fields[finding-dynamic-filters]
         schema:
           type: array
           items:
@@ -770,19 +770,18 @@ paths:
         description: endpoint return only specific fields in the response on a per-type
           basis by including a fields[TYPE] query parameter.
         explode: false
+      - in: query
+        name: filter[inserted_at]
+        schema:
+          type: string
+          format: date
+        required: true
       - name: filter[search]
         required: false
         in: query
         description: A search term.
         schema:
           type: string
-      - in: query
-        name: filter[updated_at]
-        schema:
-          type: string
-          format: date
-        description: Date in the format YYYY-MM-DD
-        required: true
       tags:
       - Finding
       security:

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -771,17 +771,399 @@ paths:
           basis by including a fields[TYPE] query parameter.
         explode: false
       - in: query
+        name: filter[check_id]
+        schema:
+          type: string
+      - in: query
+        name: filter[check_id__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[check_id__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[delta]
+        schema:
+          type: string
+          nullable: true
+          enum:
+          - changed
+          - new
+        description: |-
+          * `new` - New
+          * `changed` - Changed
+      - in: query
+        name: filter[delta__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[id]
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: filter[id__in]
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[impact]
+        schema:
+          type: string
+          enum:
+          - critical
+          - high
+          - informational
+          - low
+          - medium
+        description: |-
+          * `critical` - Critical
+          * `high` - High
+          * `medium` - Medium
+          * `low` - Low
+          * `informational` - Informational
+      - in: query
+        name: filter[impact__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
         name: filter[inserted_at]
         schema:
           type: string
           format: date
-        required: true
+      - in: query
+        name: filter[inserted_at__date]
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: filter[inserted_at__gte]
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: filter[inserted_at__lte]
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: filter[provider]
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: filter[provider__in]
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[provider_alias]
+        schema:
+          type: string
+      - in: query
+        name: filter[provider_alias__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[provider_alias__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[provider_type]
+        schema:
+          type: string
+          enum:
+          - aws
+          - azure
+          - gcp
+          - kubernetes
+        description: |-
+          * `aws` - AWS
+          * `azure` - Azure
+          * `gcp` - GCP
+          * `kubernetes` - Kubernetes
+      - in: query
+        name: filter[provider_type__in]
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - aws
+            - azure
+            - gcp
+            - kubernetes
+        description: |-
+          Multiple values may be separated by commas.
+
+          * `aws` - AWS
+          * `azure` - Azure
+          * `gcp` - GCP
+          * `kubernetes` - Kubernetes
+        explode: false
+        style: form
+      - in: query
+        name: filter[provider_uid]
+        schema:
+          type: string
+      - in: query
+        name: filter[provider_uid__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[provider_uid__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[region]
+        schema:
+          type: string
+      - in: query
+        name: filter[region__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[region__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_name]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_name__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_name__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_type]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_type__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_type__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_uid]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_uid__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_uid__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resources]
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[scan]
+        schema:
+          type: string
+          format: uuid
+      - in: query
+        name: filter[scan__in]
+        schema:
+          type: array
+          items:
+            type: string
+            format: uuid
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - name: filter[search]
         required: false
         in: query
         description: A search term.
         schema:
           type: string
+      - in: query
+        name: filter[service]
+        schema:
+          type: string
+      - in: query
+        name: filter[service__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[service__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[severity]
+        schema:
+          type: string
+          enum:
+          - critical
+          - high
+          - informational
+          - low
+          - medium
+        description: |-
+          * `critical` - Critical
+          * `high` - High
+          * `medium` - Medium
+          * `low` - Low
+          * `informational` - Informational
+      - in: query
+        name: filter[severity__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[status]
+        schema:
+          type: string
+          enum:
+          - FAIL
+          - MANUAL
+          - MUTED
+          - PASS
+        description: |-
+          * `FAIL` - Fail
+          * `PASS` - Pass
+          * `MANUAL` - Manual
+          * `MUTED` - Muted
+      - in: query
+        name: filter[status__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[uid]
+        schema:
+          type: string
+      - in: query
+        name: filter[uid__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[updated_at]
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: filter[updated_at__gte]
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: filter[updated_at__lte]
+        schema:
+          type: string
+          format: date-time
+      - name: sort
+        required: false
+        in: query
+        description: '[list of fields to sort by](https://jsonapi.org/format/#fetching-sorting)'
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - id
+            - -id
+            - status
+            - -status
+            - severity
+            - -severity
+            - check_id
+            - -check_id
+            - inserted_at
+            - -inserted_at
+            - updated_at
+            - -updated_at
+        explode: false
       tags:
       - Finding
       security:

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -751,6 +751,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/FindingResponse'
           description: ''
+  /api/v1/findings/findings_services_regions:
+    get:
+      operationId: findings_findings_services_regions_retrieve
+      description: Fetch services and regions affected in a finding by date.
+      summary: Retrieve the services and regions that are impacted by a finding in
+        a specific date
+      parameters:
+      - in: query
+        name: fields[findings-services-regions]
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - services
+            - regions
+        description: endpoint return only specific fields in the response on a per-type
+          basis by including a fields[TYPE] query parameter.
+        explode: false
+      - name: filter[search]
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      - in: query
+        name: filter[updated_at]
+        schema:
+          type: string
+          format: date
+        description: Date in the format YYYY-MM-DD
+        required: true
+      tags:
+      - Finding
+      security:
+      - jwtAuth: []
+      responses:
+        '201':
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/OpenApiResponseResponse'
+          description: ''
   /api/v1/invitations/accept:
     post:
       operationId: invitations_accept_create
@@ -4620,6 +4663,7 @@ components:
       type: object
       required:
       - type
+      - id
       additionalProperties: false
       properties:
         type:
@@ -4628,6 +4672,9 @@ components:
           description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
             member is used to describe resource objects that share common attributes
             and relationships.
+        id:
+          type: string
+          format: uuid
         attributes:
           type: object
           properties:

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -2456,14 +2456,14 @@ class TestFindingViewSet:
         finding_1, *_ = findings_fixture
         response = authenticated_client.get(
             reverse("finding-findings_services_regions"),
-            {"filter[updated_at]": finding_1.updated_at.strftime("%Y-%m-%d")},
+            {"filter[inserted_at]": finding_1.updated_at.strftime("%Y-%m-%d")},
         )
         data = response.json()
 
         expected_services = {"ec2", "s3"}
-        expected_regions = {"us-east-1", "eu-west-1"}
+        expected_regions = {"eu-west-1", "us-east-1"}
 
-        assert data["data"]["type"] == "findings-services-regions"
+        assert data["data"]["type"] == "finding-dynamic-filters"
         assert data["data"]["id"] is None
         assert set(data["data"]["attributes"]["services"]) == expected_services
         assert set(data["data"]["attributes"]["regions"]) == expected_regions
@@ -2471,23 +2471,18 @@ class TestFindingViewSet:
     def test_findings_services_regions_future_date(self, authenticated_client):
         response = authenticated_client.get(
             reverse("finding-findings_services_regions"),
-            {"filter[updated_at]": "2048-01-01"},
+            {"filter[inserted_at]": "2048-01-01"},
         )
-        assert response.json() == {
-            "errors": [
-                {
-                    "detail": "The date must be a date in the past.",
-                    "status": "400",
-                    "source": {"pointer": "/data"},
-                    "code": "invalid",
-                }
-            ]
-        }
+        data = response.json()
+        assert data["data"]["type"] == "finding-dynamic-filters"
+        assert data["data"]["id"] is None
+        assert data["data"]["attributes"]["services"] == []
+        assert data["data"]["attributes"]["regions"] == []
 
     def test_findings_services_regions_invalid_date(self, authenticated_client):
         response = authenticated_client.get(
             reverse("finding-findings_services_regions"),
-            {"filter[updated_at]": "2048-01-011"},
+            {"filter[inserted_at]": "2048-01-011"},
         )
         assert response.json() == {
             "errors": [

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -2468,6 +2468,27 @@ class TestFindingViewSet:
         assert set(data["data"]["attributes"]["services"]) == expected_services
         assert set(data["data"]["attributes"]["regions"]) == expected_regions
 
+    def test_findings_services_regions_severity_retrieve(
+        self, authenticated_client, findings_fixture
+    ):
+        finding_1, *_ = findings_fixture
+        response = authenticated_client.get(
+            reverse("finding-findings_services_regions"),
+            {
+                "filter[severity__in]": ["low", "medium"],
+                "filter[inserted_at]": finding_1.updated_at.strftime("%Y-%m-%d"),
+            },
+        )
+        data = response.json()
+
+        expected_services = {"s3"}
+        expected_regions = {"eu-west-1"}
+
+        assert data["data"]["type"] == "finding-dynamic-filters"
+        assert data["data"]["id"] is None
+        assert set(data["data"]["attributes"]["services"]) == expected_services
+        assert set(data["data"]["attributes"]["regions"]) == expected_regions
+
     def test_findings_services_regions_future_date(self, authenticated_client):
         response = authenticated_client.get(
             reverse("finding-findings_services_regions"),
@@ -2487,9 +2508,9 @@ class TestFindingViewSet:
         assert response.json() == {
             "errors": [
                 {
-                    "detail": "Invalid date format.",
+                    "detail": "Enter a valid date.",
                     "status": "400",
-                    "source": {"pointer": "/data"},
+                    "source": {"pointer": "/data/attributes/inserted_at"},
                     "code": "invalid",
                 }
             ]

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -708,11 +708,11 @@ class FindingSerializer(RLSSerializer):
 
 
 class FindingDynamicFilterSerializer(serializers.Serializer):
-    services = serializers.ListField(child=serializers.CharField())
-    regions = serializers.ListField(child=serializers.CharField())
+    services = serializers.ListField(child=serializers.CharField(), allow_empty=True)
+    regions = serializers.ListField(child=serializers.CharField(), allow_empty=True)
 
     class Meta:
-        resource_name = "findings-services-regions"
+        resource_name = "finding-dynamic-filters"
 
 
 # Provider secrets

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -707,6 +707,14 @@ class FindingSerializer(RLSSerializer):
     }
 
 
+class FindingDynamicFilterSerializer(serializers.Serializer):
+    services = serializers.ListField(child=serializers.CharField())
+    regions = serializers.ListField(child=serializers.CharField())
+
+    class Meta:
+        resource_name = "findings-services-regions"
+
+
 # Provider secrets
 class BaseWriteProviderSecretSerializer(BaseWriteSerializer):
     @staticmethod


### PR DESCRIPTION
### Context

In this PR I have added the endpoint to get the filters dynamically depending on the findings of a date.

### Description

Using the specified date, all the findings of that date and the services and regions associated with them are extracted.
```
{
    "data": {
        "type": "findings-services-regions",
        "id": null,
        "attributes": {
            "services": [
                "accessanalyzer",
                "account"
            ],
            "regions": [
                "ap-northeast-1",
                "ap-northeast-2",
                "ap-northeast-3",
                "ap-south-1",
                "ap-southeast-1",
                "ap-southeast-2",
                "ca-central-1",
                "eu-central-1",
                "eu-central-2",
                "eu-north-1",
                "eu-south-2",
                "eu-west-1",
                "eu-west-2",
                "eu-west-3",
                "sa-east-1",
                "us-east-1",
                "us-east-2",
                "us-west-1",
                "us-west-2"
            ]
        }
    }
}
```

![image](https://github.com/user-attachments/assets/0d044b19-896e-43f3-8b6f-540bd21c046a)


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.