### PR TITLE
fix(rds): add invalid SG to status_extended

### DIFF
--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
@@ -47,7 +47,28 @@ class rds_instance_no_public_access(Check):
                                     and vpc_client.vpc_subnets[subnet_id].public
                                 ):
                                     report.status = "FAIL"
-                                    report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible and security group {security_group.name} ({security_group.id}) has {db_instance.engine} port {db_instance_port} open to the Internet at endpoint {db_instance.endpoint.get('Address')} in a public subnet {subnet_id}."
+                                    invalid_security_groups = []
+                                    for (
+                                        security_group
+                                    ) in ec2_client.security_groups.values():
+                                        if (
+                                            security_group.id
+                                            in db_instance.security_groups
+                                        ):
+                                            for (
+                                                ingress_rule
+                                            ) in security_group.ingress_rules:
+                                                if check_security_group(
+                                                    ingress_rule,
+                                                    "tcp",
+                                                    [db_instance_port],
+                                                    any_address=True,
+                                                ):
+                                                    invalid_security_groups.append(
+                                                        f"{security_group.name} ({security_group.id})"
+                                                    )
+                                                    break
+                                    report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible and security group{'s' if len(invalid_security_groups) > 1 else ''} ({', '.join(invalid_security_groups)}) has {db_instance.engine} port {db_instance_port} open to the Internet at endpoint {db_instance.endpoint.get('Address')} in a public subnet {subnet_id}."
                                     break
 
             findings.append(report)

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -373,7 +373,7 @@ class Test_rds_instance_no_public_access:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"RDS Instance db-master-1 is set as publicly accessible and security group default ({default_sg_id}) has postgres port 5432 open to the Internet at endpoint db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com in a public subnet {subnet_id}."
+                    == f"RDS Instance db-master-1 is set as publicly accessible and security group (default ({default_sg_id})) has postgres port 5432 open to the Internet at endpoint db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com in a public subnet {subnet_id}."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1

--- a/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
+++ b/tests/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_test.py
@@ -373,7 +373,7 @@ class Test_rds_instance_no_public_access:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == f"RDS Instance db-master-1 is set as publicly accessible and security group (default ({default_sg_id})) has postgres port 5432 open to the Internet at endpoint db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com in a public subnet {subnet_id}."
+                    == f"RDS Instance db-master-1 is set as publicly accessible and security group default ({default_sg_id}) has postgres port 5432 open to the Internet at endpoint db-master-1.aaaaaaaaaa.us-east-1.rds.amazonaws.com in a public subnet {subnet_id}."
                 )
                 assert result[0].resource_id == "db-master-1"
                 assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

Fix #5868

### Description

Added some changes to `rds_instance_no_public_access` in order to report the invalid Security Groups.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.