### PR TITLE
feat(scan): add state filter for scans endpoints

### DIFF
--- a/api/src/backend/api/filters.py
+++ b/api/src/backend/api/filters.py
@@ -166,6 +166,10 @@ class ScanFilter(ProviderRelationshipFilterSet):
     started_at = DateFilter(field_name="started_at", lookup_expr="date")
     next_scan_at = DateFilter(field_name="next_scan_at", lookup_expr="date")
     trigger = ChoiceFilter(choices=Scan.TriggerChoices.choices)
+    state = ChoiceFilter(choices=StateChoices.choices)
+    state__in = ChoiceInFilter(
+        field_name="state", choices=StateChoices.choices, lookup_expr="in"
+    )
 
     class Meta:
         model = Scan

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -2761,6 +2761,7 @@ paths:
             - duration
             - provider
             - task
+            - inserted_at
             - started_at
             - completed_at
             - scheduled_at
@@ -2907,6 +2908,48 @@ paths:
           type: string
           format: date-time
       - in: query
+        name: filter[state]
+        schema:
+          type: string
+          enum:
+          - available
+          - cancelled
+          - completed
+          - executing
+          - failed
+          - scheduled
+        description: |-
+          * `available` - Available
+          * `scheduled` - Scheduled
+          * `executing` - Executing
+          * `completed` - Completed
+          * `failed` - Failed
+          * `cancelled` - Cancelled
+      - in: query
+        name: filter[state__in]
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - available
+            - cancelled
+            - completed
+            - executing
+            - failed
+            - scheduled
+        description: |-
+          Multiple values may be separated by commas.
+
+          * `available` - Available
+          * `scheduled` - Scheduled
+          * `executing` - Executing
+          * `completed` - Completed
+          * `failed` - Failed
+          * `cancelled` - Cancelled
+        explode: false
+        style: form
+      - in: query
         name: filter[trigger]
         schema:
           type: string
@@ -3014,6 +3057,7 @@ paths:
             - duration
             - provider
             - task
+            - inserted_at
             - started_at
             - completed_at
             - scheduled_at
@@ -7091,6 +7135,10 @@ components:
               maximum: 2147483647
               minimum: -2147483648
               nullable: true
+            inserted_at:
+              type: string
+              format: date-time
+              readOnly: true
             started_at:
               type: string
               format: date-time

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -16,6 +16,7 @@ from api.models import (
     ProviderGroupMembership,
     ProviderSecret,
     Scan,
+    StateChoices,
     User,
 )
 from api.rls import Tenant
@@ -1932,6 +1933,10 @@ class TestScanViewSet:
                 ("started_at", "2024-01-02", 3),
                 ("started_at.gte", "2024-01-01", 3),
                 ("started_at.lte", "2024-01-01", 0),
+                ("trigger", Scan.TriggerChoices.MANUAL, 1),
+                ("state", StateChoices.AVAILABLE, 2),
+                ("state", StateChoices.FAILED, 1),
+                ("state.in", f"{StateChoices.FAILED},{StateChoices.AVAILABLE}", 3),
                 ("trigger", Scan.TriggerChoices.MANUAL, 1),
             ]
         ),

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -127,7 +127,7 @@ def perform_scheduled_scan_task(self, tenant_id: str, provider_id: str):
             "tenant_id": tenant_id,
             "scan_id": str(scan_instance.id),
         }
-    ),
+    )
     return result
 
 


### PR DESCRIPTION
### Description

The following filters for `GET /scans` have been added:
- `filter[state]`
- `filter[state.in]` or `filter[state__in]`

![image](https://github.com/user-attachments/assets/cdf70c66-6d4b-4b6e-99a4-19afb5a576e6)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.