### PR TITLE
feat(s3): add new fixer `s3_bucket_policy_public_write_access_fixer`

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer.py
@@ -1,5 +1,3 @@
-import json
-
 from prowler.lib.logger import logger
 from prowler.providers.aws.services.s3.s3_client import s3_client
 
@@ -7,15 +5,15 @@ from prowler.providers.aws.services.s3.s3_client import s3_client
 def fixer(resource_id: str, region: str) -> bool:
     """
     Modify the S3 bucket's policy to remove public access.
-    Specifically, this fixer replaces any policy allowing public access
-    with a trusted access policy for the AWS account. Requires the s3:SetBucketPolicy permission.
+    Specifically, this fixer delete the policy of the public bucket.
+    Requires the s3:DeleteBucketPolicy permission.
     Permissions:
     {
         "Version": "2012-10-17",
         "Statement": [
             {
                 "Effect": "Allow",
-                "Action": "s3:SetBucketPolicy",
+                "Action": "s3:DeleteBucketPolicy",
                 "Resource": "*"
             }
         ]
@@ -28,28 +26,13 @@ def fixer(resource_id: str, region: str) -> bool:
     """
     try:
         regional_client = s3_client.regional_clients[region]
-        account_id = s3_client.audited_account
-        audited_partition = s3_client.audited_partition
-        trusted_policy = {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "ProwlerFixerStatement",
-                    "Effect": "Allow",
-                    "Principal": {
-                        "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
-                    },
-                    "Action": "s3:*",
-                }
-            ],
-        }
 
-        regional_client.put_bucket_policy(
-            Bucket=resource_id, Policy=json.dumps(trusted_policy)
-        )
+        regional_client.delete_bucket_policy(Bucket=resource_id)
 
     except Exception as error:
         logger.error(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False
+    else:
+        return True

--- a/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer.py
@@ -1,0 +1,55 @@
+import json
+
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.s3.s3_client import s3_client
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the S3 bucket's policy to remove public access.
+    Specifically, this fixer replaces any policy allowing public access
+    with a trusted access policy for the AWS account. Requires the s3:SetBucketPolicy permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "s3:SetBucketPolicy",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The S3 bucket name.
+        region (str): AWS region where the S3 bucket exists.
+    Returns:
+        bool: True if the operation is successful (policy updated), False otherwise.
+    """
+    try:
+        regional_client = s3_client.regional_clients[region]
+        account_id = s3_client.audited_account
+        audited_partition = s3_client.audited_partition
+        trusted_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "ProwlerFixerStatement",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
+                    },
+                    "Action": "s3:*",
+                }
+            ],
+        }
+
+        regional_client.put_bucket_policy(
+            Bucket=resource_id, Policy=json.dumps(trusted_policy)
+        )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False

--- a/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer_test.py
+++ b/tests/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer_test.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+
+class Test_s3_bucket_policy_public_write_access_fixer:
+    @mock_aws
+    def test_bucket_public_write_policy(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
+        )
+        public_write_policy = '{"Version": "2012-10-17","Id": "PutObjPolicy","Statement": [{"Sid": "PublicWritePolicy","Effect": "Allow","Principal": "*","Action": "s3:PutObject","Resource": "arn:aws:s3:::bucket_test_us/*"}]}'
+        s3_client_us_east_1.put_bucket_policy(
+            Bucket=bucket_name_us,
+            Policy=public_write_policy,
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_policy_public_write_access.s3_bucket_policy_public_write_access_fixer.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.s3.s3_bucket_policy_public_write_access.s3_bucket_policy_public_write_access_fixer import (
+                fixer,
+            )
+
+            assert fixer(bucket_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_bucket_public_write_policy_error(self):
+        s3_client_us_east_1 = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client_us_east_1.create_bucket(
+            Bucket=bucket_name_us, ObjectOwnership="BucketOwnerEnforced"
+        )
+        public_write_policy = '{"Version": "2012-10-17","Id": "PutObjPolicy","Statement": [{"Sid": "PublicWritePolicy","Effect": "Allow","Principal": "*","Action": "s3:PutObject","Resource": "arn:aws:s3:::bucket_test_us/*"}]}'
+        s3_client_us_east_1.put_bucket_policy(
+            Bucket=bucket_name_us,
+            Policy=public_write_policy,
+        )
+
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.s3.s3_bucket_policy_public_write_access.s3_bucket_policy_public_write_access_fixer.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.s3.s3_bucket_policy_public_write_access.s3_bucket_policy_public_write_access_fixer import (
+                fixer,
+            )
+
+            assert not fixer("bucket_name_non_existing", AWS_REGION_US_EAST_1)


### PR DESCRIPTION
### Context

Developed a new fixer that removes public write access from the bucket policy of S3 buckets, ensuring that only authorized users and roles can modify the bucket contents. This will help prevent unauthorized modifications to the data, enhancing the security and integrity of S3 resources.

### Description

Added new fixer `s3_bucket_policy_public_write_access_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.