### PR TITLE
fix(aws): add missing sqs service without subservice

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -789,7 +789,14 @@ class AwsProvider(Provider):
         # Handle if there are audit resources so only their services are executed
         if self._audit_resources:
             # TODO: this should be retrieved automatically
-            services_without_subservices = ["guardduty", "kms", "s3", "elb", "efs"]
+            services_without_subservices = [
+                "guardduty",
+                "kms",
+                "s3",
+                "elb",
+                "efs",
+                "sqs",
+            ]
             service_list = set()
             sub_service_list = set()
             for resource in self._audit_resources:


### PR DESCRIPTION
### Context

There is a problem when scanning SQS queues with other ARNs.

fix #6346

### Description

Added sqs to service without subservices list.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.