### PR TITLE
fix(cloudformation): fix flaky tests

### DIFF
--- a/tests/providers/aws/services/cloudformation/cloudformation_stack_cdktoolkit_bootstrap_version/cloudformation_stack_cdktoolkit_bootstrap_version_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_stack_cdktoolkit_bootstrap_version/cloudformation_stack_cdktoolkit_bootstrap_version_test.py
@@ -12,6 +12,9 @@ class Test_cloudformation_stack_cdktoolkit_bootstrap_version:
         cloudformation_client.stacks = []
         cloudformation_client.audit_config = {"recommended_cdk_bootstrap_version": 21}
         with mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
+            new=cloudformation_client,
+        ), mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
             new=cloudformation_client,
         ):
@@ -37,6 +40,9 @@ class Test_cloudformation_stack_cdktoolkit_bootstrap_version:
         cloudformation_client.audit_config = {"recommended_cdk_bootstrap_version": 21}
 
         with mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
+            new=cloudformation_client,
+        ), mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
             new=cloudformation_client,
         ):
@@ -73,6 +79,9 @@ class Test_cloudformation_stack_cdktoolkit_bootstrap_version:
         cloudformation_client.audit_config = {"recommended_cdk_bootstrap_version": 21}
 
         with mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
+            new=cloudformation_client,
+        ), mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
             new=cloudformation_client,
         ):

--- a/tests/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_stack_outputs_find_secrets/cloudformation_stack_outputs_find_secrets_test.py
@@ -10,8 +10,12 @@ class Test_cloudformation_stack_outputs_find_secrets:
     def test_no_stacks(self):
         cloudformation_client = mock.MagicMock
         cloudformation_client.stacks = []
+        cloudformation_client.audit_config = {"secrets_ignore_patterns": []}
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
+            new=cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
             new=cloudformation_client,
         ):
             # Test Check
@@ -36,9 +40,14 @@ class Test_cloudformation_stack_outputs_find_secrets:
             )
         ]
 
+        cloudformation_client.audit_config = {"secrets_ignore_patterns": []}
+
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
+            new=cloudformation_client,
         ):
             from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
                 cloudformation_stack_outputs_find_secrets,
@@ -75,9 +84,14 @@ class Test_cloudformation_stack_outputs_find_secrets:
             )
         ]
 
+        cloudformation_client.audit_config = {"secrets_ignore_patterns": []}
+
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
+            new=cloudformation_client,
         ):
             from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
                 cloudformation_stack_outputs_find_secrets,
@@ -112,9 +126,14 @@ class Test_cloudformation_stack_outputs_find_secrets:
             )
         ]
 
+        cloudformation_client.audit_config = {"secrets_ignore_patterns": []}
+
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
+            new=cloudformation_client,
         ):
             from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
                 cloudformation_stack_outputs_find_secrets,
@@ -149,9 +168,14 @@ class Test_cloudformation_stack_outputs_find_secrets:
             )
         ]
 
+        cloudformation_client.audit_config = {"secrets_ignore_patterns": []}
+
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
+            new=cloudformation_client,
         ):
             from prowler.providers.aws.services.cloudformation.cloudformation_stack_outputs_find_secrets.cloudformation_stack_outputs_find_secrets import (
                 cloudformation_stack_outputs_find_secrets,

--- a/tests/providers/aws/services/cloudformation/cloudformation_stacks_termination_protection_enabled/cloudformation_stacks_termination_protection_enabled_test.py
+++ b/tests/providers/aws/services/cloudformation/cloudformation_stacks_termination_protection_enabled/cloudformation_stacks_termination_protection_enabled_test.py
@@ -13,6 +13,9 @@ class Test_cloudformation_stacks_termination_protection_enabled:
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             new=cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
+            new=cloudformation_client,
         ):
             # Test Check
             from prowler.providers.aws.services.cloudformation.cloudformation_stacks_termination_protection_enabled.cloudformation_stacks_termination_protection_enabled import (
@@ -40,6 +43,9 @@ class Test_cloudformation_stacks_termination_protection_enabled:
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
+            new=cloudformation_client,
         ):
             from prowler.providers.aws.services.cloudformation.cloudformation_stacks_termination_protection_enabled.cloudformation_stacks_termination_protection_enabled import (
                 cloudformation_stacks_termination_protection_enabled,
@@ -78,6 +84,9 @@ class Test_cloudformation_stacks_termination_protection_enabled:
         with mock.patch(
             "prowler.providers.aws.services.cloudformation.cloudformation_service.CloudFormation",
             cloudformation_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.cloudformation.cloudformation_client.cloudformation_client",
+            new=cloudformation_client,
         ):
             from prowler.providers.aws.services.cloudformation.cloudformation_stacks_termination_protection_enabled.cloudformation_stacks_termination_protection_enabled import (
                 cloudformation_stacks_termination_protection_enabled,


### PR DESCRIPTION
### Context

Pepe noticed that some tests from CloudFormation service are failing, I've made an easy solution continuing using MagicMock to see if they stop failing, if this does not work it’ll be necessary to change them to Moto (if they are covered) or Botocore.

### Description

Modified tests from all the CloudFormation checks.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.