### PR TITLE
feat(provider): add include query parameter for provider_groups

### DIFF
--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -754,9 +754,8 @@ paths:
   /api/v1/findings/findings_services_regions:
     get:
       operationId: findings_findings_services_regions_retrieve
-      description: Fetch services and regions affected in findings by date.
-      summary: Retrieve the services and regions that are impacted by findings in
-        a specific date
+      description: Fetch services and regions affected in findings.
+      summary: Retrieve the services and regions that are impacted by findings
       parameters:
       - in: query
         name: fields[finding-dynamic-filters]
@@ -1863,6 +1862,7 @@ paths:
             - alias
             - connection
             - secret
+            - provider_groups
             - url
         description: endpoint return only specific fields in the response on a per-type
           basis by including a fields[TYPE] query parameter.
@@ -1979,6 +1979,17 @@ paths:
         schema:
           type: string
           format: date-time
+      - in: query
+        name: include
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - provider_groups
+        description: include query parameter to allow the client to customize which
+          related resources should be returned.
+        explode: false
       - name: page[number]
         required: false
         in: query
@@ -2072,6 +2083,7 @@ paths:
             - alias
             - connection
             - secret
+            - provider_groups
             - url
         description: endpoint return only specific fields in the response on a per-type
           basis by including a fields[TYPE] query parameter.
@@ -2083,6 +2095,17 @@ paths:
           format: uuid
         description: A UUID string identifying this provider.
         required: true
+      - in: query
+        name: include
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - provider_groups
+        description: include query parameter to allow the client to customize which
+          related resources should be returned.
+        explode: false
       tags:
       - Provider
       security:
@@ -5956,6 +5979,35 @@ components:
               - data
               description: The identifier of the related object.
               title: Resource Identifier
+            provider_groups:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        title: Resource Identifier
+                        description: The identifier of the related object.
+                      type:
+                        type: string
+                        enum:
+                        - provider-groups
+                        title: Resource Type Name
+                        description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                          member is used to describe resource objects that share common
+                          attributes and relationships.
+                    required:
+                    - id
+                    - type
+              required:
+              - data
+              description: A related resource object from type provider-groups
+              title: provider-groups
+              readOnly: true
           required:
           - secret
     ProviderCreate:

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -783,10 +783,49 @@ class TestMembershipViewSet:
 
 @pytest.mark.django_db
 class TestProviderViewSet:
+    @pytest.fixture(scope="function")
+    def create_provider_group_relationship(
+        self, tenants_fixture, providers_fixture, provider_groups_fixture
+    ):
+        tenant, *_ = tenants_fixture
+        provider1, *_ = providers_fixture
+        provider_group1, *_ = provider_groups_fixture
+        provider_group_membership = ProviderGroupMembership.objects.create(
+            tenant=tenant, provider=provider1, provider_group=provider_group1
+        )
+        return provider_group_membership
+
     def test_providers_list(self, authenticated_client, providers_fixture):
         response = authenticated_client.get(reverse("provider-list"))
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()["data"]) == len(providers_fixture)
+
+    @pytest.mark.parametrize(
+        "include_values, expected_resources",
+        [
+            ("provider_groups", ["provider-groups"]),
+        ],
+    )
+    def test_providers_list_include(
+        self,
+        include_values,
+        expected_resources,
+        authenticated_client,
+        providers_fixture,
+        create_provider_group_relationship,
+    ):
+        response = authenticated_client.get(
+            reverse("provider-list"), {"include": include_values}
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["data"]) == len(providers_fixture)
+        assert "included" in response.json()
+
+        included_data = response.json()["included"]
+        for expected_type in expected_resources:
+            assert any(
+                d.get("type") == expected_type for d in included_data
+            ), f"Expected type '{expected_type}' not found in included data"
 
     def test_providers_retrieve(self, authenticated_client, providers_fixture):
         provider1, *_ = providers_fixture

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -389,6 +389,12 @@ class ProviderGroupSerializer(RLSSerializer, BaseWriteSerializer):
         }
 
 
+class ProviderGroupIncludedSerializer(RLSSerializer, BaseWriteSerializer):
+    class Meta:
+        model = ProviderGroup
+        fields = ["id", "name"]
+
+
 class ProviderGroupUpdateSerializer(RLSSerializer, BaseWriteSerializer):
     """
     Serializer for updating the ProviderGroup model.
@@ -452,6 +458,10 @@ class ProviderSerializer(RLSSerializer):
     provider = ProviderEnumSerializerField()
     connection = serializers.SerializerMethodField(read_only=True)
 
+    included_serializers = {
+        "provider_groups": "api.v1.serializers.ProviderGroupIncludedSerializer",
+    }
+
     class Meta:
         model = Provider
         fields = [
@@ -464,6 +474,7 @@ class ProviderSerializer(RLSSerializer):
             "connection",
             # "scanner_args",
             "secret",
+            "provider_groups",
             "url",
         ]
 


### PR DESCRIPTION
### Context

We needed to return provider_groups detailed information when requested from `GET /providers`.

### Description

Added `include=provider_groups` to `GET /providers`:

![image](https://github.com/user-attachments/assets/637038a8-0f2a-49ae-8291-7eb80d6c81fe)


![image](https://github.com/user-attachments/assets/b39db92b-5245-4a3a-832c-835af10b076a)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.