### PR TITLE
fix(RLS): enforce config security

### DIFF
--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -75,6 +75,11 @@ class BaseTenantViewset(BaseViewSet):
         ):
             user_id = str(request.user.id)
 
+            try:
+                uuid.UUID(user_id)
+            except ValueError:
+                raise ValidationError("User ID must be a valid UUID")
+
             with connection.cursor() as cursor:
                 cursor.execute("SELECT set_config('api.user_id', %s, TRUE);", [user_id])
                 return super().initial(request, *args, **kwargs)

--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -1,5 +1,6 @@
 import uuid
 
+from db_utils import tenant_transaction
 from django.db import connection, transaction
 from rest_framework import permissions
 from rest_framework.exceptions import NotAuthenticated
@@ -47,15 +48,7 @@ class BaseRLSViewSet(BaseViewSet):
         if tenant_id is None:
             raise NotAuthenticated("Tenant ID is not present in token")
 
-        try:
-            uuid.UUID(tenant_id)
-        except ValueError:
-            raise ValidationError("Tenant ID must be a valid UUID")
-
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
-            )
+        with tenant_transaction(tenant_id):
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)
 
@@ -94,15 +87,7 @@ class BaseTenantViewset(BaseViewSet):
         if tenant_id is None:
             raise NotAuthenticated("Tenant ID is not present in token")
 
-        try:
-            uuid.UUID(tenant_id)
-        except ValueError:
-            raise ValidationError("Tenant ID must be a valid UUID")
-
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
-            )
+        with tenant_transaction(tenant_id):
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)
 
@@ -123,14 +108,6 @@ class BaseUserViewset(BaseViewSet):
         if tenant_id is None:
             raise NotAuthenticated("Tenant ID is not present in token")
 
-        try:
-            uuid.UUID(tenant_id)
-        except ValueError:
-            raise ValidationError("Tenant ID must be a valid UUID")
-
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
-            )
+        with tenant_transaction(tenant_id):
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)

--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -9,7 +9,7 @@ from rest_framework_json_api.serializers import ValidationError
 from rest_framework_json_api.views import ModelViewSet
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
-from api.db_utils import tenant_transaction
+from api.db_utils import POSTGRES_USER_VAR, tenant_transaction
 from api.filters import CustomDjangoFilterBackend
 
 
@@ -75,7 +75,7 @@ class BaseTenantViewset(BaseViewSet):
             except ValueError:
                 raise ValidationError("User ID must be a valid UUID")
 
-            with tenant_transaction(value=user_id, parameter="api.user_id"):
+            with tenant_transaction(value=user_id, parameter=POSTGRES_USER_VAR):
                 return super().initial(request, *args, **kwargs)
 
         # TODO: DRY this when we have time

--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -53,7 +53,9 @@ class BaseRLSViewSet(BaseViewSet):
             raise ValidationError("Tenant ID must be a valid UUID")
 
         with connection.cursor() as cursor:
-            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
+            cursor.execute(
+                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
+            )
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)
 
@@ -98,7 +100,9 @@ class BaseTenantViewset(BaseViewSet):
             raise ValidationError("Tenant ID must be a valid UUID")
 
         with connection.cursor() as cursor:
-            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
+            cursor.execute(
+                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
+            )
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)
 
@@ -125,6 +129,8 @@ class BaseUserViewset(BaseViewSet):
             raise ValidationError("Tenant ID must be a valid UUID")
 
         with connection.cursor() as cursor:
-            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
+            cursor.execute(
+                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
+            )
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)

--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -53,7 +53,7 @@ class BaseRLSViewSet(BaseViewSet):
             raise ValidationError("Tenant ID must be a valid UUID")
 
         with connection.cursor() as cursor:
-            cursor.execute(f"SELECT set_config('api.tenant_id', '{tenant_id}', TRUE);")
+            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)
 
@@ -76,7 +76,7 @@ class BaseTenantViewset(BaseViewSet):
             user_id = str(request.user.id)
 
             with connection.cursor() as cursor:
