### PR TITLE
ref(rbac): enable relationship creation when objects is created

### DIFF
--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -309,7 +309,7 @@ class ProviderGroup(RowLevelSecurityProtectedModel):
         ]
 
     class JSONAPIMeta:
-        resource_name = "provider-group"
+        resource_name = "provider-groups"
 
 
 class ProviderGroupMembership(RowLevelSecurityProtectedModel):
@@ -926,7 +926,7 @@ class Role(RowLevelSecurityProtectedModel):
         ]
 
     class JSONAPIMeta:
-        resource_name = "role"
+        resource_name = "roles"
 
 
 class RoleProviderGroupRelationship(RowLevelSecurityProtectedModel):

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -1833,13 +1833,13 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: '#/components/schemas/ProviderGroupRequest'
+              $ref: '#/components/schemas/ProviderGroupCreateRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProviderGroupRequest'
+              $ref: '#/components/schemas/ProviderGroupCreateRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProviderGroupRequest'
+              $ref: '#/components/schemas/ProviderGroupCreateRequest'
         required: true
       security:
       - jwtAuth: []
@@ -1848,7 +1848,7 @@ paths:
           content:
             application/vnd.api+json:
               schema:
-                $ref: '#/components/schemas/ProviderGroupResponse'
+                $ref: '#/components/schemas/ProviderGroupCreateResponse'
           description: ''
   /api/v1/provider-groups/{id}:
     get:
@@ -7383,7 +7383,7 @@ components:
       properties:
         type:
           allOf:
-          - $ref: '#/components/schemas/ProviderGroupTypeEnum'
+          - $ref: '#/components/schemas/Type34dEnum'
           description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
             member is used to describe resource objects that share common attributes
             and relationships.
@@ -7465,35 +7465,94 @@ components:
               - data
               description: A related resource object from type roles
               title: roles
-    ProviderGroupMembershipRequest:
+    ProviderGroupCreate:
       type: object
+      required:
+      - type
+      additionalProperties: false
       properties:
-        data:
+        type:
+          allOf:
+          - $ref: '#/components/schemas/Type34dEnum'
+          description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+            member is used to describe resource objects that share common attributes
+            and relationships.
+        attributes:
           type: object
-          required:
-          - type
-          additionalProperties: false
           properties:
-            type:
+            name:
               type: string
-              description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
-                member is used to describe resource objects that share common attributes
-                and relationships.
-              enum:
-              - provider_groups-provider
-            attributes:
+              maxLength: 255
+            inserted_at:
+              type: string
+              format: date-time
+              readOnly: true
+            updated_at:
+              type: string
+              format: date-time
+              readOnly: true
+          required:
+          - name
+        relationships:
+          type: object
+          properties:
+            providers:
               type: object
               properties:
-                providers:
+                data:
                   type: array
                   items:
-                    $ref: '#/components/schemas/ProviderResourceIdentifierRequest'
-                  description: List of resource identifier objects representing providers.
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        title: Resource Identifier
+                        description: The identifier of the related object.
+                      type:
+                        type: string
+                        enum:
+                        - providers
+                        title: Resource Type Name
+                        description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                          member is used to describe resource objects that share common
+                          attributes and relationships.
+                    required:
+                    - id
+                    - type
               required:
-              - providers
-      required:
-      - data
-    ProviderGroupRequest:
+              - data
+              description: A related resource object from type providers
+              title: providers
+            roles:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        title: Resource Identifier
+                        description: The identifier of the related object.
+                      type:
+                        type: string
+                        enum:
+                        - roles
+                        title: Resource Type Name
+                        description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                          member is used to describe resource objects that share common
+                          attributes and relationships.
+                    required:
+                    - id
+                    - type
+              required:
+              - data
+              description: A related resource object from type roles
+              title: roles
+    ProviderGroupCreateRequest:
       type: object
       properties:
         data:
@@ -7587,6 +7646,41 @@ components:
                   title: roles
       required:
       - data
+    ProviderGroupCreateResponse:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/ProviderGroupCreate'
+      required:
+      - data
+    ProviderGroupMembershipRequest:
+      type: object
+      properties:
+        data:
+          type: object
+          required:
+          - type
+          additionalProperties: false
+          properties:
+            type:
+              type: string
+              description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                member is used to describe resource objects that share common attributes
+                and relationships.
+              enum:
+              - provider_groups-provider
+            attributes:
+              type: object
+              properties:
+                providers:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ProviderResourceIdentifierRequest'
+                  description: List of resource identifier objects representing providers.
+              required:
+              - providers
+      required:
+      - data
     ProviderGroupResourceIdentifierRequest:
       type: object
       properties:
@@ -7624,10 +7718,6 @@ components:
           $ref: '#/components/schemas/ProviderGroup'
       required:
       - data
-    ProviderGroupTypeEnum:
-      type: string
-      enum:
-      - provider-groups
     ProviderResourceIdentifierRequest:
       type: object
       properties:
@@ -8501,7 +8591,6 @@ components:
               - data
               description: A related resource object from type provider-groups
               title: provider-groups
-              readOnly: true
             users:
               type: object
               properties:
@@ -8530,7 +8619,6 @@ components:
               - data
               description: A related resource object from type users
               title: users
-              readOnly: true
             invitations:
               type: object
               properties:
@@ -9512,6 +9600,10 @@ components:
       type: string
       enum:
       - providers
+    Type34dEnum:
+      type: string
+      enum:
+      - provider-groups
     Type6bbEnum:
       type: string
       enum:
@@ -9664,37 +9756,6 @@ components:
           - name
           - password
           - email
-        relationships:
-          type: object
-          properties:
-            roles:
-              type: object
-              properties:
-                data:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        format: uuid
-                        title: Resource Identifier
-                        description: The identifier of the related object.
-                      type:
-                        type: string
-                        enum:
-                        - roles
-                        title: Resource Type Name
-                        description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
-                          member is used to describe resource objects that share common
-                          attributes and relationships.
-                    required:
-                    - id
-                    - type
-              required:
-              - data
-              description: A related resource object from type roles
-              title: roles
     UserCreateRequest:
       type: object
       properties:
@@ -9735,37 +9796,6 @@ components:
               - name
               - password
               - email
