### PR TITLE
feat(GHA): add gha for API

### DIFF
--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -8,14 +8,13 @@ on:
       - "api/**"
       - ".github/workflows/api-build-lint-push-containers.yml"
 
-  # Uncomment the below code to test this action on PRs
-  # Do not forget to set `push: false`
-  pull_request:
-    branches:
-      - "master"
-    paths:
-      - "api/**"
-      - ".github/workflows/api-build-lint-push-containers.yml"
+  # Uncomment the code below to test this action on PRs
+  # pull_request:
+  #   branches:
+  #     - "master"
+  #   paths:
+  #     - "api/**"
+  #     - ".github/workflows/api-build-lint-push-containers.yml"
 
   release:
     types: [published]
@@ -55,20 +54,22 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push container image (latest)
-        # if: github.event_name == 'push'
+        # Uncomment the following line for testing
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
-          push: false
+          # Set push: false for testing
+          push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Build and push container image (release)
-        # if: github.event_name == 'release'
+        if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
-          push: false
+          push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}
           cache-from: type=gha

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -40,11 +40,9 @@ jobs:
 
     steps:
       - name: Repository check
+        working-directory: /tmp
         run: |
           [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 0
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -10,12 +10,12 @@ on:
 
   # Uncomment the below code to test this action on PRs
   # Do not forget to set `push: false`
-  # pull_request:
-  #   branches:
-  #     - "master"
-  #   paths:
-  #     - "api/**"
-  #     - ".github/workflows/api-build-lint-push-containers.yml"
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - "api/**"
+      - ".github/workflows/api-build-lint-push-containers.yml"
 
   release:
     types: [published]
@@ -26,7 +26,6 @@ env:
   RELEASE_TAG: ${{ github.event.release.tag_name }}
 
   WORKING_DIRECTORY: ./api
-  DOCKERFILE_PATH: ./api/Dockerfile
 
   # Container Registries
   PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
@@ -56,24 +55,23 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push container image (latest)
-        if: github.event_name == 'push'
+        # if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
-          push: true
+          context: .
+          push: false
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
-          file: ${{ env.DOCKERFILE_PATH }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Build and push container image (release)
-        if: github.event_name == 'release'
+        # if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: false
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}
-          file: ${{ env.DOCKERFILE_PATH }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -58,7 +58,6 @@ jobs:
         # if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: false
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
@@ -69,7 +68,6 @@ jobs:
         # if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: false
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -1,0 +1,163 @@
+name: API - Build and Push containers
+
+on:
+  push:
+    branches:
+      - "master"
+    paths-ignore:
+      - ".github/**"
+      - "README.md"
+      - "docs/**"
+      - "ui/**"
+      - "prowler/**"
+
+  release:
+    types: [published]
+
+env:
+  # Tags
+  LATEST_TAG: latest
+  #STABLE_TAG: stable
+  # The RELEASE_TAG is set during runtime in releases
+  RELEASE_TAG: ""
+  # The PROWLER_API_VERSION and PROWLER_API_VERSION_MAJOR are set during runtime in releases
+  PROWLER_API_VERSION: ""
+  PROWLER_API_VERSION_MAJOR: ""
+  # TEMPORARY_TAG: temporary
+
+  # Python configuration
+  PYTHON_VERSION: 3.12
+
+  # Container Registries
+  PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
+  PROWLERAPI_DOCKERHUB_IMAGE: prowler-api
+
+jobs:
+  # Build Prowler OSS container
+  container-build-push:
+    # needs: dockerfile-linter
+    runs-on: ubuntu-latest
+    outputs:
+      prowler_version_major: ${{ steps.get-prowler-version.outputs.PROWLER_API_VERSION_MAJOR }}
+      prowler_version: ${{ steps.get-prowler-version.outputs.PROWLER_API_VERSION }}
+    env:
+      POETRY_VIRTUALENVS_CREATE: "false"
+    defaults:
+      run:
+        working-directory: ./api
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: |
+          pipx install poetry
+          pipx inject poetry poetry-bumpversion
+
+      - name: Get Prowler API version
+        id: get-prowler-version
+        run: |
+          PROWLER_API_VERSION="$(poetry version -s 2>/dev/null)"
+          echo "PROWLER_API_VERSION=${PROWLER_API_VERSION}" >> "${GITHUB_ENV}"
+          echo "PROWLER_API_VERSION=${PROWLER_API_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          # Store prowler version major just for the release
+          PROWLER_API_VERSION_MAJOR="${PROWLER_API_VERSION%%.*}"
+          echo "PROWLER_API_VERSION_MAJOR=${PROWLER_API_VERSION_MAJOR}" >> "${GITHUB_ENV}"
+          echo "PROWLER_API_VERSION_MAJOR=${PROWLER_API_VERSION_MAJOR}" >> "${GITHUB_OUTPUT}"
+
+          case ${PROWLER_API_VERSION_MAJOR} in
+          3)
+              echo "LATEST_TAG=v3-latest" >> "${GITHUB_ENV}"
+              echo "STABLE_TAG=v3-stable" >> "${GITHUB_ENV}"
+              ;;
+
+
+          4)
+              echo "LATEST_TAG=v4-latest" >> "${GITHUB_ENV}"
+              echo "STABLE_TAG=v4-stable" >> "${GITHUB_ENV}"
+              ;;
+
+          5)
+              echo "LATEST_TAG=latest" >> "${GITHUB_ENV}"
+              echo "STABLE_TAG=stable" >> "${GITHUB_ENV}"
+              ;;
+
+          *)
+              # Fallback if any other version is present
+              echo "Releasing another Prowler major version, aborting..."
+              exit 1
+              ;;
+          esac
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push container image (latest)
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
+            ${{ env.PROWLERAPI_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERAPI_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push container image (release)
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@v6
+        with:
+          # Use local context to get changes
+          # https://github.com/docker/build-push-action#path-context
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.PROWLER_API_VERSION }}
+            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
+            ${{ env.PROWLERAPI_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERAPI_DOCKERHUB_IMAGE }}:${{ env.PROWLER_API_VERSION }}
+            ${{ env.PROWLERAPI_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERAPI_DOCKERHUB_IMAGE }}:${{ env.STABLE_TAG }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  dispatch-action:
+    needs: container-build-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get latest commit info (latest)
+        if: github.event_name == 'push'
+        run: |
+          LATEST_COMMIT_HASH=$(echo ${{ github.event.after }} | cut -b -7)
+          echo "LATEST_COMMIT_HASH=${LATEST_COMMIT_HASH}" >> $GITHUB_ENV
+
+      - name: Dispatch event (latest)
+        if: github.event_name == 'push' && needs.container-build-push.outputs.prowler_version_major == '3'
+        run: |
+          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data '{"event_type":"dispatch","client_payload":{"version":"v3-latest", "tag": "${{ env.LATEST_COMMIT_HASH }}"}}'
+
+      - name: Dispatch event (release)
+        if: github.event_name == 'release' && needs.container-build-push.outputs.prowler_version_major == '3'
+        run: |
+          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ needs.container-build-push.outputs.prowler_version }}"}}'

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -16,8 +16,8 @@ env:
   LATEST_TAG: latest
   RELEASE_TAG: ${{ github.event.release.tag_name }}
 
