### PR TITLE
fix(users): fix /users/me behavior when having more than 1 users in the same tenant

### DIFF
--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -98,9 +98,9 @@ from api.v1.serializers import (
     OverviewServiceSerializer,
     OverviewSeveritySerializer,
     ProviderCreateSerializer,
+    ProviderGroupCreateSerializer,
     ProviderGroupMembershipSerializer,
     ProviderGroupSerializer,
-    ProviderGroupCreateSerializer,
     ProviderGroupUpdateSerializer,
     ProviderSecretCreateSerializer,
     ProviderSecretSerializer,
@@ -192,7 +192,7 @@ class SchemaView(SpectacularAPIView):
 
     def get(self, request, *args, **kwargs):
         spectacular_settings.TITLE = "Prowler API"
-        spectacular_settings.VERSION = "1.1.0"
+        spectacular_settings.VERSION = "1.1.1"
         spectacular_settings.DESCRIPTION = (
             "Prowler API specification.\n\nThis file is auto-generated."
         )
@@ -328,7 +328,7 @@ class UserViewSet(BaseUserViewset):
 
     @action(detail=False, methods=["get"], url_name="me")
     def me(self, request):
-        user = self.get_queryset().first()
+        user = self.request.user
         serializer = UserSerializer(user, context=self.get_serializer_context())
         return Response(
             data=serializer.data,


### PR DESCRIPTION
### Context

We were retrieving the first user ordered by memberships in the `GET /users/me` endpoint, leading to incorrect behavior when having more than user in the same tenant.

### Description

It has been fixed to properly return the requesting user info.

#### User1 info

![image](https://github.com/user-attachments/assets/4d81d3bd-a087-4496-bb34-1ea6b4895504)


#### User2 info

![image](https://github.com/user-attachments/assets/40d5e1e9-8bb8-4704-8e11-5df0c0adbf61)


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.