### PR TITLE
fix(codeartifact): fix flaky tests

### DIFF
--- a/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
+++ b/tests/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_test.py
@@ -52,6 +52,9 @@ class Test_codeartifact_packages_external_public_publishing_disabled:
         with mock.patch(
             "prowler.providers.aws.services.codeartifact.codeartifact_service.CodeArtifact",
             new=codeartifact_client,
+        ), mock.patch(
+            "prowler.providers.aws.services.codeartifact.codeartifact_client.codeartifact_client",
+            new=codeartifact_client,
         ):
             # Test Check
             from prowler.providers.aws.services.codeartifact.codeartifact_packages_external_public_publishing_disabled.codeartifact_packages_external_public_publishing_disabled import (


### PR DESCRIPTION
### Context

Tests created with MagicMock for CodeArtifact are flaky, sometimes they fail and sometimes they pass.

I’ve tried to run them with Pytest on local and they don’t fail, but I’ve noticed that one of the different unit tests for the check that is causing problems did not have the patch of MagicMock well done, I’ll change that and let see if that works.

### Description

Modified the unit test mentioned before.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.