### PR TITLE
feat(azure): include resource metadata in Check_Report_Azure

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -5,7 +5,7 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Set
+from typing import Any, Set
 
 from pydantic import BaseModel, ValidationError, validator
 
@@ -453,12 +453,34 @@ class Check_Report_Azure(Check_Report):
     subscription: str
     location: str
 
-    def __init__(self, metadata):
-        super().__init__(metadata)
-        self.resource_name = ""
-        self.resource_id = ""
-        self.subscription = ""
-        self.location = "global"
+    def __init__(self, metadata: dict, resource_metadata: Any = None) -> None:
+        """Initialize the Azure Check's finding information.
+
+        Args:
+            metadata: The metadata of the check.
+            resource_metadata: Basic information about the resource. Defaults to None.
+        """
+        super().__init__(metadata, resource_metadata)
+        self.resource_name = (
+            resource_metadata.name
+            if hasattr(resource_metadata, "name")
+            else (
+                resource_metadata.resource_name
+                if hasattr(resource_metadata, "resource_name")
+                else ""
+            )
+        )
+        self.resource_id = (
+            resource_metadata.id
+            if hasattr(resource_metadata, "id")
+            else (
+                resource_metadata.resource_id
+                if hasattr(resource_metadata, "resource_id")
+                else ""
+            )
+        )
+        self.subscription = getattr(resource_metadata, "subscription", "")
+        self.location = getattr(resource_metadata, "location", "global")
 
 
 @dataclass

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -479,7 +479,7 @@ class Check_Report_Azure(Check_Report):
                 else ""
             )
         )
-        self.subscription = getattr(resource_metadata, "subscription", "")
+        self.subscription = ""
         self.location = getattr(resource_metadata, "location", "global")
 
 


### PR DESCRIPTION
### Context

Due to the new way in which the report metadata is being generated in the PR #6440 for AWS, this PR does the same thing but for Azure.

### Description

Pass resource metadata to Check_Report and automate the extraction of basic attributes from resource metadata.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.