### PR TITLE
feat(appinsights): extract App Insights resource metadata in automated way

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -416,12 +416,16 @@ class Check_Report:
         Args:
             metadata: The metadata of the check.
             resource: Basic information about the resource. Defaults to None.
-                      Only accepted BaseModels (dict attribute), custom models (to_dict attribute) or objects with __dict__.
+                      Only accepted dict, list, BaseModels (dict attribute), custom models (with to_dict attribute) or objects with __dict__.
         """
         self.status = ""
         self.check_metadata = CheckMetadata.parse_raw(metadata)
 
-        if hasattr(resource, "dict"):
+        if isinstance(resource, dict):
+            self.resource_metadata = resource
+        elif isinstance(resource, list):
+            self.resource_metadata = dict(enumerate(resource))
+        elif hasattr(resource, "dict"):
             self.resource_metadata = resource.dict()
         elif hasattr(resource, "to_dict"):
             self.resource_metadata = resource.to_dict()

--- a/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
+++ b/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
@@ -9,7 +9,7 @@ class appinsights_ensure_is_configured(Check):
         findings = []
 
         for subscription_name, components in appinsights_client.components.items():
-            report = Check_Report_Azure(self.metadata())
+            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata={})
             report.status = "PASS"
             report.subscription = subscription_name
             report.resource_name = "AppInsights"


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from App Insights service.

### Description

- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.