### PR TITLE
feat(ec2): include resource metadata in Check_Report

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -405,16 +405,20 @@ class Check_Report:
     status: str
     status_extended: str
     check_metadata: CheckMetadata
+    resource_metadata: dict
     resource_details: str
     resource_tags: list
     muted: bool
 
-    def __init__(self, metadata):
+    def __init__(self, metadata, resource_metadata=None):
         self.status = ""
         self.check_metadata = CheckMetadata.parse_raw(metadata)
+        self.resource_metadata = resource_metadata.dict() if resource_metadata else {}
         self.status_extended = ""
         self.resource_details = ""
-        self.resource_tags = []
+        self.resource_tags = (
+            getattr(resource_metadata, "tags", []) if resource_metadata else []
+        )
         self.muted = False
 
 
@@ -426,11 +430,20 @@ class Check_Report_AWS(Check_Report):
     resource_arn: str
     region: str
 
-    def __init__(self, metadata):
-        super().__init__(metadata)
-        self.resource_id = ""
-        self.resource_arn = ""
-        self.region = ""
+    def __init__(self, metadata, resource_metadata=None):
+        super().__init__(metadata, resource_metadata)
+        if resource_metadata:
+            self.resource_id = (
+                getattr(resource_metadata, "id", None)
+                or getattr(resource_metadata, "name", None)
+                or ""
+            )
+            self.resource_arn = getattr(resource_metadata, "arn", "")
+            self.region = getattr(resource_metadata, "region", "")
+        else:
+            self.resource_id = ""
+            self.resource_arn = ""
+            self.region = ""
 
 
 @dataclass

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -410,15 +410,13 @@ class Check_Report:
     resource_tags: list
     muted: bool
 
-    def __init__(self, metadata, resource_metadata=None):
+    def __init__(self, metadata, resource=None):
         self.status = ""
         self.check_metadata = CheckMetadata.parse_raw(metadata)
-        self.resource_metadata = resource_metadata.dict() if resource_metadata else {}
+        self.resource_metadata = resource.dict() if resource else {}
         self.status_extended = ""
         self.resource_details = ""
-        self.resource_tags = (
-            getattr(resource_metadata, "tags", []) if resource_metadata else []
-        )
+        self.resource_tags = getattr(resource, "tags", []) if resource else []
         self.muted = False
 
 

--- a/prowler/lib/outputs/common.py
+++ b/prowler/lib/outputs/common.py
@@ -14,7 +14,7 @@ def fill_common_finding_data(finding: dict, unix_timestamp: bool) -> dict:
         "status_extended": finding.status_extended,
         "muted": finding.muted,
         "resource_details": finding.resource_details,
-        "resource_metadata": finding.resource_metadata,
+        # "resource_metadata": finding.resource_metadata, TODO: add resource_metadata to the finding
         "resource_tags": unroll_tags(finding.resource_tags),
     }
     return finding_data

--- a/prowler/lib/outputs/common.py
+++ b/prowler/lib/outputs/common.py
@@ -14,6 +14,7 @@ def fill_common_finding_data(finding: dict, unix_timestamp: bool) -> dict:
         "status_extended": finding.status_extended,
         "muted": finding.muted,
         "resource_details": finding.resource_details,
+        "resource_metadata": finding.resource_metadata,
         "resource_tags": unroll_tags(finding.resource_tags),
     }
     return finding_data

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -35,6 +35,7 @@ class Finding(BaseModel):
     status_extended: str
     muted: bool = False
     resource_uid: str
+    resource_metadata: dict = Field(default_factory=dict)
     resource_name: str
     resource_details: str
     resource_tags: dict = Field(default_factory=dict)

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -35,7 +35,7 @@ class Finding(BaseModel):
     status_extended: str
     muted: bool = False
     resource_uid: str
-    resource_metadata: dict = Field(default_factory=dict)
+    # resource_metadata: dict = Field(default_factory=dict) TODO: add resource_metadata to the finding
     resource_name: str
     resource_details: str
     resource_tags: dict = Field(default_factory=dict)

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -113,7 +113,7 @@ class OCSF(Output):
                                 region=finding.region,
                                 data={
                                     "details": finding.resource_details,
-                                    "metadata": finding.resource_metadata,
+                                    # "metadata": finding.resource_metadata, TODO: add the resource_metadata to the finding
                                 },
                             )
                         ]

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -127,7 +127,7 @@ class OCSF(Output):
                                 type=finding.metadata.ResourceType,
                                 data={
                                     "details": finding.resource_details,
-                                    "metadata": finding.resource_metadata,
+                                    # "metadata": finding.resource_metadata, TODO: add the resource_metadata to the finding
                                 },
                                 namespace=finding.region.replace("namespace: ", ""),
                             )

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -111,7 +111,10 @@ class OCSF(Output):
                                 # TODO: this should be included only if using the Cloud profile
                                 cloud_partition=finding.partition,
                                 region=finding.region,
-                                data={"details": finding.resource_details},
+                                data={
+                                    "details": finding.resource_details,
+                                    "metadata": finding.resource_metadata,
+                                },
                             )
                         ]
                         if finding.metadata.Provider != "kubernetes"
@@ -122,7 +125,10 @@ class OCSF(Output):
                                 uid=finding.resource_uid,
                                 group=Group(name=finding.metadata.ServiceName),
                                 type=finding.metadata.ResourceType,
-                                data={"details": finding.resource_details},
+                                data={
+                                    "details": finding.resource_details,
+                                    "metadata": finding.resource_metadata,
+                                },
                                 namespace=finding.region.replace("namespace: ", ""),
                             )
                         ]

