### PR TITLE
feat(ec2): add new fixer `ec2_instance_port_cifs_exposed_to_internet_fixer`

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer.py
@@ -1,9 +1,10 @@
 from prowler.lib.logger import logger
 from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 
+
 def fixer(resource_id: str, region: str) -> bool:
     """
-    Revokes any ingress rule allowing CIFS ports (139, 445) from any address (0.0.0.0/0) 
+    Revokes any ingress rule allowing CIFS ports (139, 445) from any address (0.0.0.0/0)
     for the EC2 instance's security groups.
     This fixer will only be triggered if the check identifies CIFS ports open to the Internet.
     Requires the ec2:RevokeSecurityGroupIngress permission.
@@ -26,36 +27,84 @@ def fixer(resource_id: str, region: str) -> bool:
     """
     try:
         regional_client = ec2_client.regional_clients[region]
-        
+
         response = regional_client.describe_instances(InstanceIds=[resource_id])
-        
+
         security_group_ids = [
-            sg['GroupId'] for sg in response['Reservations'][0]['Instances'][0]['SecurityGroups']
+            sg["GroupId"]
+            for sg in response["Reservations"][0]["Instances"][0]["SecurityGroups"]
         ]
 
         for sg_id in security_group_ids:
-            regional_client.revoke_security_group_ingress(
-                GroupId=sg_id,
-                IpPermissions=[
-                    {
-                        "IpProtocol": "tcp",
-                        "FromPort": 139,
-                        "ToPort": 139,
-                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
-                    },
-                ]
-            )
-            regional_client.revoke_security_group_ingress(
-                GroupId=sg_id,
-                IpPermissions=[
-                    {
-                        'IpProtocol': 'tcp',
-                        'FromPort': 445,
-                        'ToPort': 445,
-                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
-                    },
-                ]
-            )
+            ip_permissions = regional_client.describe_security_groups(GroupIds=[sg_id])[
+                "SecurityGroups"
+            ][0]["IpPermissions"]
+
+            for permission in ip_permissions:
+                if permission.get("FromPort") == 139:
+                    if any(
+                        ip_range.get("CidrIp") == "0.0.0.0/0"
+                        for ip_range in permission.get("IpRanges", [])
+                    ):
+                        regional_client.revoke_security_group_ingress(
+                            GroupId=sg_id,
+                            IpPermissions=[
+                                {
+                                    "IpProtocol": "tcp",
+                                    "FromPort": 139,
+                                    "ToPort": 139,
+                                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                                },
+                            ],
+                        )
+                    if any(
+                        ip_range.get("CidrIpv6") == "::/0"
+                        for ip_range in permission.get("Ipv6Ranges", [])
+                    ):
+                        regional_client.revoke_security_group_ingress(
+                            GroupId=sg_id,
+                            IpPermissions=[
+                                {
+                                    "IpProtocol": "tcp",
+                                    "FromPort": 139,
+                                    "ToPort": 139,
+                                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+                                },
+                            ],
+                        )
+
+            for permission in ip_permissions:
+                if permission.get("FromPort") == 445:
+                    if any(
+                        ip_range.get("CidrIp") == "0.0.0.0/0"
+                        for ip_range in permission.get("IpRanges", [])
+                    ):
+                        regional_client.revoke_security_group_ingress(
+                            GroupId=sg_id,
+                            IpPermissions=[
+                                {
+                                    "IpProtocol": "tcp",
+                                    "FromPort": 445,
+                                    "ToPort": 445,
+                                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                                },
+                            ],
+                        )
+                    if any(
+                        ip_range.get("CidrIpv6") == "::/0"
+                        for ip_range in permission.get("Ipv6Ranges", [])
+                    ):
+                        regional_client.revoke_security_group_ingress(
+                            GroupId=sg_id,
+                            IpPermissions=[
+                                {
+                                    "IpProtocol": "tcp",
+                                    "FromPort": 445,
+                                    "ToPort": 445,
+                                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
+                                },
+                            ],
+                        )
 
     except Exception as error:
         logger.error(

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer.py
@@ -1,0 +1,66 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing CIFS ports (139, 445) from any address (0.0.0.0/0) 
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies CIFS ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        
+        response = regional_client.describe_instances(InstanceIds=[resource_id])
+        
+        security_group_ids = [
+            sg['GroupId'] for sg in response['Reservations'][0]['Instances'][0]['SecurityGroups']
+        ]
+
+        for sg_id in security_group_ids:
+            regional_client.revoke_security_group_ingress(
+                GroupId=sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 139,
+                        "ToPort": 139,
+                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                    },
+                ]
+            )
+            regional_client.revoke_security_group_ingress(
+                GroupId=sg_id,
+                IpPermissions=[
+                    {
+                        'IpProtocol': 'tcp',
+                        'FromPort': 445,
+                        'ToPort': 445,
+                        "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                    },
+                ]
+            )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
@@ -1,0 +1,207 @@
+from unittest import mock
+
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_REGION_EU_WEST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 139,
+                    "ToPort": 139,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 139,
+                    "ToPort": 139,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)
+
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_with_public_ip_in_public_subnet(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 139,
+                    "ToPort": 139,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        # add default route of subnet to an internet gateway to make it public
+        igw_id = ec2_client.create_internet_gateway()["InternetGateway"][
+            "InternetGatewayId"
+        ]
+        # attach internet gateway to subnet
+        ec2_client.attach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
+        # create route table
+        route_table_id = ec2_client.create_route_table(VpcId=vpc_id)["RouteTable"][
+            "RouteTableId"
+        ]
+        # associate route table with subnet
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_id, SubnetId=subnet_id
+        )
+        # add route to route table
+        ec2_client.create_route(
+            RouteTableId=route_table_id,
+            DestinationCidrBlock="0.0.0.0/0",
+            GatewayId=igw_id,
+        )
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
@@ -22,8 +22,8 @@ class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 139,
-                    "ToPort": 139,
+                    "FromPort": 1,
+                    "ToPort": 1000,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },

--- a/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
@@ -3,15 +3,12 @@ from unittest import mock
 from boto3 import client, resource
 from moto import mock_aws
 
-from tests.providers.aws.utils import (
-    AWS_REGION_EU_WEST_1,
-    set_mocked_aws_provider,
-)
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
 
 
 class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
     @mock_aws
-    def test_ec2_instance_exposed_port_in_private_subnet(self):
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
@@ -27,8 +24,16 @@ class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
                     "IpProtocol": "tcp",
                     "FromPort": 139,
                     "ToPort": 139,
-                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
-                }
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 445,
+                    "ToPort": 445,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
             ],
         )
         subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
@@ -64,9 +69,128 @@ class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
 
             assert fixer(instance_id, AWS_REGION_EU_WEST_1)
 
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 139,
+                    "ToPort": 139,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 445,
+                    "ToPort": 445,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
 
     @mock_aws
-    def test_ec2_instance_exposed_port_in_public_subnet(self):
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 139,
+                    "ToPort": 139,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 445,
+                    "ToPort": 445,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_139_port(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
@@ -125,9 +249,10 @@ class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
 
             assert fixer(instance.id, AWS_REGION_EU_WEST_1)
 
-
     @mock_aws
-    def test_ec2_instance_exposed_port_with_public_ip_in_public_subnet(self):
+    def test_ec2_instance_exposed_port_with_public_ip_in_public_subnet_only_445_port(
+        self,
+    ):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
@@ -141,8 +266,8 @@ class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 139,
-                    "ToPort": 139,
+                    "FromPort": 445,
+                    "ToPort": 445,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
                 }
             ],

--- a/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer_test.py
@@ -1,9 +1,27 @@
 from unittest import mock
 
+import botocore
+import botocore.client
 from boto3 import client, resource
 from moto import mock_aws
 
 from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
 
 
 class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
@@ -68,6 +86,86 @@ class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
             )
 
             assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 1000,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 445,
+                        "ToPort": 445,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
 
     @mock_aws
     def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):


### PR DESCRIPTION
### Context

Developed a new fixer that updates the security group rules for EC2 instances to restrict access to the CIFS/SMB port, ensuring it is only accessible from trusted IP addresses or private networks. This will prevent unauthorized access and reduce the risk of data leaks and potential malware infections.

In order to do this, I have followed the same structure of the check but at the moment that the report is done on the check (there is a FAIL) in the fixer I use the `revoke_security_group_ingress` boto3 call.

### Description

Added new fixer `ec2_instance_port_cifs_exposed_to_internet_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.