-                cursor.execute(f"SELECT set_config('api.user_id', '{user_id}', TRUE);")
+                cursor.execute("SELECT set_config('api.user_id', %s, TRUE);", [user_id])
                 return super().initial(request, *args, **kwargs)
 
         # TODO: DRY this when we have time
@@ -93,7 +93,7 @@ class BaseTenantViewset(BaseViewSet):
             raise ValidationError("Tenant ID must be a valid UUID")
 
         with connection.cursor() as cursor:
-            cursor.execute(f"SELECT set_config('api.tenant_id', '{tenant_id}', TRUE);")
+            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)
 
@@ -120,6 +120,6 @@ class BaseUserViewset(BaseViewSet):
             raise ValidationError("Tenant ID must be a valid UUID")
 
         with connection.cursor() as cursor:
-            cursor.execute(f"SELECT set_config('api.tenant_id', '{tenant_id}', TRUE);")
+            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
             self.request.tenant_id = tenant_id
             return super().initial(request, *args, **kwargs)

--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -1,11 +1,8 @@
-import uuid
-
 from django.db import transaction
 from rest_framework import permissions
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.filters import SearchFilter
 from rest_framework_json_api import filters
-from rest_framework_json_api.serializers import ValidationError
 from rest_framework_json_api.views import ModelViewSet
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
@@ -69,11 +66,6 @@ class BaseTenantViewset(BaseViewSet):
             and request.method != "DELETE"
         ):
             user_id = str(request.user.id)
-
-            try:
-                uuid.UUID(user_id)
-            except ValueError:
-                raise ValidationError("User ID must be a valid UUID")
 
             with tenant_transaction(value=user_id, parameter=POSTGRES_USER_VAR):
                 return super().initial(request, *args, **kwargs)

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -25,6 +25,8 @@ TASK_RUNNER_DB_TABLE = "django_celery_results_taskresult"
 POSTGRES_TENANT_VAR = "api.tenant_id"
 POSTGRES_USER_VAR = "api.user_id"
 
+SET_API_TENANT_ID_QUERY = "SELECT set_config('api.tenant_id', %s::text, TRUE);"
+
 
 @contextmanager
 def psycopg_connection(database_alias: str):
@@ -54,9 +56,7 @@ def tenant_transaction(tenant_id: str):
                 uuid.UUID(str(tenant_id))
             except ValueError:
                 raise ValidationError("Tenant ID must be a valid UUID")
-            cursor.execute(
-                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
-            )
+            cursor.execute(SET_API_TENANT_ID_QUERY, [tenant_id])
             yield cursor
 
 

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -50,7 +50,8 @@ def tenant_transaction(tenant_id: str):
     with transaction.atomic():
         with connection.cursor() as cursor:
             try:
-                uuid.UUID(tenant_id)
+                # just in case the tenant_id is an UUID object
+                uuid.UUID(str(tenant_id))
             except ValueError:
                 raise ValidationError("Tenant ID must be a valid UUID")
             cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -25,7 +25,7 @@ TASK_RUNNER_DB_TABLE = "django_celery_results_taskresult"
 POSTGRES_TENANT_VAR = "api.tenant_id"
 POSTGRES_USER_VAR = "api.user_id"
 
-SET_API_TENANT_ID_QUERY = "SELECT set_config('api.tenant_id', %s::text, TRUE);"
+SET_CONFIG_QUERY = "SELECT set_config(%s, %s::text, TRUE);"
 
 
 @contextmanager
@@ -48,15 +48,15 @@ def psycopg_connection(database_alias: str):
 
 
 @contextmanager
-def tenant_transaction(tenant_id: str):
+def tenant_transaction(value: str, parameter: str = "api.tenant_id"):
     with transaction.atomic():
         with connection.cursor() as cursor:
             try:
-                # just in case the tenant_id is an UUID object
-                uuid.UUID(str(tenant_id))
+                # just in case the tenant_id|user_id is an UUID object
+                uuid.UUID(str(value))
             except ValueError:
