### PR TITLE
fix(vpc): add new principal wildcard verification

### DIFF
--- a/tests/providers/aws/services/vpc/vpc_endpoint_services_allowed_principals_trust_boundaries/vpc_endpoint_services_allowed_principals_trust_boundaries_test.py
+++ b/tests/providers/aws/services/vpc/vpc_endpoint_services_allowed_principals_trust_boundaries/vpc_endpoint_services_allowed_principals_trust_boundaries_test.py
@@ -367,3 +367,67 @@ class Test_vpc_endpoint_services_allowed_principals_trust_boundaries:
                 assert result[0].resource_arn == endpoint_arn
                 assert result[0].resource_tags == []
                 assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_vpc_endpoint_service_with_principal_wildcard(self):
+        # Create VPC Mocked Resources
+        ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+        elbv2_client = client("elbv2", region_name=AWS_REGION_US_EAST_1)
+
+        vpc = ec2_client.create_vpc(
+            CidrBlock="172.28.7.0/24", InstanceTenancy="default"
+        )
+        subnet = ec2_client.create_subnet(
+            VpcId=vpc["Vpc"]["VpcId"],
+            CidrBlock="172.28.7.192/26",
+            AvailabilityZone=f"{AWS_REGION_US_EAST_1}a",
+        )
+        lb_name = "lb_vpce-test"
+        lb_arn = elbv2_client.create_load_balancer(
+            Name=lb_name,
+            Subnets=[subnet["Subnet"]["SubnetId"]],
+            Scheme="internal",
+            Type="network",
+        )["LoadBalancers"][0]["LoadBalancerArn"]
+
+        endpoint_id = ec2_client.create_vpc_endpoint_service_configuration(
+            NetworkLoadBalancerArns=[lb_arn]
+        )["ServiceConfiguration"]["ServiceId"]
+
+        # Add allowed principals
+        ec2_client.modify_vpc_endpoint_service_permissions(
+            ServiceId=endpoint_id, AddAllowedPrincipals=["*"]
+        )
+
+        endpoint_arn = f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:vpc-endpoint-service/{endpoint_id}"
+
+        from prowler.providers.aws.services.vpc.vpc_service import VPC
+
+        aws_provider = set_mocked_aws_provider(audited_regions=[AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.vpc.vpc_endpoint_services_allowed_principals_trust_boundaries.vpc_endpoint_services_allowed_principals_trust_boundaries.vpc_client",
+                new=VPC(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.vpc.vpc_endpoint_services_allowed_principals_trust_boundaries.vpc_endpoint_services_allowed_principals_trust_boundaries import (
+                    vpc_endpoint_services_allowed_principals_trust_boundaries,
+                )
+
+                check = vpc_endpoint_services_allowed_principals_trust_boundaries()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert (
+                    result[0].status_extended
+                    == f"Wildcard principal found in VPC Endpoint Service {endpoint_id}."
+                )
+                assert result[0].resource_id == endpoint_id
+                assert result[0].resource_arn == endpoint_arn
+                assert result[0].resource_tags == []
+                assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

Check `vpc_endpoint_services_allowed_principals_trust_boundaries` wasn't having in count wildcard as Principal.

### Description

Check for a wildcard if the principal is not an AWS account and add a test case.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.