### PR TITLE
env_file key requires list of strings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ services:
     hostname: "prowler-api"
     image: prowlercloud/prowler-api:${PROWLER_API_VERSION:-stable}
     env_file:
-      - path: .env
-        required: false
+      - .env
     ports:
       - "${DJANGO_PORT:-8080}:${DJANGO_PORT:-8080}"
     depends_on:
@@ -19,8 +18,7 @@ services:
   ui:
     image: prowlercloud/prowler-ui:${PROWLER_UI_VERSION:-stable}
     env_file:
-      - path: .env
-        required: false
+      - .env
     ports:
       - ${UI_PORT:-3000}:${UI_PORT:-3000}
 
@@ -34,8 +32,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_ADMIN_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
     env_file:
-      - path: .env
-        required: false
+      - .env
     ports:
       - "${POSTGRES_PORT:-5432}:${POSTGRES_PORT:-5432}"
     healthcheck:
@@ -50,8 +47,7 @@ services:
     volumes:
       - ./_data/valkey:/data
     env_file:
-      - path: .env
-        required: false
+      - .env
     ports:
       - "${VALKEY_PORT:-6379}:6379"
     healthcheck:
@@ -63,8 +59,7 @@ services:
   worker:
     image: prowlercloud/prowler-api:${PROWLER_API_VERSION:-stable}
     env_file:
-      - path: .env
-        required: false
+      - .env
     depends_on:
       valkey:
         condition: service_healthy
@@ -77,8 +72,7 @@ services:
   worker-beat:
     image: prowlercloud/prowler-api:${PROWLER_API_VERSION:-stable}
     env_file:
-      - path: ./.env
-        required: false
+      - .env
     depends_on:
       valkey:
         condition: service_healthy


### PR DESCRIPTION
### Context

The env_file key for all containers requires a list of strings.

If fixes an issue please add it with `Fix #XXXX`

### Description

Removed all sub keys and converted it to a list of strings

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.