### PR TITLE
chore(findings): remove delta new as filter by default in findings

### DIFF
--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -140,7 +140,6 @@ const SSRDataTable = async ({
   // Extract all filter parameters and combine with default filters
   const defaultFilters = {
     "filter[status__in]": "FAIL, PASS",
-    "filter[delta__in]": "new",
   };
 
   const filters: Record<string, string> = {


### PR DESCRIPTION

### Description

- Remove ` "filter[delta__in]": "new"` as filter by default on findings.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.