### PR TITLE
fix(backport): remove v from branch prefix

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,7 +6,9 @@ on:
     types: ['labeled', 'closed']
 
 env:
-  BACKPORT_LABEL_PREFIX: backport-to-v
+  # The prefix of the label that triggers the backport must not contain the branch name
+  # so, for example, if the branch is 'master', the label should be 'backport-to-<branch>'
+  BACKPORT_LABEL_PREFIX: backport-to-
   BACKPORT_LABEL_IGNORE: was-backported
 
 jobs:
@@ -25,8 +27,8 @@ jobs:
         with:
           allow_failure: true
           prefix_mode: true
-          one_of: ${{ env.BACKPORT_LABEL_PREFIX}}
-          none_of: ${{ env.BACKPORT_LABEL_IGNORE}}
+          one_of: ${{ env.BACKPORT_LABEL_PREFIX }}
+          none_of: ${{ env.BACKPORT_LABEL_IGNORE }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Backport Action
@@ -34,7 +36,7 @@ jobs:
         uses: sorenlouv/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
-          auto_backport_label_prefix: ${{ env.BACKPORT_LABEL_PREFIX}}
+          auto_backport_label_prefix: ${{ env.BACKPORT_LABEL_PREFIX }}
 
       - name: Info log
         if: ${{ success() && steps.preview_label_check.outputs.label_check == 'success' }}


### PR DESCRIPTION
### Description

Remove `v` from branch name since the suffix is used to get the backport destination branch.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed. -> No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.