### PR TITLE
Discussion Wanted: Truly anonymised telemetry for prowler OSS.

### DIFF
--- a/prowler/lib/cli/parser.py
+++ b/prowler/lib/cli/parser.py
@@ -51,6 +51,11 @@ Detailed documentation at https://docs.prowler.com
             action="store_true",
             help="show Prowler version",
         )
+        self.parser.add_argument(
+            "--no-telemetry",
+            action="store_true",
+            help="Opt out of sending anonymous usage statistics",
+        )
         # Common arguments parser
         self.common_providers_parser = argparse.ArgumentParser(add_help=False)
 


### PR DESCRIPTION
### Context

This PR contains code showing how i'd like to collect anonymous usage data for prowler. 
I wanted to "show my working", with respect to privacy, metrics and telemetry are a sensitive topic and I beleive i've been careful to collect only non-sensitive data that can help improve the tool while respecting privacy. 

Please take a look and feel free to discuss either in this Pull Request or in our community slack at https://goto.prowler.com/slack 👍 

In the PR's code, i've suggested collecting the following data.

##### Basic execution info:
- Provider type (AWS/Azure/GCP/Kubernetes)
- Number of checks executed
- Execution duration
- Prowler version
- Operating system type (no specifics)
- Python version (major/minor)

##### Aggregated result numbers 
- Total number of findings by status (PASS/FAIL/ERROR)
- Number of compliance frameworks used.
- Output formats used (csv/json/html etc).
- Whether features like quick inventory or fixer were used.

##### Anonymous feature usage:
- Which command line flags were used (without their values)
- Categories/services scanned (counts only)
- Number of custom checks used (integer, no details)

On top of this, a list of failed checks containing ONLY the check_id name, the reasoning for this:
- Identify which checks are failing most frequently
- Prioritize which checks need better documentation or fixes
- Understand which security issues are most common
- Guide the development of new features and improvements

to my mind, the check IDs are generic identifiers (like "iam_user_mfa_enabled") and don't contain any sensitive information about the actual resources or findings. Inversely, we do not collect custom check ID's as these may be named more sensitively.

##### Automatic and manual disabling of telemetry.
Continuing the "open, transparent, privacy-first" theme. The code is designed to sacrifice telemetry over anything else:
- Performance: If the telemetry POST takes more than 2 seconds, it will be abandoned.
- Performance: The whole telemetry section is currently wrapped in a try>except>pass block, we'll silently fail rather than annoying the user if we have any issues with telemetry collection.
- Privacy: Higher-security environments usually block outbound internet access via default routes/gateways and only allow access via proxies. To that end, the code automatically disables telemetry if any env variable relating to proxies is set.
- A new global option of `--no-telemetry` will also disable the telemetry.

### Description

For easier readability/discussion, the telemetry code is currently in a function in prowler/prowler/main.py, and called at the end of the file before the exit() block. It will be moved to a utils file before a PR is considered for merging.

Tests are being worked on, as is a new documentation page which will be added to this PR.

The "receiving end" of the telemetry will also be open source, so that users can A. See the global trends of prowler for themselves and B. Confirm that no other data is being collected from both client and server-side of the codebase.


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [WIP] Review if the code is being covered by tests.
- [WIP] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [NO] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.