### PR TITLE
feat(mysql): extract MySQL resource metadata automated

### DIFF
--- a/prowler/providers/azure/services/mysql/mysql_flexible_server_audit_log_connection_activated/mysql_flexible_server_audit_log_connection_activated.py
+++ b/prowler/providers/azure/services/mysql/mysql_flexible_server_audit_log_connection_activated/mysql_flexible_server_audit_log_connection_activated.py
@@ -10,17 +10,13 @@ class mysql_flexible_server_audit_log_connection_activated(Check):
             subscription_name,
             servers,
         ) in mysql_client.flexible_servers.items():
-            for (
-                server_name,
-                server,
-            ) in servers.items():
-                report = Check_Report_Azure(self.metadata())
-                report.status = "FAIL"
+            for server in servers.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription_name
-                report.resource_name = server_name
-                report.resource_id = server_name
-                report.location = server.location
-                report.status_extended = f"Audit log is disabled for server {server_name} in subscription {subscription_name}."
+                report.status = "FAIL"
+                report.status_extended = f"Audit log is disabled for server {server.name} in subscription {subscription_name}."
 
                 if "audit_log_events" in server.configurations:
                     report.resource_id = server.configurations[
@@ -31,7 +27,7 @@ class mysql_flexible_server_audit_log_connection_activated(Check):
                         "audit_log_events"
                     ].value.split(","):
                         report.status = "PASS"
-                        report.status_extended = f"Audit log is enabled for server {server_name} in subscription {subscription_name}."
+                        report.status_extended = f"Audit log is enabled for server {server.name} in subscription {subscription_name}."
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/mysql/mysql_flexible_server_audit_log_enabled/mysql_flexible_server_audit_log_enabled.py
+++ b/prowler/providers/azure/services/mysql/mysql_flexible_server_audit_log_enabled/mysql_flexible_server_audit_log_enabled.py
@@ -10,17 +10,13 @@ class mysql_flexible_server_audit_log_enabled(Check):
             subscription_name,
             servers,
         ) in mysql_client.flexible_servers.items():
-            for (
-                server_name,
-                server,
-            ) in servers.items():
-                report = Check_Report_Azure(self.metadata())
+            for server in servers.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.status = "FAIL"
                 report.subscription = subscription_name
-                report.resource_name = server_name
-                report.resource_id = server_name
-                report.location = server.location
-                report.status_extended = f"Audit log is disabled for server {server_name} in subscription {subscription_name}."
+                report.status_extended = f"Audit log is disabled for server {server.name} in subscription {subscription_name}."
 
                 if "audit_log_enabled" in server.configurations:
                     report.resource_id = server.configurations[
@@ -29,7 +25,7 @@ class mysql_flexible_server_audit_log_enabled(Check):
 
                     if server.configurations["audit_log_enabled"].value == "ON":
                         report.status = "PASS"
-                        report.status_extended = f"Audit log is enabled for server {server_name} in subscription {subscription_name}."
+                        report.status_extended = f"Audit log is enabled for server {server.name} in subscription {subscription_name}."
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/mysql/mysql_flexible_server_minimum_tls_version_12/mysql_flexible_server_minimum_tls_version_12.py
+++ b/prowler/providers/azure/services/mysql/mysql_flexible_server_minimum_tls_version_12/mysql_flexible_server_minimum_tls_version_12.py
@@ -10,30 +10,26 @@ class mysql_flexible_server_minimum_tls_version_12(Check):
             subscription_name,
             servers,
         ) in mysql_client.flexible_servers.items():
-            for (
-                server_name,
-                server,
-            ) in servers.items():
-                report = Check_Report_Azure(self.metadata())
-                report.status = "FAIL"
+            for server in servers.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription_name
-                report.resource_name = server_name
-                report.resource_id = server_name
-                report.location = server.location
-                report.status_extended = f"TLS version is not configured in server {server_name} in subscription {subscription_name}."
+                report.status = "FAIL"
+                report.status_extended = f"TLS version is not configured in server {server.name} in subscription {subscription_name}."
 
                 if "tls_version" in server.configurations:
-                    report.status = "PASS"
                     report.resource_id = server.configurations[
                         "tls_version"
                     ].resource_id
-                    report.status_extended = f"TLS version is {server.configurations['tls_version'].value} in server {server_name} in subscription {subscription_name}. This version of TLS is considered secure."
+                    report.status = "PASS"
+                    report.status_extended = f"TLS version is {server.configurations['tls_version'].value} in server {server.name} in subscription {subscription_name}. This version of TLS is considered secure."
 
                     tls_aviable = server.configurations["tls_version"].value.split(",")
 
                     if "TLSv1.0" in tls_aviable or "TLSv1.1" in tls_aviable:
                         report.status = "FAIL"