-            relationships:
-              type: object
-              properties:
-                roles:
-                  type: object
-                  properties:
-                    data:
-                      type: array
-                      items:
-                        type: object
-                        properties:
-                          id:
-                            type: string
-                            format: uuid
-                            title: Resource Identifier
-                            description: The identifier of the related object.
-                          type:
-                            type: string
-                            enum:
-                            - roles
-                            title: Resource Type Name
-                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
-                              member is used to describe resource objects that share
-                              common attributes and relationships.
-                        required:
-                        - id
-                        - type
-                  required:
-                  - data
-                  description: A related resource object from type roles
-                  title: roles
       required:
       - data
     UserCreateResponse:

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -1696,7 +1696,7 @@ paths:
       summary: List all provider groups
       parameters:
       - in: query
-        name: fields[provider-group]
+        name: fields[provider-groups]
         schema:
           type: array
           items:
@@ -1858,7 +1858,7 @@ paths:
       summary: Retrieve data from a provider group
       parameters:
       - in: query
-        name: fields[provider-group]
+        name: fields[provider-groups]
         schema:
           type: array
           items:
@@ -2939,7 +2939,7 @@ paths:
       summary: List all roles
       parameters:
       - in: query
-        name: fields[role]
+        name: fields[roles]
         schema:
           type: array
           items:
@@ -3138,7 +3138,7 @@ paths:
       summary: Retrieve data from a role
       parameters:
       - in: query
-        name: fields[role]
+        name: fields[roles]
         schema:
           type: array
           items:
@@ -3750,6 +3750,7 @@ paths:
         name: filter[state]
         schema:
           type: string
+          title: Task State
           enum:
           - available
           - cancelled
@@ -3758,6 +3759,8 @@ paths:
           - failed
           - scheduled
         description: |-
+          Current state of the task being run
+
           * `available` - Available
           * `scheduled` - Scheduled
           * `executing` - Executing
@@ -5536,7 +5539,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - role
+                        - roles
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -5546,8 +5549,8 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type role
-              title: role
+              description: A related resource object from type roles
+              title: roles
             inviter:
               type: object
               properties:
@@ -5689,7 +5692,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - role
+                        - roles
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -5699,8 +5702,8 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type role
-              title: role
+              description: A related resource object from type roles
+              title: roles
           required:
           - roles
     InvitationCreateRequest:
@@ -5796,7 +5799,7 @@ components:
                           type:
                             type: string
                             enum:
-                            - role
+                            - roles
                             title: Resource Type Name
                             description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                               member is used to describe resource objects that share
@@ -5806,8 +5809,8 @@ components:
                         - type
                   required:
                   - data
-                  description: A related resource object from type role
-                  title: role
+                  description: A related resource object from type roles
+                  title: roles
               required:
               - roles
       required:
@@ -5887,7 +5890,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - role
+                        - roles
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -5897,8 +5900,8 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type role
-              title: role
+              description: A related resource object from type roles
+              title: roles
           required:
           - roles
     InvitationUpdateResponse:
@@ -6422,7 +6425,7 @@ components:
                           type:
                             type: string
                             enum:
-                            - role
+                            - roles
                             title: Resource Type Name
                             description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                               member is used to describe resource objects that share
@@ -6432,8 +6435,8 @@ components:
                         - type
                   required:
                   - data
-                  description: A related resource object from type role
-                  title: role
+                  description: A related resource object from type roles
+                  title: roles
               required:
               - roles
       required:
@@ -6486,7 +6489,7 @@ components:
                 member is used to describe resource objects that share common attributes
                 and relationships.
               enum:
-              - provider-group
+              - provider-groups
             id:
               type: string
               format: uuid
@@ -6497,8 +6500,75 @@ components:
                   type: string
                   minLength: 1
                   maxLength: 255
+                inserted_at:
+                  type: string
+                  format: date-time
+                  readOnly: true
+                updated_at:
+                  type: string
+                  format: date-time
+                  readOnly: true
               required:
               - name
+            relationships:
+              type: object
+              properties:
+                providers:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                            title: Resource Identifier
+                            description: The identifier of the related object.
+                          type:
+                            type: string
+                            enum:
+                            - providers
+                            title: Resource Type Name
+                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                              member is used to describe resource objects that share
+                              common attributes and relationships.
+                        required:
+                        - id
+                        - type
+                  required:
+                  - data
+                  description: A related resource object from type providers
+                  title: providers
+                roles:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                            title: Resource Identifier
+                            description: The identifier of the related object.
+                          type:
+                            type: string
+                            enum:
+                            - roles
+                            title: Resource Type Name
+                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                              member is used to describe resource objects that share
+                              common attributes and relationships.
+                        required:
+                        - id
+                        - type
+                  required:
+                  - data
+                  description: A related resource object from type roles
+                  title: roles
       required:
       - data
     PatchedProviderSecretUpdateRequest:
@@ -6765,7 +6835,7 @@ components:
                 member is used to describe resource objects that share common attributes
                 and relationships.
               enum:
-              - role
+              - roles
             id:
               type: string
               format: uuid
@@ -6788,10 +6858,109 @@ components:
                   type: boolean
                 manage_scans:
                   type: boolean
+                permission_state:
+                  type: string
+                  readOnly: true
                 unlimited_visibility:
                   type: boolean
+                inserted_at:
+                  type: string
+                  format: date-time
+                  readOnly: true
+                updated_at:
+                  type: string
+                  format: date-time
+                  readOnly: true
               required:
               - name
+            relationships:
+              type: object
+              properties:
+                provider_groups:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                            title: Resource Identifier
+                            description: The identifier of the related object.
+                          type:
+                            type: string
+                            enum:
+                            - provider-groups
+                            title: Resource Type Name
+                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                              member is used to describe resource objects that share
+                              common attributes and relationships.
+                        required:
+                        - id
+                        - type
+                  required:
+                  - data
+                  description: A related resource object from type provider-groups
+                  title: provider-groups
+                users:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                            title: Resource Identifier
+                            description: The identifier of the related object.
+                          type:
+                            type: string
+                            enum:
+                            - users
+                            title: Resource Type Name
+                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                              member is used to describe resource objects that share
+                              common attributes and relationships.
+                        required:
+                        - id
+                        - type
+                  required:
+                  - data
+                  description: A related resource object from type users
+                  title: users
+                invitations:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                            title: Resource Identifier
+                            description: The identifier of the related object.
+                          type:
+                            type: string
+                            enum:
+                            - invitations
+                            title: Resource Type Name
+                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                              member is used to describe resource objects that share
+                              common attributes and relationships.
+                        required:
+                        - id
+                        - type
+                  required:
+                  - data
+                  description: A related resource object from type invitations
+                  title: invitations
+                  readOnly: true
       required:
       - data
     PatchedScanUpdateRequest:
