### PR TITLE
fix(aws): disallow child-accounts to overwrite policy for `ai_services_opt_out`

### DIFF
--- a/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.metadata.json
+++ b/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.metadata.json
@@ -1,14 +1,14 @@
 {
   "Provider": "aws",
   "CheckID": "organizations_opt_out_ai_services_policy",
-  "CheckTitle": "Ensure that AWS Organizations opt-out of AI services policy is enabled.",
+  "CheckTitle": "Ensure that AWS Organizations opt-out of AI services policy is enabled and disallow child-accounts to overwrite this policy.",
   "CheckType": [],
   "ServiceName": "organizations",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:service::account-id:organization/organization-id",
   "Severity": "low",
   "ResourceType": "Other",
-  "Description": "This control checks whether the AWS Organizations opt-out of AI services policy is enabled. The control fails if the policy is not enabled.",
+  "Description": "This control checks whether the AWS Organizations opt-out of AI services policy is enabled and whether child-accounts are disallowed to overwrite this policy. The control fails if the policy is not enabled or if child-accounts are not disallowed to overwrite this policy.",
   "Risk": "By default, AWS may be using your data to train its AI models. This may include data from your AWS CloudTrail logs, AWS Config rules, and AWS GuardDuty findings. If you opt out of AI services, AWS will not use your data to train its AI models.",
   "RelatedUrl": "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_ai-opt-out_all.html",
   "Remediation": {
@@ -19,7 +19,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Artificial Intelligence (AI) services opt-out policies enable you to control whether AWS AI services can store and use your content. Enable the AWS Organizations opt-out of AI services policy.",
+      "Text": "Artificial Intelligence (AI) services opt-out policies enable you to control whether AWS AI services can store and use your content. Enable the AWS Organizations opt-out of AI services policy and disallow child-accounts to overwrite this policy.",
       "Url": "https://docs.aws.amazon.com/organizations/latest/userguide/disable-policy-type.html"
     }
   },

