### PR TITLE
fix(aws): set unique resource IDs

### DIFF
--- a/prowler/providers/aws/services/backup/backup_recovery_point_encrypted/backup_recovery_point_encrypted.py
+++ b/prowler/providers/aws/services/backup/backup_recovery_point_encrypted/backup_recovery_point_encrypted.py
@@ -8,14 +8,14 @@ class backup_recovery_point_encrypted(Check):
         for recovery_point in backup_client.recovery_points:
             report = Check_Report_AWS(self.metadata())
             report.region = recovery_point.backup_vault_region
-            report.resource_id = recovery_point.backup_vault_name
+            report.resource_id = recovery_point.id
             report.resource_arn = recovery_point.arn
             report.resource_tags = recovery_point.tags
             report.status = "FAIL"
-            report.status_extended = f"Backup Recovery Point {recovery_point.arn} for Backup Vault {recovery_point.backup_vault_name} is not encrypted at rest."
+            report.status_extended = f"Backup Recovery Point {recovery_point.id} for Backup Vault {recovery_point.backup_vault_name} is not encrypted at rest."
             if recovery_point.encrypted:
                 report.status = "PASS"
-                report.status_extended = f"Backup Recovery Point {recovery_point.arn} for Backup Vault {recovery_point.backup_vault_name} is encrypted at rest."
+                report.status_extended = f"Backup Recovery Point {recovery_point.id} for Backup Vault {recovery_point.backup_vault_name} is encrypted at rest."
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -195,6 +195,7 @@ class Backup(AWSService):
                                 self.recovery_points.append(
                                     RecoveryPoint(
                                         arn=arn,
+                                        id=arn.split(":")[-1],
                                         backup_vault_name=backup_vault.name,
                                         encrypted=recovery_point.get(
                                             "IsEncrypted", False
@@ -246,6 +247,7 @@ class BackupReportPlan(BaseModel):
 
 class RecoveryPoint(BaseModel):
     arn: str
+    id: str
     backup_vault_name: str
     encrypted: bool
     backup_vault_region: str

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled_logging_management_events/cloudtrail_multi_region_enabled_logging_management_events.py
@@ -48,7 +48,7 @@ class cloudtrail_multi_region_enabled_logging_management_events(Check):
                         report.resource_id = trail.name
                         report.resource_arn = trail.arn
                         report.resource_tags = trail.tags
-                        report.region = trail.home_region
+                        report.region = region
                         report.status = "PASS"
                         if trail.is_multiregion:
                             report.status_extended = f"Trail {trail.name} from home region {trail.home_region} is multi-region, is logging and have management events enabled."

--- a/prowler/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover.py
+++ b/prowler/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover.py
@@ -29,7 +29,9 @@ class route53_dangling_ip_subdomain_takeover(Check):
                     # Check if record is an IP Address
                     if validate_ip_address(record):
                         report = Check_Report_AWS(self.metadata())
-                        report.resource_id = f"{record_set.hosted_zone_id}/{record}"
+                        report.resource_id = (
+                            f"{record_set.hosted_zone_id}/{record_set.name}/{record}"
+                        )
                         report.resource_arn = route53_client.hosted_zones[
                             record_set.hosted_zone_id
                         ].arn

--- a/tests/providers/aws/services/backup/backup_recovery_point_encrypted/backup_recovery_point_encrypted_test.py
+++ b/tests/providers/aws/services/backup/backup_recovery_point_encrypted/backup_recovery_point_encrypted_test.py
@@ -94,12 +94,15 @@ class Test_backup_recovery_point_encrypted:
 
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted.backup_client",
-            new=Backup(aws_provider),
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted.backup_client",
+                new=Backup(aws_provider),
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted import (
@@ -124,12 +127,15 @@ class Test_backup_recovery_point_encrypted:
 
             aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
-            with mock.patch(
-                "prowler.providers.common.provider.Provider.get_global_provider",
-                return_value=aws_provider,
-            ), mock.patch(
-                "prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted.backup_client",
-                new=Backup(aws_provider),
+            with (
+                mock.patch(
+                    "prowler.providers.common.provider.Provider.get_global_provider",
+                    return_value=aws_provider,
+                ),
+                mock.patch(
+                    "prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted.backup_client",
+                    new=Backup(aws_provider),
+                ),
             ):
                 # Test Check
                 from prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted import (
@@ -142,9 +148,9 @@ class Test_backup_recovery_point_encrypted:
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
                 assert result[0].status_extended == (
-                    "Backup Recovery Point arn:aws:backup:eu-west-1:123456789012:recovery-point:1 for Backup Vault Test Vault is not encrypted at rest."
+                    "Backup Recovery Point 1 for Backup Vault Test Vault is not encrypted at rest."
                 )
-                assert result[0].resource_id == "Test Vault"
+                assert result[0].resource_id == "1"
                 assert (
                     result[0].resource_arn
                     == "arn:aws:backup:eu-west-1:123456789012:recovery-point:1"
@@ -165,12 +171,15 @@ class Test_backup_recovery_point_encrypted:
 
             aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
-            with mock.patch(
-                "prowler.providers.common.provider.Provider.get_global_provider",
-                return_value=aws_provider,
-            ), mock.patch(
-                "prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted.backup_client",
-                new=Backup(aws_provider),
+            with (
+                mock.patch(
+                    "prowler.providers.common.provider.Provider.get_global_provider",
+                    return_value=aws_provider,
+                ),
+                mock.patch(
+                    "prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted.backup_client",
+                    new=Backup(aws_provider),
+                ),
             ):
                 # Test Check
                 from prowler.providers.aws.services.backup.backup_recovery_point_encrypted.backup_recovery_point_encrypted import (
@@ -183,9 +192,9 @@ class Test_backup_recovery_point_encrypted:
                 assert len(result) == 1
                 assert result[0].status == "PASS"
                 assert result[0].status_extended == (
-                    "Backup Recovery Point arn:aws:backup:eu-west-1:123456789012:recovery-point:1 for Backup Vault Test Vault is encrypted at rest."
+                    "Backup Recovery Point 1 for Backup Vault Test Vault is encrypted at rest."
                 )
-                assert result[0].resource_id == "Test Vault"
+                assert result[0].resource_id == "1"
                 assert (
                     result[0].resource_arn
                     == "arn:aws:backup:eu-west-1:123456789012:recovery-point:1"

--- a/tests/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover_test.py
+++ b/tests/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover_test.py
@@ -131,7 +131,10 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     )
                     assert (
                         result[0].resource_id
-                        == zone_id.replace("/hostedzone/", "") + "/192.168.1.1"
+                        == zone_id.replace("/hostedzone/", "")
+                        + "/"
+                        + record_set_name
+                        + "/192.168.1.1"
                     )
                     assert (
                         result[0].resource_arn
@@ -196,7 +199,10 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     )
                     assert (
                         result[0].resource_id
-                        == zone_id.replace("/hostedzone/", "") + "/17.5.7.3"
+                        == zone_id.replace("/hostedzone/", "")
+                        + "/"
+                        + record_set_name
+                        + "/17.5.7.3"
                     )
                     assert (
                         result[0].resource_arn
@@ -261,7 +267,10 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     )
                     assert (
                         result[0].resource_id
-                        == zone_id.replace("/hostedzone/", "") + "/54.152.12.70"
+                        == zone_id.replace("/hostedzone/", "")
+                        + "/"
+                        + record_set_name
+                        + "/54.152.12.70"
                     )
                     assert (
                         result[0].resource_arn
@@ -330,7 +339,10 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     )
                     assert (
                         result[0].resource_id
-                        == zone_id.replace("/hostedzone/", "") + "/17.5.7.3"
+                        == zone_id.replace("/hostedzone/", "")
+                        + "/"
+                        + record_set_name
+                        + "/17.5.7.3"
                     )
                     assert (
                         result[0].resource_arn
@@ -405,7 +417,10 @@ class Test_route53_dangling_ip_subdomain_takeover:
                     )
                     assert (
                         result[0].resource_id
-                        == zone_id.replace("/hostedzone/", "") + "/17.5.7.3"
+                        == zone_id.replace("/hostedzone/", "")
+                        + "/"
+                        + record_set_name
+                        + "/17.5.7.3"
                     )
                     assert (
                         result[0].resource_arn


### PR DESCRIPTION
### Context

Fix #6138 

### Description

Set unique resource IDs in `backup_recovery_point_encrypted`, `route53_dangling_ip_subdomain_takeover` and `cloudtrail_multi_region_enabled_logging_management_events` checks.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.