### PR TITLE
docs: add note about containers arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/mast
 docker compose up -d
 ```
 
+> Containers are built for `linux/amd64`. If your workstation's architecture is different, please set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in your environment.
 > Enjoy Prowler App at http://localhost:3000 by signing up with your email and password.
 
 ### From GitHub

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,8 @@ Prowler App can be installed in different ways, depending on your environment:
     docker compose up -d
     ```
 
+    > Containers are built for `linux/amd64`. If your workstation's architecture is different, please set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in your environment.
+
     > Enjoy Prowler App at http://localhost:3000 by signing up with your email and password.
 
     ???+ note


### PR DESCRIPTION
### Description

Add a note about Prowler App container's architecture:

Containers are built for `linux/amd64`. If your workstation's architecture is different, please set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in your environment.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.