-                raise ValidationError("Tenant ID must be a valid UUID")
-            cursor.execute(SET_API_TENANT_ID_QUERY, [tenant_id])
+                raise ValidationError("Must be a valid UUID")
+            cursor.execute(SET_CONFIG_QUERY, [parameter, value])
             yield cursor
 
 

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -47,7 +47,12 @@ def psycopg_connection(database_alias: str):
 def tenant_transaction(tenant_id: str):
     with transaction.atomic():
         with connection.cursor() as cursor:
-            cursor.execute(f"SELECT set_config('api.tenant_id', '{tenant_id}', TRUE);")
+            # TODO
+            # try:
+            #     uuid.UUID(tenant_id)
+            # except ValueError:
+            #     raise ValidationError("Tenant ID must be a valid UUID")
+            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
             yield cursor
 
 

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -54,7 +54,9 @@ def tenant_transaction(tenant_id: str):
                 uuid.UUID(str(tenant_id))
             except ValueError:
                 raise ValidationError("Tenant ID must be a valid UUID")
-            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
+            cursor.execute(
+                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
+            )
             yield cursor
 
 

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -48,7 +48,7 @@ def psycopg_connection(database_alias: str):
 
 
 @contextmanager
-def tenant_transaction(value: str, parameter: str = "api.tenant_id"):
+def tenant_transaction(value: str, parameter: str = POSTGRES_TENANT_VAR):
     with transaction.atomic():
         with connection.cursor() as cursor:
             try:

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -49,10 +49,18 @@ def psycopg_connection(database_alias: str):
 
 @contextmanager
 def tenant_transaction(value: str, parameter: str = POSTGRES_TENANT_VAR):
+    """
+    Creates a new database transaction setting the given configuration value. It validates the
+    if the value is a valid UUID to be used for Postgres RLS.
+
+    Args:
+        value (str): Database configuration parameter value.
+        parameter (str): Database configuration parameter name
+    """
     with transaction.atomic():
         with connection.cursor() as cursor:
             try:
-                # just in case the tenant_id|user_id is an UUID object
+                # just in case the value is an UUID object
                 uuid.UUID(str(value))
             except ValueError:
                 raise ValidationError("Must be a valid UUID")

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -51,7 +51,9 @@ def set_tenant(func):
         except ValueError:
             raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:
-            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
+            cursor.execute(
+                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
+            )
 
         return func(*args, **kwargs)
 

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -43,9 +43,13 @@ def set_tenant(func):
             tenant_id = kwargs.pop("tenant_id")
         except KeyError:
             raise KeyError("This task requires the tenant_id")
-
+        # TODO
+        # try:
+        #     uuid.UUID(tenant_id)
+        # except ValueError:
+        #     raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:
-            cursor.execute(f"SELECT set_config('api.tenant_id', '{tenant_id}', TRUE);")
+            cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
 
         return func(*args, **kwargs)
 

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -46,7 +46,8 @@ def set_tenant(func):
         except KeyError:
             raise KeyError("This task requires the tenant_id")
         try:
-            uuid.UUID(tenant_id)
+            # just in case the tenant_id is an UUID object
+            uuid.UUID(str(tenant_id))
         except ValueError:
             raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -4,7 +4,7 @@ from functools import wraps
 from django.db import connection, transaction
 from rest_framework_json_api.serializers import ValidationError
 
-from api.db_utils import SET_API_TENANT_ID_QUERY
+from api.db_utils import SET_CONFIG_QUERY
 
 
 def set_tenant(func):
@@ -52,7 +52,7 @@ def set_tenant(func):
         except ValueError:
             raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:
-            cursor.execute(SET_API_TENANT_ID_QUERY, [tenant_id])
+            cursor.execute(SET_CONFIG_QUERY, ["api.tenant_id", tenant_id])
 
         return func(*args, **kwargs)
 

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -4,7 +4,7 @@ from functools import wraps
 from django.db import connection, transaction
 from rest_framework_json_api.serializers import ValidationError
 
-from api.src.backend.api.db_utils import SET_API_TENANT_ID_QUERY
+from api.db_utils import SET_API_TENANT_ID_QUERY
 
 
 def set_tenant(func):
@@ -35,7 +35,7 @@ def set_tenant(func):
             pass
 
         # When calling the task
