### PR TITLE
chore(labeler): add provider github

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,11 @@ provider/kubernetes:
       - any-glob-to-any-file: "prowler/providers/kubernetes/**"
       - any-glob-to-any-file: "tests/providers/kubernetes/**"
 
+provider/github:
+  - changed-files:
+      - any-glob-to-any-file: "prowler/providers/github/**"
+      - any-glob-to-any-file: "tests/providers/github/**"
+
 github_actions:
   - changed-files:
       - any-glob-to-any-file: ".github/workflows/*"


### PR DESCRIPTION
### Description

This pull request includes changes to the `.github/labeler.yml` file to add new labeler rules for the GitHub provider. The most important change is the addition of labeler rules for the `provider/github` section.

Labeler rule additions:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR25-R29): Added new labeler rules for files under `prowler/providers/github/**` and `tests/providers/github/**`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.