--- a/prowler/providers/aws/services/datasync/datasync_task_logging_enabled/datasync_task_logging_enabled.py
+++ b/prowler/providers/aws/services/datasync/datasync_task_logging_enabled/datasync_task_logging_enabled.py
@@ -22,11 +22,7 @@ class datasync_task_logging_enabled(Check):
         """
         findings = []
         for task in datasync_client.tasks.values():
-            report = Check_Report_AWS(self.metadata())
-            report.region = task.region
-            report.resource_id = task.id
-            report.resource_arn = task.arn
-            report.resource_tags = task.tags
+            report = Check_Report_AWS(self.metadata(), task)
             report.status = "PASS"
             report.status_extended = f"DataSync task {task.name} has logging enabled."
 

--- a/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
+++ b/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
@@ -23,7 +23,7 @@ class dms_instance_no_public_access(Check):
                 if instance.security_groups:
                     report.status = "PASS"
                     report.status_extended = f"DMS Replication Instance {instance.id} is set as publicly accessible but filtered with security groups."
-                    for security_group in ec2_client.security_groups.items():
+                    for security_group in ec2_client.security_groups.values():
                         if security_group.id in instance.security_groups:
                             for ingress_rule in security_group.ingress_rules:
                                 if check_security_group(

--- a/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
+++ b/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
@@ -23,10 +23,7 @@ class dms_instance_no_public_access(Check):
                 if instance.security_groups:
                     report.status = "PASS"
                     report.status_extended = f"DMS Replication Instance {instance.id} is set as publicly accessible but filtered with security groups."
-                    for (
-                        security_group_arn,
-                        security_group,
-                    ) in ec2_client.security_groups.items():
+                    for security_group in ec2_client.security_groups.items():
                         if security_group.id in instance.security_groups:
                             for ingress_rule in security_group.ingress_rules:
                                 if check_security_group(

--- a/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
+++ b/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
@@ -23,7 +23,10 @@ class dms_instance_no_public_access(Check):
                 if instance.security_groups:
                     report.status = "PASS"
                     report.status_extended = f"DMS Replication Instance {instance.id} is set as publicly accessible but filtered with security groups."
-                    for security_group in ec2_client.security_groups.values():
+                    for (
+                        security_group_arn,
+                        security_group,
+                    ) in ec2_client.security_groups.items():
                         if security_group.id in instance.security_groups:
                             for ingress_rule in security_group.ingress_rules:
                                 if check_security_group(

--- a/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public.py
+++ b/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public.py
@@ -6,11 +6,7 @@ class ec2_ami_public(Check):
     def execute(self):
         findings = []
         for image in ec2_client.images:
-            report = Check_Report_AWS(self.metadata())
-            report.region = image.region
-            report.resource_id = image.id
-            report.resource_arn = image.arn
-            report.resource_tags = image.tags
+            report = Check_Report_AWS(self.metadata(), image)
             report.status = "PASS"
             report.status_extended = (
                 f"EC2 AMI {image.name if image.name else image.id} is not public."

--- a/prowler/providers/aws/services/ec2/ec2_client_vpn_endpoint_connection_logging_enabled/ec2_client_vpn_endpoint_connection_logging_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_client_vpn_endpoint_connection_logging_enabled/ec2_client_vpn_endpoint_connection_logging_enabled.py
@@ -6,11 +6,7 @@ class ec2_client_vpn_endpoint_connection_logging_enabled(Check):
     def execute(self):
         findings = []
         for vpn_arn, vpn_endpoint in ec2_client.vpn_endpoints.items():
-            report = Check_Report_AWS(self.metadata())
-            report.region = vpn_endpoint.region
-            report.resource_id = vpn_endpoint.id
-            report.resource_arn = vpn_arn
-            report.resource_tags = vpn_endpoint.tags
+            report = Check_Report_AWS(self.metadata(), vpn_endpoint)
 
             if vpn_endpoint.connection_logging:
                 report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption.py
@@ -7,8 +7,7 @@ class ec2_ebs_default_encryption(Check):
         findings = []
         for ebs_encryption in ec2_client.ebs_encryption_by_default:
             if ebs_encryption.volumes or ec2_client.provider.scan_unused_services:
-                report = Check_Report_AWS(self.metadata())
-                report.region = ebs_encryption.region
+                report = Check_Report_AWS(self.metadata(), ebs_encryption)
                 report.resource_arn = ec2_client._get_volume_arn_template(
                     ebs_encryption.region
                 )

--- a/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot.py
@@ -6,13 +6,9 @@ class ec2_ebs_public_snapshot(Check):
     def execute(self):
         findings = []
         for snapshot in ec2_client.snapshots:
-            report = Check_Report_AWS(self.metadata())
-            report.region = snapshot.region
-            report.resource_arn = snapshot.arn
-            report.resource_tags = snapshot.tags
+            report = Check_Report_AWS(self.metadata(), snapshot)
             report.status = "PASS"
             report.status_extended = f"EBS Snapshot {snapshot.id} is not Public."
-            report.resource_id = snapshot.id
             if snapshot.public:
                 report.status = "FAIL"
                 report.status_extended = (

--- a/prowler/providers/aws/services/ec2/ec2_ebs_snapshot_account_block_public_access/ec2_ebs_snapshot_account_block_public_access.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_snapshot_account_block_public_access/ec2_ebs_snapshot_account_block_public_access.py
@@ -12,8 +12,7 @@ class ec2_ebs_snapshot_account_block_public_access(Check):
                 ebs_snapshot_block_status.snapshots
                 or ec2_client.provider.scan_unused_services
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = ebs_snapshot_block_status.region
+                report = Check_Report_AWS(self.metadata(), ebs_snapshot_block_status)
                 report.resource_arn = ec2_client.account_arn_template
                 report.resource_id = ec2_client.audited_account
                 if ebs_snapshot_block_status.status == "block-all-sharing":

--- a/prowler/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_snapshots_encrypted/ec2_ebs_snapshots_encrypted.py
@@ -6,17 +6,12 @@ class ec2_ebs_snapshots_encrypted(Check):
     def execute(self):
         findings = []
         for snapshot in ec2_client.snapshots:
-            report = Check_Report_AWS(self.metadata())
-            report.region = snapshot.region
-            report.resource_arn = snapshot.arn
-            report.resource_tags = snapshot.tags
+            report = Check_Report_AWS(self.metadata(), snapshot)
             report.status = "PASS"
             report.status_extended = f"EBS Snapshot {snapshot.id} is encrypted."
-            report.resource_id = snapshot.id
             if not snapshot.encrypted:
                 report.status = "FAIL"
                 report.status_extended = f"EBS Snapshot {snapshot.id} is unencrypted."
-                report.resource_id = snapshot.id
             findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_volume_encryption/ec2_ebs_volume_encryption.py
@@ -6,11 +6,7 @@ class ec2_ebs_volume_encryption(Check):
     def execute(self):
         findings = []
         for volume in ec2_client.volumes:
-            report = Check_Report_AWS(self.metadata())
-            report.region = volume.region
-            report.resource_id = volume.id
-            report.resource_arn = volume.arn
-            report.resource_tags = volume.tags
+            report = Check_Report_AWS(self.metadata(), volume)
             report.status = "PASS"
             report.status_extended = f"EBS Snapshot {volume.id} is encrypted."
             if not volume.encrypted:

--- a/prowler/providers/aws/services/ec2/ec2_ebs_volume_protected_by_backup_plan/ec2_ebs_volume_protected_by_backup_plan.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_volume_protected_by_backup_plan/ec2_ebs_volume_protected_by_backup_plan.py
@@ -7,11 +7,7 @@ class ec2_ebs_volume_protected_by_backup_plan(Check):
     def execute(self):
         findings = []
         for volume in ec2_client.volumes:
-            report = Check_Report_AWS(self.metadata())
-            report.region = volume.region
-            report.resource_id = volume.id
-            report.resource_arn = volume.arn
-            report.resource_tags = volume.tags
+            report = Check_Report_AWS(self.metadata(), volume)
             report.status = "FAIL"
             report.status_extended = (
                 f"EBS Volume {volume.id} is not protected by a backup plan."

--- a/prowler/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_volume_snapshots_exists/ec2_ebs_volume_snapshots_exists.py
@@ -6,12 +6,8 @@ class ec2_ebs_volume_snapshots_exists(Check):
     def execute(self):
         findings = []
         for volume in ec2_client.volumes:
-            report = Check_Report_AWS(self.metadata())
+            report = Check_Report_AWS(self.metadata(), volume)
             report.status = "FAIL"
-            report.region = volume.region
-            report.resource_id = volume.id
-            report.resource_arn = volume.arn
-            report.resource_tags = volume.tags
             report.status_extended = (
                 f"Snapshots not found for the EBS volume {volume.id}."
             )

--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan.py
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan.py
@@ -12,10 +12,7 @@ class ec2_elastic_ip_shodan(Check):
         if shodan_api_key:
             api = shodan.Shodan(shodan_api_key)
             for eip in ec2_client.elastic_ips:
-                report = Check_Report_AWS(self.metadata())
-                report.region = eip.region
-                report.resource_arn = eip.arn
-                report.resource_tags = eip.tags
+                report = Check_Report_AWS(self.metadata(), eip)
                 if eip.public_ip:
                     try:
                         shodan_info = api.host(eip.public_ip)

--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned.py
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_unassigned/ec2_elastic_ip_unassigned.py
@@ -6,12 +6,9 @@ class ec2_elastic_ip_unassigned(Check):
     def execute(self):
         findings = []
         for eip in ec2_client.elastic_ips:
-            report = Check_Report_AWS(self.metadata())
-            report.region = eip.region
+            report = Check_Report_AWS(self.metadata(), eip)
             if eip.public_ip:
                 report.resource_id = eip.public_ip
-                report.resource_arn = eip.arn
-                report.resource_tags = eip.tags
                 report.status = "FAIL"
                 report.status_extended = f"Elastic IP {eip.public_ip} is not associated with an instance or network interface."
                 if eip.association_id:

--- a/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled.py
@@ -10,8 +10,7 @@ class ec2_instance_account_imdsv2_enabled(Check):
                 instance_metadata_default.instances
                 or ec2_client.provider.scan_unused_services
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = instance_metadata_default.region
+                report = Check_Report_AWS(self.metadata(), instance_metadata_default)
                 report.resource_arn = ec2_client.account_arn_template
                 report.resource_id = ec2_client.audited_account
                 if instance_metadata_default.http_tokens == "required":

--- a/prowler/providers/aws/services/ec2/ec2_instance_detailed_monitoring_enabled/ec2_instance_detailed_monitoring_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_detailed_monitoring_enabled/ec2_instance_detailed_monitoring_enabled.py
@@ -6,8 +6,7 @@ class ec2_instance_detailed_monitoring_enabled(Check):
     def execute(self):
         findings = []
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.resource_id = instance.id
             report.resource_arn = instance.arn
             report.resource_tags = instance.tags

--- a/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_imdsv2_enabled/ec2_instance_imdsv2_enabled.py
@@ -7,11 +7,7 @@ class ec2_instance_imdsv2_enabled(Check):
         findings = []
         for instance in ec2_client.instances:
             if instance.state != "terminated":
-                report = Check_Report_AWS(self.metadata())
-                report.region = instance.region
-                report.resource_id = instance.id
-                report.resource_arn = instance.arn
-                report.resource_tags = instance.tags
+                report = Check_Report_AWS(self.metadata(), instance)
                 report.status = "FAIL"
                 report.status_extended = (
                     f"EC2 Instance {instance.id} has IMDSv2 disabled or not required."

--- a/prowler/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_internet_facing_with_instance_profile/ec2_instance_internet_facing_with_instance_profile.py
@@ -7,11 +7,7 @@ class ec2_instance_internet_facing_with_instance_profile(Check):
         findings = []
         for instance in ec2_client.instances:
             if instance.state != "terminated":
-                report = Check_Report_AWS(self.metadata())
-                report.region = instance.region
-                report.resource_id = instance.id
-                report.resource_arn = instance.arn
-                report.resource_tags = instance.tags
+                report = Check_Report_AWS(self.metadata(), instance)
                 report.status = "PASS"
                 report.status_extended = f"EC2 Instance {instance.id} is not internet facing with an instance profile."
                 if instance.public_ip and instance.instance_profile:

--- a/prowler/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_managed_by_ssm/ec2_instance_managed_by_ssm.py
@@ -7,8 +7,7 @@ class ec2_instance_managed_by_ssm(Check):
     def execute(self):
         findings = []
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.resource_arn = instance.arn
             report.resource_tags = instance.tags
             report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_older_than_specific_days/ec2_instance_older_than_specific_days.py
@@ -13,8 +13,7 @@ class ec2_instance_older_than_specific_days(Check):
             "max_ec2_instance_age_in_days", 180
         )
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.resource_id = instance.id
             report.resource_arn = instance.arn
             report.resource_tags = instance.tags

--- a/prowler/providers/aws/services/ec2/ec2_instance_paravirtual_type/ec2_instance_paravirtual_type.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_paravirtual_type/ec2_instance_paravirtual_type.py
@@ -7,19 +7,14 @@ class ec2_instance_paravirtual_type(Check):
         findings = []
         for instance in ec2_client.instances:
             if instance.state != "terminated":
-                report = Check_Report_AWS(self.metadata())
-                report.region = instance.region
-                report.resource_arn = instance.arn
-                report.resource_tags = instance.tags
+                report = Check_Report_AWS(self.metadata(), instance)
                 report.status = "PASS"
                 report.status_extended = (
                     f"EC2 Instance {instance.id} virtualization type is set to HVM."
                 )
-                report.resource_id = instance.id
                 if instance.virtualization_type == "paravirtual":
                     report.status = "FAIL"
                     report.status_extended = f"EC2 Instance {instance.id} virtualization type is set to paravirtual."
-                    report.resource_id = instance.id
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_cassandra_exposed_to_internet(Check):
         findings = []
         check_ports = [7000, 7001, 7199, 9042, 9160]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Cassandra ports open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet.py
@@ -11,15 +11,11 @@ class ec2_instance_port_cifs_exposed_to_internet(Check):
         findings = []
         check_ports = [139, 445]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = (
                 f"Instance {instance.id} does not have CIFS ports open to the Internet."
             )
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_elasticsearch_kibana_exposed_to_internet(Check):
         findings = []
         check_ports = [9200, 9300, 5601]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Elasticsearch/Kibana ports open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet.py
@@ -11,15 +11,11 @@ class ec2_instance_port_ftp_exposed_to_internet(Check):
         findings = []
         check_ports = [20, 21]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = (
                 f"Instance {instance.id} does not have FTP ports open to the Internet."
             )
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_kafka_exposed_to_internet(Check):
         findings = []
         check_ports = [9092]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Kafka port 9092 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_kerberos_exposed_to_internet(Check):
         findings = []
         check_ports = [88, 464, 749, 750]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Kerberos ports open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet.py
@@ -11,8 +11,7 @@ class ec2_instance_port_ldap_exposed_to_internet(Check):
         findings = []
         check_ports = [389, 636]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = (
                 f"Instance {instance.id} does not have LDAP ports open to the Internet."

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_memcached_exposed_to_internet(Check):
         findings = []
         check_ports = [11211]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Memcached port 11211 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_mongodb_exposed_to_internet(Check):
         findings = []
         check_ports = [27017, 27018]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have MongoDB ports open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_mysql_exposed_to_internet(Check):
         findings = []
         check_ports = [3306]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have MySQL port 3306 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_oracle_exposed_to_internet(Check):
         findings = []
         check_ports = [1521, 2483, 2484]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Oracle ports open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_postgresql_exposed_to_internet(Check):
         findings = []
         check_ports = [5432]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have PostgreSQL port 5432 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_rdp_exposed_to_internet(Check):
         findings = []
         check_ports = [3389]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have RDP port 3389 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_redis_exposed_to_internet(Check):
         findings = []
         check_ports = [6379]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Redis port 6379 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_sqlserver_exposed_to_internet(Check):
         findings = []
         check_ports = [1433, 1434]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have SQL Server ports open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_ssh_exposed_to_internet(Check):
         findings = []
         check_ports = [22]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have SSH port 22 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet.py
@@ -11,13 +11,9 @@ class ec2_instance_port_telnet_exposed_to_internet(Check):
         findings = []
         check_ports = [23]
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.status = "PASS"
             report.status_extended = f"Instance {instance.id} does not have Telnet port 23 open to the Internet."
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             is_open_port = False
             if instance.security_groups:
                 for sg in ec2_client.security_groups.values():

--- a/prowler/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_profile_attached/ec2_instance_profile_attached.py
@@ -7,11 +7,7 @@ class ec2_instance_profile_attached(Check):
         findings = []
         for instance in ec2_client.instances:
             if instance.state != "terminated":
-                report = Check_Report_AWS(self.metadata())
-                report.region = instance.region
-                report.resource_id = instance.id
-                report.resource_arn = instance.arn
-                report.resource_tags = instance.tags
+                report = Check_Report_AWS(self.metadata(), instance)
                 report.status = "FAIL"
                 report.status_extended = f"EC2 Instance {instance.id} not associated with an Instance Profile Role."
                 if instance.instance_profile:

--- a/prowler/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_public_ip/ec2_instance_public_ip.py
@@ -7,19 +7,14 @@ class ec2_instance_public_ip(Check):
         findings = []
         for instance in ec2_client.instances:
             if instance.state != "terminated":
-                report = Check_Report_AWS(self.metadata())
-                report.region = instance.region
-                report.resource_arn = instance.arn
-                report.resource_tags = instance.tags
+                report = Check_Report_AWS(self.metadata(), instance)
                 report.status = "PASS"
                 report.status_extended = (
                     f"EC2 Instance {instance.id} does not have a Public IP."
                 )
-                report.resource_id = instance.id
                 if instance.public_ip:
                     report.status = "FAIL"
                     report.status_extended = f"EC2 Instance {instance.id} has a Public IP: {instance.public_ip} ({instance.public_dns})."
-                    report.resource_id = instance.id
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
@@ -16,11 +16,7 @@ class ec2_instance_secrets_user_data(Check):
         )
         for instance in ec2_client.instances:
             if instance.state != "terminated":
-                report = Check_Report_AWS(self.metadata())
-                report.region = instance.region
-                report.resource_id = instance.id
-                report.resource_arn = instance.arn
-                report.resource_tags = instance.tags
+                report = Check_Report_AWS(self.metadata(), instance)
                 if instance.user_data:
                     user_data = b64decode(instance.user_data)
                     try:

--- a/prowler/providers/aws/services/ec2/ec2_instance_uses_single_eni/ec2_instance_uses_single_eni.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_uses_single_eni/ec2_instance_uses_single_eni.py
@@ -7,9 +7,6 @@ class ec2_instance_uses_single_eni(Check):
         findings = []
         for instance in ec2_client.instances:
             report = Check_Report_AWS(self.metadata(), instance)
-            report.resource_id = instance.id
-            report.resource_arn = instance.arn
-            report.resource_tags = instance.tags
             eni_types = {"efa": [], "interface": [], "trunk": []}
             if not instance.network_interfaces:
                 report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_instance_uses_single_eni/ec2_instance_uses_single_eni.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_uses_single_eni/ec2_instance_uses_single_eni.py
@@ -6,8 +6,7 @@ class ec2_instance_uses_single_eni(Check):
     def execute(self):
         findings = []
         for instance in ec2_client.instances:
-            report = Check_Report_AWS(self.metadata())
-            report.region = instance.region
+            report = Check_Report_AWS(self.metadata(), instance)
             report.resource_id = instance.id
             report.resource_arn = instance.arn
             report.resource_tags = instance.tags

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_imdsv2_required/ec2_launch_template_imdsv2_required.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_imdsv2_required/ec2_launch_template_imdsv2_required.py
@@ -6,11 +6,7 @@ class ec2_launch_template_imdsv2_required(Check):
     def execute(self):
         findings = []
         for template in ec2_client.launch_templates:
-            report = Check_Report_AWS(self.metadata())
-            report.region = template.region
-            report.resource_id = template.id
-            report.resource_arn = template.arn
-            report.resource_tags = template.tags
+            report = Check_Report_AWS(self.metadata(), template)
 
             versions_with_imdsv2_required = []
             versions_with_metadata_disabled = []

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_public_ip/ec2_launch_template_no_public_ip.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_public_ip/ec2_launch_template_no_public_ip.py
@@ -6,11 +6,7 @@ class ec2_launch_template_no_public_ip(Check):
     def execute(self):
         findings = []
         for template in ec2_client.launch_templates:
-            report = Check_Report_AWS(self.metadata())
-            report.region = template.region
-            report.resource_id = template.id
-            report.resource_arn = template.arn
-            report.resource_tags = template.tags
+            report = Check_Report_AWS(self.metadata(), template)
 
             versions_with_autoassign_public_ip = []
             versions_with_network_interfaces_public_ip = []

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
@@ -15,11 +15,7 @@ class ec2_launch_template_no_secrets(Check):
             "secrets_ignore_patterns", []
         )
         for template in ec2_client.launch_templates:
-            report = Check_Report_AWS(self.metadata())
-            report.region = template.region
-            report.resource_id = template.id
-            report.resource_arn = template.arn
-            report.resource_tags = template.tags
+            report = Check_Report_AWS(self.metadata(), template)
 
             versions_with_secrets = []
 

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_any_port/ec2_networkacl_allow_ingress_any_port.py
@@ -13,22 +13,13 @@ class ec2_networkacl_allow_ingress_any_port(Check):
                 ec2_client.provider.scan_unused_services
                 or network_acl.region in ec2_client.regions_with_sgs
             ):
+                report = Check_Report_AWS(self.metadata(), network_acl)
                 # If some entry allows it, that ACL is not securely configured
                 if check_network_acl(network_acl.entries, tcp_protocol, check_port):
-                    report = Check_Report_AWS(self.metadata())
-                    report.resource_id = network_acl.id
-                    report.region = network_acl.region
-                    report.resource_arn = arn
-                    report.resource_tags = network_acl.tags
                     report.status = "FAIL"
                     report.status_extended = f"Network ACL {network_acl.name if network_acl.name else network_acl.id} has every port open to the Internet."
                     findings.append(report)
                 else:
-                    report = Check_Report_AWS(self.metadata())
-                    report.resource_id = network_acl.id
-                    report.region = network_acl.region
-                    report.resource_arn = network_acl.arn
-                    report.resource_tags = network_acl.tags
                     report.status = "PASS"
                     report.status_extended = f"Network ACL {network_acl.name if network_acl.name else network_acl.id} does not have every port open to the Internet."
                     findings.append(report)

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_22/ec2_networkacl_allow_ingress_tcp_port_22.py
@@ -13,22 +13,13 @@ class ec2_networkacl_allow_ingress_tcp_port_22(Check):
                 ec2_client.provider.scan_unused_services
                 or network_acl.region in ec2_client.regions_with_sgs
             ):
+                report = Check_Report_AWS(self.metadata(), network_acl)
                 # If some entry allows it, that ACL is not securely configured
                 if check_network_acl(network_acl.entries, tcp_protocol, check_port):
-                    report = Check_Report_AWS(self.metadata())
-                    report.resource_id = network_acl.id
-                    report.region = network_acl.region
-                    report.resource_arn = arn
-                    report.resource_tags = network_acl.tags
                     report.status = "FAIL"
                     report.status_extended = f"Network ACL {network_acl.name if network_acl.name else network_acl.id} has SSH port 22 open to the Internet."
                     findings.append(report)
                 else:
-                    report = Check_Report_AWS(self.metadata())
-                    report.resource_id = network_acl.id
-                    report.region = network_acl.region
-                    report.resource_arn = network_acl.arn
-                    report.resource_tags = network_acl.tags
                     report.status = "PASS"
                     report.status_extended = f"Network ACL {network_acl.name if network_acl.name else network_acl.id} does not have SSH port 22 open to the Internet."
                     findings.append(report)

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_allow_ingress_tcp_port_3389/ec2_networkacl_allow_ingress_tcp_port_3389.py
@@ -13,22 +13,13 @@ class ec2_networkacl_allow_ingress_tcp_port_3389(Check):
                 ec2_client.provider.scan_unused_services
                 or network_acl.region in ec2_client.regions_with_sgs
             ):
+                report = Check_Report_AWS(self.metadata(), network_acl)
                 # If some entry allows it, that ACL is not securely configured
                 if check_network_acl(network_acl.entries, tcp_protocol, check_port):
-                    report = Check_Report_AWS(self.metadata())
-                    report.resource_id = network_acl.id
-                    report.region = network_acl.region
-                    report.resource_arn = arn
-                    report.resource_tags = network_acl.tags
                     report.status = "FAIL"
                     report.status_extended = f"Network ACL {network_acl.name if network_acl.name else network_acl.id} has Microsoft RDP port 3389 open to the Internet."
                     findings.append(report)
                 else:
-                    report = Check_Report_AWS(self.metadata())
-                    report.resource_id = network_acl.id
-                    report.region = network_acl.region
-                    report.resource_arn = network_acl.arn
-                    report.resource_tags = network_acl.tags
                     report.status = "PASS"
                     report.status_extended = f"Network ACL {network_acl.name if network_acl.name else network_acl.id} does not have Microsoft RDP port 3389 open to the Internet."
                     findings.append(report)

--- a/prowler/providers/aws/services/ec2/ec2_networkacl_unused/ec2_networkacl_unused.py
+++ b/prowler/providers/aws/services/ec2/ec2_networkacl_unused/ec2_networkacl_unused.py
@@ -7,11 +7,7 @@ class ec2_networkacl_unused(Check):
         findings = []
         for arn, network_acl in ec2_client.network_acls.items():
             if not network_acl.default:
-                report = Check_Report_AWS(self.metadata())
-                report.resource_id = network_acl.id
-                report.region = network_acl.region
-                report.resource_arn = arn
-                report.resource_tags = network_acl.tags
+                report = Check_Report_AWS(self.metadata(), network_acl)
 
                 if not network_acl.in_use:
                     report.status = "FAIL"

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.py
@@ -14,14 +14,11 @@ class ec2_securitygroup_allow_ingress_from_internet_to_all_ports(Check):
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
+                report.resource_details = security_group.name
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have all ports open to the Internet."
-                report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
+
                 for ingress_rule in security_group.ingress_rules:
                     if check_security_group(ingress_rule, "-1", any_address=True):
                         ec2_client.set_failed_check(

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_any_port/ec2_securitygroup_allow_ingress_from_internet_to_any_port.py
@@ -23,14 +23,10 @@ class ec2_securitygroup_allow_ingress_from_internet_to_any_port(Check):
                     and vpc_client.vpcs[security_group.vpc_id].in_use
                     and len(security_group.network_interfaces) > 0
                 ):
-                    report = Check_Report_AWS(self.metadata())
-                    report.region = security_group.region
+                    report = Check_Report_AWS(self.metadata(), security_group)
+                    report.resource_details = security_group.name
                     report.status = "PASS"
                     report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have any port open to the Internet."
-                    report.resource_details = security_group.name
-                    report.resource_id = security_group.id
-                    report.resource_arn = security_group_arn
-                    report.resource_tags = security_group.tags
                     for ingress_rule in security_group.ingress_rules:
                         if check_security_group(
                             ingress_rule, "-1", ports=None, any_address=True

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports.py
@@ -17,12 +17,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports(Check
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have any high-risk port open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
@@ -32,7 +32,7 @@ def fixer(resource_id: str, region: str) -> bool:
             "ec2_high_risk_ports",
             [25, 110, 135, 143, 445, 3000, 4333, 5000, 5500, 8080, 8088],
         )
-        for security_group in ec2_client.security_groups.items():
+        for security_group in ec2_client.security_groups.values():
             if security_group.id == resource_id:
                 for ingress_rule in security_group.ingress_rules:
                     if check_security_group(

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
@@ -32,7 +32,7 @@ def fixer(resource_id: str, region: str) -> bool:
             "ec2_high_risk_ports",
             [25, 110, 135, 143, 445, 3000, 4333, 5000, 5500, 8080, 8088],
         )
-        for security_group in ec2_client.security_groups.values():
+        for security_group_arn, security_group in ec2_client.security_groups.items():
             if security_group.id == resource_id:
                 for ingress_rule in security_group.ingress_rules:
                     if check_security_group(

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
@@ -32,7 +32,7 @@ def fixer(resource_id: str, region: str) -> bool:
             "ec2_high_risk_ports",
             [25, 110, 135, 143, 445, 3000, 4333, 5000, 5500, 8080, 8088],
         )
-        for security_group_arn, security_group in ec2_client.security_groups.items():
+        for security_group in ec2_client.security_groups.items():
             if security_group.id == resource_id:
                 for ingress_rule in security_group.ingress_rules:
                     if check_security_group(

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018/ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_port_mongodb_27017_27018(
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have MongoDB ports 27017 and 27018 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21/ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21.py
@@ -18,14 +18,11 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_ftp_port_20_21(Check)
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
+                report.resource_details = security_group.name
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have FTP ports 20 and 21 open to the Internet."
-                report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
+
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice
                 if not ec2_client.is_failed_check(
                     ec2_securitygroup_allow_ingress_from_internet_to_all_ports.__name__,

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22.py
@@ -18,14 +18,11 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22(Check):
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
+                report.resource_details = security_group.name
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have SSH port 22 open to the Internet."
-                report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
+
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice
                 if not ec2_client.is_failed_check(
                     ec2_securitygroup_allow_ingress_from_internet_to_all_ports.__name__,

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389.py
@@ -18,14 +18,11 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389(Check):
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
+                report.resource_details = security_group.name
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Microsoft RDP port 3389 open to the Internet."
-                report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
+
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice
                 if not ec2_client.is_failed_check(
                     ec2_securitygroup_allow_ingress_from_internet_to_all_ports.__name__,

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888.py
@@ -20,12 +20,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Casandra ports 7199, 8888 and 9160 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601.py
@@ -20,12 +20,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_ki
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Elasticsearch/Kibana ports 9200, 9300 and 5601 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092(Check
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Kafka port 9092 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211(
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Memcached port 11211 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306(Check
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have MySQL port 3306 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Oracle ports 1521 and 2483 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432(Ch
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Postgres port 5432 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379(Check
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Redis port 6379 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434.py
@@ -20,12 +20,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Microsoft SQL Server ports 1433 and 1434 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23/ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23.py
@@ -18,12 +18,8 @@ class ec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23(Check)
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) does not have Telnet port 23 open to the Internet."
                 # only proceed if check "..._to_all_ports" did not run or did not FAIL to avoid to report open ports twice

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_wide_open_public_ipv4/ec2_securitygroup_allow_wide_open_public_ipv4.py
@@ -16,12 +16,8 @@ class ec2_securitygroup_allow_wide_open_public_ipv4(Check):
                 and vpc_client.vpcs[security_group.vpc_id].in_use
                 and len(security_group.network_interfaces) > 0
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) has no potential wide-open non-RFC1918 address."
                 # Loop through every security group's ingress rule and check it

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic.py
@@ -16,12 +16,8 @@ class ec2_securitygroup_default_restrict_traffic(Check):
                     and len(security_group.network_interfaces) > 0
                 )
             ):
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "FAIL"
                 report.status_extended = (
                     f"Default Security Group ({security_group.id}) rules allow traffic."

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
@@ -5,7 +5,7 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 class ec2_securitygroup_from_launch_wizard(Check):
     def execute(self):
         findings = []
-        for security_group in ec2_client.security_groups.items():
+        for security_group in ec2_client.security_groups.values():
             report = Check_Report_AWS(self.metadata(), security_group)
             report.resource_details = security_group.name
             report.status = "PASS"

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
@@ -5,9 +5,8 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 class ec2_securitygroup_from_launch_wizard(Check):
     def execute(self):
         findings = []
-        for security_group_arn, security_group in ec2_client.security_groups.items():
+        for security_group in ec2_client.security_groups.items():
             report = Check_Report_AWS(self.metadata(), security_group)
-            report.region = security_group.region
             report.resource_details = security_group.name
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) was not created using the EC2 Launch Wizard."

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_from_launch_wizard/ec2_securitygroup_from_launch_wizard.py
@@ -6,12 +6,9 @@ class ec2_securitygroup_from_launch_wizard(Check):
     def execute(self):
         findings = []
         for security_group_arn, security_group in ec2_client.security_groups.items():
-            report = Check_Report_AWS(self.metadata())
+            report = Check_Report_AWS(self.metadata(), security_group)
             report.region = security_group.region
             report.resource_details = security_group.name
-            report.resource_id = security_group.id
-            report.resource_arn = security_group_arn
-            report.resource_tags = security_group.tags
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) was not created using the EC2 Launch Wizard."
             if "launch-wizard" in security_group.name:

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
@@ -11,9 +11,6 @@ class ec2_securitygroup_not_used(Check):
             if security_group.name != "default":
                 report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
-                report.resource_id = security_group.id
-                report.resource_arn = security_group_arn
-                report.resource_tags = security_group.tags
                 report.status = "PASS"
                 report.status_extended = f"Security group {security_group.name} ({security_group.id}) it is being used."
                 sg_in_lambda = False

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_not_used/ec2_securitygroup_not_used.py
@@ -9,8 +9,7 @@ class ec2_securitygroup_not_used(Check):
         for security_group_arn, security_group in ec2_client.security_groups.items():
             # Default security groups can not be deleted, so ignore them
             if security_group.name != "default":
-                report = Check_Report_AWS(self.metadata())
-                report.region = security_group.region
+                report = Check_Report_AWS(self.metadata(), security_group)
                 report.resource_details = security_group.name
                 report.resource_id = security_group.id
                 report.resource_arn = security_group_arn

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_with_many_ingress_egress_rules/ec2_securitygroup_with_many_ingress_egress_rules.py
@@ -11,12 +11,8 @@ class ec2_securitygroup_with_many_ingress_egress_rules(Check):
             "max_security_group_rules", 50
         )
         for security_group_arn, security_group in ec2_client.security_groups.items():
-            report = Check_Report_AWS(self.metadata())
-            report.region = security_group.region
+            report = Check_Report_AWS(self.metadata(), security_group)
             report.resource_details = security_group.name
-            report.resource_id = security_group.id
-            report.resource_arn = security_group_arn
-            report.resource_tags = security_group.tags
             report.status = "PASS"
             report.status_extended = f"Security group {security_group.name} ({security_group.id}) has {len(security_group.ingress_rules)} inbound rules and {len(security_group.egress_rules)} outbound rules."
             if (

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -137,6 +137,7 @@ class EC2(AWSService):
                             name=sg["GroupName"],
                             region=regional_client.region,
                             id=sg["GroupId"],
+                            arn=arn,
                             ingress_rules=sg["IpPermissions"],
                             egress_rules=sg["IpPermissionsEgress"],
                             associated_sgs=associated_sgs,
@@ -708,6 +709,7 @@ class NetworkInterface(BaseModel):
 class SecurityGroup(BaseModel):
     name: str
     region: str
+    arn: str
     id: str
     vpc_id: str
     associated_sgs: list
@@ -788,6 +790,7 @@ class LaunchTemplate(BaseModel):
 
 class VpnEndpoint(BaseModel):
     id: str
+    arn: str
     connection_logging: bool
     region: str
     tags: Optional[list] = []

--- a/prowler/providers/aws/services/ec2/ec2_transitgateway_auto_accept_vpc_attachments/ec2_transitgateway_auto_accept_vpc_attachments.py
+++ b/prowler/providers/aws/services/ec2/ec2_transitgateway_auto_accept_vpc_attachments/ec2_transitgateway_auto_accept_vpc_attachments.py
@@ -6,11 +6,7 @@ class ec2_transitgateway_auto_accept_vpc_attachments(Check):
     def execute(self):
         findings = []
         for tgw_arn, tgw in ec2_client.transit_gateways.items():
-            report = Check_Report_AWS(self.metadata())
-            report.region = tgw.region
-            report.resource_id = tgw.id
-            report.resource_arn = tgw_arn
-            report.resource_tags = tgw.tags
+            report = Check_Report_AWS(self.metadata(), tgw)
 
             if tgw.auto_accept_shared_attachments:
                 report.status = "FAIL"

--- a/prowler/providers/aws/services/ec2/ec2_transitgateway_auto_accept_vpc_attachments/ec2_transitgateway_auto_accept_vpc_attachments.py
+++ b/prowler/providers/aws/services/ec2/ec2_transitgateway_auto_accept_vpc_attachments/ec2_transitgateway_auto_accept_vpc_attachments.py
@@ -5,7 +5,7 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 class ec2_transitgateway_auto_accept_vpc_attachments(Check):
     def execute(self):
         findings = []
-        for tgw_arn, tgw in ec2_client.transit_gateways.items():
+        for tgw in ec2_client.transit_gateways.items():
             report = Check_Report_AWS(self.metadata(), tgw)
 
             if tgw.auto_accept_shared_attachments:

--- a/prowler/providers/aws/services/ec2/ec2_transitgateway_auto_accept_vpc_attachments/ec2_transitgateway_auto_accept_vpc_attachments.py
+++ b/prowler/providers/aws/services/ec2/ec2_transitgateway_auto_accept_vpc_attachments/ec2_transitgateway_auto_accept_vpc_attachments.py
@@ -5,7 +5,7 @@ from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 class ec2_transitgateway_auto_accept_vpc_attachments(Check):
     def execute(self):
         findings = []
-        for tgw in ec2_client.transit_gateways.items():
+        for tgw in ec2_client.transit_gateways.values():
             report = Check_Report_AWS(self.metadata(), tgw)
 
             if tgw.auto_accept_shared_attachments:

--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
@@ -26,7 +26,7 @@ class rds_instance_no_public_access(Check):
                     report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible but filtered with security groups."
                     db_instance_port = db_instance.endpoint.get("Port")
                     if db_instance_port:
-                        for security_group in ec2_client.security_groups.items():
+                        for security_group in ec2_client.security_groups.values():
                             if security_group.id in db_instance.security_groups:
                                 for ingress_rule in security_group.ingress_rules:
                                     if check_security_group(

--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
@@ -26,7 +26,10 @@ class rds_instance_no_public_access(Check):
                     report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible but filtered with security groups."
                     db_instance_port = db_instance.endpoint.get("Port")
                     if db_instance_port:
-                        for security_group in ec2_client.security_groups.values():
+                        for (
+                            security_group_arn,
+                            security_group,
+                        ) in ec2_client.security_groups.items():
                             if security_group.id in db_instance.security_groups:
                                 for ingress_rule in security_group.ingress_rules:
                                     if check_security_group(

--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access.py
@@ -26,10 +26,7 @@ class rds_instance_no_public_access(Check):
                     report.status_extended = f"RDS Instance {db_instance.id} is set as publicly accessible but filtered with security groups."
                     db_instance_port = db_instance.endpoint.get("Port")
                     if db_instance_port:
-                        for (
-                            security_group_arn,
-                            security_group,
-                        ) in ec2_client.security_groups.items():
+                        for security_group in ec2_client.security_groups.items():
                             if security_group.id in db_instance.security_groups:
                                 for ingress_rule in security_group.ingress_rules:
                                     if check_security_group(

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -77,7 +77,8 @@ class TestOCSF:
         assert output_data.resources[0].cloud_partition == findings[0].partition
         assert output_data.resources[0].region == findings[0].region
         assert output_data.resources[0].data == {
-            "details": findings[0].resource_details
+            "details": findings[0].resource_details,
+            "metadata": {},
         }
         assert output_data.metadata.profiles == ["cloud", "datetime"]
         assert output_data.metadata.tenant_uid == "test-organization-id"
@@ -191,7 +192,7 @@ class TestOCSF:
                     {
                         "cloud_partition": "aws",
                         "region": "eu-west-1",
-                        "data": {"details": "resource_details"},
+                        "data": {"details": "resource_details", "metadata": {}},
                         "group": {"name": "test-service"},
                         "labels": [],
                         "name": "resource_name",
@@ -315,7 +316,10 @@ class TestOCSF:
         assert resource_details[0].type == finding_output.metadata.ResourceType
         assert resource_details[0].cloud_partition == finding_output.partition
         assert resource_details[0].region == finding_output.region
-        assert resource_details[0].data == {"details": finding_output.resource_details}
+        assert resource_details[0].data == {
+            "details": finding_output.resource_details,
+            "metadata": {},
+        }
 
         resource_details_group = resource_details[0].group
         assert isinstance(resource_details_group, Group)

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -78,7 +78,7 @@ class TestOCSF:
         assert output_data.resources[0].region == findings[0].region
         assert output_data.resources[0].data == {
             "details": findings[0].resource_details,
-            "metadata": {},
+            # "metadata": {}, TODO: add metadata to the resource details
         }
         assert output_data.metadata.profiles == ["cloud", "datetime"]
         assert output_data.metadata.tenant_uid == "test-organization-id"

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -192,7 +192,10 @@ class TestOCSF:
                     {
                         "cloud_partition": "aws",
                         "region": "eu-west-1",
-                        "data": {"details": "resource_details", "metadata": {}},
+                        "data": {
+                            "details": "resource_details",
+                            # "metadata": {} TODO: add metadata to the resource details
+                        },
                         "group": {"name": "test-service"},
                         "labels": [],
                         "name": "resource_name",
@@ -318,7 +321,7 @@ class TestOCSF:
         assert resource_details[0].region == finding_output.region
         assert resource_details[0].data == {
             "details": finding_output.resource_details,
-            "metadata": {},
+            # "metadata": {}, TODO: add metadata to the resource details
         }
 
         resource_details_group = resource_details[0].group

--- a/tests/providers/aws/services/ec2/ec2_client_vpn_endpoint_connection_logging_enabled/ec2_client_vpn_endpoint_connection_logging_enabled_test.py
+++ b/tests/providers/aws/services/ec2/ec2_client_vpn_endpoint_connection_logging_enabled/ec2_client_vpn_endpoint_connection_logging_enabled_test.py
@@ -19,12 +19,15 @@ class Test_ec2_client_vpn_endpoint_connection_logging_enabled:
             [AWS_REGION_EU_WEST_1, AWS_REGION_US_EAST_1]
         )
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client",
-            new=EC2(aws_provider),
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client",
+                new=EC2(aws_provider),
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled import (
@@ -51,18 +54,22 @@ class Test_ec2_client_vpn_endpoint_connection_logging_enabled:
         ec2.vpn_endpoints = {
             "arn:aws:ec2:us-east-1:123456789012:client-vpn-endpoint/cvpn-endpoint-1234567890abcdef0": VpnEndpoint(
                 id="cvpn-endpoint-1234567890abcdef0",
+                arn="arn:aws:ec2:us-east-1:123456789012:client-vpn-endpoint/cvpn-endpoint-1234567890abcdef0",
                 connection_logging=False,
                 region=AWS_REGION_US_EAST_1,
                 tags=None,
             )
         }
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client",
-            new=ec2,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client",
+                new=ec2,
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled import (
@@ -100,18 +107,22 @@ class Test_ec2_client_vpn_endpoint_connection_logging_enabled:
         ec2.vpn_endpoints = {
             "arn:aws:ec2:us-east-1:123456789012:client-vpn-endpoint/cvpn-endpoint-1234567890abcdef0": VpnEndpoint(
                 id="cvpn-endpoint-1234567890abcdef0",
+                arn="arn:aws:ec2:us-east-1:123456789012:client-vpn-endpoint/cvpn-endpoint-1234567890abcdef0",
                 connection_logging=True,
                 region=AWS_REGION_US_EAST_1,
                 tags=None,
             )
         }
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=aws_provider,
-        ), mock.patch(
-            "prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client",
-            new=ec2,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client",
+                new=ec2,
+            ),
         ):
             # Test Check
             from prowler.providers.aws.services.ec2.ec2_client_vpn_endpoint_connection_logging_enabled.ec2_client_vpn_endpoint_connection_logging_enabled import (


### PR DESCRIPTION
### Context

This PR refactors the `Check_Report` and `Check_Report_AWS` classes to dynamically handle `resource_metadata`. For now, the changes are applied only to the EC2 service, allowing EC2-specific details to be included in the `data` field of the OCSF output. This improves the context of findings for EC2 resources while maintaining flexibility for future expansion to other services.

### Description

- Added `resource_metadata` to `Check_Report`: Dynamically extracts attributes from the EC2 metadata object and serializes them into a dictionary.
- Updated `Check_Report_AWS`: Automatically populates `resource_id`, `resource_arn`, and region for EC2 findings using `resource_metadata`.
- Improved OCSF Output: Includes `resource_metadata` in the `data` field under `metadata`, providing enriched context for EC2 findings.
- Initialization Updates: EC2 `Check_Report_AWS` instances now require `resource_metadata` as part of their initialization to ensure consistent data handling.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.