### PR TITLE
fix(ci): move poetry deprecated command to new one

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -114,7 +114,7 @@ jobs:
         working-directory: ./api
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |
-          poetry lock --check
+          poetry check --lock
 
       - name: Lint with ruff
         working-directory: ./api

--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Poetry check
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |
-          poetry lock --check
+          poetry check --lock
 
       - name: Lint with flake8
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'


### PR DESCRIPTION
### Description

In this PR we have changed the deprecated command poetry lock --check to poetry check --lock because in the latest version of poetry (2.0.0) changes related to deprecations have been implemented.

<img width="1318" alt="image" src="https://github.com/user-attachments/assets/c978f315-3d60-4e20-a3f1-d0b69b36eb98" />

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.