### PR TITLE
feat(cosmosdb): extract CosmosDB resource metadata in automated way

### DIFF
--- a/prowler/providers/azure/services/cosmosdb/cosmosdb_account_firewall_use_selected_networks/cosmosdb_account_firewall_use_selected_networks.py
+++ b/prowler/providers/azure/services/cosmosdb/cosmosdb_account_firewall_use_selected_networks/cosmosdb_account_firewall_use_selected_networks.py
@@ -7,12 +7,11 @@ class cosmosdb_account_firewall_use_selected_networks(Check):
         findings = []
         for subscription, accounts in cosmosdb_client.accounts.items():
             for account in accounts:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=account
+                )
                 report.subscription = subscription
-                report.resource_name = account.name
-                report.resource_id = account.id
                 report.status = "FAIL"
-                report.location = account.location
                 report.status_extended = f"CosmosDB account {account.name} from subscription {subscription} has firewall rules that allow access from all networks."
                 if account.is_virtual_network_filter_enabled:
                     report.status = "PASS"

--- a/prowler/providers/azure/services/cosmosdb/cosmosdb_account_use_aad_and_rbac/cosmosdb_account_use_aad_and_rbac.py
+++ b/prowler/providers/azure/services/cosmosdb/cosmosdb_account_use_aad_and_rbac/cosmosdb_account_use_aad_and_rbac.py
@@ -7,12 +7,11 @@ class cosmosdb_account_use_aad_and_rbac(Check):
         findings = []
         for subscription, accounts in cosmosdb_client.accounts.items():
             for account in accounts:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=account
+                )
                 report.subscription = subscription
-                report.resource_name = account.name
-                report.resource_id = account.id
                 report.status = "FAIL"
-                report.location = account.location
                 report.status_extended = f"CosmosDB account {account.name} from subscription {subscription} is not using AAD and RBAC"
                 if account.disable_local_auth:
                     report.status = "PASS"

--- a/prowler/providers/azure/services/cosmosdb/cosmosdb_account_use_private_endpoints/cosmosdb_account_use_private_endpoints.py
+++ b/prowler/providers/azure/services/cosmosdb/cosmosdb_account_use_private_endpoints/cosmosdb_account_use_private_endpoints.py
@@ -7,12 +7,11 @@ class cosmosdb_account_use_private_endpoints(Check):
         findings = []
         for subscription, accounts in cosmosdb_client.accounts.items():
             for account in accounts:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=account
+                )
                 report.subscription = subscription
-                report.resource_name = account.name
-                report.resource_id = account.id
                 report.status = "FAIL"
-                report.location = account.location
                 report.status_extended = f"CosmosDB account {account.name} from subscription {subscription} is not using private endpoints connections"
                 if account.private_endpoint_connections:
                     report.status = "PASS"

--- a/prowler/providers/azure/services/cosmosdb/cosmosdb_service.py
+++ b/prowler/providers/azure/services/cosmosdb/cosmosdb_service.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from azure.mgmt.cosmosdb import CosmosDBManagementClient
 from azure.mgmt.cosmosdb.models import PrivateEndpointConnection
@@ -50,5 +50,7 @@ class Account:
     tags: dict
     is_virtual_network_filter_enabled: bool
     location: str
-    private_endpoint_connections: list[PrivateEndpointConnection] = None
+    private_endpoint_connections: list[PrivateEndpointConnection] = field(
+        default_factory=list
+    )
     disable_local_auth: bool = False


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from Cosmos DB service.

### Description

- Using new `Check_Report_Azure` constructor
- Add default value to `private_endpoint_connections` in a proper way.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.