-                        report.status_extended = f"TLS version is {server.configurations['tls_version'].value} in server {server_name} in subscription {subscription_name}. There is at leat one version of TLS that is considered insecure."
+                        report.status_extended = f"TLS version is {server.configurations['tls_version'].value} in server {server.name} in subscription {subscription_name}. There is at leat one version of TLS that is considered insecure."
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/mysql/mysql_flexible_server_ssl_connection_enabled/mysql_flexible_server_ssl_connection_enabled.py
+++ b/prowler/providers/azure/services/mysql/mysql_flexible_server_ssl_connection_enabled/mysql_flexible_server_ssl_connection_enabled.py
@@ -10,17 +10,13 @@ class mysql_flexible_server_ssl_connection_enabled(Check):
             subscription_name,
             servers,
         ) in mysql_client.flexible_servers.items():
-            for (
-                server_name,
-                server,
-            ) in servers.items():
-                report = Check_Report_Azure(self.metadata())
-                report.status = "FAIL"
+            for server in servers.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription_name
-                report.resource_name = server_name
-                report.resource_id = server_name
-                report.location = server.location
-                report.status_extended = f"SSL connection is disabled for server {server_name} in subscription {subscription_name}."
+                report.status = "FAIL"
+                report.status_extended = f"SSL connection is disabled for server {server.name} in subscription {subscription_name}."
 
                 if "require_secure_transport" in server.configurations:
                     report.resource_id = server.configurations[
@@ -28,7 +24,7 @@ class mysql_flexible_server_ssl_connection_enabled(Check):
                     ].resource_id
                     if server.configurations["require_secure_transport"].value == "ON":
                         report.status = "PASS"
