### PR TITLE
fix(deploy): temporal fix for the alpine-python segmentation fault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine
+FROM python:3.12.8-alpine3.20
 
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -37,7 +37,7 @@ services:
       - 3000:3000
 
   postgres:
-    image: postgres:16.3-alpine
+    image: postgres:16.3-alpine3.20
     hostname: "postgres-db"
     volumes:
       - ./_data/postgres:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ${UI_PORT:-3000}:${UI_PORT:-3000}
 
   postgres:
-    image: postgres:16.3-alpine
+    image: postgres:16.3-alpine3.20
     hostname: "postgres-db"
     volumes:
       - ./_data/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
### Context

There is a problem with the current version of Python with Alpine 3.21, according to our tests there is a segmentation fault when building images that depend on this base: https://github.com/docker-library/python/issues/993

### Description

We have decided to fix the Alpine versions to 3.20.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.