### PR TITLE
fix(pre-commit): add api needed excludes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,7 @@ repos:
       - id: bandit
         name: bandit
         description: "Bandit is a tool for finding common security issues in Python code"
-        entry: bash -c 'bandit -q -lll -x '*_test.py,./contrib/' -r .'
+        entry: bash -c 'bandit -q -lll -x '*_test.py,./contrib/,./.venv/' -r .'
         language: system
         files: '.*\.py'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,6 @@ repos:
       - id: vulture
         name: vulture
         description: "Vulture finds unused code in Python programs."
-        entry: bash -c 'vulture --exclude "contrib" --min-confidence 100 .'
-        exclude: 'api/src/backend/'
+        entry: bash -c 'vulture --exclude "contrib,.venv,api/src/backend/api/tests/,api/src/backend/conftest.py,api/src/backend/tasks/tests/" --min-confidence 100 .'
         language: system
         files: '.*\.py'


### PR DESCRIPTION
### Description
This pull request includes a change to the `.pre-commit-config.yaml` file to refine the configuration of the `vulture` tool by updating the `entry` command and adjusting the list of excluded directories and files.
Also, exclude `.venv` from bandit.

Thanks @johannes-engler-mw for your insight here: https://github.com/prowler-cloud/prowler/pull/6351/files#r1901833884

Configuration update for `vulture`:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L106-R106): Modified the `entry` command for `vulture` to exclude additional directories and files, including `.venv`, `api/src/backend/api/tests/`, `api/src/backend/conftest.py`, and `api/src/backend/tasks/tests/`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.