### PR TITLE
fix(db-manager): set health check and conn_max_age to 1 hour

### DIFF
--- a/api/src/backend/config/django/production.py
+++ b/api/src/backend/config/django/production.py
@@ -1,7 +1,6 @@
 from config.django.base import *  # noqa
 from config.env import env
 
-
 DEBUG = env.bool("DJANGO_DEBUG", default=False)
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
 
@@ -15,6 +14,8 @@ DATABASES = {
         "PASSWORD": env("POSTGRES_PASSWORD"),
         "HOST": env("POSTGRES_HOST"),
         "PORT": env("POSTGRES_PORT"),
+        "CONN_MAX_AGE": 3600,
+        "CONN_HEALTH_CHECKS": True,
     },
     "admin": {
         "ENGINE": "psqlextra.backend",
@@ -23,6 +24,8 @@ DATABASES = {
         "PASSWORD": env("POSTGRES_ADMIN_PASSWORD"),
         "HOST": env("POSTGRES_HOST"),
         "PORT": env("POSTGRES_PORT"),
+        "CONN_MAX_AGE": 3600,
+        "CONN_HEALTH_CHECKS": True,
     },
 }
 DATABASES["default"] = DATABASES["prowler_user"]

--- a/api/src/backend/config/django/production.py
+++ b/api/src/backend/config/django/production.py
@@ -15,7 +15,6 @@ DATABASES = {
         "HOST": env("POSTGRES_HOST"),
         "PORT": env("POSTGRES_PORT"),
         "CONN_MAX_AGE": 3600,
-        "CONN_HEALTH_CHECKS": True,
     },
     "admin": {
         "ENGINE": "psqlextra.backend",
@@ -25,7 +24,6 @@ DATABASES = {
         "HOST": env("POSTGRES_HOST"),
         "PORT": env("POSTGRES_PORT"),
         "CONN_MAX_AGE": 3600,
-        "CONN_HEALTH_CHECKS": True,
     },
 }
 DATABASES["default"] = DATABASES["prowler_user"]


### PR DESCRIPTION
### Context

Django is revoking connections with the following exception: `django.db.utils.InterfaceError: connection already closed`

### Description

- Configure `CONN_MAX_AGE` for an hour instead of 0 which automatically closes the connection.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.