### PR TITLE
feat(aws): include resource metadata to remaining checks

### DIFF
--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
@@ -15,9 +15,7 @@ class backup_plans_exist(Check):
             report.resource_id = backup_client.backup_plans[0].name
             findings.append(report)
         elif backup_client.backup_vaults:
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource_metadata=backup_client
-            )
+            report = Check_Report_AWS(metadata=self.metadata(), resource_metadata={})
             report.status = "FAIL"
             report.status_extended = "No Backup Plan exist."
             report.resource_arn = backup_client.backup_plan_arn_template

--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
@@ -15,7 +15,9 @@ class backup_plans_exist(Check):
             report.resource_id = backup_client.backup_plans[0].name
             findings.append(report)
         elif backup_client.backup_vaults:
-            report = Check_Report_AWS(self.metadata(), resource_metadata=backup_client)
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource_metadata=backup_client
+            )
             report.status = "FAIL"
             report.status_extended = "No Backup Plan exist."
             report.resource_arn = backup_client.backup_plan_arn_template

--- a/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
+++ b/prowler/providers/aws/services/backup/backup_plans_exist/backup_plans_exist.py
@@ -16,6 +16,7 @@ class backup_plans_exist(Check):
             findings.append(report)
         elif backup_client.backup_vaults:
             report = Check_Report_AWS(metadata=self.metadata(), resource_metadata={})
+            report.region = backup_client.region
             report.status = "FAIL"
             report.status_extended = "No Backup Plan exist."
             report.resource_arn = backup_client.backup_plan_arn_template

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_cross_account_sharing_disabled/cloudwatch_cross_account_sharing_disabled.py
@@ -16,7 +16,9 @@ class cloudwatch_cross_account_sharing_disabled(Check):
             report.resource_id = iam_client.audited_account
             for role in iam_client.roles:
                 if role.name == "CloudWatch-CrossAccountSharingRole":
