### PR TITLE
fix(api): cascade deletion and next scan at time

### DIFF
--- a/api/src/backend/tasks/beat.py
+++ b/api/src/backend/tasks/beat.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta, timezone
 
 from django_celery_beat.models import IntervalSchedule, PeriodicTask
 from rest_framework_json_api.serializers import ValidationError
@@ -28,6 +29,9 @@ def schedule_provider_scan(provider_instance: Provider):
             }
         ),
         one_off=False,
+        defaults={
+            "start_time": datetime.now(timezone.utc) + timedelta(hours=24),
+        },
     )
     if not created:
         raise ValidationError(

--- a/api/src/backend/tasks/jobs/deletion.py
+++ b/api/src/backend/tasks/jobs/deletion.py
@@ -2,7 +2,7 @@ from celery.utils.log import get_task_logger
 from django.db import transaction
 
 from api.db_utils import batch_delete
-from api.models import Finding, Provider, Resource, Scan
+from api.models import Finding, Provider, Resource, Scan, ScanSummary
 
 logger = get_task_logger(__name__)
 
@@ -25,6 +25,11 @@ def delete_provider(pk: str):
     deletion_summary = {}
 
     with transaction.atomic():
+        # Delete Scan Summaries
+        scan_summaries_qs = ScanSummary.all_objects.filter(scan__provider=instance)
+        _, scans_summ_summary = batch_delete(scan_summaries_qs)
+        deletion_summary.update(scans_summ_summary)
+
         # Delete Findings
         findings_qs = Finding.all_objects.filter(scan__provider=instance)
         _, findings_summary = batch_delete(findings_qs)

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -105,7 +105,7 @@ def perform_scheduled_scan_task(self, tenant_id: str, provider_id: str):
             name=f"scan-perform-scheduled-{provider_id}"
         )
         next_scan_date = datetime.combine(
-            datetime.now(timezone.utc), periodic_task_instance.date_changed.time()
+            datetime.now(timezone.utc), periodic_task_instance.start_time.time()
         ) + timedelta(hours=24)
 
         scan_instance = Scan.objects.create(


### PR DESCRIPTION
### Description

This PR fixes two bugs in the API:

- Cascade deletion for `ScanSummary` during DELETE /providers.
- Correct calculation for the `Scan.next_scan_at`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.