### PR TITLE
fix(app): add support for TLS 1.3 to Web Apps check

### DIFF
--- a/prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py
+++ b/prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py
@@ -23,7 +23,7 @@ class app_minimum_tls_version_12(Check):
                     app.configurations, "min_tls_version", ""
                 ) in ["1.2", "1.3"]:
                     report.status = "PASS"
-                    report.status_extended = f"Minimum TLS version is set to 1.2 for app '{app_name}' in subscription '{subscription_name}'."
+                    report.status_extended = f"Minimum TLS version is set to {app.configurations.min_tls_version} for app '{app_name}' in subscription '{subscription_name}'."
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py
+++ b/prowler/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12.py
@@ -19,10 +19,9 @@ class app_minimum_tls_version_12(Check):
                 report.location = app.location
                 report.status_extended = f"Minimum TLS version is not set to 1.2 for app '{app_name}' in subscription '{subscription_name}'."
 
-                if (
-                    app.configurations
-                    and getattr(app.configurations, "min_tls_version", "") == "1.2"
-                ):
+                if app.configurations and getattr(
+                    app.configurations, "min_tls_version", ""
+                ) in ["1.2", "1.3"]:
                     report.status = "PASS"
                     report.status_extended = f"Minimum TLS version is set to 1.2 for app '{app_name}' in subscription '{subscription_name}'."
 

--- a/tests/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12_test.py
+++ b/tests/providers/azure/services/app/app_minimum_tls_version_12/app_minimum_tls_version_12_test.py
@@ -171,3 +171,45 @@ class Test_app_minimum_tls_version_12:
             assert result[0].resource_name == "app_id-1"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].location == "West Europe"
+
+    def test_app_min_tls_version_13(self):
+        resource_id = f"/subscriptions/{uuid4()}"
+        app_client = mock.MagicMock
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_azure_provider(),
+        ), mock.patch(
+            "prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12.app_client",
+            new=app_client,
+        ):
+            from prowler.providers.azure.services.app.app_minimum_tls_version_12.app_minimum_tls_version_12 import (
+                app_minimum_tls_version_12,
+            )
+            from prowler.providers.azure.services.app.app_service import WebApp
+
+            app_client.apps = {
+                AZURE_SUBSCRIPTION_ID: {
+                    "app_id-1": WebApp(
+                        resource_id=resource_id,
+                        auth_enabled=False,
+                        configurations=mock.MagicMock(min_tls_version="1.3"),
+                        client_cert_mode="Ignore",
+                        https_only=False,
+                        identity=None,
+                        location="West Europe",
+                    )
+                }
+            }
+            check = app_minimum_tls_version_12()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Minimum TLS version is set to 1.3 for app 'app_id-1' in subscription '{AZURE_SUBSCRIPTION_ID}'."
+            )
+            assert result[0].resource_id == resource_id
+            assert result[0].resource_name == "app_id-1"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].location == "West Europe"


### PR DESCRIPTION
### Context

FIx #5997

New version TLS 1.3 added to Azure Web apps, so it is needed to update check `app_minimum_tls_version_12`

### Description

Added support for TLS 1.2 and 1.3.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.