### PR TITLE
feat(policy): extract Policy resource metadata automated

### DIFF
--- a/prowler/providers/azure/services/policy/policy_ensure_asc_enforcement_enabled/policy_ensure_asc_enforcement_enabled.py
+++ b/prowler/providers/azure/services/policy/policy_ensure_asc_enforcement_enabled/policy_ensure_asc_enforcement_enabled.py
@@ -8,13 +8,13 @@ class policy_ensure_asc_enforcement_enabled(Check):
 
         for subscription_name, policies in policy_client.policy_assigments.items():
             if "SecurityCenterBuiltIn" in policies:
-                report = Check_Report_Azure(self.metadata())
-                report.status = "PASS"
+                report = Check_Report_Azure(
+                    metadata=self.metadata(),
+                    resource_metadata=policies["SecurityCenterBuiltIn"],
+                )
                 report.subscription = subscription_name
-                report.resource_name = "SecurityCenterBuiltIn"
-                report.resource_id = policies["SecurityCenterBuiltIn"].id
+                report.status = "PASS"
                 report.status_extended = f"Policy assigment '{policies['SecurityCenterBuiltIn'].id}' is configured with enforcement mode '{policies['SecurityCenterBuiltIn'].enforcement_mode}'."
-
                 if policies["SecurityCenterBuiltIn"].enforcement_mode != "Default":
                     report.status = "FAIL"
                     report.status_extended = f"Policy assigment '{policies['SecurityCenterBuiltIn'].id}' is not configured with enforcement mode Default."

--- a/prowler/providers/azure/services/policy/policy_service.py
+++ b/prowler/providers/azure/services/policy/policy_service.py
@@ -7,7 +7,6 @@ from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.lib.service.service import AzureService
 
 
-########################## Policy
 class Policy(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(PolicyClient, provider)
@@ -27,6 +26,7 @@ class Policy(AzureService):
                         {
                             policy_assigment.name: PolicyAssigment(
                                 id=policy_assigment.id,
+                                name=policy_assigment.name,
                                 enforcement_mode=policy_assigment.enforcement_mode,
                             )
                         }
@@ -42,4 +42,5 @@ class Policy(AzureService):
 @dataclass
 class PolicyAssigment:
     id: str
+    name: str
     enforcement_mode: str

--- a/tests/providers/azure/services/policy/policy_ensure_asc_enforcement_enabled/policy_ensure_asc_enforcement_enabled_test.py
+++ b/tests/providers/azure/services/policy/policy_ensure_asc_enforcement_enabled/policy_ensure_asc_enforcement_enabled_test.py
@@ -13,12 +13,15 @@ class Test_policy_ensure_asc_enforcement_enabled:
         policy_client = mock.MagicMock
         policy_client.policy_assigments = {}
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
-            new=policy_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
+                new=policy_client,
+            ),
         ):
             from prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled import (
                 policy_ensure_asc_enforcement_enabled,
@@ -32,12 +35,15 @@ class Test_policy_ensure_asc_enforcement_enabled:
         policy_client = mock.MagicMock
         policy_client.policy_assigments = {AZURE_SUBSCRIPTION_ID: {}}
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
-            new=policy_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
+                new=policy_client,
+            ),
         ):
             from prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled import (
                 policy_ensure_asc_enforcement_enabled,
@@ -52,16 +58,21 @@ class Test_policy_ensure_asc_enforcement_enabled:
         resource_id = uuid4()
         policy_client.policy_assigments = {
             AZURE_SUBSCRIPTION_ID: {
-                "policy-1": PolicyAssigment(id=resource_id, enforcement_mode="Default")
+                "policy-1": PolicyAssigment(
+                    id=resource_id, name="policy-1", enforcement_mode="Default"
+                )
             }
         }
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
-            new=policy_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
+                new=policy_client,
+            ),
         ):
             from prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled import (
                 policy_ensure_asc_enforcement_enabled,
@@ -73,21 +84,26 @@ class Test_policy_ensure_asc_enforcement_enabled:
 
     def test_policy_subscription_asc_default(self):
         policy_client = mock.MagicMock
-        resource_id = uuid4()
+        resource_id = str(uuid4())
         policy_client.policy_assigments = {
             AZURE_SUBSCRIPTION_ID: {
                 "SecurityCenterBuiltIn": PolicyAssigment(
-                    id=resource_id, enforcement_mode="Default"
+                    id=resource_id,
+                    name="SecurityCenterBuiltIn",
+                    enforcement_mode="Default",
                 )
             }
         }
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
-            new=policy_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
+                new=policy_client,
+            ),
         ):
             from prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled import (
                 policy_ensure_asc_enforcement_enabled,
@@ -107,22 +123,26 @@ class Test_policy_ensure_asc_enforcement_enabled:
 
     def test_policy_subscription_asc_not_default(self):
         policy_client = mock.MagicMock
-        resource_id = uuid4()
+        resource_id = str(uuid4())
         policy_client.policy_assigments = {
             AZURE_SUBSCRIPTION_ID: {
                 "SecurityCenterBuiltIn": PolicyAssigment(
                     id=resource_id,
+                    name="SecurityCenterBuiltIn",
                     enforcement_mode="DoNotEnforce",
                 )
             }
         }
 
-        with mock.patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=set_mocked_azure_provider(),
-        ), mock.patch(
-            "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
-            new=policy_client,
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled.policy_client",
+                new=policy_client,
+            ),
         ):
             from prowler.providers.azure.services.policy.policy_ensure_asc_enforcement_enabled.policy_ensure_asc_enforcement_enabled import (
                 policy_ensure_asc_enforcement_enabled,

--- a/tests/providers/azure/services/policy/policy_service_test.py
+++ b/tests/providers/azure/services/policy/policy_service_test.py
@@ -13,7 +13,9 @@ from tests.providers.azure.azure_fixtures import (
 def mock_policy_assigments(_):
     return {
         AZURE_SUBSCRIPTION_ID: {
-            "policy-1": PolicyAssigment(id="id-1", enforcement_mode="Default")
+            "policy-1": PolicyAssigment(
+                id="id-1", name="policy-1", enforcement_mode="Default"
+            )
         }
     }
 


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from Policy service.

### Description

- Add name to PolicyAssigment model
- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.