### PR TITLE
fix(aws): get firewall manager managed rule groups

### DIFF
--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -150,6 +150,22 @@ class WAFv2(AWSService):
                         else:
                             acl.rules.append(new_rule)
 
+                    firewall_manager_managed_rg = get_web_acl.get("WebACL", {}).get(
+                        "PreProcessFirewallManagerRuleGroups", []
+                    ) + get_web_acl.get("WebACL", {}).get(
+                        "PostProcessFirewallManagerRuleGroups", []
+                    )
+
+                    for rule in firewall_manager_managed_rg:
+                        acl.rules.append(
+                            Rule(
+                                name=rule.get("Name", ""),
+                                cloudwatch_metrics_enabled=rule.get(
+                                    "VisibilityConfig", {}
+                                ).get("CloudWatchMetricsEnabled", False),
+                            )
+                        )
+
                 except Exception as error:
                     logger.error(
                         f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -188,13 +204,6 @@ class Scope(Enum):
 
 class Rule(BaseModel):
     """Model representing a rule for the Web ACL."""
-
-    name: str
-    cloudwatch_metrics_enabled: bool = False
-
-
-class FirewallManagerRuleGroup(BaseModel):
-    """Model representing a rule group for the Web ACL."""
 
     name: str
     cloudwatch_metrics_enabled: bool = False

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -157,7 +157,7 @@ class WAFv2(AWSService):
                     )
 
                     for rule in firewall_manager_managed_rg:
-                        acl.rules.append(
+                        acl.rule_groups.append(
                             Rule(
                                 name=rule.get("Name", ""),
                                 cloudwatch_metrics_enabled=rule.get(


### PR DESCRIPTION
### Context

`Firewall Manager` managed `rule groups` were previously not being accounted for, resulting in false positives.

Fix #6030

### Description

This issue has now been corrected, and false positives should no longer occur.

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.