### PR TITLE
feat: add resource metadata to `emr_cluster_account_public_block_enabled`

### DIFF
--- a/prowler/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled.py
+++ b/prowler/providers/aws/services/emr/emr_cluster_account_public_block_enabled/emr_cluster_account_public_block_enabled.py
@@ -6,7 +6,10 @@ class emr_cluster_account_public_block_enabled(Check):
     def execute(self):
         findings = []
         for region in emr_client.block_public_access_configuration:
-            report = Check_Report_AWS(self.metadata())
+            report = Check_Report_AWS(
+                metadata=self.metadata(),
+                resource_metadata=emr_client.block_public_access_configuration,
+            )
             report.region = region
             report.resource_id = emr_client.audited_account
             report.resource_arn = emr_client._get_cluster_arn_template(region)


### PR DESCRIPTION
### Context

In a previous pr #6532 I did not include this check.

### Description

Resource metadata has been implemented in `emr_cluster_account_public_block_enabled` check.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
