### PR TITLE
docs(api): add commands to run API scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ cd src/backend
 python -m celery -A config.celery worker -l info -E
 ```
 
+**Commands to run the API Scheduler**
+
+``` console
+git clone https://github.com/prowler-cloud/prowler
+cd prowler/api
+poetry install
+poetry shell
+set -a
+source .env
+cd src/backend
+python -m celery -A config.celery beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+```
+
 **Commands to run the UI**
 
 ``` console

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,6 +98,19 @@ Prowler App can be installed in different ways, depending on your environment:
     python -m celery -A config.celery worker -l info -E
     ```
 
+    _Commands to run the API Scheduler_:
+
+    ``` bash
+    git clone https://github.com/prowler-cloud/prowler \
+    cd prowler/api \
+    poetry install \
+    poetry shell \
+    set -a \
+    source .env \
+    cd src/backend \
+    python -m celery -A config.celery beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+    ```
+
     _Commands to run the UI_:
 
     ``` bash


### PR DESCRIPTION
### Description

Add commands to run API scheduler in README and in the documentation.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.