-                        report.status_extended = f"SSL connection is enabled for server {server_name} in subscription {subscription_name}."
+                        report.status_extended = f"SSL connection is enabled for server {server.name} in subscription {subscription_name}."
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/mysql/mysql_service.py
+++ b/prowler/providers/azure/services/mysql/mysql_service.py
@@ -7,7 +7,6 @@ from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.lib.service.service import AzureService
 
 
-########################## MySQL
 class MySQL(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(MySQLManagementClient, provider)
@@ -24,8 +23,9 @@ class MySQL(AzureService):
                 for server in servers_list:
                     servers[subscription_name].update(
                         {
-                            server.name: FlexibleServer(
+                            server.id: FlexibleServer(
                                 resource_id=server.id,
+                                name=server.name,
                                 location=server.location,
                                 version=server.version,
                                 configurations=self._get_configurations(
@@ -74,6 +74,7 @@ class Configuration:
 @dataclass
 class FlexibleServer:
     resource_id: str
+    name: str
     location: str
     version: str
     configurations: dict[Configuration]

--- a/tests/providers/azure/services/mysql/mysql_flexible_server_audit_log_connection_activated/mysql_flexible_server_audit_log_connection_activated_test.py
+++ b/tests/providers/azure/services/mysql/mysql_flexible_server_audit_log_connection_activated/mysql_flexible_server_audit_log_connection_activated_test.py
@@ -55,8 +55,9 @@ class Test_mysql_flexible_server_audit_log_connection_activated:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -102,8 +103,9 @@ class Test_mysql_flexible_server_audit_log_connection_activated:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -149,8 +151,9 @@ class Test_mysql_flexible_server_audit_log_connection_activated:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={

--- a/tests/providers/azure/services/mysql/mysql_flexible_server_audit_log_enabled/mysql_flexible_server_audit_log_enabled_test.py
+++ b/tests/providers/azure/services/mysql/mysql_flexible_server_audit_log_enabled/mysql_flexible_server_audit_log_enabled_test.py
@@ -16,12 +16,15 @@ class Test_mysql_flexible_server_audit_log_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {}
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
-            new=mysql_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
+                new=mysql_client,
+            ),
         ):
             from prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled import (
                 mysql_flexible_server_audit_log_enabled,
@@ -35,12 +38,15 @@ class Test_mysql_flexible_server_audit_log_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {AZURE_SUBSCRIPTION_ID: {}}
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
-            new=mysql_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
+                new=mysql_client,
+            ),
         ):
             from prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled import (
                 mysql_flexible_server_audit_log_enabled,
@@ -55,8 +61,9 @@ class Test_mysql_flexible_server_audit_log_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -70,12 +77,15 @@ class Test_mysql_flexible_server_audit_log_enabled:
             }
         }
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
-            new=mysql_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
+                new=mysql_client,
+            ),
         ):
             from prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled import (
                 mysql_flexible_server_audit_log_enabled,
@@ -102,8 +112,9 @@ class Test_mysql_flexible_server_audit_log_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -117,12 +128,15 @@ class Test_mysql_flexible_server_audit_log_enabled:
             }
         }
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
-            new=mysql_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled.mysql_client",
+                new=mysql_client,
+            ),
         ):
             from prowler.providers.azure.services.mysql.mysql_flexible_server_audit_log_enabled.mysql_flexible_server_audit_log_enabled import (
                 mysql_flexible_server_audit_log_enabled,

--- a/tests/providers/azure/services/mysql/mysql_flexible_server_minimum_tls_version_12/mysql_flexible_server_minimum_tls_version_12_test.py
+++ b/tests/providers/azure/services/mysql/mysql_flexible_server_minimum_tls_version_12/mysql_flexible_server_minimum_tls_version_12_test.py
@@ -55,8 +55,9 @@ class Test_mysql_flexible_server_minimum_tls_version_12:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={},
@@ -80,7 +81,7 @@ class Test_mysql_flexible_server_minimum_tls_version_12:
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == server_name
-            assert result[0].resource_id == server_name
+            assert result[0].resource_id == "/subscriptions/resource_id"
             assert result[0].location == "location"
             assert (
                 result[0].status_extended
@@ -92,8 +93,9 @@ class Test_mysql_flexible_server_minimum_tls_version_12:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -138,8 +140,9 @@ class Test_mysql_flexible_server_minimum_tls_version_12:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -184,8 +187,9 @@ class Test_mysql_flexible_server_minimum_tls_version_12:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -230,8 +234,9 @@ class Test_mysql_flexible_server_minimum_tls_version_12:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={

--- a/tests/providers/azure/services/mysql/mysql_flexible_server_ssl_connection_enabled/mysql_flexible_server_ssl_connection_enabled_test.py
+++ b/tests/providers/azure/services/mysql/mysql_flexible_server_ssl_connection_enabled/mysql_flexible_server_ssl_connection_enabled_test.py
@@ -55,8 +55,9 @@ class Test_mysql_flexible_server_ssl_connection_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -102,8 +103,9 @@ class Test_mysql_flexible_server_ssl_connection_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={
@@ -149,8 +151,9 @@ class Test_mysql_flexible_server_ssl_connection_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name: FlexibleServer(
+                "/subscriptions/resource_id": FlexibleServer(
                     resource_id="/subscriptions/resource_id",
+                    name=server_name,
                     location="location",
                     version="version",
                     configurations={},
@@ -175,7 +178,7 @@ class Test_mysql_flexible_server_ssl_connection_enabled:
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].resource_name == server_name
-            assert result[0].resource_id == server_name
+            assert result[0].resource_id == "/subscriptions/resource_id"
             assert result[0].location == "location"
             assert (
                 result[0].status_extended
@@ -188,8 +191,9 @@ class Test_mysql_flexible_server_ssl_connection_enabled:
         mysql_client = mock.MagicMock
         mysql_client.flexible_servers = {
             AZURE_SUBSCRIPTION_ID: {
-                server_name_1: FlexibleServer(
-                    resource_id="/subscriptions/resource_id",
+                "/subscriptions/resource_id1": FlexibleServer(
+                    resource_id="/subscriptions/resource_id1",
+                    name=server_name_1,
                     location="location",
                     version="version",
                     configurations={
@@ -200,8 +204,9 @@ class Test_mysql_flexible_server_ssl_connection_enabled:
                         )
                     },
                 ),
-                server_name_2: FlexibleServer(
-                    resource_id="/subscriptions/resource_id",
+                "/subscriptions/resource_id2": FlexibleServer(
+                    resource_id="/subscriptions/resource_id2",
+                    name=server_name_2,
                     location="location",
                     version="version",
                     configurations={

--- a/tests/providers/azure/services/mysql/mysql_service_test.py
+++ b/tests/providers/azure/services/mysql/mysql_service_test.py
@@ -14,8 +14,9 @@ from tests.providers.azure.azure_fixtures import (
 def mock_mysql_get_servers(_):
     return {
         AZURE_SUBSCRIPTION_ID: {
-            "test": FlexibleServer(
+            "/subscriptions/resource_id": FlexibleServer(
                 resource_id="/subscriptions/resource_id",
+                name="test",
                 location="location",
                 version="version",
                 configurations={
@@ -64,33 +65,45 @@ class Test_MySQL_Service:
         mysql = MySQL(set_mocked_azure_provider())
         assert len(mysql.flexible_servers) == 1
         assert (
-            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["test"].resource_id
+            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID][
+                "/subscriptions/resource_id"
+            ].resource_id
             == "/subscriptions/resource_id"
         )
         assert (
-            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["test"].location == "location"
+            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID][
+                "/subscriptions/resource_id"
+            ].location
+            == "location"
         )
         assert (
-            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["test"].version == "version"
+            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID][
+                "/subscriptions/resource_id"
+            ].version
+            == "version"
         )
         assert (
-            len(mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["test"].configurations)
+            len(
+                mysql.flexible_servers[AZURE_SUBSCRIPTION_ID][
+                    "/subscriptions/resource_id"
+                ].configurations
+            )
             == 1
         )
         assert (
-            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["test"]
+            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["/subscriptions/resource_id"]
             .configurations["test"]
             .resource_id
             == "/subscriptions/test/resource_id"
         )
         assert (
-            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["test"]
+            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["/subscriptions/resource_id"]
             .configurations["test"]
             .description
             == "description"
         )
         assert (
-            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["test"]
+            mysql.flexible_servers[AZURE_SUBSCRIPTION_ID]["/subscriptions/resource_id"]
             .configurations["test"]
             .value
             == "value"


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from MySQL service.

### Description

- Added name to mysql flexible server model
- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.