### PR TITLE
feat(network): extract Network resource metadata automated

### DIFF
--- a/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
+++ b/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
@@ -18,7 +18,7 @@ class network_bastion_host_exists(Check):
                 status = "PASS"
                 status_extended = f"Bastion Host from subscription {subscription} available are: {bastion_names}"
 
-            report = Check_Report_Azure(self.metadata())
+            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata={})
             report.subscription = subscription
             report.resource_name = "Bastion Host"
             report.resource_id = "Bastion Host"

--- a/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
+++ b/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
@@ -18,7 +18,7 @@ class network_bastion_host_exists(Check):
                 status = "PASS"
                 status_extended = f"Bastion Host from subscription {subscription} available are: {bastion_names}"
 
-            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata={})
+            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata=bastion_hosts)
             report.subscription = subscription
             report.resource_name = "Bastion Host"
             report.resource_id = "Bastion Host"

--- a/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
+++ b/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
@@ -18,7 +18,9 @@ class network_bastion_host_exists(Check):
                 status = "PASS"
                 status_extended = f"Bastion Host from subscription {subscription} available are: {bastion_names}"
 
-            report = Check_Report_Azure(metadata=self.metadata(), resource_metadata=bastion_hosts)
+            report = Check_Report_Azure(
+                metadata=self.metadata(), resource_metadata=bastion_hosts
+            )
             report.subscription = subscription
             report.resource_name = "Bastion Host"
             report.resource_id = "Bastion Host"

--- a/prowler/providers/azure/services/network/network_flow_log_captured_sent/network_flow_log_captured_sent.py
+++ b/prowler/providers/azure/services/network/network_flow_log_captured_sent/network_flow_log_captured_sent.py
@@ -7,12 +7,11 @@ class network_flow_log_captured_sent(Check):
         findings = []
         for subscription, network_watchers in network_client.network_watchers.items():
             for network_watcher in network_watchers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=network_watcher
+                )
                 report.subscription = subscription
-                report.resource_name = network_watcher.name
-                report.resource_id = network_watcher.id
                 report.status = "FAIL"
-                report.location = network_watcher.location
                 report.status_extended = f"Network Watcher {network_watcher.name} from subscription {subscription} has no flow logs"
                 if network_watcher.flow_logs:
                     report.status = "FAIL"

--- a/prowler/providers/azure/services/network/network_flow_log_more_than_90_days/network_flow_log_more_than_90_days.py
+++ b/prowler/providers/azure/services/network/network_flow_log_more_than_90_days/network_flow_log_more_than_90_days.py
@@ -7,11 +7,10 @@ class network_flow_log_more_than_90_days(Check):
         findings = []
         for subscription, network_watchers in network_client.network_watchers.items():
             for network_watcher in network_watchers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=network_watcher
+                )
                 report.subscription = subscription
-                report.resource_name = network_watcher.name
-                report.resource_id = network_watcher.id
-                report.location = network_watcher.location
                 if network_watcher.flow_logs:
                     report.status = "PASS"
                     report.status_extended = f"Network Watcher {network_watcher.name} from subscription {subscription} has flow logs enabled for more than 90 days"

--- a/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
@@ -7,12 +7,11 @@ class network_http_internet_access_restricted(Check):
         findings = []
         for subscription, security_groups in network_client.security_groups.items():
             for security_group in security_groups:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=security_group
+                )
                 report.subscription = subscription
-                report.resource_name = security_group.name
-                report.resource_id = security_group.id
                 report.status = "PASS"
-                report.location = security_group.location
                 report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access restricted."
                 rule_fail_condition = any(
                     (

--- a/prowler/providers/azure/services/network/network_public_ip_shodan/network_public_ip_shodan.py
+++ b/prowler/providers/azure/services/network/network_public_ip_shodan/network_public_ip_shodan.py
@@ -13,11 +13,10 @@ class network_public_ip_shodan(Check):
             api = shodan.Shodan(shodan_api_key)
             for subscription, public_ips in network_client.public_ip_addresses.items():
                 for ip in public_ips:
-                    report = Check_Report_Azure(self.metadata())
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=ip
+                    )
                     report.subscription = subscription
-                    report.resource_name = ip.name
-                    report.resource_id = ip.id
-                    report.location = ip.location
                     try:
                         shodan_info = api.host(ip.ip_address)
                         report.status = "FAIL"

--- a/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
@@ -7,12 +7,11 @@ class network_rdp_internet_access_restricted(Check):
         findings = []
         for subscription, security_groups in network_client.security_groups.items():
             for security_group in security_groups:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=security_group
+                )
                 report.subscription = subscription
-                report.resource_name = security_group.name
-                report.resource_id = security_group.id
                 report.status = "PASS"
-                report.location = security_group.location
                 report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access restricted."
                 rule_fail_condition = any(
                     (

--- a/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
@@ -7,12 +7,11 @@ class network_ssh_internet_access_restricted(Check):
         findings = []
         for subscription, security_groups in network_client.security_groups.items():
             for security_group in security_groups:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=security_group
+                )
                 report.subscription = subscription
-                report.resource_name = security_group.name
-                report.resource_id = security_group.id
                 report.status = "PASS"
-                report.location = security_group.location
                 report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access restricted."
                 rule_fail_condition = any(
                     (

--- a/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
@@ -7,12 +7,11 @@ class network_udp_internet_access_restricted(Check):
         findings = []
         for subscription, security_groups in network_client.security_groups.items():
             for security_group in security_groups:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=security_group
+                )
                 report.subscription = subscription
-                report.resource_name = security_group.name
-                report.resource_id = security_group.id
                 report.status = "PASS"
-                report.location = security_group.location
                 report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access restricted."
                 rule_fail_condition = any(
                     rule.protocol in ["UDP", "Udp"]

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
@@ -6,7 +6,9 @@ class network_watcher_enabled(Check):
     def execute(self) -> list[Check_Report_Azure]:
         findings = []
         for subscription, network_watchers in network_client.network_watchers.items():
-            report = Check_Report_Azure(self.metadata())
+            report = Check_Report_Azure(
+                metadata=self.metadata(), resource_metadata=network_watchers
+            )
             report.subscription = subscription
             report.resource_name = "Network Watcher"
             report.location = "global"


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from network service.

### Description

- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.