### PR TITLE
feat(codeartifact): add new fixer `codeartifact_packages_external_public_publishing_disabled_fixer`

### DIFF
--- a/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.py
@@ -15,7 +15,7 @@ class codeartifact_packages_external_public_publishing_disabled(Check):
             for package in repository.packages:
                 report = Check_Report_AWS(self.metadata())
                 report.region = repository.region
-                report.resource_id = package.name
+                report.resource_id = f"{repository.domain_name}/{package.name}"
                 report.resource_arn = f"{repository.arn}/{package.namespace + ':' if package.namespace else ''}{package.name}"
                 report.resource_tags = repository.tags
 
@@ -28,10 +28,10 @@ class codeartifact_packages_external_public_publishing_disabled(Check):
                         == RestrictionValues.ALLOW
                     ):
                         report.status = "FAIL"
-                        report.status_extended = f"Internal package {package.name} is vulnerable to dependency confusion in repository {repository.arn}."
+                        report.status_extended = f"Internal package {package.name} is vulnerable to dependency confusion in repository {repository.domain_name}."
                     else:
                         report.status = "PASS"
-                        report.status_extended = f"Internal package {package.name} is not vulnerable to dependency confusion in repository {repository.arn}."
+                        report.status_extended = f"Internal package {package.name} is not vulnerable to dependency confusion in repository {repository.domain_name}."
 
                     findings.append(report)
 

--- a/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer.py
@@ -1,0 +1,43 @@
+from prowler.lib.logger import logger
+from prowler.providers.aws.services.codeartifact.codeartifact_client import (
+    codeartifact_client,
+)
+
+
+def fixer(resource_id: str, region: str) -> bool:
+    """
+    Modify the CodeArtifact package's configuration to restrict public access.
+    Specifically, this fixer changes the package's configuration to block public access by
+    setting restrictions on the "publish" and "upstream" actions.
+    Requires the codeartifact:PutPackageOriginConfiguration permission.
+    Permissions:
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": "codeartifact:PutPackageOriginConfiguration",
+                "Resource": "*"
+            }
+        ]
+    }
+    Args:
+        resource_id (str): The CodeArtifact package name.
+        region (str): AWS region where the CodeArtifact package exists.
+    Returns:
+        bool: True if the operation is successful (configuration updated), False otherwise.
+    """
+    try:
+        regional_client = codeartifact_client.regional_clients[region]
+        regional_client.put_package_origin_configuration(
+            package=resource_id,
+            restrictions={"publish": "ALLOW", "upstream": "BLOCK"},
+        )
+
+    except Exception as error:
+        logger.error(
+            f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+        )
+        return False
+    else:
+        return True

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer_test.py
@@ -1,0 +1,137 @@
+from unittest import mock
+
+import botocore
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_EU_WEST_1
+
+mock_make_api_call = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call_codeartifact(self, operation_name, kwarg):
+    if operation_name == "PutPackageOriginConfiguration":
+        return {
+            "PackageOriginConfiguration": {
+                "Restrictions": {
+                    "Publish": "BLOCK",
+                    "Upstream": "BLOCK",
+                }
+            }
+        }
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+def mock_make_api_call_codeartifact_error(self, operation_name, kwarg):
+    if operation_name == "PutPackageOriginConfiguration":
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "PackageNotFound",
+                    "Message": "PackageNotFound",
+                }
+            },
+            operation_name,
+        )
+    return mock_make_api_call(self, operation_name, kwarg)
+
+
+class Test_codeartifact_packages_external_public_publishing_disabled_fixer:
+    @mock_aws
+    def test_repository_package_public_publishing_origin_internal(self):
+        codeartifact_client = mock.MagicMock()
+        package_name = "test-package"
+        package_namespace = "test-namespace"
+        repository_arn = f"arn:aws:codebuild:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:repository/test-repository"
+
+        # Setup mock data
+        codeartifact_client.repositories = {
+            "test-repository": {
+                "name": "test-repository",
+                "arn": repository_arn,
+                "domain_name": "",
+                "domain_owner": "",
+                "region": AWS_REGION_EU_WEST_1,
+                "packages": [
+                    {
+                        "name": package_name,
+                        "namespace": package_namespace,
+                        "format": "pypi",
+                        "origin_configuration": {
+                            "restrictions": {
+                                "publish": "ALLOW",
+                                "upstream": "ALLOW",
+                            }
+                        },
+                        "latest_version": {
+                            "version": "latest",
+                            "status": "Published",
+                            "origin": {"origin_type": "INTERNAL"},
+                        },
+                    }
+                ],
+            }
+        }
+
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_codeartifact,
+        ), mock.patch(
+            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
+            new=codeartifact_client,
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled_fixer import (
+                fixer,
+            )
+
+            assert fixer(package_name, AWS_REGION_EU_WEST_1)
+
+    @mock_aws
+    def test_repository_package_public_publishing_origin_internal_error(self):
+        codeartifact_client = mock.MagicMock()
+        package_name = "test-package"
+        package_namespace = "test-namespace"
+        repository_arn = f"arn:aws:codebuild:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:repository/test-repository"
+
+        # Setup mock data
+        codeartifact_client.repositories = {
+            "test-repository": {
+                "name": "test-repository",
+                "arn": repository_arn,
+                "domain_name": "",
+                "domain_owner": "",
+                "region": AWS_REGION_EU_WEST_1,
+                "packages": [
+                    {
+                        "name": package_name,
+                        "namespace": package_namespace,
+                        "format": "pypi",
+                        "origin_configuration": {
+                            "restrictions": {
+                                "publish": "ALLOW",
+                                "upstream": "ALLOW",
+                            }
+                        },
+                        "latest_version": {
+                            "version": "latest",
+                            "status": "Published",
+                            "origin": {"origin_type": "INTERNAL"},
+                        },
+                    }
+                ],
+            }
+        }
+
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_codeartifact_error,
+        ), mock.patch(
+            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
+            new=codeartifact_client,
+        ):
+            # Test Fixer
+            from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled_fixer import (
+                fixer,
+            )
+
+            assert not fixer("package_name_non_existing", AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer_test.py
@@ -59,7 +59,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled_fixer:
                     fixer,
                 )
 
