### PR TITLE
chore(gha): build and push OSS UI

### DIFF
--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -8,6 +8,15 @@ on:
       - "ui/**"
       - ".github/workflows/ui-build-lint-push-containers.yml"
 
+  # Uncomment the below code to test this action on PRs
+  # Do not forget to set `push: false`
+  # pull_request:
+  #   branches:
+  #     - "master"
+  #   paths:
+  #     - "ui/**"
+  #     - ".github/workflows/ui-build-lint-push-containers.yml"
+
   release:
     types: [published]
 
@@ -32,6 +41,11 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
     steps:
+      - name: Repository check
+        working-directory: /tmp
+        run: |
+          [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 0
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -9,12 +9,12 @@ on:
       - ".github/workflows/ui-build-lint-push-containers.yml"
 
   # Uncomment the below code to test this action on PRs
-  pull_request:
-    branches:
-      - "master"
-    paths:
-      - "ui/**"
-      - ".github/workflows/ui-build-lint-push-containers.yml"
+  # pull_request:
+  #   branches:
+  #     - "master"
+  #   paths:
+  #     - "ui/**"
+  #     - ".github/workflows/ui-build-lint-push-containers.yml"
 
   release:
     types: [published]
@@ -63,7 +63,7 @@ jobs:
         with:
           context: ${{ env.WORKING_DIRECTORY }}
           # Set push: false for testing
-          push: false
+          push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
           cache-from: type=gha

--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 0
 
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build and push container image (latest)
         # Comment the following line for testing
-        # if: github.event_name == 'push'
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -58,6 +58,7 @@ jobs:
         # if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
+          context: ${{ env.WORKING_DIRECTORY }}
           # Set push: false for testing
           push: false
           tags: |
@@ -69,6 +70,7 @@ jobs:
         if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
+          context: ${{ env.WORKING_DIRECTORY }}
           push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}

--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -9,12 +9,12 @@ on:
       - ".github/workflows/ui-build-lint-push-containers.yml"
 
   # Uncomment the below code to test this action on PRs
-  # pull_request:
-  #   branches:
-  #     - "master"
-  #   paths:
-  #     - "ui/**"
-  #     - ".github/workflows/ui-build-lint-push-containers.yml"
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - "ui/**"
+      - ".github/workflows/ui-build-lint-push-containers.yml"
 
   release:
     types: [published]
@@ -44,9 +44,6 @@ jobs:
         run: |
           [[ ${{ github.repository }} != "prowler-cloud/prowler" ]] && echo "This action only runs for prowler-cloud/prowler"; exit 0
 
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -57,12 +54,12 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push container image (latest)
-        # Uncomment the following line for testing
-        if: github.event_name == 'push'
+        # Comment the following line for testing
+        # if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           # Set push: false for testing
-          push: true
+          push: false
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
           cache-from: type=gha

--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -1,0 +1,68 @@
+name: UI - Build and Push containers
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "ui/**"
+      - ".github/workflows/ui-build-lint-push-containers.yml"
+
+  release:
+    types: [published]
+
+env:
+  # Tags
+  LATEST_TAG: latest
+  RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+  WORKING_DIRECTORY: ./ui
+  DOCKERFILE_PATH: ./ui/Dockerfile
+
+  # Container Registries
+  PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
+  PROWLERCLOUD_DOCKERHUB_IMAGE: prowler-ui
+
+jobs:
+  # Build Prowler OSS container
+  container-build-push:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push container image (latest)
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push container image (release)
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -9,7 +9,6 @@ on:
       - ".github/workflows/ui-build-lint-push-containers.yml"
 
   # Uncomment the below code to test this action on PRs
-  # Do not forget to set `push: false`
   # pull_request:
   #   branches:
   #     - "master"
@@ -26,7 +25,6 @@ env:
   RELEASE_TAG: ${{ github.event.release.tag_name }}
 
   WORKING_DIRECTORY: ./ui
-  DOCKERFILE_PATH: ./ui/Dockerfile
 
   # Container Registries
   PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
@@ -59,13 +57,14 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push container image (latest)
+        # Uncomment the following line for testing
         if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
+          # Set push: false for testing
           push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
-          file: ${{ env.DOCKERFILE_PATH }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -73,10 +72,8 @@ jobs:
         if: github.event_name == 'release'
         uses: docker/build-push-action@v6
         with:
-          context: .
           push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}
-          file: ${{ env.DOCKERFILE_PATH }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
### Description

This pull request introduces a new GitHub Actions workflow for building and pushing Docker containers for the UI component. The workflow is triggered on pushes to the master branch and on published releases.

New GitHub Actions workflow:

* Added a new workflow file `.github/workflows/ui-build-lint-push-containers.yml` to handle building and pushing Docker containers for the UI. The workflow triggers on pushes to the master branch and on published releases.
* Configured environment variables for tags, working directory, Dockerfile path, and container registries.
* Included steps for repository check, checkout, DockerHub login, setting up Docker Buildx, and building and pushing the container images for both latest and release tags.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.