-  # Python configuration
-  PYTHON_VERSION: 3.12
+  WORKING_DIRECTORY: ./api
+  DOCKERFILE_PATH: ./api/Dockerfile
 
   # Container Registries
   PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
@@ -32,9 +32,12 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
     steps:
+      - name: Repository check
+        run: |
+          [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 1
+
       - name: Checkout
         uses: actions/checkout@v4
-
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -8,12 +8,14 @@ on:
       - "api/**"
       - ".github/workflows/api-build-lint-push-containers.yml"
 
-  pull_request:
-    branches:
-      - "master"
-    paths:
-      - "api/**"
-      - ".github/workflows/api-build-lint-push-containers.yml"
+  # Uncomment the below code to test this action on PRs
+  # Do not forget to set `push: false`
+  # pull_request:
+  #   branches:
+  #     - "master"
+  #   paths:
+  #     - "api/**"
+  #     - ".github/workflows/api-build-lint-push-containers.yml"
 
   release:
     types: [published]
@@ -57,7 +59,7 @@ jobs:
         if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
-          push: false
+          push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}
@@ -69,7 +71,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: false
+          push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -27,8 +27,6 @@ jobs:
   # Build Prowler OSS container
   container-build-push:
     runs-on: ubuntu-latest
-    env:
-      POETRY_VIRTUALENVS_CREATE: "false"
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -8,6 +8,13 @@ on:
       - "api/**"
       - ".github/workflows/api-build-lint-push-containers.yml"
 
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - "api/**"
+      - ".github/workflows/api-build-lint-push-containers.yml"
+
   release:
     types: [published]
 
