### PR TITLE
chore(celery-beat): disable periodic cleanup

### DIFF
--- a/api/src/backend/config/celery.py
+++ b/api/src/backend/config/celery.py
@@ -3,7 +3,7 @@ from celery import Celery, Task
 celery_app = Celery("tasks")
 
 celery_app.config_from_object("django.conf:settings", namespace="CELERY")
-celery_app.conf.update(result_extended=True)
+celery_app.conf.update(result_extended=True, result_expires=None)
 
 celery_app.autodiscover_tasks(["api"])
 
@@ -20,8 +20,9 @@ class RLSTask(Task):
         shadow=None,
         **options,
     ):
-        from api.models import Task as APITask
         from django_celery_results.models import TaskResult
+
+        from api.models import Task as APITask
 
         result = super().apply_async(
             args=args,


### PR DESCRIPTION
### Context

By default, celery tasks results would be removed every day, deleting scan entries in our database.

### Description

This default cleanup has been disabled and we will implement our own in the near future.

#### Before the change

```shell
prowler_db=# select * from django_celery_beat_periodictask;
 id |          name          |          task          | args | kwargs | queue | exchange | routing_key | expires | enabled | last_run_at | total_run_count |         date_changed          | description | crontab_id | interval_id | solar_id | one_off | start_time | priority | headers | clocked_id | expire_seconds
----+------------------------+------------------------+------+--------+-------+----------+-------------+---------+---------+-------------+-----------------+-------------------------------+-------------+------------+-------------+----------+---------+------------+----------+---------+------------+----------------
  1 | celery.backend_cleanup | celery.backend_cleanup | []   | {}     |       |          |             |         | t       |             |               0 | 2024-12-02 11:33:06.638211+00 |             |          1 |             |          | f       |            |          | {}      |            |          43200
(1 row)

prowler_db=#
```

#### After the change

```shell
prowler_db=# select * from django_celery_beat_periodictask;
 id | name | task | args | kwargs | queue | exchange | routing_key | expires | enabled | last_run_at | total_run_count | date_changed | description | crontab_id | interval_id | solar_id | one_off | start_time | priority | headers | clocked_id | expire_seconds
----+------+------+------+--------+-------+----------+-------------+---------+---------+-------------+-----------------+--------------+-------------+------------+-------------+----------+---------+------------+----------+---------+------------+----------------
(0 rows)

prowler_db=#

# We schedule the daily scan for a provider

prowler_db=#
prowler_db=# select * from django_celery_beat_periodictask;
 id |                            name                             |          task          | args |                                                    kwargs                                                    | queue | exchange | routing_key | expires | enabled | last_run_at | total_run_count |         date_changed          | description | crontab_id | interval_id | solar_id | one_off | start_time | priority | headers | clocked_id | expire_seconds
----+-------------------------------------------------------------+------------------------+------+--------------------------------------------------------------------------------------------------------------+-------+----------+-------------+---------+---------+-------------+-----------------+-------------------------------+-------------+------------+-------------+----------+---------+------------+----------+---------+------------+----------------
  1 | scan-perform-scheduled-15fce1fa-ecaa-433f-a9dc-62553f3a2555 | scan-perform-scheduled | []   | {"tenant_id": "12646005-9067-4d2a-a098-8bb378604362", "provider_id": "15fce1fa-ecaa-433f-a9dc-62553f3a2555"} |       |          |             |         | t       |             |               0 | 2024-12-02 11:28:52.782887+00 |             |            |           1 |          | f       |            |          | {}      |            |
(1 row)

prowler_db=#
```

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.