### PR TITLE
feat(s3): add new fixer `s3_bucket_public_list_acl_fixer`

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_fixer.py
@@ -1,0 +1,40 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.s3.s3_client import s3_client
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the S3 bucket ACL to restrict public read access.
+    Specifically, this fixer sets the ACL of the bucket to 'private' to prevent
+    any public access to the S3 bucket.
+    Requires the s3:PutBucketAcl permission.
+
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "s3:PutBucketAcl",
+                "Resource": "*"
+            }
+        ]
+    }
+
+    Args:
+        resource_id (str): The S3 bucket name.
+        region (str): AWS region where the S3 bucket exists.
+
+    Returns:
+        bool: True if the operation is successful (bucket access is updated), False otherwise.
+    """
+    try:
+        regional_client = s3_client.regional_clients[region]
+        regional_client.put_bucket_acl(Bucket=resource_id, ACL="private")
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/tests/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_fixer_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_fixer_test.py
@@ -1,0 +1,432 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_ACCOUNT_NUMBER,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_s3_bucket_public_list_acl_fixer:
+    @mock_aws
+    def test_bucket_public_list_ACL_AllUsers_READ(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_bucket_acl(
+            Bucket=bucket_name_us,
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                            "Type": "Group",
+                        },
+                        "Permission": "READ",
+                    },
+                ],
+                "Owner": bucket_owner,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer import (
+                    fixer,
+                )
+
+                assert fixer(bucket_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_bucket_public_list_ACL_AllUsers_READ_ACP(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_bucket_acl(
+            Bucket=bucket_name_us,
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                            "Type": "Group",
+                        },
+                        "Permission": "READ_ACP",
+                    },
+                ],
+                "Owner": bucket_owner,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer import (
+                    fixer,
+                )
+
+                assert fixer(bucket_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_bucket_public_list_ACL_AllUsers_FULL_CONTROL(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_bucket_acl(
+            Bucket=bucket_name_us,
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                            "Type": "Group",
+                        },
+                        "Permission": "FULL_CONTROL",
+                    },
+                ],
+                "Owner": bucket_owner,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer import (
+                    fixer,
+                )
+
+                assert fixer(bucket_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_bucket_public_list_ACL_AuthenticatedUsers_READ(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_bucket_acl(
+            Bucket=bucket_name_us,
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
+                            "Type": "Group",
+                        },
+                        "Permission": "READ",
+                    },
+                ],
+                "Owner": bucket_owner,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer import (
+                    fixer,
+                )
+
+                assert fixer(bucket_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_bucket_public_list_ACL_AuthenticatedUsers_READ_ACP(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_bucket_acl(
+            Bucket=bucket_name_us,
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
+                            "Type": "Group",
+                        },
+                        "Permission": "READ_ACP",
+                    },
+                ],
+                "Owner": bucket_owner,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer import (
+                    fixer,
+                )
+
+                assert fixer(bucket_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_bucket_public_list_ACL_AuthenticatedUsers_FULL_CONTROL(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_bucket_acl(
+            Bucket=bucket_name_us,
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
+                            "Type": "Group",
+                        },
+                        "Permission": "FULL_CONTROL",
+                    },
+                ],
+                "Owner": bucket_owner,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer import (
+                    fixer,
+                )
+
+                assert fixer(bucket_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_bucket_public_list_ACL_AllUsers_READ_error(self):
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        bucket_owner = s3_client.get_bucket_acl(Bucket=bucket_name_us)["Owner"]
+        # Generate S3Control Client
+        s3control_client = client("s3control", region_name=AWS_REGION_US_EAST_1)
+        s3control_client.put_public_access_block(
+            AccountId=AWS_ACCOUNT_NUMBER,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_public_access_block(
+            Bucket=bucket_name_us,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": False,
+                "IgnorePublicAcls": False,
+                "BlockPublicPolicy": False,
+                "RestrictPublicBuckets": False,
+            },
+        )
+        s3_client.put_bucket_acl(
+            Bucket=bucket_name_us,
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                            "Type": "Group",
+                        },
+                        "Permission": "READ",
+                    },
+                ],
+                "Owner": bucket_owner,
+            },
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer.s3_client",
+                new=S3(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.s3.s3_bucket_public_list_acl.s3_bucket_public_list_acl_fixer import (
+                    fixer,
+                )
+
+                assert not fixer("bucket_name_us_non_existing", AWS_REGION_US_EAST_1)


### PR DESCRIPTION
### Context

Developed a new fixer that removes public list access permissions from the ACLs of S3 buckets. The fixer will ensure that only authorized users, roles, or services can list the contents of the S3 bucket, thus protecting sensitive or proprietary data from being exposed to unauthorized entities.

### Description

Added new fixer `s3_bucket_public_list_acl_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.