### PR TITLE
fix(overview): retrieve aggregated findings from completed scans

### DIFF
--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -65,6 +65,7 @@ from api.models import (
     Scan,
     ScanSummary,
     SeverityChoices,
+    StateChoices,
     StatusChoices,
     Task,
     User,
@@ -76,8 +77,8 @@ from api.uuid_utils import datetime_to_uuid7
 from api.v1.serializers import (
     ComplianceOverviewFullSerializer,
     ComplianceOverviewSerializer,
-    FindingSerializer,
     FindingDynamicFilterSerializer,
+    FindingSerializer,
     InvitationAcceptSerializer,
     InvitationCreateSerializer,
     InvitationSerializer,
@@ -1480,7 +1481,9 @@ class OverviewViewSet(BaseRLSViewSet):
         filtered_queryset = self.filter_queryset(queryset)
 
         latest_scan_subquery = (
-            Scan.objects.filter(provider_id=OuterRef("scan__provider_id"))
+            Scan.objects.filter(
+                state=StateChoices.COMPLETED, provider_id=OuterRef("scan__provider_id")
+            )
             .order_by("-id")
             .values("id")[:1]
         )
@@ -1520,7 +1523,9 @@ class OverviewViewSet(BaseRLSViewSet):
         filtered_queryset = self.filter_queryset(queryset)
 
         latest_scan_subquery = (
-            Scan.objects.filter(provider_id=OuterRef("scan__provider_id"))
+            Scan.objects.filter(
+                state=StateChoices.COMPLETED, provider_id=OuterRef("scan__provider_id")
+            )
             .order_by("-id")
             .values("id")[:1]
         )


### PR DESCRIPTION
### Context

API findings overviews endpoints were trying to retrieve data from aggregated findings with uncompleted or failed scans.

### Description

The findings overviews endpoints will now pull data from completed scans from each existing provider, returning realistic results.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.