### PR TITLE
feat(monitor): extract monitor resource metadata automated

### DIFF
--- a/prowler/providers/azure/services/monitor/monitor_alert_create_policy_assignment/monitor_alert_create_policy_assignment.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_policy_assignment/monitor_alert_create_policy_assignment.py
@@ -11,22 +11,26 @@ class monitor_alert_create_policy_assignment(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for creating Policy Assignments in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Authorization/policyAssignments/write"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for creating Policy Assignments in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for creating Policy Assignments in subscription {subscription_name}."
 
             findings.append(report)
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_nsg/monitor_alert_create_update_nsg.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_nsg/monitor_alert_create_update_nsg.py
@@ -11,22 +11,27 @@ class monitor_alert_create_update_nsg(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for creating/updating Network Security Groups in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Network/networkSecurityGroups/write"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for creating/updating Network Security Groups in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for creating/updating Network Security Groups in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_public_ip_address_rule/monitor_alert_create_update_public_ip_address_rule.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_public_ip_address_rule/monitor_alert_create_update_public_ip_address_rule.py
@@ -11,22 +11,27 @@ class monitor_alert_create_update_public_ip_address_rule(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for creating/updating Public IP address rule in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Network/publicIPAddresses/write"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for creating/updating Public IP address rule in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for creating/updating Public IP address rule in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_security_solution/monitor_alert_create_update_security_solution.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_security_solution/monitor_alert_create_update_security_solution.py
@@ -11,22 +11,27 @@ class monitor_alert_create_update_security_solution(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for creating/updating Security Solution in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Security/securitySolutions/write"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for creating/updating Security Solution in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for creating/updating Security Solution in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_sqlserver_fr/monitor_alert_create_update_sqlserver_fr.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_sqlserver_fr/monitor_alert_create_update_sqlserver_fr.py
@@ -11,22 +11,27 @@ class monitor_alert_create_update_sqlserver_fr(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for creating/updating SQL Server firewall rule in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Sql/servers/firewallRules/write"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for creating/updating SQL Server firewall rule in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for creating/updating SQL Server firewall rule in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_nsg/monitor_alert_delete_nsg.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_nsg/monitor_alert_delete_nsg.py
@@ -11,24 +11,28 @@ class monitor_alert_delete_nsg(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for deleting Network Security Groups in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Network/networkSecurityGroups/delete"
                 ) or check_alert_rule(
                     alert_rule, "Microsoft.ClassicNetwork/networkSecurityGroups/delete"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for deleting Network Security Groups in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for deleting Network Security Groups in subscription {subscription_name}."
 
             findings.append(report)
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_policy_assignment/monitor_alert_delete_policy_assignment.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_policy_assignment/monitor_alert_delete_policy_assignment.py
@@ -11,22 +11,27 @@ class monitor_alert_delete_policy_assignment(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for deleting policy assignment in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Authorization/policyAssignments/delete"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for deleting policy assignment in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for deleting policy assignment in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_public_ip_address_rule/monitor_alert_delete_public_ip_address_rule.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_public_ip_address_rule/monitor_alert_delete_public_ip_address_rule.py
@@ -11,22 +11,27 @@ class monitor_alert_delete_public_ip_address_rule(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for deleting public IP address rule in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Network/publicIPAddresses/delete"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for deleting public IP address rule in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for deleting public IP address rule in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_security_solution/monitor_alert_delete_security_solution.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_security_solution/monitor_alert_delete_security_solution.py
@@ -11,22 +11,27 @@ class monitor_alert_delete_security_solution(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for deleting Security Solution in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Security/securitySolutions/delete"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for deleting Security Solution in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for deleting Security Solution in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_sqlserver_fr/monitor_alert_delete_sqlserver_fr.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_sqlserver_fr/monitor_alert_delete_sqlserver_fr.py
@@ -11,22 +11,27 @@ class monitor_alert_delete_sqlserver_fr(Check):
             subscription_name,
             activity_log_alerts,
         ) in monitor_client.alert_rules.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status_extended = f"There is not an alert for deleting SQL Server firewall rule in subscription {subscription_name}."
             for alert_rule in activity_log_alerts:
                 if check_alert_rule(
                     alert_rule, "Microsoft.Sql/servers/firewallRules/delete"
                 ):
-                    report.status = "PASS"
-                    report.resource_name = alert_rule.name
-                    report.resource_id = alert_rule.id
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=alert_rule
+                    )
                     report.subscription = subscription_name
+                    report.status = "PASS"
                     report.status_extended = f"There is an alert configured for deleting SQL Server firewall rule in subscription {subscription_name}."
                     break
+            else:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata={}
+                )
+                report.subscription = subscription_name
+                report.resource_name = "Monitor"
+                report.resource_id = "Monitor"
+                report.status = "FAIL"
+                report.status_extended = f"There is not an alert for deleting SQL Server firewall rule in subscription {subscription_name}."
 
             findings.append(report)
+
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
@@ -10,11 +10,11 @@ class monitor_diagnostic_setting_with_appropriate_categories(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            report = Check_Report_Azure(self.metadata())
-            report.status = "FAIL"
+            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata={})
             report.subscription = subscription_name
             report.resource_name = "Monitor"
             report.resource_id = "Monitor"
+            report.status = "FAIL"
             report.status_extended = f"There are no diagnostic settings capturing appropiate categories in subscription {subscription_name}."
             administrative_enabled = False
             security_enabled = False

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
@@ -10,7 +10,9 @@ class monitor_diagnostic_setting_with_appropriate_categories(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata=diagnostic_settings)
+            report = Check_Report_Azure(
+                metadata=self.metadata(), resource_metadata=diagnostic_settings
+            )
             report.subscription = subscription_name
             report.resource_name = "Monitor"
             report.resource_id = "Monitor"

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
@@ -10,7 +10,7 @@ class monitor_diagnostic_setting_with_appropriate_categories(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata={})
+            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata=diagnostic_settings)
             report.subscription = subscription_name
             report.resource_name = "Monitor"
             report.resource_id = "Monitor"

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
@@ -10,7 +10,7 @@ class monitor_diagnostic_settings_exists(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            report = Check_Report_Azure(self.metadata())
+            report = Check_Report_Azure(self.metadata(), diagnostic_settings)
             report.subscription = subscription_name
             report.resource_name = "Diagnostic Settings"
             report.resource_id = "diagnostic_settings"

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
@@ -12,6 +12,8 @@ class monitor_diagnostic_settings_exists(Check):
         ) in monitor_client.diagnostics_settings.items():
             report = Check_Report_Azure(self.metadata())
             report.subscription = subscription_name
+            report.resource_name = "Diagnostic Settings"
+            report.resource_id = "diagnostic_settings"
             report.status = "FAIL"
             report.status_extended = (
                 f"No diagnostic settings found in subscription {subscription_name}."

--- a/prowler/providers/azure/services/monitor/monitor_service.py
+++ b/prowler/providers/azure/services/monitor/monitor_service.py
@@ -8,7 +8,6 @@ from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.lib.service.service import AzureService
 
 
-########################## Monitor
 class Monitor(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(MonitorManagementClient, provider)

--- a/prowler/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_cmk_encrypted/monitor_storage_account_with_activity_logs_cmk_encrypted.py
+++ b/prowler/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_cmk_encrypted/monitor_storage_account_with_activity_logs_cmk_encrypted.py
@@ -16,11 +16,10 @@ class monitor_storage_account_with_activity_logs_cmk_encrypted(Check):
                     subscription_name
                 ]:
                     if storage_account.name == diagnostic_setting.storage_account_name:
-                        report = Check_Report_Azure(self.metadata())
+                        report = Check_Report_Azure(
+                            metadata=self.metadata(), resource_metadata=storage_account
+                        )
                         report.subscription = subscription_name
-                        report.resource_name = storage_account.name
-                        report.resource_id = storage_account.id
-                        report.location = storage_account.location
                         if storage_account.encryption_type == "Microsoft.Storage":
                             report.status = "FAIL"
                             report.status_extended = f"Storage account {storage_account.name} storing activity log in subscription {subscription_name} is not encrypted with Customer Managed Key."

--- a/prowler/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_is_private/monitor_storage_account_with_activity_logs_is_private.py
+++ b/prowler/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_is_private/monitor_storage_account_with_activity_logs_is_private.py
@@ -16,11 +16,10 @@ class monitor_storage_account_with_activity_logs_is_private(Check):
                     subscription_name
                 ]:
                     if storage_account.name == diagnostic_setting.storage_account_name:
-                        report = Check_Report_Azure(self.metadata())
+                        report = Check_Report_Azure(
+                            metadata=self.metadata(), resource_metadata=storage_account
+                        )
                         report.subscription = subscription_name
-                        report.resource_name = storage_account.name
-                        report.resource_id = storage_account.id
-                        report.location = storage_account.location
                         if storage_account.allow_blob_public_access:
                             report.status = "FAIL"
                             report.status_extended = f"Blob public access enabled in storage account {storage_account.name} storing activity logs in subscription {subscription_name}."


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from monitor service.

### Description

- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.