@@ -6962,6 +7131,37 @@ components:
               required:
               - name
               - email
+            relationships:
+              type: object
+              properties:
+                roles:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                            title: Resource Identifier
+                            description: The identifier of the related object.
+                          type:
+                            type: string
+                            enum:
+                            - roles
+                            title: Resource Type Name
+                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                              member is used to describe resource objects that share
+                              common attributes and relationships.
+                        required:
+                        - id
+                        - type
+                  required:
+                  - data
+                  description: A related resource object from type roles
+                  title: roles
       required:
       - data
     Provider:
@@ -7068,7 +7268,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - provider-group
+                        - provider-groups
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -7078,8 +7278,8 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type provider-group
-              title: provider-group
+              description: A related resource object from type provider-groups
+              title: provider-groups
               readOnly: true
           required:
           - secret
@@ -7237,7 +7437,6 @@ components:
               - data
               description: A related resource object from type providers
               title: providers
-              readOnly: true
             roles:
               type: object
               properties:
@@ -7254,7 +7453,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - role
+                        - roles
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -7264,9 +7463,8 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type role
-              title: role
-              readOnly: true
+              description: A related resource object from type roles
+              title: roles
     ProviderGroupMembershipRequest:
       type: object
       properties:
@@ -7310,7 +7508,7 @@ components:
                 member is used to describe resource objects that share common attributes
                 and relationships.
               enum:
-              - provider-group
+              - provider-groups
             attributes:
               type: object
               properties:
@@ -7359,7 +7557,6 @@ components:
                   - data
                   description: A related resource object from type providers
                   title: providers
-                  readOnly: true
                 roles:
                   type: object
                   properties:
@@ -7376,7 +7573,7 @@ components:
                           type:
                             type: string
                             enum:
-                            - role
+                            - roles
                             title: Resource Type Name
                             description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                               member is used to describe resource objects that share
@@ -7386,9 +7583,8 @@ components:
                         - type
                   required:
                   - data
-                  description: A related resource object from type role
-                  title: role
-                  readOnly: true
+                  description: A related resource object from type roles
+                  title: roles
       required:
       - data
     ProviderGroupResourceIdentifierRequest:
@@ -7431,7 +7627,7 @@ components:
     ProviderGroupTypeEnum:
       type: string
       enum:
-      - provider-group
+      - provider-groups
     ProviderResourceIdentifierRequest:
       type: object
       properties:
@@ -8234,7 +8430,7 @@ components:
       properties:
         type:
           allOf:
-          - $ref: '#/components/schemas/Type1aaEnum'
+          - $ref: '#/components/schemas/Type6bbEnum'
           description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
             member is used to describe resource objects that share common attributes
             and relationships.
@@ -8293,7 +8489,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - provider-group
+                        - provider-groups
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -8303,8 +8499,9 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type provider-group
-              title: provider-group
+              description: A related resource object from type provider-groups
+              title: provider-groups
+              readOnly: true
             users:
               type: object
               properties:
@@ -8363,8 +8560,6 @@ components:
               description: A related resource object from type invitations
               title: invitations
               readOnly: true
-          required:
-          - provider_groups
     RoleCreate:
       type: object
       required:
@@ -8373,7 +8568,7 @@ components:
       properties:
         type:
           allOf:
-          - $ref: '#/components/schemas/Type1aaEnum'
+          - $ref: '#/components/schemas/Type6bbEnum'
           description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
             member is used to describe resource objects that share common attributes
             and relationships.
@@ -8429,7 +8624,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - provider-group
+                        - provider-groups
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -8439,8 +8634,8 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type provider-group
-              title: provider-group
+              description: A related resource object from type provider-groups
+              title: provider-groups
             users:
               type: object
               properties:
@@ -8469,7 +8664,6 @@ components:
               - data
               description: A related resource object from type users
               title: users
-              readOnly: true
             invitations:
               type: object
               properties:
@@ -8499,8 +8693,6 @@ components:
               description: A related resource object from type invitations
               title: invitations
               readOnly: true
-          required:
-          - provider_groups
     RoleCreateRequest:
       type: object
       properties:
@@ -8516,7 +8708,7 @@ components:
                 member is used to describe resource objects that share common attributes
                 and relationships.
               enum:
-              - role
+              - roles
             attributes:
               type: object
               properties:
@@ -8570,7 +8762,7 @@ components:
                           type:
                             type: string
                             enum:
-                            - provider-group
+                            - provider-groups
                             title: Resource Type Name
                             description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                               member is used to describe resource objects that share
@@ -8580,8 +8772,8 @@ components:
                         - type
                   required:
                   - data
-                  description: A related resource object from type provider-group
-                  title: provider-group
+                  description: A related resource object from type provider-groups
+                  title: provider-groups
                 users:
                   type: object
                   properties:
@@ -8610,7 +8802,6 @@ components:
                   - data
                   description: A related resource object from type users
                   title: users
-                  readOnly: true
                 invitations:
                   type: object
                   properties:
@@ -8640,8 +8831,6 @@ components:
                   description: A related resource object from type invitations
                   title: invitations
                   readOnly: true
-              required:
-              - provider_groups
       required:
       - data
     RoleCreateResponse:
@@ -9319,14 +9508,14 @@ components:
       type: string
       enum:
       - provider-secrets
-    Type1aaEnum:
-      type: string
-      enum:
-      - role
     Type227Enum:
       type: string
       enum:
       - providers
+    Type6bbEnum:
+      type: string
+      enum:
+      - roles
     Type7f7Enum:
       type: string
       enum:
@@ -9429,7 +9618,7 @@ components:
                       type:
                         type: string
                         enum:
-                        - role
+                        - roles
                         title: Resource Type Name
                         description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
                           member is used to describe resource objects that share common
@@ -9439,8 +9628,8 @@ components:
                     - type
               required:
               - data
