### PR TITLE
fix(detect_secrets): refactor logic for detect-secrets

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 from prowler.lib.check.models import Check, Check_Report_AWS
@@ -28,11 +29,19 @@ class awslambda_function_no_secrets_in_variables(Check):
                     data=json.dumps(function.environment, indent=2),
                     excluded_secrets=secrets_ignore_patterns,
                 )
+                original_env_vars = {}
+                for name, value in function.environment.items():
+                    original_env_vars.update(
+                        {
+                            hashlib.sha1(  # nosec B324 SHA1 is used here for non-security-critical unique identifiers
+                                value.encode("utf-8")
+                            ).hexdigest(): name
+                        }
+                    )
                 if detect_secrets_output:
-                    environment_variable_names = list(function.environment.keys())
                     secrets_string = ", ".join(
                         [
-                            f"{secret['type']} in variable {environment_variable_names[int(secret['line_number']) - 2]}"
+                            f"{secret['type']} in variable {original_env_vars[secret['hashed_secret']]}"
                             for secret in detect_secrets_output
                         ]
                     )

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -1,3 +1,4 @@
+import hashlib
 from json import dumps
 
 from prowler.lib.check.models import Check, Check_Report_AWS
@@ -25,8 +26,16 @@ class ecs_task_definitions_no_environment_secrets(Check):
 
                 if container.environment:
                     dump_env_vars = {}
+                    original_env_vars = {}
                     for env_var in container.environment:
                         dump_env_vars.update({env_var.name: env_var.value})
+                        original_env_vars.update(
+                            {
+                                hashlib.sha1(  # nosec B324 SHA1 is used here for non-security-critical unique identifiers
+                                    env_var.value.encode("utf-8")
+                                ).hexdigest(): env_var.name
+                            }
+                        )
 
                     env_data = dumps(dump_env_vars, indent=2)
                     detect_secrets_output = detect_secrets_scan(
@@ -35,7 +44,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
                     if detect_secrets_output:
                         secrets_string = ", ".join(
                             [
-                                f"{secret['type']} on line {secret['line_number']}"
+                                f"{secret['type']} on env var {original_env_vars[secret['hashed_secret']]}"
                                 for secret in detect_secrets_output
                             ]
                         )

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -44,7 +44,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
                     if detect_secrets_output:
                         secrets_string = ", ".join(
                             [
-                                f"{secret['type']} on env var {original_env_vars[secret['hashed_secret']]}"
+                                f"{secret['type']} on the environment variable {original_env_vars[secret['hashed_secret']]}"
                                 for secret in detect_secrets_output
                             ]
                         )

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -132,7 +132,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on env var DB_PASSWORD."
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on the environment variable DB_PASSWORD."
             )
             assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
             assert result[0].resource_arn == task_arn

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -132,7 +132,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on line 2."
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on env var DB_PASSWORD."
             )
             assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
             assert result[0].resource_arn == task_arn


### PR DESCRIPTION
### Context

Fix #6467
Thanks @kagahd for the heads up! 🚀 
### Description

This PR change the logic from the checks: `ecs_task_definitions_no_environment_secrets`, `awslambda_function_no_secrets_in_variables`
The main problem here is that we are re-writing the ecs env vars into a format that Detect-Secrets could find them and we were using the line from the output to create the `status_extended`. That's why the line was incorrect (it was taking the lines from the re-written variables).

The new approach changes the status extended from:
`...Secret keyword on line 2.`
to
`...Secret keyword on env var DB_PASSWORD.`

This way, the user will have the env name on the output.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
