### PR TITLE
feat(findings): Add resource_tag filters for findings endpoint

### DIFF
--- a/api/src/backend/api/filters.py
+++ b/api/src/backend/api/filters.py
@@ -374,6 +374,12 @@ class FindingFilter(FilterSet):
             },
         }
 
+    @property
+    def qs(self):
+        # Force distinct results to prevent duplicates with many-to-many relationships
+        parent_qs = super().qs
+        return parent_qs.distinct()
+
     #  Convert filter values to UUIDv7 values for use with partitioning
     def filter_scan_id(self, queryset, name, value):
         try:

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -478,6 +478,51 @@ paths:
         explode: false
         style: form
       - in: query
+        name: filter[resource_tag_key]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_key__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_key__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_tag_value]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_value__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_value__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_tags]
+        schema:
+          type: array
+          items:
+            type: string
+        description: |-
+          Filter by resource tags `key:value` pairs.
+          Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
         name: filter[resource_type]
         schema:
           type: string
@@ -984,6 +1029,51 @@ paths:
         explode: false
         style: form
       - in: query
+        name: filter[resource_tag_key]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_key__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_key__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_tag_value]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_value__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_value__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_tags]
+        schema:
+          type: array
+          items:
+            type: string
+        description: |-
+          Filter by resource tags `key:value` pairs.
+          Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
         name: filter[resource_type]
         schema:
           type: string
@@ -1408,6 +1498,51 @@ paths:
           items:
             type: string
         description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_tag_key]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_key__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_key__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_tag_value]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_value__icontains]
+        schema:
+          type: string
+      - in: query
+        name: filter[resource_tag_value__in]
+        schema:
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
+      - in: query
+        name: filter[resource_tags]
+        schema:
+          type: array
+          items:
+            type: string
+        description: |-
+          Filter by resource tags `key:value` pairs.
+          Multiple values may be separated by commas.
         explode: false
         style: form
       - in: query

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -2444,6 +2444,15 @@ class TestFindingViewSet:
                 ("search", "ec2", 2),
                 # full text search on finding tags
                 ("search", "value2", 2),
+                ("resource_tag_key", "key", 2),
+                ("resource_tag_key__in", "key,key2", 2),
+                ("resource_tag_key__icontains", "key", 2),
+                ("resource_tag_value", "value", 2),
+                ("resource_tag_value__in", "value,value2", 2),
+                ("resource_tag_value__icontains", "value", 2),
+                ("resource_tags", "key:value", 2),
+                ("resource_tags", "not:exists", 0),
+                ("resource_tags", "not:exists,key:value", 2),
             ]
         ),
     )
@@ -2592,7 +2601,7 @@ class TestFindingViewSet:
 
         expected_services = {"ec2", "s3"}
         expected_regions = {"eu-west-1", "us-east-1"}
-        expected_tags = {"key": "value", "key2": "value2"}
+        expected_tags = {"key": ["value"], "key2": ["value2"]}
         expected_resource_types = {"prowler-test"}
 
         assert data["data"]["type"] == "findings-metadata"
@@ -2619,7 +2628,7 @@ class TestFindingViewSet:
 
         expected_services = {"s3"}
         expected_regions = {"eu-west-1"}
-        expected_tags = {"key": "value", "key2": "value2"}
+        expected_tags = {"key": ["value"], "key2": ["value2"]}
         expected_resource_types = {"prowler-test"}
 
         assert data["data"]["type"] == "findings-metadata"

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1414,7 +1414,14 @@ class FindingViewSet(BaseRLSViewSet):
         if result["tags"] is None:
             result["tags"] = []
 
-        result["tags"] = {t["key"]: t["value"] for t in result["tags"]}
+        tags_dict = {}
+        for t in result["tags"]:
+            key, value = t["key"], t["value"]
+            if key not in tags_dict:
+                tags_dict[key] = []
+            tags_dict[key].append(value)
+
+        result["tags"] = tags_dict
 
         serializer = self.get_serializer(
             data=result,


### PR DESCRIPTION
### Description

New filters have been added to the following endpoints:

- `GET /findings`
- `GET /findings/metadata`

![image](https://github.com/user-attachments/assets/dd2ae70e-96b9-4c8b-8081-a50cfb248e01)

In addition, the `GET /findings/metadata` endpoint will not return a list of values for each tag.

### Examples

Every filter is self explanatory except for the `filter[resource_tags]`, which expects a list of key:value pairs separated by commas:

![image](https://github.com/user-attachments/assets/fdf1a662-d287-4fd4-8da6-e8d7ddedb502)

> Same behavior for `GET /findings`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.