-                    report = Check_Report_AWS(self.metadata(), role)
+                    report = Check_Report_AWS(
+                        metadata=self.metadata(), resource_metadata=role
+                    )
                     report.region = iam_client.region
                     report.status = "FAIL"
                     report.status_extended = (

--- a/prowler/providers/aws/services/directconnect/directconnect_virtual_interface_redundancy/directconnect_virtual_interface_redundancy.py
+++ b/prowler/providers/aws/services/directconnect/directconnect_virtual_interface_redundancy/directconnect_virtual_interface_redundancy.py
@@ -8,10 +8,7 @@ class directconnect_virtual_interface_redundancy(Check):
     def execute(self):
         findings = []
         for vgw in directconnect_client.vgws.values():
-            report = Check_Report_AWS(self.metadata())
-            report.resource_arn = vgw.arn
-            report.region = vgw.region
-            report.resource_id = vgw.id
+            report = Check_Report_AWS(metadata=self.metadata(), resource_metadata=vgw)
             if len(vgw.vifs) < 2:
                 report.status = "FAIL"
                 report.status_extended = (

--- a/prowler/providers/aws/services/efs/efs_mount_target_not_publicly_accessible/efs_mount_target_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/efs/efs_mount_target_not_publicly_accessible/efs_mount_target_not_publicly_accessible.py
@@ -7,11 +7,7 @@ class efs_mount_target_not_publicly_accessible(Check):
     def execute(self):
         findings = []
         for fs in efs_client.filesystems.values():
-            report = Check_Report_AWS(self.metadata())
-            report.region = fs.region
-            report.resource_id = fs.id
-            report.resource_arn = fs.arn
-            report.resource_tags = fs.tags
+            report = Check_Report_AWS(metadata=self.metadata(), resource_metadata=fs)
             report.status = "PASS"
             report.status_extended = (
                 f"EFS {fs.id} does not have any public mount targets."

--- a/prowler/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_insecure_ssl_ciphers/elbv2_insecure_ssl_ciphers.py
@@ -17,12 +17,8 @@ class elbv2_insecure_ssl_ciphers(Check):
             "ELBSecurityPolicy-TLS13-1-2-Ext1-2021-06",
             "ELBSecurityPolicy-TLS13-1-2-Ext2-2021-06",
         ]
-        for lb_arn, lb in elbv2_client.loadbalancersv2.items():
-            report = Check_Report_AWS(self.metadata())
-            report.region = lb.region
-            report.resource_id = lb.name
-            report.resource_arn = lb_arn
-            report.resource_tags = lb.tags
+        for lb in elbv2_client.loadbalancersv2.values():
+            report = Check_Report_AWS(metadata=self.metadata(), resource_metadata=lb)
             report.status = "PASS"
             report.status_extended = (
                 f"ELBv2 {lb.name} does not have insecure SSL protocols or ciphers."

--- a/prowler/providers/aws/services/eventbridge/eventbridge_bus_cross_account_access/eventbridge_bus_cross_account_access.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_bus_cross_account_access/eventbridge_bus_cross_account_access.py
@@ -9,11 +9,7 @@ class eventbridge_bus_cross_account_access(Check):
     def execute(self):
         findings = []
         for bus in eventbridge_client.buses.values():
-            report = Check_Report_AWS(self.metadata())
-            report.resource_id = bus.name
-            report.resource_arn = bus.arn
-            report.resource_tags = bus.tags
-            report.region = bus.region
+            report = Check_Report_AWS(metadata=self.metadata(), resource_metadata=bus)
             report.status = "PASS"
             report.status_extended = (
                 f"EventBridge event bus {bus.name} does not allow cross-account access."

--- a/prowler/providers/aws/services/iam/iam_user_accesskey_unused/iam_user_accesskey_unused.py
+++ b/prowler/providers/aws/services/iam/iam_user_accesskey_unused/iam_user_accesskey_unused.py
@@ -47,7 +47,9 @@ class iam_user_accesskey_unused(Check):
                         ) - parser.parse(user["access_key_1_last_used_date"])
                         if access_key_1_last_used_date.days > maximum_expiration_days:
                             old_access_keys = True
-                            report = Check_Report_AWS(self.metadata())
+                            report = Check_Report_AWS(
+                                metadata=self.metadata(), resource_metadata=user
+                            )
                             report.region = iam_client.region
                             report.resource_id = user["user"] + "/AccessKey1"
                             report.resource_arn = user["arn"]
@@ -63,7 +65,9 @@ class iam_user_accesskey_unused(Check):
                         ) - parser.parse(user["access_key_2_last_used_date"])
                         if access_key_2_last_used_date.days > maximum_expiration_days:
                             old_access_keys = True
-                            report = Check_Report_AWS(self.metadata())
+                            report = Check_Report_AWS(
+                                metadata=self.metadata(), resource_metadata=user
+                            )
                             report.region = iam_client.region
                             report.resource_id = user["user"] + "/AccessKey2"
                             report.resource_arn = user["arn"]
@@ -73,7 +77,9 @@ class iam_user_accesskey_unused(Check):
                             findings.append(report)
 
                 if not old_access_keys:
-                    report = Check_Report_AWS(self.metadata())
+                    report = Check_Report_AWS(
+                        metadata=self.metadata(), resource_metadata=user
+                    )
                     report.region = iam_client.region
                     report.resource_id = user["user"]
                     report.resource_arn = user["arn"]

--- a/prowler/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover.py
+++ b/prowler/providers/aws/services/route53/route53_dangling_ip_subdomain_takeover/route53_dangling_ip_subdomain_takeover.py
@@ -28,7 +28,9 @@ class route53_dangling_ip_subdomain_takeover(Check):
                 for record in record_set.records:
                     # Check if record is an IP Address
                     if validate_ip_address(record):
-                        report = Check_Report_AWS(self.metadata())
+                        report = Check_Report_AWS(
+                            metadata=self.metadata(), resource_metadata=record_set
+                        )
                         report.resource_id = (
                             f"{record_set.hosted_zone_id}/{record_set.name}/{record}"
                         )
@@ -38,7 +40,6 @@ class route53_dangling_ip_subdomain_takeover(Check):
                         report.resource_tags = route53_client.hosted_zones[
                             record_set.hosted_zone_id
                         ].tags
-                        report.region = record_set.region
                         report.status = "PASS"
                         report.status_extended = f"Route53 record {record} (name: {record_set.name}) in Hosted Zone {route53_client.hosted_zones[record_set.hosted_zone_id].name} is not a dangling IP."
                         # If Public IP check if it is in the AWS Account

--- a/prowler/providers/aws/services/sagemaker/sagemaker_models_vpc_settings_configured/sagemaker_models_vpc_settings_configured.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_models_vpc_settings_configured/sagemaker_models_vpc_settings_configured.py
@@ -6,11 +6,7 @@ class sagemaker_models_vpc_settings_configured(Check):
     def execute(self):
         findings = []
         for model in sagemaker_client.sagemaker_models:
-            report = Check_Report_AWS(self.metadata())
-            report.region = model.region
-            report.resource_id = model.name
-            report.resource_arn = model.arn
-            report.resource_tags = model.tags
+            report = Check_Report_AWS(metadata=self.metadata(), resource_metadata=model)
             report.status = "PASS"
             report.status_extended = (
                 f"Sagemaker notebook instance {model.name} has VPC settings enabled."

--- a/prowler/providers/aws/services/shield/shield_advanced_protection_in_internet_facing_load_balancers/shield_advanced_protection_in_internet_facing_load_balancers.py
+++ b/prowler/providers/aws/services/shield/shield_advanced_protection_in_internet_facing_load_balancers/shield_advanced_protection_in_internet_facing_load_balancers.py
@@ -9,11 +9,10 @@ class shield_advanced_protection_in_internet_facing_load_balancers(Check):
         if shield_client.enabled:
             for elbv2_arn, elbv2 in elbv2_client.loadbalancersv2.items():
                 if elbv2.type == "application" and elbv2.scheme == "internet-facing":
-                    report = Check_Report_AWS(self.metadata())
+                    report = Check_Report_AWS(
+                        metadata=self.metadata(), resource_metadata=elbv2
+                    )
                     report.region = shield_client.region
-                    report.resource_id = elbv2.name
-                    report.resource_arn = elbv2_arn
-                    report.resource_tags = elbv2.tags
                     report.status = "FAIL"
                     report.status_extended = f"ELBv2 ALB {elbv2.name} is not protected by AWS Shield Advanced."
 

--- a/prowler/providers/aws/services/sns/sns_subscription_not_using_http_endpoints/sns_subscription_not_using_http_endpoints.py
+++ b/prowler/providers/aws/services/sns/sns_subscription_not_using_http_endpoints/sns_subscription_not_using_http_endpoints.py
@@ -9,9 +9,9 @@ class sns_subscription_not_using_http_endpoints(Check):
             for subscription in topic.subscriptions:
                 if subscription.arn == "PendingConfirmation":
                     continue
-                report = Check_Report_AWS(self.metadata())
-                report.resource_id = subscription.id
-                report.resource_arn = subscription.arn
+                report = Check_Report_AWS(
+                    metadata=self.metadata(), resource_metadata=subscription
+                )
                 report.resource_details = topic.arn
                 report.status = "PASS"
                 report.status_extended = (

--- a/prowler/providers/aws/services/ssm/ssm_document_secrets/ssm_document_secrets.py
+++ b/prowler/providers/aws/services/ssm/ssm_document_secrets/ssm_document_secrets.py
@@ -12,11 +12,9 @@ class ssm_document_secrets(Check):
             "secrets_ignore_patterns", []
         )
         for document in ssm_client.documents.values():
-            report = Check_Report_AWS(self.metadata())
-            report.region = document.region
-            report.resource_arn = document.arn
-            report.resource_id = document.name
-            report.resource_tags = document.tags
+            report = Check_Report_AWS(
+                metadata=self.metadata(), resource_metadata=document
+            )
             report.status = "PASS"
             report.status_extended = (
                 f"No secrets found in SSM Document {document.name}."


### PR DESCRIPTION
### Context

Refactor the Check_Report_AWS initialization for the remaining checks to pass the resource_metadata object directly.

- Remove assignments for region, resource_id, tags, and resource_arn within each check.
- Ensure the Check_Report_AWS constructor dynamically extracts this information from resource_metadata.

### Description

Modified some checks that were left to be done.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
