### PR TITLE
fix(backup): modify list recovery points call

### DIFF
--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -189,15 +189,17 @@ class Backup(AWSService):
                 )
                 for page in paginator.paginate(BackupVaultName=backup_vault.name):
                     for recovery_point in page.get("RecoveryPoints", []):
-                        self.recovery_points.append(
-                            RecoveryPoint(
-                                arn=recovery_point.get("RecoveryPointArn"),
-                                backup_vault_name=backup_vault.name,
-                                encrypted=recovery_point.get("IsEncrypted", False),
-                                backup_vault_region=backup_vault.region,
-                                tags=[],
+                        arn = recovery_point.get("RecoveryPointArn")
+                        if arn:
+                            self.recovery_points.append(
+                                RecoveryPoint(
+                                    arn=arn,
+                                    backup_vault_name=backup_vault.name,
+                                    encrypted=recovery_point.get("IsEncrypted", False),
+                                    backup_vault_region=backup_vault.region,
+                                    tags=[],
+                                )
                             )
-                        )
         except ClientError as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -183,23 +183,26 @@ class Backup(AWSService):
     def _list_recovery_points(self, regional_client):
         logger.info("Backup - Listing Recovery Points...")
         try:
-            for backup_vault in self.backup_vaults:
-                paginator = regional_client.get_paginator(
-                    "list_recovery_points_by_backup_vault"
-                )
-                for page in paginator.paginate(BackupVaultName=backup_vault.name):
-                    for recovery_point in page.get("RecoveryPoints", []):
-                        arn = recovery_point.get("RecoveryPointArn")
-                        if arn:
-                            self.recovery_points.append(
-                                RecoveryPoint(
-                                    arn=arn,
-                                    backup_vault_name=backup_vault.name,
-                                    encrypted=recovery_point.get("IsEncrypted", False),
-                                    backup_vault_region=backup_vault.region,
-                                    tags=[],
+            if self.backup_vaults:
+                for backup_vault in self.backup_vaults:
+                    paginator = regional_client.get_paginator(
+                        "list_recovery_points_by_backup_vault"
+                    )
+                    for page in paginator.paginate(BackupVaultName=backup_vault.name):
+                        for recovery_point in page.get("RecoveryPoints", []):
+                            arn = recovery_point.get("RecoveryPointArn")
+                            if arn:
+                                self.recovery_points.append(
+                                    RecoveryPoint(
+                                        arn=arn,
+                                        backup_vault_name=backup_vault.name,
+                                        encrypted=recovery_point.get(
+                                            "IsEncrypted", False
+                                        ),
+                                        backup_vault_region=backup_vault.region,
+                                        tags=[],
+                                    )
                                 )
-                            )
         except ClientError as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Context
@jfagoagas  notified an issue when an object is empty in the call from Backup “Listing Recovery Points”:

![image](https://github.com/user-attachments/assets/bd965f94-b7ab-47c4-87f2-3eff4bae777a)


### Description

Added a condition to check if the recovery point list is empty or if the ARN does not exist. In such cases, no recovery point will be added to the list.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.