-              description: A related resource object from type role
-              title: role
+              description: A related resource object from type roles
+              title: roles
               readOnly: true
     UserCreate:
       type: object
@@ -9475,6 +9664,37 @@ components:
           - name
           - password
           - email
+        relationships:
+          type: object
+          properties:
+            roles:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        title: Resource Identifier
+                        description: The identifier of the related object.
+                      type:
+                        type: string
+                        enum:
+                        - roles
+                        title: Resource Type Name
+                        description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                          member is used to describe resource objects that share common
+                          attributes and relationships.
+                    required:
+                    - id
+                    - type
+              required:
+              - data
+              description: A related resource object from type roles
+              title: roles
     UserCreateRequest:
       type: object
       properties:
@@ -9515,6 +9735,37 @@ components:
               - name
               - password
               - email
+            relationships:
+              type: object
+              properties:
+                roles:
+                  type: object
+                  properties:
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            format: uuid
+                            title: Resource Identifier
+                            description: The identifier of the related object.
+                          type:
+                            type: string
+                            enum:
+                            - roles
+                            title: Resource Type Name
+                            description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                              member is used to describe resource objects that share
+                              common attributes and relationships.
+                        required:
+                        - id
+                        - type
+                  required:
+                  - data
+                  description: A related resource object from type roles
+                  title: roles
       required:
       - data
     UserCreateResponse:
@@ -9596,6 +9847,37 @@ components:
           required:
           - name
           - email
+        relationships:
+          type: object
+          properties:
+            roles:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                        title: Resource Identifier
+                        description: The identifier of the related object.
+                      type:
+                        type: string
+                        enum:
+                        - roles
+                        title: Resource Type Name
+                        description: The [type](https://jsonapi.org/format/#document-resource-object-identification)
+                          member is used to describe resource objects that share common
+                          attributes and relationships.
+                    required:
+                    - id
+                    - type
+              required:
+              - data
+              description: A related resource object from type roles
+              title: roles
     UserUpdateResponse:
       type: object
       properties:

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -2834,9 +2834,10 @@ class TestInvitationViewSet:
         )
 
     def test_invitations_partial_update_valid(
-        self, authenticated_client, invitations_fixture
+        self, authenticated_client, invitations_fixture, roles_fixture
     ):
         invitation, *_ = invitations_fixture
+        role1, role2, *_ = roles_fixture
         new_email = "new_email@prowler.com"
         new_expires_at = datetime.now(timezone.utc) + timedelta(days=7)
         new_expires_at_iso = new_expires_at.isoformat()
@@ -2847,6 +2848,14 @@ class TestInvitationViewSet:
                 "attributes": {
                     "email": new_email,
                     "expires_at": new_expires_at_iso,
+                },
+                "relationships": {
+                    "roles": {
+                        "data": [
+                            {"type": "roles", "id": str(role1.id)},
+                            {"type": "roles", "id": str(role2.id)},
+                        ]
+                    },
                 },
             }
         }
@@ -2866,6 +2875,7 @@ class TestInvitationViewSet:
 
         assert invitation.email == new_email
         assert invitation.expires_at == new_expires_at
