### PR TITLE
feat(cloudtrail): add new fixer `cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer`

### DIFF
--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.py
@@ -1,0 +1,86 @@
+import json
+
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.cloudtrail.cloudtrail_client import (
+    cloudtrail_client,
+)
+from prowler.providers.aws.services.s3.s3_client import s3_client
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the CloudTrail's associated S3 bucket's policy and public access settings to ensure the bucket is not publicly accessible.
+    Specifically, this fixer:
+    1. Modifies the S3 bucket's policy to remove any public access.
+    2. Configures the S3 bucket's public access block settings to block all public access.
+    Requires the s3:SetBucketPolicy and s3:PutBucketAcl permissions.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "s3:SetBucketPolicy",
+                "Resource": "*"
+            },
+            {
+                "Effect": "Allow",
+                "Action": "s3:PutBucketAcl",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The CloudTrail name.
+        region (str): AWS region where the CloudTrail and S3 bucket exist.
+    Returns:
+        bool: True if the operation is successful (policy and ACL updated), False otherwise.
+    """
+    try:
+        trail = cloudtrail_client.trails.get(resource_id)
+        if not trail:
+            logger.error(f"{region} -- CloudTrail {resource_id} not found.")
+            return False
+
+        trail_bucket = trail.s3_bucket
+
+        regional_client = s3_client.regional_clients[region]
+        account_id = s3_client.audited_account
+        audited_partition = s3_client.audited_partition
+
+        trusted_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "ProwlerFixerStatement",
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": f"arn:{audited_partition}:iam::{account_id}:root"
+                    },
+                    "Action": "s3:*",
+                    "Resource": f"arn:{audited_partition}:s3:::{trail_bucket}/*",
+                }
+            ],
+        }
+
+        regional_client.put_bucket_policy(
+            Bucket=trail_bucket, Policy=json.dumps(trusted_policy)
+        )
+
+        regional_client.put_public_access_block(
+            Bucket=trail_bucket,
+            PublicAccessBlockConfiguration={
+                "BlockPublicAcls": True,
+                "IgnorePublicAcls": True,
+                "BlockPublicPolicy": True,
+                "RestrictPublicBuckets": True,
+            },
+        )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer_test.py
@@ -28,7 +28,7 @@ def mock_make_api_call_error(self, operation_name, kwarg):
     return mock_make_api_call(self, operation_name, kwarg)
 
 
-class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
+class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer:
     @mock_aws
     def test_trail_bucket_public_acl(self):
         aws_provider = set_mocked_aws_provider(

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer_test.py
@@ -1,0 +1,122 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import (
+    AWS_REGION_EU_WEST_1,
+    AWS_REGION_US_EAST_1,
+    set_mocked_aws_provider,
+)
+
+
+class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
+    @mock_aws
+    def test_trail_bucket_public_acl(self):
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        s3_client.put_bucket_acl(
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "DisplayName": "test",
+                            "EmailAddress": "",
+                            "ID": "test_ID",
+                            "Type": "Group",
+                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                        },
+                        "Permission": "READ",
+                    },
+                ],
+                "Owner": {"DisplayName": "test", "ID": "test_id"},
+            },
+            Bucket=bucket_name_us,
+        )
+
+        trail_name_us = "trail_test_us"
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client.create_trail(
+            Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
+        )
+
+        from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
+            Cloudtrail,
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.cloudtrail_client",
+            new=Cloudtrail(aws_provider),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert fixer(trail_name_us, AWS_REGION_US_EAST_1)
+
+    @mock_aws
+    def test_trail_bucket_public_acl_error(self):
+        aws_provider = set_mocked_aws_provider(
+            [AWS_REGION_US_EAST_1, AWS_REGION_EU_WEST_1]
+        )
+        s3_client = client("s3", region_name=AWS_REGION_US_EAST_1)
+        bucket_name_us = "bucket_test_us"
+        s3_client.create_bucket(Bucket=bucket_name_us)
+        s3_client.put_bucket_acl(
+            AccessControlPolicy={
+                "Grants": [
+                    {
+                        "Grantee": {
+                            "DisplayName": "test",
+                            "EmailAddress": "",
+                            "ID": "test_ID",
+                            "Type": "Group",
+                            "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                        },
+                        "Permission": "READ",
+                    },
+                ],
+                "Owner": {"DisplayName": "test", "ID": "test_id"},
+            },
+            Bucket=bucket_name_us,
+        )
+
+        trail_name_us = "trail_test_us"
+        cloudtrail_client = client("cloudtrail", region_name=AWS_REGION_US_EAST_1)
+        cloudtrail_client.create_trail(
+            Name=trail_name_us, S3BucketName=bucket_name_us, IsMultiRegionTrail=False
+        )
+
+        from prowler.providers.aws.services.cloudtrail.cloudtrail_service import (
+            Cloudtrail,
+        )
+        from prowler.providers.aws.services.s3.s3_service import S3
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.cloudtrail_client",
+            new=Cloudtrail(aws_provider),
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.s3_client",
+            new=S3(aws_provider),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.cloudtrail.cloudtrail_logs_s3_bucket_is_not_publicly_accessible.cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer import (
+                fixer,
+            )
+
+            assert fixer("trail_name_us_non_existing", AWS_REGION_US_EAST_1)

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
@@ -10,7 +10,7 @@ from tests.providers.aws.utils import (
 )
 
 
-class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer:
+class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
     @mock_aws
     def test_not_trails(self):
         aws_provider = set_mocked_aws_provider(

--- a/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_test.py
@@ -10,7 +10,7 @@ from tests.providers.aws.utils import (
 )
 
 
-class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible:
+class Test_cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer:
     @mock_aws
     def test_not_trails(self):
         aws_provider = set_mocked_aws_provider(


### PR DESCRIPTION
### Context

Develop a new fixer that configures CloudTrail S3 buckets to restrict public access, ensuring that only authorized entities can view and manage CloudTrail logs. This will help prevent unauthorized access and potential misuse of sensitive audit log data. So, this fixer remove the publicly accessible settings from the S3 Bucket associated with the Trail.

### Description

Added new fixer `cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer` with its unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.