-                assert fixer("test-package", AWS_REGION_EU_WEST_1)
+                assert fixer("test/test-package", AWS_REGION_EU_WEST_1)
 
     @mock_aws
     def test_repository_package_public_publishing_origin_internal_error(self):

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer_test.py
@@ -3,7 +3,10 @@ from unittest import mock
 import botocore
 from moto import mock_aws
 
-from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_EU_WEST_1
+from prowler.providers.aws.services.codeartifact.codeartifact_service import (
+    CodeArtifact,
+)
+from tests.providers.aws.utils import AWS_REGION_EU_WEST_1, set_mocked_aws_provider
 
 mock_make_api_call = botocore.client.BaseClient._make_api_call
 
@@ -38,100 +41,45 @@ def mock_make_api_call_codeartifact_error(self, operation_name, kwarg):
 class Test_codeartifact_packages_external_public_publishing_disabled_fixer:
     @mock_aws
     def test_repository_package_public_publishing_origin_internal(self):
-        codeartifact_client = mock.MagicMock()
-        package_name = "test-package"
-        package_namespace = "test-namespace"
-        repository_arn = f"arn:aws:codebuild:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:repository/test-repository"
-
-        # Setup mock data
-        codeartifact_client.repositories = {
-            "test-repository": {
-                "name": "test-repository",
-                "arn": repository_arn,
-                "domain_name": "",
-                "domain_owner": "",
-                "region": AWS_REGION_EU_WEST_1,
-                "packages": [
-                    {
-                        "name": package_name,
-                        "namespace": package_namespace,
-                        "format": "pypi",
-                        "origin_configuration": {
-                            "restrictions": {
-                                "publish": "ALLOW",
-                                "upstream": "ALLOW",
-                            }
-                        },
-                        "latest_version": {
-                            "version": "latest",
-                            "status": "Published",
-                            "origin": {"origin_type": "INTERNAL"},
-                        },
-                    }
-                ],
-            }
-        }
-
         with mock.patch(
             "botocore.client.BaseClient._make_api_call",
             new=mock_make_api_call_codeartifact,
-        ), mock.patch(
-            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
-            new=codeartifact_client,
         ):