-        some_task.delay(arg1, tenant_id="1234-abcd-5678")
+        some_task.delay(arg1, tenant_id="8db7ca86-03cc-4d42-99f6-5e480baf6ab5")
 
         # The tenant context will be set before the task logic executes.
     """
@@ -48,8 +48,7 @@ def set_tenant(func):
         except KeyError:
             raise KeyError("This task requires the tenant_id")
         try:
-            # just in case the tenant_id is an UUID object
-            uuid.UUID(str(tenant_id))
+            uuid.UUID(tenant_id)
         except ValueError:
             raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -4,6 +4,8 @@ from functools import wraps
 from django.db import connection, transaction
 from rest_framework_json_api.serializers import ValidationError
 
+from api.src.backend.api.db_utils import SET_API_TENANT_ID_QUERY
+
 
 def set_tenant(func):
     """
@@ -51,9 +53,7 @@ def set_tenant(func):
         except ValueError:
             raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id]
-            )
+            cursor.execute(SET_API_TENANT_ID_QUERY, [tenant_id])
 
         return func(*args, **kwargs)
 

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -4,7 +4,7 @@ from functools import wraps
 from django.db import connection, transaction
 from rest_framework_json_api.serializers import ValidationError
 
-from api.db_utils import SET_CONFIG_QUERY
+from api.db_utils import POSTGRES_TENANT_VAR, SET_CONFIG_QUERY
 
 
 def set_tenant(func):
@@ -52,7 +52,7 @@ def set_tenant(func):
         except ValueError:
             raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:
-            cursor.execute(SET_CONFIG_QUERY, ["api.tenant_id", tenant_id])
+            cursor.execute(SET_CONFIG_QUERY, [POSTGRES_TENANT_VAR, tenant_id])
 
         return func(*args, **kwargs)
 

--- a/api/src/backend/api/decorators.py
+++ b/api/src/backend/api/decorators.py
@@ -1,6 +1,8 @@
+import uuid
 from functools import wraps
 
 from django.db import connection, transaction
+from rest_framework_json_api.serializers import ValidationError
 
 
 def set_tenant(func):
@@ -43,11 +45,10 @@ def set_tenant(func):
             tenant_id = kwargs.pop("tenant_id")
         except KeyError:
             raise KeyError("This task requires the tenant_id")
