### PR TITLE
refactor(gcp): use always <client>.region for checks

### DIFF
--- a/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
@@ -10,7 +10,7 @@ class compute_instance_block_project_wide_ssh_keys_disabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "FAIL"
             report.status_extended = f"The VM Instance {instance.name} is making use of common/shared project-wide SSH key(s)."
             if instance.metadata.get("items"):

--- a/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
@@ -10,7 +10,7 @@ class compute_instance_block_project_wide_ssh_keys_disabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "FAIL"
             report.status_extended = f"The VM Instance {instance.name} is making use of common/shared project-wide SSH key(s)."
             if instance.metadata.get("items"):

--- a/prowler/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_confidential_computing_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "PASS"
             report.status_extended = (
                 f"VM Instance {instance.name} has Confidential Computing enabled."

--- a/prowler/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_confidential_computing_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = (
                 f"VM Instance {instance.name} has Confidential Computing enabled."

--- a/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use.py
@@ -10,7 +10,7 @@ class compute_instance_default_service_account_in_use(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = f"The default service account is not configured to be used with VM Instance {instance.name}."
             if (

--- a/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use.py
@@ -10,7 +10,7 @@ class compute_instance_default_service_account_in_use(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "PASS"
             report.status_extended = f"The default service account is not configured to be used with VM Instance {instance.name}."
             if (

--- a/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access.py
@@ -10,7 +10,7 @@ class compute_instance_default_service_account_in_use_with_full_api_access(Check
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "PASS"
             report.status_extended = f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs."
             for service_account in instance.service_accounts:

--- a/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access.py
@@ -10,7 +10,7 @@ class compute_instance_default_service_account_in_use_with_full_api_access(Check
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs."
             for service_account in instance.service_accounts:

--- a/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_encryption_with_csek_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "FAIL"
             report.status_extended = f"The VM Instance {instance.name} has the following unencrypted disks: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'."
             if all([i[1] for i in instance.disks_encryption]):

--- a/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_encryption_with_csek_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "FAIL"
             report.status_extended = f"The VM Instance {instance.name} has the following unencrypted disks: '{', '.join([i[0] for i in instance.disks_encryption if not i[1]])}'."
             if all([i[1] for i in instance.disks_encryption]):

--- a/prowler/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_ip_forwarding_is_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "PASS"
             report.status_extended = (
                 f"The IP Forwarding of VM Instance {instance.name} is not enabled."

--- a/prowler/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_ip_forwarding_is_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = (
                 f"The IP Forwarding of VM Instance {instance.name} is not enabled."

--- a/prowler/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip.py
@@ -10,7 +10,7 @@ class compute_instance_public_ip(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = (
                 f"VM Instance {instance.name} does not have a public IP."

--- a/prowler/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip.py
@@ -10,7 +10,7 @@ class compute_instance_public_ip(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "PASS"
             report.status_extended = (
                 f"VM Instance {instance.name} does not have a public IP."

--- a/prowler/providers/gcp/services/compute/compute_instance_serial_ports_in_use/compute_instance_serial_ports_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_serial_ports_in_use/compute_instance_serial_ports_in_use.py
@@ -10,7 +10,7 @@ class compute_instance_serial_ports_in_use(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "PASS"
             report.status_extended = f"VM Instance {instance.name} has Enable Connecting to Serial Ports off."
             if instance.metadata.get("items"):

--- a/prowler/providers/gcp/services/compute/compute_instance_serial_ports_in_use/compute_instance_serial_ports_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_serial_ports_in_use/compute_instance_serial_ports_in_use.py
@@ -10,7 +10,7 @@ class compute_instance_serial_ports_in_use(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = f"VM Instance {instance.name} has Enable Connecting to Serial Ports off."
             if instance.metadata.get("items"):

--- a/prowler/providers/gcp/services/compute/compute_instance_shielded_vm_enabled/compute_instance_shielded_vm_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_shielded_vm_enabled/compute_instance_shielded_vm_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_shielded_vm_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = instance.zone
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = f"VM Instance {instance.name} has vTPM or Integrity Monitoring set to on."
             if (

--- a/prowler/providers/gcp/services/compute/compute_instance_shielded_vm_enabled/compute_instance_shielded_vm_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_shielded_vm_enabled/compute_instance_shielded_vm_enabled.py
@@ -10,7 +10,7 @@ class compute_instance_shielded_vm_enabled(Check):
             report.project_id = instance.project_id
             report.resource_id = instance.id
             report.resource_name = instance.name
-            report.location = compute_client.region
+            report.location = instance.region
             report.status = "PASS"
             report.status_extended = f"VM Instance {instance.name} has vTPM or Integrity Monitoring set to on."
             if (

--- a/prowler/providers/gcp/services/compute/compute_network_default_in_use/compute_network_default_in_use.py
+++ b/prowler/providers/gcp/services/compute/compute_network_default_in_use/compute_network_default_in_use.py
@@ -18,7 +18,7 @@ class compute_network_default_in_use(Check):
             report.project_id = project
             report.resource_id = "default"
             report.resource_name = "default"
-            report.location = "global"
+            report.location = compute_client.region
 
             if project in projects_with_default_network:
                 report.status = "FAIL"

--- a/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
@@ -9,7 +9,7 @@ class compute_project_os_login_enabled(Check):
             report = Check_Report_GCP(self.metadata())
             report.project_id = project.id
             report.resource_id = project.id
-            report.location = "global"
+            report.location = compute_client.region
             report.status = "PASS"
             report.status_extended = f"Project {project.id} has OS Login enabled."
             if not project.enable_oslogin:

--- a/prowler/providers/gcp/services/compute/compute_service.py
+++ b/prowler/providers/gcp/services/compute/compute_service.py
@@ -101,6 +101,7 @@ class Compute(GCPService):
                                 name=instance["name"],
                                 id=instance["id"],
                                 zone=zone,
+                                region=zone.rsplit("-", 1)[0],
                                 public_ip=public_ip,
                                 metadata=instance.get("metadata", {}),
                                 shielded_enabled_vtpm=instance.get(
@@ -306,6 +307,7 @@ class Instance(BaseModel):
     name: str
     id: str
     zone: str
+    region: str
     public_ip: bool
     project_id: str
     metadata: dict

--- a/prowler/providers/gcp/services/dataproc/dataproc_encrypted_with_cmks_disabled/dataproc_encrypted_with_cmks_disabled.py
+++ b/prowler/providers/gcp/services/dataproc/dataproc_encrypted_with_cmks_disabled/dataproc_encrypted_with_cmks_disabled.py
@@ -10,6 +10,7 @@ class dataproc_encrypted_with_cmks_disabled(Check):
             report.project_id = cluster.project_id
             report.resource_id = cluster.id
             report.resource_name = cluster.name
+            report.location = dataproc_client.region
             report.status = "PASS"
             report.status_extended = f"Dataproc cluster {cluster.name} is encrypted with customer managed encryption keys."
             if cluster.encryption_config.get("gcePdKmsKeyName") is None:

--- a/prowler/providers/gcp/services/dns/dns_dnssec_disabled/dns_dnssec_disabled.py
+++ b/prowler/providers/gcp/services/dns/dns_dnssec_disabled/dns_dnssec_disabled.py
@@ -10,6 +10,7 @@ class dns_dnssec_disabled(Check):
             report.project_id = managed_zone.project_id
             report.resource_id = managed_zone.id
             report.resource_name = managed_zone.name
+            report.location = dns_client.region
             report.status = "PASS"
             report.status_extended = (
                 f"Cloud DNS {managed_zone.name} has DNSSEC enabled."

--- a/prowler/providers/gcp/services/dns/dns_rsasha1_in_use_to_key_sign_in_dnssec/dns_rsasha1_in_use_to_key_sign_in_dnssec.py
+++ b/prowler/providers/gcp/services/dns/dns_rsasha1_in_use_to_key_sign_in_dnssec/dns_rsasha1_in_use_to_key_sign_in_dnssec.py
@@ -10,6 +10,7 @@ class dns_rsasha1_in_use_to_key_sign_in_dnssec(Check):
             report.project_id = managed_zone.project_id
             report.resource_id = managed_zone.id
             report.resource_name = managed_zone.name
+            report.location = dns_client.region
             report.status = "PASS"
             report.status_extended = f"Cloud DNS {managed_zone.name} is not using RSASHA1 algorithm as key signing."
             if any(

--- a/prowler/providers/gcp/services/dns/dns_rsasha1_in_use_to_zone_sign_in_dnssec/dns_rsasha1_in_use_to_zone_sign_in_dnssec.py
+++ b/prowler/providers/gcp/services/dns/dns_rsasha1_in_use_to_zone_sign_in_dnssec/dns_rsasha1_in_use_to_zone_sign_in_dnssec.py
@@ -10,6 +10,7 @@ class dns_rsasha1_in_use_to_zone_sign_in_dnssec(Check):
             report.project_id = managed_zone.project_id
             report.resource_id = managed_zone.id
             report.resource_name = managed_zone.name
+            report.location = dns_client.region
             report.status = "PASS"
             report.status_extended = f"Cloud DNS {managed_zone.name} is not using RSASHA1 algorithm as zone signing."
             if any(

--- a/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.py
+++ b/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.py
@@ -10,7 +10,7 @@ class gke_cluster_no_default_service_account(Check):
             report.project_id = cluster.project_id
             report.resource_id = cluster.id
             report.resource_name = cluster.name
-            report.location = cluster.location
+            report.location = gke_client.region
             report.status = "PASS"
             report.status_extended = f"GKE cluster {cluster.name} is not using the Compute Engine default service account."
             if not cluster.node_pools and cluster.service_account == "default":

--- a/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.py
+++ b/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.py
@@ -10,7 +10,7 @@ class gke_cluster_no_default_service_account(Check):
             report.project_id = cluster.project_id
             report.resource_id = cluster.id
             report.resource_name = cluster.name
-            report.location = gke_client.region
+            report.location = cluster.region
             report.status = "PASS"
             report.status_extended = f"GKE cluster {cluster.name} is not using the Compute Engine default service account."
             if not cluster.node_pools and cluster.service_account == "default":

--- a/prowler/providers/gcp/services/gke/gke_service.py
+++ b/prowler/providers/gcp/services/gke/gke_service.py
@@ -60,6 +60,7 @@ class GKE(GCPService):
                     name=cluster["name"],
                     id=cluster["id"],
                     location=cluster["location"],
+                    region=cluster["location"].rsplit("-", 1)[0],
                     service_account=cluster["nodeConfig"]["serviceAccount"],
                     node_pools=node_pools,
                     project_id=location.project_id,
@@ -85,6 +86,7 @@ class NodePool(BaseModel):
 class Cluster(BaseModel):
     name: str
     id: str
+    region: str
     location: str
     service_account: str
     node_pools: list[NodePool]

--- a/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -10,7 +10,7 @@ class kms_key_not_publicly_accessible(Check):
             report.project_id = key.project_id
             report.resource_id = key.id
             report.resource_name = key.name
-            report.location = kms_client.region
+            report.location = key.location
             report.status = "PASS"
             report.status_extended = f"Key {key.name} is not exposed to Public."
             for member in key.members:

--- a/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
+++ b/prowler/providers/gcp/services/kms/kms_key_not_publicly_accessible/kms_key_not_publicly_accessible.py
@@ -10,7 +10,7 @@ class kms_key_not_publicly_accessible(Check):
             report.project_id = key.project_id
             report.resource_id = key.id
             report.resource_name = key.name
-            report.location = key.location
+            report.location = kms_client.region
             report.status = "PASS"
             report.status_extended = f"Key {key.name} is not exposed to Public."
             for member in key.members:

--- a/prowler/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled.py
+++ b/prowler/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled.py
@@ -12,7 +12,7 @@ class kms_key_rotation_enabled(Check):
             report.project_id = key.project_id
             report.resource_id = key.id
             report.resource_name = key.name
-            report.location = key.location
+            report.location = kms_client.region
             now = datetime.datetime.now()
             condition_next_rotation_time = False
             if key.next_rotation_time:

--- a/prowler/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled.py
+++ b/prowler/providers/gcp/services/kms/kms_key_rotation_enabled/kms_key_rotation_enabled.py
@@ -12,7 +12,7 @@ class kms_key_rotation_enabled(Check):
             report.project_id = key.project_id
             report.resource_id = key.id
             report.resource_name = key.name
-            report.location = kms_client.region
+            report.location = key.location
             now = datetime.datetime.now()
             condition_next_rotation_time = False
             if key.next_rotation_time:

--- a/tests/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled_test.py
@@ -46,6 +46,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -68,6 +69,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_without_metadata(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -90,6 +92,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -112,6 +115,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_with_block_project_ssh_keys_false(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -134,6 +138,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -156,3 +161,4 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"

--- a/tests/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled_test.py
@@ -32,6 +32,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "block-project-ssh-keys", "value": "true"}]},
             shielded_enabled_vtpm=True,
@@ -46,7 +47,6 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -69,7 +69,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_without_metadata(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -78,6 +78,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -92,7 +93,6 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -115,7 +115,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_with_block_project_ssh_keys_false(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -124,6 +124,7 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "block-project-ssh-keys", "value": "false"}]},
             shielded_enabled_vtpm=True,
@@ -138,7 +139,6 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -161,4 +161,4 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled_test.py
@@ -32,6 +32,7 @@ class Test_compute_instance_confidential_computing_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -46,7 +47,6 @@ class Test_compute_instance_confidential_computing_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -70,7 +70,7 @@ class Test_compute_instance_confidential_computing_enabled:
             )
             assert result[0].resource_id == instance.id
             assert result[0].resource_name == instance.name
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_one_instance_with_shielded_vtpm_disabled(self):
@@ -80,6 +80,7 @@ class Test_compute_instance_confidential_computing_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=False,
@@ -94,7 +95,6 @@ class Test_compute_instance_confidential_computing_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "us-central1-a"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -118,5 +118,5 @@ class Test_compute_instance_confidential_computing_enabled:
             )
             assert result[0].resource_id == instance.id
             assert result[0].resource_name == instance.name
-            assert result[0].location == "us-central1-a"
+            assert result[0].location == "us-central1"
             assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_confidential_computing_enabled/compute_instance_confidential_computing_enabled_test.py
@@ -46,6 +46,7 @@ class Test_compute_instance_confidential_computing_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -69,7 +70,7 @@ class Test_compute_instance_confidential_computing_enabled:
             )
             assert result[0].resource_id == instance.id
             assert result[0].resource_name == instance.name
-            assert result[0].location == instance.zone
+            assert result[0].location == "global"
             assert result[0].project_id == GCP_PROJECT_ID
 
     def test_one_instance_with_shielded_vtpm_disabled(self):
@@ -93,6 +94,7 @@ class Test_compute_instance_confidential_computing_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "us-central1-a"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -116,5 +118,5 @@ class Test_compute_instance_confidential_computing_enabled:
             )
             assert result[0].resource_id == instance.id
             assert result[0].resource_name == instance.name
-            assert result[0].location == instance.zone
+            assert result[0].location == "us-central1-a"
             assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_default_service_account_in_use/compute_instance_default_service_account_in_use_test.py
@@ -30,6 +30,7 @@ class Test_compute_instance_default_service_account_in_use:
         instance = Instance(
             name="test",
             id="1234567890",
+            region="us-central1",
             zone="us-central1-a",
             public_ip=True,
             metadata={},
@@ -67,6 +68,7 @@ class Test_compute_instance_default_service_account_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"
 
     def test_one_compliant_instance_gke(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -75,6 +77,7 @@ class Test_compute_instance_default_service_account_in_use:
             name="gke-test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -113,6 +116,7 @@ class Test_compute_instance_default_service_account_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"
 
     def test_instance_with_default_service_account(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -121,6 +125,7 @@ class Test_compute_instance_default_service_account_in_use:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -159,3 +164,4 @@ class Test_compute_instance_default_service_account_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_default_service_account_in_use_with_full_api_access/compute_instance_default_service_account_in_use_with_full_api_access_test.py
@@ -32,6 +32,7 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -72,6 +73,7 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
                 == f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs."
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"
 
     def test_one_compliant_instance_gke(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -80,6 +82,7 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
             name="gke-test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -123,6 +126,7 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
                 == f"The VM Instance {instance.name} is not configured to use the default service account with full access to all cloud APIs."
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"
 
     def test_instance_with_default_service_account(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -131,6 +135,7 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -174,3 +179,4 @@ class Test_compute_instance_default_service_account_in_use_with_full_api_access:
                 == f"The VM Instance {instance.name} is configured to use the default service account with full access to all cloud APIs."
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
@@ -46,6 +46,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -68,6 +69,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_with_one_unecrypted_disk(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -90,6 +92,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -112,6 +115,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_with_all_unencrypted_disks(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -134,6 +138,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -156,3 +161,4 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"

--- a/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_encryption_with_csek_enabled/compute_instance_encryption_with_csek_enabled_test.py
@@ -32,6 +32,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "block-project-ssh-keys", "value": "true"}]},
             shielded_enabled_vtpm=True,
@@ -46,7 +47,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
+        compute_client.region = "us-central1"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -69,7 +70,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_with_one_unecrypted_disk(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -78,6 +79,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -92,7 +94,6 @@ class Test_compute_instance_encryption_with_csek_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -115,7 +116,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_with_all_unencrypted_disks(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -124,6 +125,7 @@ class Test_compute_instance_encryption_with_csek_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "block-project-ssh-keys", "value": "false"}]},
             shielded_enabled_vtpm=True,
@@ -138,7 +140,6 @@ class Test_compute_instance_encryption_with_csek_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -161,4 +162,4 @@ class Test_compute_instance_encryption_with_csek_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled_test.py
@@ -45,6 +45,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -67,6 +68,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_compliant_instance_gke(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -91,6 +93,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -113,6 +116,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_instance_with_ip_forwarding_enabled(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -137,6 +141,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -159,3 +164,4 @@ class Test_compute_instance_ip_forwarding_is_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"

--- a/tests/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_ip_forwarding_is_enabled/compute_instance_ip_forwarding_is_enabled_test.py
@@ -31,6 +31,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -45,7 +46,6 @@ class Test_compute_instance_ip_forwarding_is_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -68,7 +68,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_compliant_instance_gke(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -77,6 +77,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
             name="gke-test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -93,7 +94,6 @@ class Test_compute_instance_ip_forwarding_is_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -116,7 +116,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_instance_with_ip_forwarding_enabled(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -125,6 +125,7 @@ class Test_compute_instance_ip_forwarding_is_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -141,7 +142,6 @@ class Test_compute_instance_ip_forwarding_is_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -164,4 +164,4 @@ class Test_compute_instance_ip_forwarding_is_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip_test.py
@@ -42,6 +42,7 @@ class Test_compute_instance_public_ip:
                 name="test",
                 id="1234567890",
                 zone="us-central1-a",
+                region="us-central1",
                 public_ip=False,
                 metadata={},
                 shielded_enabled_vtpm=True,
@@ -57,7 +58,6 @@ class Test_compute_instance_public_ip:
 
             compute_client.project_ids = [GCP_PROJECT_ID]
             compute_client.instances = [instance]
-            compute_client.region = "global"
 
             check = compute_instance_public_ip()
             result = check.execute()
@@ -71,7 +71,7 @@ class Test_compute_instance_public_ip:
             assert result[0].resource_id == "1234567890"
             assert result[0].project_id == GCP_PROJECT_ID
             assert result[0].resource_name == "test"
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_public_ip_instance(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -80,6 +80,7 @@ class Test_compute_instance_public_ip:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -96,7 +97,6 @@ class Test_compute_instance_public_ip:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -118,4 +118,4 @@ class Test_compute_instance_public_ip:
             assert result[0].resource_id == "1234567890"
             assert result[0].project_id == GCP_PROJECT_ID
             assert result[0].resource_name == "test"
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_public_ip/compute_instance_public_ip_test.py
@@ -57,6 +57,7 @@ class Test_compute_instance_public_ip:
 
             compute_client.project_ids = [GCP_PROJECT_ID]
             compute_client.instances = [instance]
+            compute_client.region = "global"
 
             check = compute_instance_public_ip()
             result = check.execute()
@@ -70,7 +71,7 @@ class Test_compute_instance_public_ip:
             assert result[0].resource_id == "1234567890"
             assert result[0].project_id == GCP_PROJECT_ID
             assert result[0].resource_name == "test"
-            assert result[0].location == "us-central1-a"
+            assert result[0].location == "global"
 
     def test_public_ip_instance(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -95,6 +96,7 @@ class Test_compute_instance_public_ip:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -116,4 +118,4 @@ class Test_compute_instance_public_ip:
             assert result[0].resource_id == "1234567890"
             assert result[0].project_id == GCP_PROJECT_ID
             assert result[0].resource_name == "test"
-            assert result[0].location == "us-central1-a"
+            assert result[0].location == "global"

--- a/tests/providers/gcp/services/compute/compute_network_default_in_use/compute_network_default_in_use_test.py
+++ b/tests/providers/gcp/services/compute/compute_network_default_in_use/compute_network_default_in_use_test.py
@@ -41,6 +41,7 @@ class Test_compute_network_default_in_use:
 
             compute_client.project_ids = [GCP_PROJECT_ID]
             compute_client.networks = []
+            compute_client.region = "global"
 
             check = compute_network_default_in_use()
             result = check.execute()
@@ -79,6 +80,7 @@ class Test_compute_network_default_in_use:
                     project_id=GCP_PROJECT_ID,
                 )
             ]
+            compute_client.region = "global"
 
             check = compute_network_default_in_use()
             result = check.execute()
@@ -117,6 +119,7 @@ class Test_compute_network_default_in_use:
                     project_id=GCP_PROJECT_ID,
                 )
             ]
+            compute_client.region = "global"
 
             check = compute_network_default_in_use()
             result = check.execute()

--- a/tests/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled_test.py
@@ -36,6 +36,7 @@ class Test_compute_project_os_login_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.projects = [project]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -72,6 +73,7 @@ class Test_compute_project_os_login_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.projects = [project]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/gcp/services/compute/compute_serial_ports_in_use/compute_serial_ports_in_use_test.py
+++ b/tests/providers/gcp/services/compute/compute_serial_ports_in_use/compute_serial_ports_in_use_test.py
@@ -134,6 +134,7 @@ class Test_compute_instance_serial_ports_in_use:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -156,6 +157,7 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_with_serial_ports_enable_1(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -178,6 +180,7 @@ class Test_compute_instance_serial_ports_in_use:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -200,6 +203,7 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_with_serial_ports_enable_true(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -222,6 +226,7 @@ class Test_compute_instance_serial_ports_in_use:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -244,3 +249,4 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"

--- a/tests/providers/gcp/services/compute/compute_serial_ports_in_use/compute_serial_ports_in_use_test.py
+++ b/tests/providers/gcp/services/compute/compute_serial_ports_in_use/compute_serial_ports_in_use_test.py
@@ -32,6 +32,7 @@ class Test_compute_instance_serial_ports_in_use:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -68,6 +69,7 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"
 
     def test_one_compliant_instance_with_0(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -76,6 +78,7 @@ class Test_compute_instance_serial_ports_in_use:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "serial-port-enabled", "value": "0"}]},
             shielded_enabled_vtpm=True,
@@ -112,6 +115,7 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"
 
     def test_one_compliant_instance_with_false(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -120,6 +124,7 @@ class Test_compute_instance_serial_ports_in_use:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "serial-port-enabled", "value": "false"}]},
             shielded_enabled_vtpm=True,
@@ -134,7 +139,6 @@ class Test_compute_instance_serial_ports_in_use:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -157,7 +161,7 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_with_serial_ports_enable_1(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -166,6 +170,7 @@ class Test_compute_instance_serial_ports_in_use:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "serial-port-enable", "value": "1"}]},
             shielded_enabled_vtpm=True,
@@ -180,7 +185,6 @@ class Test_compute_instance_serial_ports_in_use:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -203,7 +207,7 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_with_serial_ports_enable_true(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -212,6 +216,7 @@ class Test_compute_instance_serial_ports_in_use:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={"items": [{"key": "serial-port-enable", "value": "true"}]},
             shielded_enabled_vtpm=True,
@@ -226,7 +231,6 @@ class Test_compute_instance_serial_ports_in_use:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -249,4 +253,4 @@ class Test_compute_instance_serial_ports_in_use:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_service_test.py
+++ b/tests/providers/gcp/services/compute/compute_service_test.py
@@ -36,6 +36,7 @@ class TestComputeService:
             assert compute_client.instances[0].name == "instance1"
             assert compute_client.instances[0].id.__class__.__name__ == "str"
             assert compute_client.instances[0].zone == "zone1"
+            assert compute_client.instances[0].region == "zone1"
             assert compute_client.instances[0].public_ip
             assert compute_client.instances[0].project_id == GCP_PROJECT_ID
             assert compute_client.instances[0].metadata == {}
@@ -57,6 +58,7 @@ class TestComputeService:
             assert compute_client.instances[1].name == "instance2"
             assert compute_client.instances[1].id.__class__.__name__ == "str"
             assert compute_client.instances[1].zone == "zone1"
+            assert compute_client.instances[1].region == "zone1"
             assert not compute_client.instances[1].public_ip
             assert compute_client.instances[1].project_id == GCP_PROJECT_ID
             assert compute_client.instances[1].metadata == {}

--- a/tests/providers/gcp/services/compute/compute_shielded_vm_enabled/compute_shielded_vm_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_shielded_vm_enabled/compute_shielded_vm_enabled_test.py
@@ -32,6 +32,7 @@ class Test_compute_instance_shielded_vm_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -46,7 +47,6 @@ class Test_compute_instance_shielded_vm_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -69,7 +69,7 @@ class Test_compute_instance_shielded_vm_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_with_shielded_vtpm_disabled(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -78,6 +78,7 @@ class Test_compute_instance_shielded_vm_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=False,
@@ -92,7 +93,6 @@ class Test_compute_instance_shielded_vm_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -115,7 +115,7 @@ class Test_compute_instance_shielded_vm_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"
 
     def test_one_instance_with_shielded_integrity_monitoring_disabled(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -124,6 +124,7 @@ class Test_compute_instance_shielded_vm_enabled:
             name="test",
             id="1234567890",
             zone="us-central1-a",
+            region="us-central1",
             public_ip=True,
             metadata={},
             shielded_enabled_vtpm=True,
@@ -138,7 +139,6 @@ class Test_compute_instance_shielded_vm_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
-        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -161,4 +161,4 @@ class Test_compute_instance_shielded_vm_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
-            assert result[0].location == "global"
+            assert result[0].location == "us-central1"

--- a/tests/providers/gcp/services/compute/compute_shielded_vm_enabled/compute_shielded_vm_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_shielded_vm_enabled/compute_shielded_vm_enabled_test.py
@@ -46,6 +46,7 @@ class Test_compute_instance_shielded_vm_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -68,6 +69,7 @@ class Test_compute_instance_shielded_vm_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_with_shielded_vtpm_disabled(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -90,6 +92,7 @@ class Test_compute_instance_shielded_vm_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -112,6 +115,7 @@ class Test_compute_instance_shielded_vm_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"
 
     def test_one_instance_with_shielded_integrity_monitoring_disabled(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
@@ -134,6 +138,7 @@ class Test_compute_instance_shielded_vm_enabled:
         compute_client = mock.MagicMock
         compute_client.project_ids = [GCP_PROJECT_ID]
         compute_client.instances = [instance]
+        compute_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -156,3 +161,4 @@ class Test_compute_instance_shielded_vm_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == instance.id
+            assert result[0].location == "global"

--- a/tests/providers/gcp/services/dataproc/dataproc_encrypted_with_cmks_disabled/dataproc_encrypted_with_cmks_disabled_test.py
+++ b/tests/providers/gcp/services/dataproc/dataproc_encrypted_with_cmks_disabled/dataproc_encrypted_with_cmks_disabled_test.py
@@ -44,6 +44,7 @@ class Test_dataproc_encrypted_with_cmks_disabled:
                 project_id=GCP_PROJECT_ID,
             )
             dataproc_client.clusters = [cluster]
+            dataproc_client.region = "global"
 
             from prowler.providers.gcp.services.dataproc.dataproc_encrypted_with_cmks_disabled.dataproc_encrypted_with_cmks_disabled import (
                 dataproc_encrypted_with_cmks_disabled,
@@ -59,6 +60,7 @@ class Test_dataproc_encrypted_with_cmks_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == cluster.id
+            assert result[0].location == "global"
 
     def test_cluster_without_encryption(self):
         dataproc_client = mock.MagicMock
@@ -81,6 +83,7 @@ class Test_dataproc_encrypted_with_cmks_disabled:
                 project_id=GCP_PROJECT_ID,
             )
             dataproc_client.clusters = [cluster]
+            dataproc_client.region = "global"
 
             from prowler.providers.gcp.services.dataproc.dataproc_encrypted_with_cmks_disabled.dataproc_encrypted_with_cmks_disabled import (
                 dataproc_encrypted_with_cmks_disabled,
@@ -96,3 +99,4 @@ class Test_dataproc_encrypted_with_cmks_disabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == cluster.id
+            assert result[0].location == "global"

--- a/tests/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account_test.py
+++ b/tests/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account_test.py
@@ -31,6 +31,7 @@ class Test_gke_cluster_no_default_service_account:
                 name="test",
                 id="123",
                 location="eu-west-1",
+                region="eu-west-1",
                 service_account="default",
                 node_pools=[],
                 project_id=GCP_PROJECT_ID,
@@ -40,7 +41,6 @@ class Test_gke_cluster_no_default_service_account:
         gke_client = mock.MagicMock
         gke_client.project_ids = [GCP_PROJECT_ID]
         gke_client.clusters = clusters
-        gke_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -65,7 +65,7 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == "global"
+            assert result[0].location == "eu-west-1"
 
     def test_one_cluster_without_node_pool_without_default_sa(self):
 
@@ -74,6 +74,7 @@ class Test_gke_cluster_no_default_service_account:
                 name="test",
                 id="123",
                 location="eu-west-1",
+                region="eu-west-1",
                 service_account="1231231231",
                 node_pools=[],
                 project_id=GCP_PROJECT_ID,
@@ -83,7 +84,6 @@ class Test_gke_cluster_no_default_service_account:
         gke_client = mock.MagicMock
         gke_client.project_ids = [GCP_PROJECT_ID]
         gke_client.clusters = clusters
-        gke_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -108,7 +108,7 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == "global"
+            assert result[0].location == "eu-west-1"
 
     def test_one_cluster_with_node_pool_with_default_sa(self):
 
@@ -117,6 +117,7 @@ class Test_gke_cluster_no_default_service_account:
                 name="test",
                 id="123",
                 location="eu-west-1",
+                region="eu-west-1",
                 service_account="default",
                 node_pools=[
                     NodePool(
@@ -133,7 +134,6 @@ class Test_gke_cluster_no_default_service_account:
         gke_client = mock.MagicMock
         gke_client.project_ids = [GCP_PROJECT_ID]
         gke_client.clusters = clusters
-        gke_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -158,7 +158,7 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == "global"
+            assert result[0].location == "eu-west-1"
 
     def test_one_cluster_with_node_pool_with_non_default_sa(self):
 
@@ -167,6 +167,7 @@ class Test_gke_cluster_no_default_service_account:
                 name="test",
                 id="123",
                 location="eu-west-1",
+                region="eu-west-1",
                 service_account="default",
                 node_pools=[
                     NodePool(
@@ -183,7 +184,6 @@ class Test_gke_cluster_no_default_service_account:
         gke_client = mock.MagicMock
         gke_client.project_ids = [GCP_PROJECT_ID]
         gke_client.clusters = clusters
-        gke_client.region = "global"
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -208,4 +208,4 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == "global"
+            assert result[0].location == "eu-west-1"

--- a/tests/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account_test.py
+++ b/tests/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account_test.py
@@ -65,7 +65,7 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == clusters["123"].location
+            assert result[0].location == "global"
 
     def test_one_cluster_without_node_pool_without_default_sa(self):
 
@@ -108,7 +108,7 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == clusters["123"].location
+            assert result[0].location == "global"
 
     def test_one_cluster_with_node_pool_with_default_sa(self):
 
@@ -158,7 +158,7 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == clusters["123"].location
+            assert result[0].location == "global"
 
     def test_one_cluster_with_node_pool_with_non_default_sa(self):
 
@@ -208,4 +208,4 @@ class Test_gke_cluster_no_default_service_account:
             assert result[0].project_id == clusters["123"].project_id
             assert result[0].resource_id == clusters["123"].id
             assert result[0].resource_name == clusters["123"].name
-            assert result[0].location == clusters["123"].location
+            assert result[0].location == "global"


### PR DESCRIPTION
### Description

Standardize the report.location usage in all the gcp checks:

- For checks like `compute_instance_public_ip` using `report.location = instance.zone`, use `report.location = compute_client.region`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.