### PR TITLE
fix(aws): check AWS Owned keys in `firehose_stream_encrypted_at_rest`

### DIFF
--- a/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py
+++ b/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py
@@ -31,10 +31,7 @@ class firehose_stream_encrypted_at_rest(Check):
                 f"Firehose Stream {stream.name} does have at rest encryption enabled."
             )
 
-            if (
-                stream.kms_encryption != EncryptionStatus.ENABLED
-                or not stream.kms_key_arn
-            ):
+            if stream.kms_encryption != EncryptionStatus.ENABLED:
                 report.status = "FAIL"
                 report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled."
 

--- a/tests/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest_test.py
+++ b/tests/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest_test.py
@@ -17,12 +17,15 @@ class Test_firehose_stream_encrypted_at_rest:
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.firehose.firehose_stream_encrypted_at_rest.firehose_stream_encrypted_at_rest.firehose_client",
-            new=Firehose(aws_provider),
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.firehose.firehose_stream_encrypted_at_rest.firehose_stream_encrypted_at_rest.firehose_client",
+                new=Firehose(aws_provider),
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.firehose.firehose_stream_encrypted_at_rest.firehose_stream_encrypted_at_rest import (
@@ -65,6 +68,65 @@ class Test_firehose_stream_encrypted_at_rest:
             DeliveryStreamEncryptionConfigurationInput={
                 "KeyARN": f"arn:aws:kms:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:key/test-kms-key-id",
                 "KeyType": "CUSTOMER_MANAGED_CMK",
+            },
+        )
+
+        from prowler.providers.aws.services.firehose.firehose_service import Firehose
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.firehose.firehose_stream_encrypted_at_rest.firehose_stream_encrypted_at_rest.firehose_client",
+                new=Firehose(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.firehose.firehose_stream_encrypted_at_rest.firehose_stream_encrypted_at_rest import (
+                    firehose_stream_encrypted_at_rest,
+                )
+
+                check = firehose_stream_encrypted_at_rest()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"Firehose Stream {stream_name} does have at rest encryption enabled."
+                )
+
+    @mock_aws
+    def test_stream_kms_encryption_enabled_aws_managed_key(self):
+        # Generate S3 client
+        s3_client = client("s3", region_name=AWS_REGION_EU_WEST_1)
+        s3_client.create_bucket(
+            Bucket="test-bucket",
+            CreateBucketConfiguration={"LocationConstraint": AWS_REGION_EU_WEST_1},
+        )
+
+        # Generate Firehose client
+        firehose_client = client("firehose", region_name=AWS_REGION_EU_WEST_1)
+        delivery_stream = firehose_client.create_delivery_stream(
+            DeliveryStreamName="test-delivery-stream",
+            DeliveryStreamType="DirectPut",
+            S3DestinationConfiguration={
+                "RoleARN": "arn:aws:iam::012345678901:role/firehose-role",
+                "BucketARN": "arn:aws:s3:::test-bucket",
+                "Prefix": "",
+                "BufferingHints": {"IntervalInSeconds": 300, "SizeInMBs": 5},
+                "CompressionFormat": "UNCOMPRESSED",
+            },
+            Tags=[{"Key": "key", "Value": "value"}],
+        )
+        arn = delivery_stream["DeliveryStreamARN"]
+        stream_name = arn.split("/")[-1]
+
+        firehose_client.start_delivery_stream_encryption(
+            DeliveryStreamName=stream_name,
+            DeliveryStreamEncryptionConfigurationInput={
+                "KeyType": "AWS_OWNED_CMK",
             },
         )
 


### PR DESCRIPTION
### Context

The `firehose_stream_encrypted_at_rest` check contained a logic error that led to false positives.

Fix #6065

### Description

The logic error has been solved and no more false positives should appear.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.