### PR TITLE
feat(aisearch): use Check_Report_Azure constructor properly in AISearch checks

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -5,7 +5,7 @@ import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Set
+from typing import Any, Set
 
 from pydantic import BaseModel, ValidationError, validator
 
@@ -453,12 +453,34 @@ class Check_Report_Azure(Check_Report):
     subscription: str
     location: str
 
-    def __init__(self, metadata):
-        super().__init__(metadata)
-        self.resource_name = ""
-        self.resource_id = ""
-        self.subscription = ""
-        self.location = "global"
+    def __init__(self, metadata: dict, resource_metadata: Any = None) -> None:
+        """Initialize the Azure Check's finding information.
+
+        Args:
+            metadata: The metadata of the check.
+            resource_metadata: Basic information about the resource. Defaults to None.
+        """
+        super().__init__(metadata, resource_metadata)
+        self.resource_name = (
+            resource_metadata.name
+            if hasattr(resource_metadata, "name")
+            else (
+                resource_metadata.resource_name
+                if hasattr(resource_metadata, "resource_name")
+                else ""
+            )
+        )
+        self.resource_id = (
+            resource_metadata.id
+            if hasattr(resource_metadata, "id")
+            else (
+                resource_metadata.resource_id
+                if hasattr(resource_metadata, "resource_id")
+                else ""
+            )
+        )
+        self.subscription = getattr(resource_metadata, "subscription", "")
+        self.location = getattr(resource_metadata, "location", "global")
 
 
 @dataclass

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -479,7 +479,7 @@ class Check_Report_Azure(Check_Report):
                 else ""
             )
         )
-        self.subscription = getattr(resource_metadata, "subscription", "")
+        self.subscription = ""
         self.location = getattr(resource_metadata, "location", "global")
 
 

--- a/prowler/providers/azure/services/aisearch/aisearch_service.py
+++ b/prowler/providers/azure/services/aisearch/aisearch_service.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass
-
 from azure.mgmt.search import SearchManagementClient
+from pydantic import BaseModel
 
 from prowler.lib.logger import logger
 from prowler.providers.azure.azure_provider import AzureProvider
@@ -23,6 +22,7 @@ class AISearch(AzureService):
                     aisearch_services[subscription].update(
                         {
                             aisearch_service.id: AISearchService(
+                                id=aisearch_service.id,
                                 name=aisearch_service.name,
                                 location=aisearch_service.location,
                                 public_network_access=(
@@ -41,8 +41,8 @@ class AISearch(AzureService):
         return aisearch_services
 
 
-@dataclass
-class AISearchService:
+class AISearchService(BaseModel):
+    id: str
     name: str
     location: str
     public_network_access: bool

--- a/prowler/providers/azure/services/aisearch/aisearch_service_not_publicly_accessible/aisearch_service_not_publicly_accessible.py
+++ b/prowler/providers/azure/services/aisearch/aisearch_service_not_publicly_accessible/aisearch_service_not_publicly_accessible.py
@@ -12,12 +12,11 @@ class aisearch_service_not_publicly_accessible(Check):
             subscription_name,
             aisearch_services,
         ) in aisearch_client.aisearch_services.items():
-            for aisearch_service_id, aisearch_service in aisearch_services.items():
-                report = Check_Report_Azure(self.metadata())
+            for aisearch_service in aisearch_services.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=aisearch_service
+                )
                 report.subscription = subscription_name
-                report.resource_name = aisearch_service.name
-                report.resource_id = aisearch_service_id
-                report.location = aisearch_service.location
                 report.status = "FAIL"
                 report.status_extended = f"AISearch Service {aisearch_service.name} from subscription {subscription_name} allows public access."
 

--- a/tests/providers/azure/services/aisearch/aisearch_service_public_access_level_is_disabled/aisearch_service_public_access_level_is_disabled_test.py
+++ b/tests/providers/azure/services/aisearch/aisearch_service_public_access_level_is_disabled/aisearch_service_public_access_level_is_disabled_test.py
@@ -35,6 +35,7 @@ class Test_AISearch_service_not_publicly_accessible:
         aisearch_client.aisearch_services = {
             AZURE_SUBSCRIPTION_ID: {
                 aisearch_service_id: AISearchService(
+                    id=aisearch_service_id,
                     name=aisearch_service_name,
                     location="westeurope",
                     public_network_access=True,
@@ -61,6 +62,7 @@ class Test_AISearch_service_not_publicly_accessible:
                 result[0].status_extended
                 == f"AISearch Service {aisearch_service_name} from subscription {AZURE_SUBSCRIPTION_ID} allows public access."
             )
+            assert result[0].resource_id == aisearch_service_id
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == aisearch_service_name
             assert result[0].location == "westeurope"
@@ -72,6 +74,7 @@ class Test_AISearch_service_not_publicly_accessible:
         aisearch_client.aisearch_services = {
             AZURE_SUBSCRIPTION_ID: {
                 aisearch_service_id: AISearchService(
+                    id=aisearch_service_id,
                     name=aisearch_service_name,
                     location="westeurope",
                     public_network_access=False,
@@ -98,6 +101,7 @@ class Test_AISearch_service_not_publicly_accessible:
                 result[0].status_extended
                 == f"AISearch Service {aisearch_service_name} from subscription {AZURE_SUBSCRIPTION_ID} does not allows public access."
             )
+            assert result[0].resource_id == aisearch_service_id
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == aisearch_service_name
             assert result[0].resource_id == aisearch_service_id

--- a/tests/providers/azure/services/aisearch/aisearch_service_test.py
+++ b/tests/providers/azure/services/aisearch/aisearch_service_test.py
@@ -14,6 +14,7 @@ def mock_storage_get_aisearch_services(_):
     return {
         AZURE_SUBSCRIPTION_ID: {
             "aisearch_service_id-1": AISearchService(
+                id="aisearch_service_id-1",
                 name="name",
                 location="westeurope",
                 public_network_access=True,


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from AI Search service.

### Description

- Added ID to search service model
- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.