### PR TITLE
feat(ec2): add new fixers for internet exposed ports

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Cassandra ports (7000, 7001, 7199, 9042, 9160) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies Cassandra ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [7000, 7001, 7199, 9042, 9160]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Elasticsearch and Kibana ports (9200, 9300, 5601)
+    from any address (0.0.0.0/0) for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies those ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [9200, 9300, 5601]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing FTP ports (20, 21) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies FTP ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [20, 21]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Kafka ports (9092) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies Kafka ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [9092]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Kerberos ports (88, 464, 749, 750) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies Kerberos ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [88, 464, 749, 750]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing LDAP ports (389, 636) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies LDAP ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [389, 636]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Memcached ports (11211) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies Memcached ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [11211]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing MongoDB ports (27017, 27018) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies MongoDB ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [27017, 27018]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing MySQL ports (3306) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies MySQL ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [3306]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Oracle ports (1521, 2483, 2484) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies Oracle ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [1521, 2483, 2484]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing PostgreSQL ports (5432) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies PostgreSQL ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [5432]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing RDP ports (3389) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies RDP ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [3389]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Redis ports (6379) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies Redis ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [6379]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing SQLServer ports (1433, 1434) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies SQLServer ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [1433, 1434]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing SSH ports (22) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies SSH ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [22]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet_fixer.py
@@ -1,0 +1,51 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing Telnet ports (23) from any address (0.0.0.0/0)
+    for the EC2 instance's security groups.
+    This fixer will only be triggered if the check identifies Telnet ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The EC2 instance ID.
+        region (str): The AWS region where the EC2 instance exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = [23]
+        for instance in ec2_client.instances:
+            if instance.id == resource_id:
+                for sg in ec2_client.security_groups.values():
+                    if sg.id in instance.security_groups:
+                        for ingress_rule in sg.ingress_rules:
+                            if check_security_group(
+                                ingress_rule, "tcp", check_ports, any_address=True
+                            ):
+                                regional_client.revoke_security_group_ingress(
+                                    GroupId=sg.id,
+                                    IpPermissions=[ingress_rule],
+                                )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
@@ -1,0 +1,53 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Revokes any ingress rule allowing high risk ports (25, 110, 135, 143, 445, 3000, 4333, 5000, 5500, 8080, 8088)
+    from any address (0.0.0.0/0) for the security groups.
+    This fixer will only be triggered if the check identifies high risk ports open to the Internet.
+    Requires the ec2:RevokeSecurityGroupIngress permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "ec2:RevokeSecurityGroupIngress",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The Security Group ID.
+        region (str): The AWS region where the Security Group exists.
+    Returns:
+        bool: True if the operation is successful (ingress rule revoked), False otherwise.
+    """
+    try:
+        regional_client = ec2_client.regional_clients[region]
+        check_ports = ec2_client.audit_config.get(
+            "ec2_high_risk_ports",
+            [25, 110, 135, 143, 445, 3000, 4333, 5000, 5500, 8080, 8088],
+        )
+        for security_group in ec2_client.security_groups.values():
+            if security_group.id == resource_id:
+                for ingress_rule in security_group.ingress_rules:
+                    for port in check_ports:
+                        if check_security_group(
+                            ingress_rule, "tcp", [port], any_address=True
+                        ):
+                            regional_client.revoke_security_group_ingress(
+                                GroupId=security_group.id,
+                                IpPermissions=[ingress_rule],
+                            )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
@@ -35,14 +35,13 @@ def fixer(resource_id: str, region: str) -> bool:
         for security_group in ec2_client.security_groups.values():
             if security_group.id == resource_id:
                 for ingress_rule in security_group.ingress_rules:
-                    for port in check_ports:
-                        if check_security_group(
-                            ingress_rule, "tcp", [port], any_address=True
-                        ):
-                            regional_client.revoke_security_group_ingress(
-                                GroupId=security_group.id,
-                                IpPermissions=[ingress_rule],
-                            )
+                    if check_security_group(
+                        ingress_rule, "tcp", check_ports, any_address=True
+                    ):
+                        regional_client.revoke_security_group_ingress(
+                            GroupId=security_group.id,
+                            IpPermissions=[ingress_rule],
+                        )
 
     except Exception as error:
         logger.error(

--- a/tests/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_cassandra_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 10000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 7000,
+                    "ToPort": 9160,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 10000,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 7000,
+                        "ToPort": 9160,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 7000,
+                    "ToPort": 9160,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 7000,
+                    "ToPort": 9160,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_all_ports(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 7000,
+                    "ToPort": 9160,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cassandra_exposed_to_internet.ec2_instance_port_cassandra_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer_test.py
@@ -24,7 +24,7 @@ def mock_make_api_call_error(self, operation_name, kwarg):
     return mock_make_api_call(self, operation_name, kwarg)
 
 
-class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
+class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
     @mock_aws
     def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
         # Create EC2 Mocked Resources

--- a/tests/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer_test.py
@@ -1,0 +1,430 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_cifs_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 9500,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 5700,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 9500,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 5601,
+                        "ToPort": 5601,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 9200,
+                    "ToPort": 9200,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 5601,
+                    "ToPort": 5601,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 9200,
+                    "ToPort": 9200,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 5601,
+                    "ToPort": 5601,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_139_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 9200,
+                    "ToPort": 9300,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_with_public_ip_in_public_subnet_only_445_port(
+        self,
+    ):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 5601,
+                    "ToPort": 5601,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        # add default route of subnet to an internet gateway to make it public
+        igw_id = ec2_client.create_internet_gateway()["InternetGateway"][
+            "InternetGatewayId"
+        ]
+        # attach internet gateway to subnet
+        ec2_client.attach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
+        # create route table
+        route_table_id = ec2_client.create_route_table(VpcId=vpc_id)["RouteTable"][
+            "RouteTableId"
+        ]
+        # associate route table with subnet
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_id, SubnetId=subnet_id
+        )
+        # add route to route table
+        ec2_client.create_route(
+            RouteTableId=route_table_id,
+            DestinationCidrBlock="0.0.0.0/0",
+            GatewayId=igw_id,
+        )
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_cifs_exposed_to_internet.ec2_instance_port_cifs_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer_test.py
@@ -288,7 +288,7 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             assert fixer(instance_id, AWS_REGION_EU_WEST_1)
 
     @mock_aws
-    def test_ec2_instance_exposed_port_in_public_subnet_only_139_port(self):
+    def test_ec2_instance_exposed_port_in_public_subnet_only_both_ports(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer_test.py
@@ -24,7 +24,7 @@ def mock_make_api_call_error(self, operation_name, kwarg):
     return mock_make_api_call(self, operation_name, kwarg)
 
 
-class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
+class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
     @mock_aws
     def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
         # Create EC2 Mocked Resources
@@ -41,14 +41,14 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
                 {
                     "IpProtocol": "tcp",
                     "FromPort": 1,
-                    "ToPort": 9500,
+                    "ToPort": 1000,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 1,
-                    "ToPort": 5700,
+                    "FromPort": 445,
+                    "ToPort": 445,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
@@ -77,11 +77,11 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -106,7 +106,7 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
                     {
                         "IpProtocol": "tcp",
                         "FromPort": 1,
-                        "ToPort": 9500,
+                        "ToPort": 1000,
                         "IpRanges": [
                             {"CidrIp": "0.0.0.0/0"},
                             {"CidrIp": "10.0.0.0/24"},
@@ -118,8 +118,8 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
                     },
                     {
                         "IpProtocol": "tcp",
-                        "FromPort": 5601,
-                        "ToPort": 5601,
+                        "FromPort": 445,
+                        "ToPort": 445,
                         "IpRanges": [
                             {"CidrIp": "0.0.0.0/0"},
                             {"CidrIp": "10.0.0.0/24"},
@@ -157,11 +157,11 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
                 "prowler.providers.common.provider.Provider.get_global_provider",
                 return_value=aws_provider,
             ), mock.patch(
-                "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+                "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
                 new=EC2(aws_provider),
             ):
                 # Test Fixer
-                from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+                from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
                     fixer,
                 )
 
@@ -182,14 +182,14 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 9200,
-                    "ToPort": 9200,
+                    "FromPort": 139,
+                    "ToPort": 139,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                 },
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 5601,
-                    "ToPort": 5601,
+                    "FromPort": 445,
+                    "ToPort": 445,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                 },
             ],
@@ -217,11 +217,11 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -242,14 +242,14 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 9200,
-                    "ToPort": 9200,
+                    "FromPort": 139,
+                    "ToPort": 139,
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 5601,
-                    "ToPort": 5601,
+                    "FromPort": 445,
+                    "ToPort": 445,
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
             ],
@@ -277,11 +277,11 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -302,8 +302,8 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 9200,
-                    "ToPort": 9300,
+                    "FromPort": 139,
+                    "ToPort": 139,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
                 }
             ],
@@ -337,11 +337,11 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -364,8 +364,8 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 5601,
-                    "ToPort": 5601,
+                    "FromPort": 445,
+                    "ToPort": 445,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
                 }
             ],
@@ -419,11 +419,11 @@ class Test_ec2_instance_port_elastic_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
                 fixer,
             )
 

--- a/tests/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer_test.py
@@ -263,7 +263,7 @@ class Test_ec2_instance_port_kafka_exposed_to_internet_fixer:
             assert fixer(instance_id, AWS_REGION_EU_WEST_1)
 
     @mock_aws
-    def test_ec2_instance_exposed_port_in_public_subnet_only_139_port(self):
+    def test_ec2_instance_exposed_port_in_public_subnet_only_one_port(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer_test.py
@@ -24,7 +24,7 @@ def mock_make_api_call_error(self, operation_name, kwarg):
     return mock_make_api_call(self, operation_name, kwarg)
 
 
-class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
+class Test_ec2_instance_port_kafka_exposed_to_internet_fixer:
     @mock_aws
     def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
         # Create EC2 Mocked Resources
@@ -41,14 +41,14 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
                 {
                     "IpProtocol": "tcp",
                     "FromPort": 1,
-                    "ToPort": 1000,
+                    "ToPort": 9100,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 22,
+                    "FromPort": 9092,
+                    "ToPort": 9092,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
@@ -77,11 +77,11 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -105,21 +105,8 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
                 IpPermissions=[
                     {
                         "IpProtocol": "tcp",
-                        "FromPort": 1,
-                        "ToPort": 1000,
-                        "IpRanges": [
-                            {"CidrIp": "0.0.0.0/0"},
-                            {"CidrIp": "10.0.0.0/24"},
-                        ],
-                        "Ipv6Ranges": [
-                            {"CidrIpv6": "::/0"},
-                            {"CidrIpv6": "2001:db8::/32"},
-                        ],
-                    },
-                    {
-                        "IpProtocol": "tcp",
-                        "FromPort": 20,
-                        "ToPort": 20,
+                        "FromPort": 9092,
+                        "ToPort": 9092,
                         "IpRanges": [
                             {"CidrIp": "0.0.0.0/0"},
                             {"CidrIp": "10.0.0.0/24"},
@@ -145,7 +132,7 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
                     {
                         "ResourceType": "instance",
                         "Tags": [{"Key": "Name", "Value": "test"}],
-                    }
+                    },
                 ],
             )[0].id
 
@@ -157,11 +144,11 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
                 "prowler.providers.common.provider.Provider.get_global_provider",
                 return_value=aws_provider,
             ), mock.patch(
-                "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
+                "prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer.ec2_client",
                 new=EC2(aws_provider),
             ):
                 # Test Fixer
-                from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
+                from prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer import (
                     fixer,
                 )
 
@@ -182,14 +169,8 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 20,
-                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
-                },
-                {
-                    "IpProtocol": "tcp",
-                    "FromPort": 21,
-                    "ToPort": 21,
+                    "FromPort": 9092,
+                    "ToPort": 9092,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                 },
             ],
@@ -217,11 +198,11 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -242,14 +223,8 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 20,
-                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
-                },
-                {
-                    "IpProtocol": "tcp",
-                    "FromPort": 21,
-                    "ToPort": 21,
+                    "FromPort": 9092,
+                    "ToPort": 9092,
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
             ],
@@ -277,11 +252,11 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -302,8 +277,8 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 22,
+                    "FromPort": 9092,
+                    "ToPort": 9092,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
                 }
             ],
@@ -337,11 +312,11 @@ class Test_ec2_instance_port_ftp_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_ftp_exposed_to_internet.ec2_instance_port_ftp_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kafka_exposed_to_internet.ec2_instance_port_kafka_exposed_to_internet_fixer import (
                 fixer,
             )
 

--- a/tests/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer_test.py
@@ -1,0 +1,348 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_kerberos_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 1000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 88,
+                    "ToPort": 750,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 1000,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 88,
+                        "ToPort": 464,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 88,
+                    "ToPort": 88,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 464,
+                    "ToPort": 464,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 749,
+                    "ToPort": 749,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 750,
+                    "ToPort": 750,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_139_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 88,
+                    "ToPort": 750,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_kerberos_exposed_to_internet.ec2_instance_port_kerberos_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer_test.py
@@ -288,7 +288,7 @@ class Test_ec2_instance_port_kerberos_exposed_to_internet_fixer:
             assert fixer(instance_id, AWS_REGION_EU_WEST_1)
 
     @mock_aws
-    def test_ec2_instance_exposed_port_in_public_subnet_only_139_port(self):
+    def test_ec2_instance_exposed_port_in_public_subnet_only_both_ports(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet_fixer_test.py
@@ -24,7 +24,7 @@ def mock_make_api_call_error(self, operation_name, kwarg):
     return mock_make_api_call(self, operation_name, kwarg)
 
 
-class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
+class Test_ec2_instance_port_ldap_exposed_to_internet_fixer:
     @mock_aws
     def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
         # Create EC2 Mocked Resources
@@ -41,14 +41,14 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
                 {
                     "IpProtocol": "tcp",
                     "FromPort": 1,
-                    "ToPort": 9500,
+                    "ToPort": 1000,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 1,
-                    "ToPort": 5700,
+                    "FromPort": 445,
+                    "ToPort": 445,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
@@ -77,11 +77,11 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -106,7 +106,7 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
                     {
                         "IpProtocol": "tcp",
                         "FromPort": 1,
-                        "ToPort": 9500,
+                        "ToPort": 1000,
                         "IpRanges": [
                             {"CidrIp": "0.0.0.0/0"},
                             {"CidrIp": "10.0.0.0/24"},
@@ -118,8 +118,8 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
                     },
                     {
                         "IpProtocol": "tcp",
-                        "FromPort": 5601,
-                        "ToPort": 5601,
+                        "FromPort": 389,
+                        "ToPort": 389,
                         "IpRanges": [
                             {"CidrIp": "0.0.0.0/0"},
                             {"CidrIp": "10.0.0.0/24"},
@@ -157,11 +157,11 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
                 "prowler.providers.common.provider.Provider.get_global_provider",
                 return_value=aws_provider,
             ), mock.patch(
-                "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+                "prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer.ec2_client",
                 new=EC2(aws_provider),
             ):
                 # Test Fixer
-                from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+                from prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer import (
                     fixer,
                 )
 
@@ -182,14 +182,14 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 9200,
-                    "ToPort": 9200,
+                    "FromPort": 389,
+                    "ToPort": 389,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                 },
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 5601,
-                    "ToPort": 5601,
+                    "FromPort": 636,
+                    "ToPort": 636,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                 },
             ],
@@ -217,11 +217,11 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer import (
                 fixer,
             )
 
@@ -242,14 +242,14 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 9200,
-                    "ToPort": 9200,
+                    "FromPort": 389,
+                    "ToPort": 389,
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 5601,
-                    "ToPort": 5601,
+                    "FromPort": 636,
+                    "ToPort": 636,
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
             ],
@@ -277,18 +277,18 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer import (
                 fixer,
             )
 
             assert fixer(instance_id, AWS_REGION_EU_WEST_1)
 
     @mock_aws
-    def test_ec2_instance_exposed_port_in_public_subnet_only_9200_9300_port(self):
+    def test_ec2_instance_exposed_port_in_public_subnet_only_bot_ports(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
         ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
@@ -302,8 +302,8 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 9200,
-                    "ToPort": 9300,
+                    "FromPort": 389,
+                    "ToPort": 636,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
                 }
             ],
@@ -337,93 +337,11 @@ class Test_ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer.ec2_client",
             new=EC2(aws_provider),
         ):
             # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
-                fixer,
-            )
-
-            assert fixer(instance.id, AWS_REGION_EU_WEST_1)
-
-    @mock_aws
-    def test_ec2_instance_exposed_port_with_public_ip_in_public_subnet_only_5601_port(
-        self,
-    ):
-        # Create EC2 Mocked Resources
-        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
-        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
-        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
-        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
-            "SecurityGroups"
-        ][0]
-        default_sg_id = default_sg["GroupId"]
-        ec2_client.authorize_security_group_ingress(
-            GroupId=default_sg_id,
-            IpPermissions=[
-                {
-                    "IpProtocol": "tcp",
-                    "FromPort": 5601,
-                    "ToPort": 5601,
-                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
-                }
-            ],
-        )
-        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
-            "Subnet"
-        ]["SubnetId"]
-        # add default route of subnet to an internet gateway to make it public
-        igw_id = ec2_client.create_internet_gateway()["InternetGateway"][
-            "InternetGatewayId"
-        ]
-        # attach internet gateway to subnet
-        ec2_client.attach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
-        # create route table
-        route_table_id = ec2_client.create_route_table(VpcId=vpc_id)["RouteTable"][
-            "RouteTableId"
-        ]
-        # associate route table with subnet
-        ec2_client.associate_route_table(
-            RouteTableId=route_table_id, SubnetId=subnet_id
-        )
-        # add route to route table
-        ec2_client.create_route(
-            RouteTableId=route_table_id,
-            DestinationCidrBlock="0.0.0.0/0",
-            GatewayId=igw_id,
-        )
-        instance = ec2_resource.create_instances(
-            ImageId="ami-12345678",
-            MinCount=1,
-            MaxCount=1,
-            InstanceType="t2.micro",
-            SecurityGroupIds=[default_sg_id],
-            NetworkInterfaces=[
-                {
-                    "DeviceIndex": 0,
-                    "SubnetId": subnet_id,
-                    "AssociatePublicIpAddress": True,
-                }
-            ],
-            TagSpecifications=[
-                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
-            ],
-        )[0]
-
-        from prowler.providers.aws.services.ec2.ec2_service import EC2
-
-        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
-
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.ec2_client",
-            new=EC2(aws_provider),
-        ):
-            # Test Fixer
-            from prowler.providers.aws.services.ec2.ec2_instance_port_elasticsearch_kibana_exposed_to_internet.ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer import (
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ldap_exposed_to_internet.ec2_instance_port_ldap_exposed_to_internet_fixer import (
                 fixer,
             )
 

--- a/tests/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_memcached_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 12000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 11211,
+                    "ToPort": 11211,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 11211,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 11211,
+                        "ToPort": 11211,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 11211,
+                    "ToPort": 11211,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 11211,
+                    "ToPort": 11211,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_11211_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 11211,
+                    "ToPort": 11211,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_memcached_exposed_to_internet.ec2_instance_port_memcached_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet_fixer_test.py
@@ -1,0 +1,430 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_mongodb_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 27100,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 27017,
+                    "ToPort": 27018,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 27018,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 27017,
+                        "ToPort": 27017,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 27017,
+                    "ToPort": 27017,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 27018,
+                    "ToPort": 27018,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 27017,
+                    "ToPort": 27017,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 27018,
+                    "ToPort": 27018,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_27017_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 27017,
+                    "ToPort": 27017,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_with_public_ip_in_public_subnet_only_27018_port(
+        self,
+    ):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 27018,
+                    "ToPort": 27018,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        # add default route of subnet to an internet gateway to make it public
+        igw_id = ec2_client.create_internet_gateway()["InternetGateway"][
+            "InternetGatewayId"
+        ]
+        # attach internet gateway to subnet
+        ec2_client.attach_internet_gateway(InternetGatewayId=igw_id, VpcId=vpc_id)
+        # create route table
+        route_table_id = ec2_client.create_route_table(VpcId=vpc_id)["RouteTable"][
+            "RouteTableId"
+        ]
+        # associate route table with subnet
+        ec2_client.associate_route_table(
+            RouteTableId=route_table_id, SubnetId=subnet_id
+        )
+        # add route to route table
+        ec2_client.create_route(
+            RouteTableId=route_table_id,
+            DestinationCidrBlock="0.0.0.0/0",
+            GatewayId=igw_id,
+        )
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mongodb_exposed_to_internet.ec2_instance_port_mongodb_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_mysql_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 4000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3306,
+                    "ToPort": 3306,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 4000,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 3306,
+                        "ToPort": 3306,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3306,
+                    "ToPort": 3306,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3306,
+                    "ToPort": 3306,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_3306_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3306,
+                    "ToPort": 3306,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_mysql_exposed_to_internet.ec2_instance_port_mysql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet_fixer_test.py
@@ -1,0 +1,348 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_oracle_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 2500,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1521,
+                    "ToPort": 1521,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 2483,
+                        "ToPort": 2484,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1521,
+                        "ToPort": 1521,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1521,
+                    "ToPort": 1521,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 2483,
+                    "ToPort": 2484,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1521,
+                    "ToPort": 1521,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 2483,
+                    "ToPort": 2484,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_bots_ports(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1521,
+                    "ToPort": 2484,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_oracle_exposed_to_internet.ec2_instance_port_oracle_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_postgresql_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 5500,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 5432,
+                    "ToPort": 5432,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 5500,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 5432,
+                        "ToPort": 5432,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 5432,
+                    "ToPort": 5432,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 5432,
+                    "ToPort": 5432,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_5432_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 5432,
+                    "ToPort": 5432,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_postgresql_exposed_to_internet.ec2_instance_port_postgresql_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_rdp_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 3400,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3389,
+                    "ToPort": 3389,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 3400,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 3389,
+                        "ToPort": 3389,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3389,
+                    "ToPort": 3389,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3389,
+                    "ToPort": 3389,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_3389_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 3389,
+                    "ToPort": 3389,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_rdp_exposed_to_internet.ec2_instance_port_rdp_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_redis_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 6400,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 6379,
+                    "ToPort": 6379,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 6400,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 6379,
+                        "ToPort": 6379,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 6379,
+                    "ToPort": 6379,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 6379,
+                    "ToPort": 6379,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_6379_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 6379,
+                    "ToPort": 6379,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_redis_exposed_to_internet.ec2_instance_port_redis_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet_fixer_test.py
@@ -1,0 +1,348 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_sqlserver_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 1500,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1433,
+                    "ToPort": 1434,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 1500,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1433,
+                        "ToPort": 1434,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1433,
+                    "ToPort": 1433,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1434,
+                    "ToPort": 1434,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1433,
+                    "ToPort": 1433,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1434,
+                    "ToPort": 1434,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_both_ports(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1433,
+                    "ToPort": 1434,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_sqlserver_exposed_to_internet.ec2_instance_port_sqlserver_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_ssh_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 25,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 25,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 22,
+                        "ToPort": 22,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_22_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 22,
+                    "ToPort": 22,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_ssh_exposed_to_internet.ec2_instance_port_ssh_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet_fixer_test.py
@@ -1,0 +1,336 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client, resource
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_instance_port_telnet_exposed_to_internet_fixer:
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 1,
+                    "ToPort": 25,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 23,
+                    "ToPort": 23,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+            vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 1,
+                        "ToPort": 25,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 23,
+                        "ToPort": 23,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+                "Subnet"
+            ]["SubnetId"]
+            instance_id = ec2_resource.create_instances(
+                ImageId="ami-12345678",
+                MinCount=1,
+                MaxCount=1,
+                InstanceType="t2.micro",
+                SecurityGroupIds=[default_sg_id],
+                SubnetId=subnet_id,
+                TagSpecifications=[
+                    {
+                        "ResourceType": "instance",
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                    }
+                ],
+            )[0].id
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 23,
+                    "ToPort": 23,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 23,
+                    "ToPort": 23,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance_id = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            SubnetId=subnet_id,
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0].id
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_instance_exposed_port_in_public_subnet_only_23_port(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_resource = resource("ec2", region_name=AWS_REGION_EU_WEST_1)
+        vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ][0]
+        default_sg_id = default_sg["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 23,
+                    "ToPort": 23,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                }
+            ],
+        )
+        subnet_id = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.0.0/16")[
+            "Subnet"
+        ]["SubnetId"]
+        instance = ec2_resource.create_instances(
+            ImageId="ami-12345678",
+            MinCount=1,
+            MaxCount=1,
+            InstanceType="t2.micro",
+            SecurityGroupIds=[default_sg_id],
+            NetworkInterfaces=[
+                {
+                    "DeviceIndex": 0,
+                    "SubnetId": subnet_id,
+                    "AssociatePublicIpAddress": True,
+                }
+            ],
+            TagSpecifications=[
+                {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": "test"}]}
+            ],
+        )[0]
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_instance_port_telnet_exposed_to_internet.ec2_instance_port_telnet_exposed_to_internet_fixer import (
+                fixer,
+            )
+
+            assert fixer(instance.id, AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer_test.py
@@ -29,25 +29,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_
     def test_ec2_sg_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
-        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
-        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
-        ]
-        default_sg_id = security_groups[0]["GroupId"]
+        ][0]
+        default_sg_id = default_sg["GroupId"]
         ec2_client.authorize_security_group_ingress(
             GroupId=default_sg_id,
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 9000,
-                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
-                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
-                },
-                {
-                    "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 9000,
+                    "FromPort": 10,
+                    "ToPort": 9100,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
                     "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
                 },
@@ -94,31 +87,18 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_
         ):
             # Create EC2 Mocked Resources
             ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
-            ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
-            security_groups = ec2_client.describe_security_groups(
-                GroupNames=["default"]
-            )["SecurityGroups"]
-            default_sg_id = security_groups[0]["GroupId"]
+            ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+            default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
+                "SecurityGroups"
+            ][0]
+            default_sg_id = default_sg["GroupId"]
             ec2_client.authorize_security_group_ingress(
                 GroupId=default_sg_id,
                 IpPermissions=[
                     {
                         "IpProtocol": "tcp",
-                        "FromPort": 20,
-                        "ToPort": 9000,
-                        "IpRanges": [
-                            {"CidrIp": "0.0.0.0/0"},
-                            {"CidrIp": "10.0.0.0/24"},
-                        ],
-                        "Ipv6Ranges": [
-                            {"CidrIpv6": "::/0"},
-                            {"CidrIpv6": "2001:db8::/32"},
-                        ],
-                    },
-                    {
-                        "IpProtocol": "tcp",
-                        "FromPort": 20,
-                        "ToPort": 9000,
+                        "FromPort": 10,
+                        "ToPort": 9100,
                         "IpRanges": [
                             {"CidrIp": "0.0.0.0/0"},
                             {"CidrIp": "10.0.0.0/24"},
@@ -168,19 +148,19 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_
     def test_ec2_sg_exposed_port_in_private_subnet_only_with_ip4(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
-        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
-        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
-        ]
-        default_sg_id = security_groups[0]["GroupId"]
+        ][0]
+        default_sg_id = default_sg["GroupId"]
         ec2_client.authorize_security_group_ingress(
             GroupId=default_sg_id,
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 9000,
-                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "FromPort": 10,
+                    "ToPort": 9100,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
                 },
             ],
         )
@@ -222,19 +202,19 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_
     def test_ec2_sg_exposed_port_in_private_subnet_only_with_ip6(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
-        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
-        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
-        ]
-        default_sg_id = security_groups[0]["GroupId"]
+        ][0]
+        default_sg_id = default_sg["GroupId"]
         ec2_client.authorize_security_group_ingress(
             GroupId=default_sg_id,
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 9000,
-                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                    "FromPort": 10,
+                    "ToPort": 9100,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}],
                 },
             ],
         )
@@ -276,20 +256,20 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_
     def test_ec2_sg_exposed_port_in_public_subnet_all_ports(self):
         # Create EC2 Mocked Resources
         ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
-        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
-        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+        default_sg = ec2_client.describe_security_groups(GroupNames=["default"])[
             "SecurityGroups"
-        ]
-        default_sg_id = security_groups[0]["GroupId"]
+        ][0]
+        default_sg_id = default_sg["GroupId"]
         ec2_client.authorize_security_group_ingress(
             GroupId=default_sg_id,
             IpPermissions=[
                 {
                     "IpProtocol": "tcp",
-                    "FromPort": 20,
-                    "ToPort": 9000,
+                    "FromPort": 10,
+                    "ToPort": 9100,
                     "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
-                },
+                }
             ],
         )
         ec2_client.audit_config = {

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer_test.py
@@ -1,0 +1,327 @@
+from unittest import mock
+
+import botocore
+import botocore.client
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_error(self, operation_name, kwarg):
+    if operation_name == "RevokeSecurityGroupIngress":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "InvalidPermission.NotFound",
+                    "Message": "The specified rule does not exist in this security group.",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer:
+    @mock_aws
+    def test_ec2_sg_exposed_port_in_private_subnet_with_ip4_and_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ]
+        default_sg_id = security_groups[0]["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 20,
+                    "ToPort": 9000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 20,
+                    "ToPort": 9000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        ec2_client.audit_config = {
+            "ec2_high_risk_ports": [
+                25,
+                110,
+                135,
+                143,
+                445,
+                3000,
+                4333,
+                5000,
+                5500,
+                8080,
+                8088,
+            ]
+        }
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer import (
+                fixer,
+            )
+
+            assert fixer(default_sg_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_sg_exposed_port_error(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call", new=mock_make_api_call_error
+        ):
+            # Create EC2 Mocked Resources
+            ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+            ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+            security_groups = ec2_client.describe_security_groups(
+                GroupNames=["default"]
+            )["SecurityGroups"]
+            default_sg_id = security_groups[0]["GroupId"]
+            ec2_client.authorize_security_group_ingress(
+                GroupId=default_sg_id,
+                IpPermissions=[
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 20,
+                        "ToPort": 9000,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 20,
+                        "ToPort": 9000,
+                        "IpRanges": [
+                            {"CidrIp": "0.0.0.0/0"},
+                            {"CidrIp": "10.0.0.0/24"},
+                        ],
+                        "Ipv6Ranges": [
+                            {"CidrIpv6": "::/0"},
+                            {"CidrIpv6": "2001:db8::/32"},
+                        ],
+                    },
+                ],
+            )
+            ec2_client.audit_config = {
+                "ec2_high_risk_ports": [
+                    25,
+                    110,
+                    135,
+                    143,
+                    445,
+                    3000,
+                    4333,
+                    5000,
+                    5500,
+                    8080,
+                    8088,
+                ]
+            }
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.ec2_client",
+                new=EC2(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer import (
+                    fixer,
+                )
+
+                assert not fixer(default_sg_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_sg_exposed_port_in_private_subnet_only_with_ip4(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ]
+        default_sg_id = security_groups[0]["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 20,
+                    "ToPort": 9000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}, {"CidrIp": "10.0.0.0/24"}],
+                },
+            ],
+        )
+        ec2_client.audit_config = {
+            "ec2_high_risk_ports": [
+                25,
+                110,
+                135,
+                143,
+                445,
+                3000,
+                4333,
+                5000,
+                5500,
+                8080,
+                8088,
+            ]
+        }
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer import (
+                fixer,
+            )
+
+            assert fixer(default_sg_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_sg_exposed_port_in_private_subnet_only_with_ip6(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ]
+        default_sg_id = security_groups[0]["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 20,
+                    "ToPort": 9000,
+                    "Ipv6Ranges": [{"CidrIpv6": "::/0"}, {"CidrIpv6": "2001:db8::/32"}],
+                },
+            ],
+        )
+        ec2_client.audit_config = {
+            "ec2_high_risk_ports": [
+                25,
+                110,
+                135,
+                143,
+                445,
+                3000,
+                4333,
+                5000,
+                5500,
+                8080,
+                8088,
+            ]
+        }
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer import (
+                fixer,
+            )
+
+            assert fixer(default_sg_id, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_ec2_sg_exposed_port_in_public_subnet_all_ports(self):
+        # Create EC2 Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_EU_WEST_1)
+        ec2_client.create_vpc(CidrBlock="10.0.0.0/16")
+        security_groups = ec2_client.describe_security_groups(GroupNames=["default"])[
+            "SecurityGroups"
+        ]
+        default_sg_id = security_groups[0]["GroupId"]
+        ec2_client.authorize_security_group_ingress(
+            GroupId=default_sg_id,
+            IpPermissions=[
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 20,
+                    "ToPort": 9000,
+                    "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                },
+            ],
+        )
+        ec2_client.audit_config = {
+            "ec2_high_risk_ports": [
+                25,
+                110,
+                135,
+                143,
+                445,
+                3000,
+                4333,
+                5000,
+                5500,
+                8080,
+                8088,
+            ]
+        }
+
+        from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ), mock.patch(
+            "prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.ec2_client",
+            new=EC2(aws_provider),
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer import (
+                fixer,
+            )
+
+            assert fixer(default_sg_id, AWS_REGION_EU_WEST_1)


### PR DESCRIPTION
### Context

As all this fixers are the same but with different ports I will do all in this single PR so it’s easier to code and to review.

This new fixers updates the security group rules for EC2 instances to restrict access to open ports, ensuring it is only accessible from trusted IP addresses or within private networks. This will enhance security by preventing unauthorized access and protecting sensitive data.

Also, there is a fixer that is for security groups with high risk ports open, but the way to fix this is so similar to the instances ones, that's the reason for adding it in this PR too.

### Description

Added all this new fixers with its unit tests:

- `ec2_instance_port_cassandra_exposed_to_internet_fixer`
- `ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer`
- `ec2_instance_port_ftp_exposed_to_internet_fixer`
- `ec2_instance_port_kafka_exposed_to_internet_fixer`
- `ec2_instance_port_kerberos_exposed_to_internet_fixer`
- `ec2_instance_port_ldap_exposed_to_internet_fixer`
- `ec2_instance_port_memcached_exposed_to_internet_fixer`
- `ec2_instance_port_mongodb_exposed_to_internet_fixer`
- `ec2_instance_port_mysql_exposed_to_internet_fixer`
- `ec2_instance_port_oracle_exposed_to_internet_fixer`
- `ec2_instance_port_postgresql_exposed_to_internet_fixer`
- `ec2_instance_port_rdp_exposed_to_internet_fixer`
- `ec2_instance_port_redis_exposed_to_internet_fixer`
- `ec2_instance_port_sqlserver_exposed_to_internet_fixer`
- `ec2_instance_port_ssh_exposed_to_internet_fixer`
- `ec2_instance_port_telnet_exposed_to_internet_fixer`
- `ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.