### PR TITLE
feat(containerregistry): extract Container Registry resource metadata in automated way

### DIFF
--- a/prowler/providers/azure/services/containerregistry/containerregistry_admin_user_disabled/containerregistry_admin_user_disabled.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_admin_user_disabled/containerregistry_admin_user_disabled.py
@@ -9,12 +9,11 @@ class containerregistry_admin_user_disabled(Check):
         findings = []
 
         for subscription, registries in containerregistry_client.registries.items():
-            for registry_id, container_registry_info in registries.items():
-                report = Check_Report_Azure(self.metadata())
+            for container_registry_info in registries.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=container_registry_info
+                )
                 report.subscription = subscription
-                report.resource_name = container_registry_info.name
-                report.resource_id = registry_id
-                report.location = container_registry_info.location
                 report.status = "FAIL"
                 report.status_extended = f"Container Registry {container_registry_info.name} from subscription {subscription} has its admin user enabled."
 

--- a/prowler/providers/azure/services/containerregistry/containerregistry_not_publicly_accessible/containerregistry_not_publicly_accessible.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_not_publicly_accessible/containerregistry_not_publicly_accessible.py
@@ -9,12 +9,11 @@ class containerregistry_not_publicly_accessible(Check):
         findings = []
 
         for subscription, registries in containerregistry_client.registries.items():
-            for registry_id, container_registry_info in registries.items():
-                report = Check_Report_Azure(self.metadata())
+            for container_registry_info in registries.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=container_registry_info
+                )
                 report.subscription = subscription
-                report.resource_name = container_registry_info.name
-                report.resource_id = registry_id
-                report.location = container_registry_info.location
                 report.status = "FAIL"
                 report.status_extended = f"Container Registry {container_registry_info.name} from subscription {subscription} allows unrestricted network access."
 

--- a/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_uses_private_link/containerregistry_uses_private_link.py
@@ -9,12 +9,11 @@ class containerregistry_uses_private_link(Check):
         findings = []
 
         for subscription, registries in containerregistry_client.registries.items():
-            for registry_id, container_registry_info in registries.items():
-                report = Check_Report_Azure(self.metadata())
+            for container_registry_info in registries.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=container_registry_info
+                )
                 report.subscription = subscription
-                report.resource_name = container_registry_info.name
-                report.resource_id = registry_id
-                report.location = container_registry_info.location
                 report.status = "FAIL"
                 report.status_extended = f"Container Registry {container_registry_info.name} from subscription {subscription} does not use a private link."
 


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from Container Registry service.

### Description

- Using new `Check_Report_Azure` constructor in Container Registry checks

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.