-            # Test Fixer
-            from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled_fixer import (
-                fixer,
-            )
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
-            assert fixer(package_name, AWS_REGION_EU_WEST_1)
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
+                new=CodeArtifact(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled_fixer import (
+                    fixer,
+                )
+
+                assert fixer("test-package", AWS_REGION_EU_WEST_1)
 
     @mock_aws
     def test_repository_package_public_publishing_origin_internal_error(self):
-        codeartifact_client = mock.MagicMock()
-        package_name = "test-package"
-        package_namespace = "test-namespace"
-        repository_arn = f"arn:aws:codebuild:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:repository/test-repository"
-
-        # Setup mock data
-        codeartifact_client.repositories = {
-            "test-repository": {
-                "name": "test-repository",
-                "arn": repository_arn,
-                "domain_name": "",
-                "domain_owner": "",
-                "region": AWS_REGION_EU_WEST_1,
-                "packages": [
-                    {
-                        "name": package_name,
-                        "namespace": package_namespace,
-                        "format": "pypi",
-                        "origin_configuration": {
-                            "restrictions": {
-                                "publish": "ALLOW",
-                                "upstream": "ALLOW",
-                            }
-                        },
-                        "latest_version": {
-                            "version": "latest",
-                            "status": "Published",
-                            "origin": {"origin_type": "INTERNAL"},
-                        },
-                    }
-                ],
-            }
-        }
-
         with mock.patch(
             "botocore.client.BaseClient._make_api_call",
             new=mock_make_api_call_codeartifact_error,
-        ), mock.patch(
-            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
-            new=codeartifact_client,
         ):
-            # Test Fixer
-            from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled_fixer import (
-                fixer,
-            )
 
-            assert not fixer("package_name_non_existing", AWS_REGION_EU_WEST_1)
+            aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+            with mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ), mock.patch(
+                "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
+                new=CodeArtifact(aws_provider),
+            ):
+                # Test Fixer
+                from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled_fixer import (
+                    fixer,
+                )
+
+                assert not fixer("non-existing-package", AWS_REGION_EU_WEST_1)

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
@@ -69,7 +69,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             "test-repository": Repository(
                 name="test-repository",
                 arn=repository_arn,
-                domain_name="",
+                domain_name="test",
                 domain_owner="",
                 region=AWS_REGION,
                 packages=[
@@ -108,7 +108,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
 
             assert len(result) == 1
             assert result[0].region == AWS_REGION
-            assert result[0].resource_id == "test-package"
+            assert result[0].resource_id == "test/test-package"
             assert (
                 result[0].resource_arn
                 == repository_arn + "/" + package_namespace + ":" + package_name
@@ -117,7 +117,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Internal package {package_name} is vulnerable to dependency confusion in repository {repository_arn}."
+                == f"Internal package {package_name} is vulnerable to dependency confusion in repository test."
             )
 
     def test_repository_package_private_publishing_origin_internal(self):
@@ -129,7 +129,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             "test-repository": Repository(
                 name="test-repository",
                 arn=repository_arn,
-                domain_name="",
+                domain_name="test",
                 domain_owner="",
                 region=AWS_REGION,
                 packages=[
@@ -168,7 +168,7 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
 
             assert len(result) == 1
             assert result[0].region == AWS_REGION
-            assert result[0].resource_id == "test-package"
+            assert result[0].resource_id == "test/test-package"
             assert (
                 result[0].resource_arn
                 == repository_arn + "/" + package_namespace + ":" + package_name
@@ -177,5 +177,5 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Internal package {package_name} is not vulnerable to dependency confusion in repository {repository_arn}."
+                == f"Internal package {package_name} is not vulnerable to dependency confusion in repository test."
             )

--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
@@ -23,6 +23,9 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
         with mock.patch(
             "prowler.providers.aws.services.codeartifact.codeartifact_service.CodeArtifact",
             new=codeartifact_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
+            new=codeartifact_client,
         ):
             # Test Check
             from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled import (
@@ -97,6 +100,9 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
         with mock.patch(
             "prowler.providers.aws.services.codeartifact.codeartifact_service.CodeArtifact",
             new=codeartifact_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
+            new=codeartifact_client,
         ):
             # Test Check
             from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled import (
@@ -156,6 +162,9 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
         }
         with mock.patch(
             "prowler.providers.aws.services.codeartifact.codeartifact_service.CodeArtifact",
+            new=codeartifact_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
             new=codeartifact_client,
         ):
             # Test Check


### PR DESCRIPTION
### Context

Develop a new fixer that disables external public publishing in AWS CodeArtifact repositories, ensuring that packages are only accessible and published within the intended internal AWS accounts. This mitigates the risk of exposing private packages to public access.

### Description

Added new fixer `codeartifact_packages_external_public_publishing_disabled_fixer` with its unit tests and modified the check `codeartifact_packages_external_public_publishing_disabled`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.