+        assert invitation.roles.count() == 2
 
     @pytest.mark.parametrize(
         "email",

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -815,7 +815,7 @@ class TestProviderViewSet:
     @pytest.mark.parametrize(
         "include_values, expected_resources",
         [
-            ("provider_groups", ["provider-group"]),
+            ("provider_groups", ["provider-groups"]),
         ],
     )
     def test_providers_list_include(
@@ -1200,7 +1200,7 @@ class TestProviderGroupViewSet:
     def test_provider_group_create(self, authenticated_client):
         data = {
             "data": {
-                "type": "provider-group",
+                "type": "provider-groups",
                 "attributes": {
                     "name": "Test Provider Group",
                 },
@@ -1219,7 +1219,7 @@ class TestProviderGroupViewSet:
     def test_provider_group_create_invalid(self, authenticated_client):
         data = {
             "data": {
-                "type": "provider-group",
+                "type": "provider-groups",
                 "attributes": {
                     # Name is missing
                 },
@@ -1241,7 +1241,7 @@ class TestProviderGroupViewSet:
         data = {
             "data": {
                 "id": str(provider_group.id),
-                "type": "provider-group",
+                "type": "provider-groups",
                 "attributes": {
                     "name": "Updated Provider Group Name",
                 },
@@ -1263,7 +1263,7 @@ class TestProviderGroupViewSet:
         data = {
             "data": {
                 "id": str(provider_group.id),
-                "type": "provider-group",
+                "type": "provider-groups",
                 "attributes": {
                     "name": "",  # Invalid name
                 },
@@ -1326,6 +1326,170 @@ class TestProviderGroupViewSet:
     def test_provider_group_invalid_method(self, authenticated_client):
         response = authenticated_client.put(reverse("providergroup-list"))
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_provider_group_create_with_relationships(
+        self, authenticated_client, providers_fixture, roles_fixture
+    ):
+        provider1, provider2, *_ = providers_fixture
+        role1, role2, *_ = roles_fixture
+
+        data = {
+            "data": {
+                "type": "provider-groups",
+                "attributes": {"name": "Test Provider Group with relationships"},
+                "relationships": {
+                    "providers": {
+                        "data": [
+                            {"type": "providers", "id": str(provider1.id)},
+                            {"type": "providers", "id": str(provider2.id)},
+                        ]
+                    },
+                    "roles": {
+                        "data": [
+                            {"type": "roles", "id": str(role1.id)},
+                            {"type": "roles", "id": str(role2.id)},
+                        ]
+                    },
+                },
+            }
+        }
+
+        response = authenticated_client.post(
+            reverse("providergroup-list"),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()["data"]
+        group = ProviderGroup.objects.get(id=response_data["id"])
+        assert group.name == "Test Provider Group with relationships"
+        assert set(group.providers.all()) == {provider1, provider2}
+        assert set(group.roles.all()) == {role1, role2}
+
+    def test_provider_group_update_relationships(
+        self,
+        authenticated_client,
+        provider_groups_fixture,
+        providers_fixture,
+        roles_fixture,
+    ):
+        group = provider_groups_fixture[0]
+        provider3 = providers_fixture[2]
+        provider4 = providers_fixture[3]
+        role3 = roles_fixture[2]
+        role4 = roles_fixture[3]
+
+        data = {
+            "data": {
+                "id": str(group.id),
+                "type": "provider-groups",
+                "relationships": {
+                    "providers": {
+                        "data": [
+                            {"type": "providers", "id": str(provider3.id)},
+                            {"type": "providers", "id": str(provider4.id)},
+                        ]
+                    },
+                    "roles": {
+                        "data": [
+                            {"type": "roles", "id": str(role3.id)},
+                            {"type": "roles", "id": str(role4.id)},
+                        ]
+                    },
+                },
+            }
+        }
+
+        response = authenticated_client.patch(
+            reverse("providergroup-detail", kwargs={"pk": group.id}),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        group.refresh_from_db()
+        assert set(group.providers.all()) == {provider3, provider4}
+        assert set(group.roles.all()) == {role3, role4}
+
+    def test_provider_group_clear_relationships(
+        self, authenticated_client, providers_fixture, provider_groups_fixture
+    ):
+        group = provider_groups_fixture[0]
+        provider3 = providers_fixture[2]
+        provider4 = providers_fixture[3]
+
+        data = {
+            "data": {
+                "id": str(group.id),
+                "type": "provider-groups",
+                "relationships": {
+                    "providers": {
+                        "data": [
+                            {"type": "providers", "id": str(provider3.id)},
+                            {"type": "providers", "id": str(provider4.id)},
+                        ]
+                    }
+                },
+            }
+        }
+
+        response = authenticated_client.patch(
+            reverse("providergroup-detail", kwargs={"pk": group.id}),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        data = {
+            "data": {
+                "id": str(group.id),
+                "type": "provider-groups",
+                "relationships": {
+                    "providers": {
+                        "data": []  # Removing all providers
+                    },
+                    "roles": {
+                        "data": []  # Removing all roles
+                    },
+                },
+            }
+        }
+
+        response = authenticated_client.patch(
+            reverse("providergroup-detail", kwargs={"pk": group.id}),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        group.refresh_from_db()
+        assert group.providers.count() == 0
+        assert group.roles.count() == 0
+
+    def test_provider_group_create_with_invalid_relationships(
+        self, authenticated_client
+    ):
+        invalid_provider_id = "non-existent-id"
+        data = {
+            "data": {
+                "type": "provider-groups",
+                "attributes": {"name": "Invalid relationships test"},
+                "relationships": {
+                    "providers": {
+                        "data": [{"type": "providers", "id": invalid_provider_id}]
+                    }
+                },
+            }
+        }
+
+        response = authenticated_client.post(
+            reverse("providergroup-list"),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        assert response.status_code in [status.HTTP_400_BAD_REQUEST]
 
 
 @pytest.mark.django_db
@@ -2571,7 +2735,7 @@ class TestInvitationViewSet:
                 },
                 "relationships": {
                     "roles": {
-                        "data": [{"type": "role", "id": str(roles_fixture[0].id)}]
+                        "data": [{"type": "roles", "id": str(roles_fixture[0].id)}]
                     }
                 },
             }
@@ -3121,7 +3285,7 @@ class TestRoleViewSet:
     def test_role_create(self, authenticated_client):
         data = {
             "data": {
-                "type": "role",
+                "type": "roles",
                 "attributes": {
                     "name": "Test Role",
                     "manage_users": "false",
@@ -3150,7 +3314,7 @@ class TestRoleViewSet:
     ):
         data = {
             "data": {
-                "type": "role",
+                "type": "roles",
                 "attributes": {
                     "name": "Test Role",
                     "manage_users": "false",
@@ -3164,7 +3328,7 @@ class TestRoleViewSet:
                 "relationships": {
                     "provider_groups": {
                         "data": [
-                            {"type": "provider-group", "id": str(provider_group.id)}
+                            {"type": "provider-groups", "id": str(provider_group.id)}
                             for provider_group in provider_groups_fixture[:2]
                         ]
                     }
@@ -3190,7 +3354,7 @@ class TestRoleViewSet:
     def test_role_create_invalid(self, authenticated_client):
         data = {
             "data": {
-                "type": "role",
+                "type": "roles",
                 "attributes": {
                     # Name is missing
                 },
@@ -3210,7 +3374,7 @@ class TestRoleViewSet:
         data = {
             "data": {
                 "id": str(role.id),
-                "type": "role",
+                "type": "roles",
                 "attributes": {
                     "name": "Updated Provider Group Name",
                 },
@@ -3230,7 +3394,7 @@ class TestRoleViewSet:
         data = {
             "data": {
                 "id": str(role.id),
-                "type": "role",
+                "type": "roles",
                 "attributes": {
                     "name": "",  # Invalid name
                 },
@@ -3290,6 +3454,162 @@ class TestRoleViewSet:
         response = authenticated_client.put(reverse("role-list"))
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
+    def test_role_create_with_users_and_provider_groups(
+        self, authenticated_client, users_fixture, provider_groups_fixture
+    ):
+        user1, user2, *_ = users_fixture
+        pg1, pg2, *_ = provider_groups_fixture
+
+        data = {
+            "data": {
+                "type": "roles",
+                "attributes": {
+                    "name": "Role with Users and PGs",
+                    "manage_users": "true",
+                    "manage_account": "false",
+                    "manage_billing": "true",
+                    "manage_providers": "true",
+                    "manage_integrations": "false",
+                    "manage_scans": "false",
+                    "unlimited_visibility": "false",
+                },
+                "relationships": {
+                    "users": {
+                        "data": [
+                            {"type": "users", "id": str(user1.id)},
+                            {"type": "users", "id": str(user2.id)},
+                        ]
+                    },
+                    "provider_groups": {
+                        "data": [
+                            {"type": "provider-groups", "id": str(pg1.id)},
+                            {"type": "provider-groups", "id": str(pg2.id)},
+                        ]
+                    },
+                },
+            }
+        }
+
+        response = authenticated_client.post(
+            reverse("role-list"),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        created_role = Role.objects.get(name="Role with Users and PGs")
+
+        assert created_role.users.count() == 2
+        assert set(created_role.users.all()) == {user1, user2}
+
+        assert created_role.provider_groups.count() == 2
+        assert set(created_role.provider_groups.all()) == {pg1, pg2}
+
+    def test_role_update_relationships(
+        self,
+        authenticated_client,
+        roles_fixture,
+        users_fixture,
+        provider_groups_fixture,
+    ):
+        role = roles_fixture[0]
+        user3 = users_fixture[2]
+        pg3 = provider_groups_fixture[2]
+
+        data = {
+            "data": {
+                "id": str(role.id),
+                "type": "roles",
+                "relationships": {
+                    "users": {
+                        "data": [
+                            {"type": "users", "id": str(user3.id)},
+                        ]
+                    },
+                    "provider_groups": {
+                        "data": [
+                            {"type": "provider-groups", "id": str(pg3.id)},
+                        ]
+                    },
+                },
+            }
+        }
+
+        response = authenticated_client.patch(
+            reverse("role-detail", kwargs={"pk": role.id}),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        role.refresh_from_db()
+
+        assert role.users.count() == 1
+        assert role.users.first() == user3
+        assert role.provider_groups.count() == 1
+        assert role.provider_groups.first() == pg3
+
+    def test_role_clear_relationships(self, authenticated_client, roles_fixture):
+        role = roles_fixture[0]
+        data = {
+            "data": {
+                "id": str(role.id),
+                "type": "roles",
+                "relationships": {
+                    "users": {
+                        "data": []  # Clearing all users
+                    },
+                    "provider_groups": {
+                        "data": []  # Clearing all provider groups
+                    },
+                },
+            }
+        }
+
+        response = authenticated_client.patch(
+            reverse("role-detail", kwargs={"pk": role.id}),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        role.refresh_from_db()
+        assert role.users.count() == 0
+        assert role.provider_groups.count() == 0
+
+    def test_role_create_with_invalid_user_relationship(
+        self, authenticated_client, provider_groups_fixture
+    ):
+        invalid_user_id = "non-existent-user-id"
+        pg = provider_groups_fixture[0]
+
+        data = {
+            "data": {
+                "type": "roles",
+                "attributes": {
+                    "name": "Invalid Users Role",
+                    "manage_users": "false",
+                    "manage_account": "false",
+                    "manage_billing": "false",
+                    "manage_providers": "true",
+                    "manage_integrations": "true",
+                    "manage_scans": "true",
+                    "unlimited_visibility": "true",
+                },
+                "relationships": {
+                    "users": {"data": [{"type": "users", "id": invalid_user_id}]},
+                    "provider_groups": {
+                        "data": [{"type": "provider-groups", "id": str(pg.id)}]
+                    },
+                },
+            }
+        }
+
+        response = authenticated_client.post(
+            reverse("role-list"),
+            data=json.dumps(data),
+            content_type="application/vnd.api+json",
+        )
+
+        assert response.status_code in [status.HTTP_400_BAD_REQUEST]
+
 
 @pytest.mark.django_db
 class TestUserRoleRelationshipViewSet:
@@ -3297,7 +3617,9 @@ class TestUserRoleRelationshipViewSet:
         self, authenticated_client, roles_fixture, create_test_user
     ):
         data = {
-            "data": [{"type": "role", "id": str(role.id)} for role in roles_fixture[:2]]
+            "data": [
+                {"type": "roles", "id": str(role.id)} for role in roles_fixture[:2]
+            ]
         }
         response = authenticated_client.post(
             reverse("user-roles-relationship", kwargs={"pk": create_test_user.id}),
@@ -3314,7 +3636,9 @@ class TestUserRoleRelationshipViewSet:
         self, authenticated_client, roles_fixture, create_test_user
     ):
         data = {
-            "data": [{"type": "role", "id": str(role.id)} for role in roles_fixture[:2]]
+            "data": [
+                {"type": "roles", "id": str(role.id)} for role in roles_fixture[:2]
+            ]
         }
         authenticated_client.post(
             reverse("user-roles-relationship", kwargs={"pk": create_test_user.id}),
@@ -3324,7 +3648,7 @@ class TestUserRoleRelationshipViewSet:
 
         data = {
             "data": [
-                {"type": "role", "id": str(roles_fixture[0].id)},
+                {"type": "roles", "id": str(roles_fixture[0].id)},
             ]
         }
         response = authenticated_client.post(
@@ -3341,7 +3665,7 @@ class TestUserRoleRelationshipViewSet:
     ):
         data = {
             "data": [
-                {"type": "role", "id": str(roles_fixture[2].id)},
+                {"type": "roles", "id": str(roles_fixture[2].id)},
             ]
         }
         response = authenticated_client.patch(
@@ -3356,8 +3680,8 @@ class TestUserRoleRelationshipViewSet:
 
         data = {
             "data": [
-                {"type": "role", "id": str(roles_fixture[1].id)},
-                {"type": "role", "id": str(roles_fixture[2].id)},
+                {"type": "roles", "id": str(roles_fixture[1].id)},
+                {"type": "roles", "id": str(roles_fixture[2].id)},
             ]
         }
         response = authenticated_client.patch(
@@ -3385,7 +3709,7 @@ class TestUserRoleRelationshipViewSet:
 
     def test_invalid_provider_group_id(self, authenticated_client, create_test_user):
         invalid_id = "non-existent-id"
-        data = {"data": [{"type": "provider-group", "id": invalid_id}]}
+        data = {"data": [{"type": "provider-groups", "id": invalid_id}]}
         response = authenticated_client.post(
             reverse("user-roles-relationship", kwargs={"pk": create_test_user.id}),
             data=data,
@@ -3403,7 +3727,7 @@ class TestRoleProviderGroupRelationshipViewSet:
     ):
         data = {
             "data": [
-                {"type": "provider-group", "id": str(provider_group.id)}
+                {"type": "provider-groups", "id": str(provider_group.id)}
                 for provider_group in provider_groups_fixture[:2]
             ]
         }
@@ -3429,7 +3753,7 @@ class TestRoleProviderGroupRelationshipViewSet:
     ):
         data = {
             "data": [
-                {"type": "provider-group", "id": str(provider_group.id)}
+                {"type": "provider-groups", "id": str(provider_group.id)}
                 for provider_group in provider_groups_fixture[:2]
             ]
         }
@@ -3443,7 +3767,7 @@ class TestRoleProviderGroupRelationshipViewSet:
 
         data = {
             "data": [
-                {"type": "provider-group", "id": str(provider_groups_fixture[0].id)},
+                {"type": "provider-groups", "id": str(provider_groups_fixture[0].id)},
             ]
         }
         response = authenticated_client.post(
@@ -3462,7 +3786,7 @@ class TestRoleProviderGroupRelationshipViewSet:
     ):
         data = {
             "data": [
-                {"type": "provider-group", "id": str(provider_groups_fixture[1].id)},
+                {"type": "provider-groups", "id": str(provider_groups_fixture[1].id)},
             ]
         }
         response = authenticated_client.patch(
@@ -3483,8 +3807,8 @@ class TestRoleProviderGroupRelationshipViewSet:
 
         data = {
             "data": [
-                {"type": "provider-group", "id": str(provider_groups_fixture[1].id)},
-                {"type": "provider-group", "id": str(provider_groups_fixture[2].id)},
+                {"type": "provider-groups", "id": str(provider_groups_fixture[1].id)},
+                {"type": "provider-groups", "id": str(provider_groups_fixture[2].id)},
             ]
         }
         response = authenticated_client.patch(
@@ -3520,7 +3844,7 @@ class TestRoleProviderGroupRelationshipViewSet:
 
     def test_invalid_provider_group_id(self, authenticated_client, roles_fixture):
         invalid_id = "non-existent-id"
-        data = {"data": [{"type": "provider-group", "id": invalid_id}]}
+        data = {"data": [{"type": "provider-groups", "id": invalid_id}]}
         response = authenticated_client.post(
             reverse(
                 "role-provider-groups-relationship", kwargs={"pk": roles_fixture[1].id}
@@ -3681,7 +4005,7 @@ class TestProviderGroupMembershipViewSet:
     ):
         provider_group, *_ = provider_groups_fixture
         invalid_id = "non-existent-id"
-        data = {"data": [{"type": "provider-group", "id": invalid_id}]}
+        data = {"data": [{"type": "provider-groups", "id": invalid_id}]}
         response = authenticated_client.post(
             reverse(
                 "provider_group-providers-relationship",

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -235,13 +235,10 @@ class UserCreateSerializer(BaseWriteSerializer):
 
 class UserUpdateSerializer(BaseWriteSerializer):
     password = serializers.CharField(write_only=True, required=False)
-    roles = serializers.ResourceRelatedField(
-        queryset=Role.objects.all(), many=True, required=False
-    )
 
     class Meta:
         model = User
-        fields = ["id", "name", "password", "email", "company_name", "roles"]
+        fields = ["id", "name", "password", "email", "company_name"]
         extra_kwargs = {
             "id": {"read_only": True},
         }
@@ -506,7 +503,6 @@ class ProviderGroupCreateSerializer(ProviderGroupSerializer):
             "updated_at",
             "providers",
             "roles",
-            "url",
         ]
 
     def create(self, validated_data):

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -235,10 +235,13 @@ class UserCreateSerializer(BaseWriteSerializer):
 
 class UserUpdateSerializer(BaseWriteSerializer):
     password = serializers.CharField(write_only=True, required=False)
+    roles = serializers.ResourceRelatedField(
+        queryset=Role.objects.all(), many=True, required=False
+    )
 
     class Meta:
         model = User
-        fields = ["id", "name", "password", "email", "company_name"]
+        fields = ["id", "name", "password", "email", "company_name", "roles"]
         extra_kwargs = {
             "id": {"read_only": True},
         }
@@ -445,7 +448,12 @@ class MembershipSerializer(serializers.ModelSerializer):
 
 # Provider Groups
 class ProviderGroupSerializer(RLSSerializer, BaseWriteSerializer):
-    providers = serializers.ResourceRelatedField(many=True, read_only=True)
+    providers = serializers.ResourceRelatedField(
+        queryset=Provider.objects.all(), many=True, required=False
+    )
+    roles = serializers.ResourceRelatedField(
+        queryset=Role.objects.all(), many=True, required=False
+    )
 
     def validate(self, attrs):
         if ProviderGroup.objects.filter(name=attrs.get("name")).exists():
@@ -475,21 +483,94 @@ class ProviderGroupSerializer(RLSSerializer, BaseWriteSerializer):
         }
 
 
-class ProviderGroupIncludedSerializer(RLSSerializer, BaseWriteSerializer):
+class ProviderGroupIncludedSerializer(ProviderGroupSerializer):
     class Meta:
         model = ProviderGroup
         fields = ["id", "name"]
 
 
-class ProviderGroupUpdateSerializer(RLSSerializer, BaseWriteSerializer):
-    """
-    Serializer for updating the ProviderGroup model.
-    Only allows "name" field to be updated.
-    """
+class ProviderGroupCreateSerializer(ProviderGroupSerializer):
+    providers = serializers.ResourceRelatedField(
+        queryset=Provider.objects.all(), many=True, required=False
+    )
+    roles = serializers.ResourceRelatedField(
+        queryset=Role.objects.all(), many=True, required=False
+    )
 
     class Meta:
         model = ProviderGroup
-        fields = ["id", "name"]
+        fields = [
+            "id",
+            "name",
+            "inserted_at",
+            "updated_at",
+            "providers",
+            "roles",
+            "url",
+        ]
+
+    def create(self, validated_data):
+        providers = validated_data.pop("providers", [])
+        roles = validated_data.pop("roles", [])
+        tenant_id = self.context.get("tenant_id")
+        provider_group = ProviderGroup.objects.create(
+            tenant_id=tenant_id, **validated_data
+        )
+
+        through_model_instances = [
+            ProviderGroupMembership(
+                provider_group=provider_group,
+                provider=provider,
+                tenant_id=tenant_id,
+            )
+            for provider in providers
+        ]
+        ProviderGroupMembership.objects.bulk_create(through_model_instances)
+
+        through_model_instances = [
+            RoleProviderGroupRelationship(
+                provider_group=provider_group,
+                role=role,
+                tenant_id=tenant_id,
+            )
+            for role in roles
+        ]
+        RoleProviderGroupRelationship.objects.bulk_create(through_model_instances)
+
+        return provider_group
+
+
+class ProviderGroupUpdateSerializer(ProviderGroupSerializer):
+    def update(self, instance, validated_data):
+        tenant_id = self.context.get("tenant_id")
+
+        if "providers" in validated_data:
+            providers = validated_data.pop("providers")
+            instance.providers.clear()
+            through_model_instances = [
+                ProviderGroupMembership(
+                    provider_group=instance,
+                    provider=provider,
+                    tenant_id=tenant_id,
+                )
+                for provider in providers
+            ]
+            ProviderGroupMembership.objects.bulk_create(through_model_instances)
+
+        if "roles" in validated_data:
+            roles = validated_data.pop("roles")
+            instance.roles.clear()
+            through_model_instances = [
+                RoleProviderGroupRelationship(
+                    provider_group=instance,
+                    role=role,
+                    tenant_id=tenant_id,
+                )
+                for role in roles
+            ]
+            RoleProviderGroupRelationship.objects.bulk_create(through_model_instances)
+
+        return super().update(instance, validated_data)
 
 
 class ProviderResourceIdentifierSerializer(serializers.Serializer):
@@ -1247,10 +1328,10 @@ class InvitationUpdateSerializer(InvitationBaseWriteSerializer):
         }
 
     def update(self, instance, validated_data):
-        roles = validated_data.pop("roles", [])
         tenant_id = self.context.get("tenant_id")
         invitation = super().update(instance, validated_data)
-        if roles:
+        if "roles" in validated_data:
+            roles = validated_data.pop("roles")
             instance.roles.clear()
             for role in roles:
                 InvitationRoleRelationship.objects.create(
@@ -1274,12 +1355,15 @@ class InvitationAcceptSerializer(RLSSerializer):
 
 
 class RoleSerializer(RLSSerializer, BaseWriteSerializer):
-    provider_groups = serializers.ResourceRelatedField(
-        many=True, queryset=ProviderGroup.objects.all()
-    )
     permission_state = serializers.SerializerMethodField()
+    users = serializers.ResourceRelatedField(
+        queryset=User.objects.all(), many=True, required=False
+    )
+    provider_groups = serializers.ResourceRelatedField(
+        queryset=ProviderGroup.objects.all(), many=True, required=False
+    )
 
-    def get_permission_state(self, obj):
+    def get_permission_state(self, obj) -> str:
         return obj.permission_state
 
     def validate(self, attrs):
@@ -1323,12 +1407,18 @@ class RoleSerializer(RLSSerializer, BaseWriteSerializer):
             "id": {"read_only": True},
             "inserted_at": {"read_only": True},
             "updated_at": {"read_only": True},
-            "users": {"read_only": True},
             "url": {"read_only": True},
         }
 
 
 class RoleCreateSerializer(RoleSerializer):
+    provider_groups = serializers.ResourceRelatedField(
+        many=True, queryset=ProviderGroup.objects.all(), required=False
+    )
+    users = serializers.ResourceRelatedField(
+        many=True, queryset=User.objects.all(), required=False
+    )
+
     def create(self, validated_data):
         provider_groups = validated_data.pop("provider_groups", [])
         users = validated_data.pop("users", [])
@@ -1347,7 +1437,7 @@ class RoleCreateSerializer(RoleSerializer):
 
         through_model_instances = [
             UserRoleRelationship(
-                role=user,
+                role=role,
                 user=user,
                 tenant_id=tenant_id,
             )
@@ -1358,20 +1448,37 @@ class RoleCreateSerializer(RoleSerializer):
         return role
 
 
-class RoleUpdateSerializer(RLSSerializer, BaseWriteSerializer):
-    class Meta:
-        model = Role
-        fields = [
-            "id",
-            "name",
-            "manage_users",
-            "manage_account",
-            "manage_billing",
-            "manage_providers",
-            "manage_integrations",
-            "manage_scans",
-            "unlimited_visibility",
-        ]
+class RoleUpdateSerializer(RoleSerializer):
+    def update(self, instance, validated_data):
+        tenant_id = self.context.get("tenant_id")
+
+        if "provider_groups" in validated_data:
+            provider_groups = validated_data.pop("provider_groups")
+            instance.provider_groups.clear()
+            through_model_instances = [
+                RoleProviderGroupRelationship(
+                    role=instance,
+                    provider_group=provider_group,
+                    tenant_id=tenant_id,
+                )
+                for provider_group in provider_groups
+            ]
+            RoleProviderGroupRelationship.objects.bulk_create(through_model_instances)
+
+        if "users" in validated_data:
+            users = validated_data.pop("users")
+            instance.users.clear()
+            through_model_instances = [
+                UserRoleRelationship(
+                    role=instance,
+                    user=user,
+                    tenant_id=tenant_id,
+                )
+                for user in users
+            ]
+            UserRoleRelationship.objects.bulk_create(through_model_instances)
+
+        return super().update(instance, validated_data)
 
 
 class ProviderGroupResourceIdentifierSerializer(serializers.Serializer):

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -100,6 +100,7 @@ from api.v1.serializers import (
     ProviderCreateSerializer,
     ProviderGroupMembershipSerializer,
     ProviderGroupSerializer,
+    ProviderGroupCreateSerializer,
     ProviderGroupUpdateSerializer,
     ProviderSecretCreateSerializer,
     ProviderSecretSerializer,
@@ -741,7 +742,9 @@ class ProviderGroupViewSet(BaseRLSViewSet):
         return user_roles.provider_groups.all()
 
     def get_serializer_class(self):
-        if self.action == "partial_update":
+        if self.action == "create":
+            return ProviderGroupCreateSerializer
+        elif self.action == "partial_update":
             return ProviderGroupUpdateSerializer
         return super().get_serializer_class()
 

--- a/api/src/backend/conftest.py
+++ b/api/src/backend/conftest.py
@@ -323,6 +323,20 @@ def invitations_fixture(create_test_user, tenants_fixture):
 
 
 @pytest.fixture
+def users_fixture(django_user_model):
+    user1 = User.objects.create_user(
+        name="user1", email="test_unit0@prowler.com", password="S3cret"
+    )
+    user2 = User.objects.create_user(
+        name="user2", email="test_unit1@prowler.com", password="S3cret"
+    )
+    user3 = User.objects.create_user(
+        name="user3", email="test_unit2@prowler.com", password="S3cret"
+    )
+    return user1, user2, user3
+
+
+@pytest.fixture
 def providers_fixture(tenants_fixture):
     tenant, *_ = tenants_fixture
     provider1 = Provider.objects.create(


### PR DESCRIPTION
### Context

The POST and PATCH doesn't allow the relationships creation. In this PR we have enabled it.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.