@@ -34,7 +41,7 @@ jobs:
     steps:
       - name: Repository check
         run: |
-          [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 1
+          [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 0
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +59,7 @@ jobs:
         if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: false
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}
@@ -64,7 +71,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: false
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -19,9 +19,6 @@ env:
   # Python configuration
   PYTHON_VERSION: 3.12
 
-  WORKING_DIRECTORY: ./api
-  DOCKERFILE_PATH: ./api/Dockerfile
-
   # Container Registries
   PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
   PROWLERCLOUD_DOCKERHUB_IMAGE: prowler-api
@@ -40,10 +37,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -54,7 +54,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push container image (latest)
-        # Uncomment the following line for testing
+        # Comment the following line for testing
         if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -4,12 +4,9 @@ on:
   push:
     branches:
       - "master"
-    paths-ignore:
-      - ".github/**"
-      - "README.md"
-      - "docs/**"
-      - "ui/**"
-      - "prowler/**"
+    paths:
+      - "api/**"
+      - ".github/workflows/api-build-lint-push-containers.yml"
 
   release:
     types: [published]
@@ -17,34 +14,27 @@ on:
 env:
   # Tags
   LATEST_TAG: latest
-  #STABLE_TAG: stable
-  # The RELEASE_TAG is set during runtime in releases
-  RELEASE_TAG: ""
-  # The PROWLER_API_VERSION and PROWLER_API_VERSION_MAJOR are set during runtime in releases
-  PROWLER_API_VERSION: ""
-  PROWLER_API_VERSION_MAJOR: ""
-  # TEMPORARY_TAG: temporary
+  RELEASE_TAG: ${{ github.event.release.tag_name }}
 
   # Python configuration
   PYTHON_VERSION: 3.12
 
+  WORKING_DIRECTORY: ./api
+  DOCKERFILE_PATH: ./api/Dockerfile
+
   # Container Registries
   PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
-  PROWLERAPI_DOCKERHUB_IMAGE: prowler-api
+  PROWLERCLOUD_DOCKERHUB_IMAGE: prowler-api
 
 jobs:
   # Build Prowler OSS container
   container-build-push:
-    # needs: dockerfile-linter
     runs-on: ubuntu-latest
-    outputs:
-      prowler_version_major: ${{ steps.get-prowler-version.outputs.PROWLER_API_VERSION_MAJOR }}
-      prowler_version: ${{ steps.get-prowler-version.outputs.PROWLER_API_VERSION }}
     env:
       POETRY_VIRTUALENVS_CREATE: "false"
     defaults:
       run:
-        working-directory: ./api
+        working-directory: ${{ env.WORKING_DIRECTORY }}
 
     steps:
       - name: Checkout
@@ -54,47 +44,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Poetry
-        run: |
-          pipx install poetry
-          pipx inject poetry poetry-bumpversion
-
-      - name: Get Prowler API version
-        id: get-prowler-version
-        run: |
-          PROWLER_API_VERSION="$(poetry version -s 2>/dev/null)"
-          echo "PROWLER_API_VERSION=${PROWLER_API_VERSION}" >> "${GITHUB_ENV}"
-          echo "PROWLER_API_VERSION=${PROWLER_API_VERSION}" >> "${GITHUB_OUTPUT}"
-
-          # Store prowler version major just for the release
-          PROWLER_API_VERSION_MAJOR="${PROWLER_API_VERSION%%.*}"
-          echo "PROWLER_API_VERSION_MAJOR=${PROWLER_API_VERSION_MAJOR}" >> "${GITHUB_ENV}"
-          echo "PROWLER_API_VERSION_MAJOR=${PROWLER_API_VERSION_MAJOR}" >> "${GITHUB_OUTPUT}"
-
-          case ${PROWLER_API_VERSION_MAJOR} in
-          3)
-              echo "LATEST_TAG=v3-latest" >> "${GITHUB_ENV}"
-              echo "STABLE_TAG=v3-stable" >> "${GITHUB_ENV}"
-              ;;
-
-
-          4)
-              echo "LATEST_TAG=v4-latest" >> "${GITHUB_ENV}"
-              echo "STABLE_TAG=v4-stable" >> "${GITHUB_ENV}"
-              ;;
-
-          5)
-              echo "LATEST_TAG=latest" >> "${GITHUB_ENV}"
-              echo "STABLE_TAG=stable" >> "${GITHUB_ENV}"
-              ;;
-
-          *)
-              # Fallback if any other version is present
-              echo "Releasing another Prowler major version, aborting..."
-              exit 1
-              ;;
-          esac
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -111,8 +60,7 @@ jobs:
         with:
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
-            ${{ env.PROWLERAPI_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERAPI_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -121,43 +69,10 @@ jobs:
         if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
-          # Use local context to get changes
-          # https://github.com/docker/build-push-action#path-context
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.PROWLER_API_VERSION }}
-            ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}
-            ${{ env.PROWLERAPI_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERAPI_DOCKERHUB_IMAGE }}:${{ env.PROWLER_API_VERSION }}
-            ${{ env.PROWLERAPI_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERAPI_DOCKERHUB_IMAGE }}:${{ env.STABLE_TAG }}
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}
           file: ${{ env.DOCKERFILE_PATH }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-  dispatch-action:
-    needs: container-build-push
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get latest commit info (latest)
-        if: github.event_name == 'push'
-        run: |
-          LATEST_COMMIT_HASH=$(echo ${{ github.event.after }} | cut -b -7)
-          echo "LATEST_COMMIT_HASH=${LATEST_COMMIT_HASH}" >> $GITHUB_ENV
-
-      - name: Dispatch event (latest)
-        if: github.event_name == 'push' && needs.container-build-push.outputs.prowler_version_major == '3'
-        run: |
-          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            --data '{"event_type":"dispatch","client_payload":{"version":"v3-latest", "tag": "${{ env.LATEST_COMMIT_HASH }}"}}'
-
-      - name: Dispatch event (release)
-        if: github.event_name == 'release' && needs.container-build-push.outputs.prowler_version_major == '3'
-        run: |
-          curl https://api.github.com/repos/${{ secrets.DISPATCH_OWNER }}/${{ secrets.DISPATCH_REPO }}/dispatches \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            --data '{"event_type":"dispatch","client_payload":{"version":"release", "tag":"${{ needs.container-build-push.outputs.prowler_version }}"}}'

--- a/.github/workflows/api-build-lint-push-containers.yml
+++ b/.github/workflows/api-build-lint-push-containers.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 0
 
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -58,6 +61,7 @@ jobs:
         if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
+          context: ${{ env.WORKING_DIRECTORY }}
           # Set push: false for testing
           push: true
           tags: |
@@ -69,6 +73,7 @@ jobs:
         if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
+          context: ${{ env.WORKING_DIRECTORY }}
           push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}


### PR DESCRIPTION
### Description

This pull request introduces a new GitHub Actions workflow to automate the build and push process for API containers. The workflow is triggered by pushes to the master branch and published releases, and it includes steps for setting up the environment, logging into DockerHub, and building and pushing the container images.

Key changes include:

* Added a new workflow configuration file `.github/workflows/api-build-lint-push-containers.yml` to automate the build and push process for API containers.
* Configured the workflow to trigger on pushes to the master branch and published releases.
* Set up environment variables for DockerHub repository, image names, and Python version.
* Included steps for checking out the code, setting up Python, logging into DockerHub, and building and pushing container images.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.