### PR TITLE
fix(docs): Docker compose files download

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Prowler App can be installed in different ways, depending on your environment:
 **Commands**
 
 ``` console
-curl -Lo https://github.com/prowler-cloud/prowler/blob/master/docker-compose.yml
-curl -Lo https://github.com/prowler-cloud/prowler/blob/master/.env
+curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/docker-compose.yml
+curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/.env
 docker compose up -d
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,8 @@ Prowler App can be installed in different ways, depending on your environment:
     _Commands_:
 
     ``` bash
-    curl -Lo https://github.com/prowler-cloud/prowler/blob/master/docker-compose.yml \
-    curl -Lo https://github.com/prowler-cloud/prowler/blob/master/.env \
+    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/docker-compose.yml
+    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/.env
     docker compose up -d
     ```
 


### PR DESCRIPTION
### Description

The commands to download the Docker compose files (env and YML) were not working. 
We need to use `-LO` and the URL needs to point to Github raw files.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.