### PR TITLE
fix: dependabot syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,7 +74,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    target-branch: master
+    target-branch: v4.6
     labels:
       - "dependencies"
       - "docker"


### PR DESCRIPTION
### Description

Use branch `v4.6` for v4 instead of `master`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.