### PR TITLE
feat(provider-secret): make existing external_id field mandatory

### DIFF
--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -7141,6 +7141,9 @@ components:
                         type: string
                         description: The Amazon Resource Name (ARN) of the role to
                           assume. Required for AWS role assumption.
+                      external_id:
+                        type: string
+                        description: An identifier to enhance security for role assumption.
                       aws_access_key_id:
                         type: string
                         description: The AWS access key ID. Only required if the environment
@@ -7159,10 +7162,6 @@ components:
                         maximum: 43200
                         default: 3600
                         description: The duration (in seconds) for the role session.
-                      external_id:
-                        type: string
-                        description: An optional identifier to enhance security for
-                          role assumption; may be required by the role administrator.
                       role_session_name:
                         type: string
                         description: |-
@@ -7175,6 +7174,7 @@ components:
                         pattern: ^[a-zA-Z0-9=,.@_-]+$
                     required:
                     - role_arn
+                    - external_id
                   - type: object
                     title: Azure Static Credentials
                     properties:
@@ -8352,6 +8352,9 @@ components:
                     type: string
                     description: The Amazon Resource Name (ARN) of the role to assume.
                       Required for AWS role assumption.
+                  external_id:
+                    type: string
+                    description: An identifier to enhance security for role assumption.
                   aws_access_key_id:
                     type: string
                     description: The AWS access key ID. Only required if the environment
@@ -8369,10 +8372,6 @@ components:
                     maximum: 43200
                     default: 3600
                     description: The duration (in seconds) for the role session.
-                  external_id:
-                    type: string
-                    description: An optional identifier to enhance security for role
-                      assumption; may be required by the role administrator.
                   role_session_name:
                     type: string
                     description: |-
@@ -8385,6 +8384,7 @@ components:
                     pattern: ^[a-zA-Z0-9=,.@_-]+$
                 required:
                 - role_arn
+                - external_id
               - type: object
                 title: Azure Static Credentials
                 properties:
@@ -8533,6 +8533,9 @@ components:
                         type: string
                         description: The Amazon Resource Name (ARN) of the role to
                           assume. Required for AWS role assumption.
+                      external_id:
+                        type: string
+                        description: An identifier to enhance security for role assumption.
                       aws_access_key_id:
                         type: string
                         description: The AWS access key ID. Only required if the environment
@@ -8551,10 +8554,6 @@ components:
                         maximum: 43200
                         default: 3600
                         description: The duration (in seconds) for the role session.
-                      external_id:
-                        type: string
-                        description: An optional identifier to enhance security for
-                          role assumption; may be required by the role administrator.
                       role_session_name:
                         type: string
                         description: |-
@@ -8567,6 +8566,7 @@ components:
                         pattern: ^[a-zA-Z0-9=,.@_-]+$
                     required:
                     - role_arn
+                    - external_id
                   - type: object
                     title: Azure Static Credentials
                     properties:
@@ -8732,6 +8732,9 @@ components:
                     type: string
                     description: The Amazon Resource Name (ARN) of the role to assume.
                       Required for AWS role assumption.
+                  external_id:
+                    type: string
+                    description: An identifier to enhance security for role assumption.
                   aws_access_key_id:
                     type: string
                     description: The AWS access key ID. Only required if the environment
@@ -8749,10 +8752,6 @@ components:
                     maximum: 43200
                     default: 3600
                     description: The duration (in seconds) for the role session.
-                  external_id:
-                    type: string
-                    description: An optional identifier to enhance security for role
-                      assumption; may be required by the role administrator.
                   role_session_name:
                     type: string
                     description: |-
@@ -8765,6 +8764,7 @@ components:
                     pattern: ^[a-zA-Z0-9=,.@_-]+$
                 required:
                 - role_arn
+                - external_id
               - type: object
                 title: Azure Static Credentials
                 properties:

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -1010,7 +1010,7 @@ class KubernetesProviderSecret(serializers.Serializer):
 
 class AWSRoleAssumptionProviderSecret(serializers.Serializer):
     role_arn = serializers.CharField()
-    external_id = serializers.CharField(required=False)
+    external_id = serializers.CharField()
     role_session_name = serializers.CharField(required=False)
     session_duration = serializers.IntegerField(
         required=False, min_value=900, max_value=43200
@@ -1057,6 +1057,10 @@ class AWSRoleAssumptionProviderSecret(serializers.Serializer):
                         "description": "The Amazon Resource Name (ARN) of the role to assume. Required for AWS role "
                         "assumption.",
                     },
+                    "external_id": {
+                        "type": "string",
+                        "description": "An identifier to enhance security for role assumption.",
+                    },
                     "aws_access_key_id": {
                         "type": "string",
                         "description": "The AWS access key ID. Only required if the environment lacks pre-configured "
@@ -1078,11 +1082,6 @@ class AWSRoleAssumptionProviderSecret(serializers.Serializer):
                         "default": 3600,
                         "description": "The duration (in seconds) for the role session.",
                     },
-                    "external_id": {
-                        "type": "string",
-                        "description": "An optional identifier to enhance security for role assumption; may be "
-                        "required by the role administrator.",
-                    },
                     "role_session_name": {
                         "type": "string",
                         "description": "An identifier for the role session, useful for tracking sessions in AWS logs. "
@@ -1096,7 +1095,7 @@ class AWSRoleAssumptionProviderSecret(serializers.Serializer):
                         "pattern": "^[a-zA-Z0-9=,.@_-]+$",
                     },
                 },
-                "required": ["role_arn"],
+                "required": ["role_arn", "external_id"],
             },
             {
                 "type": "object",


### PR DESCRIPTION
### Description

In this PR we have made the `external_id` field mandatory for AWS role assumption.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.