### PR TITLE
fix(aws): add missing region to Backup Recovery Point

### DIFF
--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -204,6 +204,7 @@ class Backup(AWSService):
                                             "IsEncrypted", False
                                         ),
                                         backup_vault_region=backup_vault.region,
+                                        region=regional_client.region,
                                         tags=[],
                                     )
                                 )
@@ -251,6 +252,7 @@ class BackupReportPlan(BaseModel):
 class RecoveryPoint(BaseModel):
     arn: str
     id: str
+    region: str
     backup_vault_name: str
     encrypted: bool
     backup_vault_region: str


### PR DESCRIPTION
### Description

Add missing region to Backup Recovery Point to be able to list tags.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.