--- a/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.metadata.json
+++ b/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.metadata.json
@@ -13,7 +13,7 @@
   "RelatedUrl": "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_ai-opt-out_all.html",
   "Remediation": {
     "Code": {
-      "CLI": "aws organizations enable-policy-type --root-id <root-id> --policy-type AI_SERVICES_OPT_OUT {'services': {'default': {'opt_out_policy': {'@@assign': 'optOut'}}}}",
+      "CLI": "",
       "NativeIaC": "",
       "Other": "",
       "Terraform": ""

--- a/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
+++ b/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
@@ -22,7 +22,6 @@ class organizations_opt_out_ai_services_policy(Check):
                 )
 
                 if organizations_client.organization.status == "ACTIVE":
-                    conditions_failed = []
                     all_conditions_passed = False
                     opt_out_policies = organizations_client.organization.policies.get(
                         "AISERVICES_OPT_OUT_POLICY", []
@@ -47,23 +46,16 @@ class organizations_opt_out_ai_services_policy(Check):
                                 all_conditions_passed = True
                                 break
 
-                            if not condition_1:
-                                conditions_failed.append(
-                                    "Organization has not opted out of all AI services."
-                                )
-                            if not condition_2:
-                                conditions_failed.append(
-                                    "Organization does not disallow child-accounts to overwrite the policy."
-                                )
+                            if not condition_1 and not condition_2:
+                                report.status_extended = f"AWS Organization {organizations_client.organization.id} has not opted out of all AI services and it does not disallow child-accounts to overwrite the policy."
+                            elif not condition_1:
+                                report.status_extended = f"AWS Organization {organizations_client.organization.id} has not opted out of all AI services."
+                            elif not condition_2:
+                                report.status_extended = f"AWS Organization {organizations_client.organization.id} has opted out of all AI services but it does not disallow child-accounts to overwrite the policy."
 
                         if all_conditions_passed:
                             report.status = "PASS"
                             report.status_extended = f"AWS Organization {organizations_client.organization.id} has opted out of all AI services and also disallows child-accounts to overwrite this policy."
-                        else:
-                            report.status_extended = (
-                                f"AWS Organization {organizations_client.organization.id} failed the check due to the following reason(s): "
-                                + " ".join(conditions_failed)
-                            )
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
+++ b/prowler/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy.py
@@ -30,10 +30,13 @@ class organizations_opt_out_ai_services_policy(Check):
                             .get("default", {})
                             .get("opt_out_policy", {})
                         )
-                        if (
-                            opt_out_policy.get("@@assign") == "optOut"
-                            and opt_out_policy.get("@@operators_allowed_for_child_policies") == ["@@none"]
-                        ):
+                        if opt_out_policy.get(
+                            "@@assign"
+                        ) == "optOut" and opt_out_policy.get(
+                            "@@operators_allowed_for_child_policies"
+                        ) == [
+                            "@@none"
+                        ]:
                             report.status = "PASS"
                             report.status_extended = f"AWS Organization {organizations_client.organization.id} has opted out of all AI services, not granting consent for AWS to access its data, and also disallows child-accounts to overwrite this policy."
                             break

--- a/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
+++ b/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
@@ -118,7 +118,14 @@ class Test_organizations_tags_policies_enabled_and_attached:
                         aws_managed=False,
                         content={
                             "services": {
-                                "default": {"opt_out_policy": {"@@operators_allowed_for_child_policies": ["@@none"], "@@assign": "optOut"}}
+                                "default": {
+                                    "opt_out_policy": {
+                                        "@@operators_allowed_for_child_policies": [
+                                            "@@none"
+                                        ],
+                                        "@@assign": "optOut",
+                                    }
+                                }
                             }
                         },
                         targets=[],
@@ -297,7 +304,13 @@ class Test_organizations_tags_policies_enabled_and_attached:
                         aws_managed=False,
                         content={
                             "services": {
-                                "default": {"opt_out_policy": {"@@operators_allowed_for_child_policies": ["@@none"]}}
+                                "default": {
+                                    "opt_out_policy": {
+                                        "@@operators_allowed_for_child_policies": [
+                                            "@@none"
+                                        ]
+                                    }
+                                }
                             }
                         },
                         targets=[],
@@ -337,4 +350,3 @@ class Test_organizations_tags_policies_enabled_and_attached:
                     == "arn:aws:organizations::1234567890:organization/o-1234567890"
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1
-

--- a/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
+++ b/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
@@ -141,12 +141,15 @@ class Test_organizations_tags_policies_enabled_and_attached:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ):
-            with mock.patch(
-                "prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy.organizations_client",
-                new=organizations_client,
-            ), mock.patch(
-                "prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy.organizations_client.get_unknown_arn",
-                return_value="arn:aws:organizations:eu-west-1:0123456789012:unknown",
+            with (
+                mock.patch(
+                    "prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy.organizations_client",
+                    new=organizations_client,
+                ),
+                mock.patch(
+                    "prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy.organizations_client.get_unknown_arn",
+                    return_value="arn:aws:organizations:eu-west-1:0123456789012:unknown",
+                ),
             ):
                 # Test Check
                 from prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy import (
@@ -216,7 +219,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 failed the check due to the following reason(s): Organization has not opted out of all AI services. Organization does not disallow child-accounts to overwrite the policy."
+                    == "AWS Organization o-1234567890 has not opted out of all AI services and it does not disallow child-accounts to overwrite the policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -276,7 +279,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 failed the check due to the following reason(s): Organization does not disallow child-accounts to overwrite the policy."
+                    == "AWS Organization o-1234567890 has opted out of all AI services but it does not disallow child-accounts to overwrite the policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -342,7 +345,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 failed the check due to the following reason(s): Organization has not opted out of all AI services."
+                    == "AWS Organization o-1234567890 has not opted out of all AI services."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (

--- a/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
+++ b/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
@@ -87,7 +87,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data."
+                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -96,7 +96,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1
 
-    def test_organization_with_AI_optout_policy(self):
+    def test_organization_with_AI_optout_policy_complete(self):
         organizations_client = mock.MagicMock
         organizations_client.region = AWS_REGION_EU_WEST_1
         organizations_client.audited_partition = "aws"
@@ -118,7 +118,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                         aws_managed=False,
                         content={
                             "services": {
-                                "default": {"opt_out_policy": {"@@assign": "optOut"}}
+                                "default": {"opt_out_policy": {"@@operators_allowed_for_child_policies": ["@@none"], "@@assign": "optOut"}}
                             }
                         },
                         targets=[],
@@ -153,7 +153,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has opted out of all AI services, not granting consent for AWS to access its data."
+                    == "AWS Organization o-1234567890 has opted out of all AI services, not granting consent for AWS to access its data, and also disallows child-accounts to overwrite this policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -209,7 +209,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data."
+                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -217,3 +217,124 @@ class Test_organizations_tags_policies_enabled_and_attached:
                     == "arn:aws:organizations::1234567890:organization/o-1234567890"
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_organization_with_AI_optout_policy_no_disallow(self):
+        organizations_client = mock.MagicMock
+        organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.audited_partition = "aws"
+        organizations_client.audited_account = "0123456789012"
+        organizations_client.organization = Organization(
+            id="o-1234567890",
+            arn="arn:aws:organizations::1234567890:organization/o-1234567890",
+            status="ACTIVE",
+            master_id="1234567890",
+            policies={
+                "AISERVICES_OPT_OUT_POLICY": [
+                    Policy(
+                        id="p-1234567890",
+                        arn="arn:aws:organizations::1234567890:policy/o-1234567890/p-1234567890",
+                        type="AISERVICES_OPT_OUT_POLICY",
+                        aws_managed=False,
+                        content={
+                            "services": {
+                                "default": {"opt_out_policy": {"@@assign": "optOut"}}
+                            }
+                        },
+                        targets=[],
+                    )
+                ]
+            },
+            delegated_administrators=None,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy.organizations_client",
+                new=organizations_client,
+            ):
+                # Test Check
+                from prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy import (
+                    organizations_opt_out_ai_services_policy,
+                )
+
+                check = organizations_opt_out_ai_services_policy()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
+                )
+                assert result[0].resource_id == "o-1234567890"
+                assert (
+                    result[0].resource_arn
+                    == "arn:aws:organizations::1234567890:organization/o-1234567890"
+                )
+                assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_organization_with_AI_optout_policy_no_opt_out(self):
+        organizations_client = mock.MagicMock
+        organizations_client.region = AWS_REGION_EU_WEST_1
+        organizations_client.audited_partition = "aws"
+        organizations_client.audited_account = "0123456789012"
+        organizations_client.organization = Organization(
+            id="o-1234567890",
+            arn="arn:aws:organizations::1234567890:organization/o-1234567890",
+            status="ACTIVE",
+            master_id="1234567890",
+            policies={
+                "AISERVICES_OPT_OUT_POLICY": [
+                    Policy(
+                        id="p-1234567890",
+                        arn="arn:aws:organizations::1234567890:policy/o-1234567890/p-1234567890",
+                        type="AISERVICES_OPT_OUT_POLICY",
+                        aws_managed=False,
+                        content={
+                            "services": {
+                                "default": {"opt_out_policy": {"@@operators_allowed_for_child_policies": ["@@none"]}}
+                            }
+                        },
+                        targets=[],
+                    )
+                ]
+            },
+            delegated_administrators=None,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy.organizations_client",
+                new=organizations_client,
+            ):
+                # Test Check
+                from prowler.providers.aws.services.organizations.organizations_opt_out_ai_services_policy.organizations_opt_out_ai_services_policy import (
+                    organizations_opt_out_ai_services_policy,
+                )
+
+                check = organizations_opt_out_ai_services_policy()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
+                )
+                assert result[0].resource_id == "o-1234567890"
+                assert (
+                    result[0].resource_arn
+                    == "arn:aws:organizations::1234567890:organization/o-1234567890"
+                )
+                assert result[0].region == AWS_REGION_EU_WEST_1
+

--- a/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
+++ b/tests/providers/aws/services/organizations/organizations_opt_out_ai_services_policy/organizations_opt_out_ai_services_policy_test.py
@@ -87,7 +87,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
+                    == "AWS Organization o-1234567890 has no opt-out policy for AI services."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -160,7 +160,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "PASS"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has opted out of all AI services, not granting consent for AWS to access its data, and also disallows child-accounts to overwrite this policy."
+                    == "AWS Organization o-1234567890 has opted out of all AI services and also disallows child-accounts to overwrite this policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -216,7 +216,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
+                    == "AWS Organization o-1234567890 failed the check due to the following reason(s): Organization has not opted out of all AI services. Organization does not disallow child-accounts to overwrite the policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -276,7 +276,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
+                    == "AWS Organization o-1234567890 failed the check due to the following reason(s): Organization does not disallow child-accounts to overwrite the policy."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (
@@ -342,7 +342,7 @@ class Test_organizations_tags_policies_enabled_and_attached:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
-                    == "AWS Organization o-1234567890 has not opted out of all AI services, granting consent for AWS to access its data, or does not disallow child-accounts to overwrite this policy."
+                    == "AWS Organization o-1234567890 failed the check due to the following reason(s): Organization has not opted out of all AI services."
                 )
                 assert result[0].resource_id == "o-1234567890"
                 assert (


### PR DESCRIPTION
### Context

The check `organizations_opt_out_ai_services_policy` just verifies that AWS Organizations opt-out of AI services policy is enabled. However, it does not check if child-accounts are disallowed to overwrite this policy. 
Since the check is only checking the AWS Organizations account and not the child accounts, it's important to check that child-accounts are disallowed to overwrite the opt-out policy.

### Description

This PR extends the check `organizations_opt_out_ai_services_policy` to ensure that AWS Organizations opt-out of AI services policy is enabled **and** that child-accounts are disallowed to overwrite this policy.

### Checklist

- Are there new checks included in this PR? Yes 
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.