-        # TODO
-        # try:
-        #     uuid.UUID(tenant_id)
-        # except ValueError:
-        #     raise ValidationError("Tenant ID must be a valid UUID")
+        try:
+            uuid.UUID(tenant_id)
+        except ValueError:
+            raise ValidationError("Tenant ID must be a valid UUID")
         with connection.cursor() as cursor:
             cursor.execute("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
 

--- a/api/src/backend/api/tests/test_decorators.py
+++ b/api/src/backend/api/tests/test_decorators.py
@@ -3,6 +3,7 @@ from unittest.mock import call, patch
 
 import pytest
 
+from api.db_utils import POSTGRES_TENANT_VAR, SET_CONFIG_QUERY
 from api.decorators import set_tenant
 
 
@@ -21,7 +22,7 @@ class TestSetTenantDecorator:
         result = random_func("test_arg", tenant_id=tenant_id)
 
         assert (
-            call("SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id])
+            call(SET_CONFIG_QUERY, [POSTGRES_TENANT_VAR, tenant_id])
             in mock_cursor.execute.mock_calls
         )
         assert result == "test_arg"

--- a/api/src/backend/api/tests/test_decorators.py
+++ b/api/src/backend/api/tests/test_decorators.py
@@ -16,7 +16,7 @@ class TestSetTenantDecorator:
         def random_func(arg):
             return arg
 
-        tenant_id = uuid.uuid4()
+        tenant_id = str(uuid.uuid4())
 
         result = random_func("test_arg", tenant_id=tenant_id)
 

--- a/api/src/backend/api/tests/test_decorators.py
+++ b/api/src/backend/api/tests/test_decorators.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, call
+from unittest.mock import call, patch
 
 import pytest
 
@@ -20,7 +20,7 @@ class TestSetTenantDecorator:
         result = random_func("test_arg", tenant_id=tenant_id)
 
         assert (
-            call(f"SELECT set_config('api.tenant_id', '{tenant_id}', TRUE);")
+            call("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
             in mock_cursor.execute.mock_calls
         )
         assert result == "test_arg"

--- a/api/src/backend/api/tests/test_decorators.py
+++ b/api/src/backend/api/tests/test_decorators.py
@@ -21,7 +21,7 @@ class TestSetTenantDecorator:
         result = random_func("test_arg", tenant_id=tenant_id)
 
         assert (
-            call("SELECT set_config('api.tenant_id', %s, TRUE);", [tenant_id])
+            call("SELECT set_config('api.tenant_id', %s::text, TRUE);", [tenant_id])
             in mock_cursor.execute.mock_calls
         )
         assert result == "test_arg"

--- a/api/src/backend/api/tests/test_decorators.py
+++ b/api/src/backend/api/tests/test_decorators.py
@@ -16,7 +16,7 @@ class TestSetTenantDecorator:
         def random_func(arg):
             return arg
 
-        tenant_id = uuid.UUID()
+        tenant_id = uuid.uuid4()
 
         result = random_func("test_arg", tenant_id=tenant_id)
 

--- a/api/src/backend/api/tests/test_decorators.py
+++ b/api/src/backend/api/tests/test_decorators.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import call, patch
 
 import pytest
@@ -15,7 +16,7 @@ class TestSetTenantDecorator:
         def random_func(arg):
             return arg
 
-        tenant_id = "1234-abcd-5678"
+        tenant_id = uuid.UUID()
 
         result = random_func("test_arg", tenant_id=tenant_id)
 

--- a/api/src/backend/tasks/tests/test_scan.py
+++ b/api/src/backend/tasks/tests/test_scan.py
@@ -213,7 +213,7 @@ class TestPerformScan:
         mock_get_or_create_resource,
         mock_get_or_create_tag,
     ):
-        tenant_id = uuid.UUID()
+        tenant_id = uuid.uuid4()
         provider_instance = MagicMock()
         provider_instance.id = "provider456"
 
@@ -261,7 +261,7 @@ class TestPerformScan:
         mock_get_or_create_resource,
         mock_get_or_create_tag,
     ):
-        tenant_id = uuid.UUID()
+        tenant_id = uuid.uuid4()
         provider_instance = MagicMock()
         provider_instance.id = "provider456"
 
@@ -318,7 +318,7 @@ class TestPerformScan:
         mock_get_or_create_resource,
         mock_get_or_create_tag,
     ):
-        tenant_id = uuid.UUID()
+        tenant_id = uuid.uuid4()
         provider_instance = MagicMock()
         provider_instance.id = "provider456"
 

--- a/api/src/backend/tasks/tests/test_scan.py
+++ b/api/src/backend/tasks/tests/test_scan.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -212,7 +213,7 @@ class TestPerformScan:
         mock_get_or_create_resource,
         mock_get_or_create_tag,
     ):
-        tenant_id = "tenant123"
+        tenant_id = uuid.UUID()
         provider_instance = MagicMock()
         provider_instance.id = "provider456"
 
@@ -260,7 +261,7 @@ class TestPerformScan:
         mock_get_or_create_resource,
         mock_get_or_create_tag,
     ):
-        tenant_id = "tenant123"
+        tenant_id = uuid.UUID()
         provider_instance = MagicMock()
         provider_instance.id = "provider456"
 
@@ -317,7 +318,7 @@ class TestPerformScan:
         mock_get_or_create_resource,
         mock_get_or_create_tag,
     ):
-        tenant_id = "tenant123"
+        tenant_id = uuid.UUID()
         provider_instance = MagicMock()
         provider_instance.id = "provider456"
 


### PR DESCRIPTION
### Context

Protect the queries setting the `tenant_id` for RLS using parameters to prevent SQLi. Although the scenario to exploit this is difficult since the `tenant_id` comes from the token which is signed by us and cannot be verified otherwise.

### Description

- Use placeholders with `cursor.execute` as recommended https://docs.djangoproject.com/en/5.1/topics/db/sql/#executing-custom-sql-directly
- Unify RLS parameter setting in just one place

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.