### PR TITLE
feat(postgresql): extract PostgreSQL resource metadata automated

### DIFF
--- a/prowler/providers/azure/services/postgresql/postgresql_flexible_server_allow_access_services_disabled/postgresql_flexible_server_allow_access_services_disabled.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_flexible_server_allow_access_services_disabled/postgresql_flexible_server_allow_access_services_disabled.py
@@ -12,12 +12,11 @@ class postgresql_flexible_server_allow_access_services_disabled(Check):
             flexible_servers,
         ) in postgresql_client.flexible_servers.items():
             for server in flexible_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription
-                report.resource_name = server.name
-                report.resource_id = server.id
                 report.status = "FAIL"
-                report.location = server.location
                 report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has allow public access from any Azure service enabled"
                 if not any(
                     rule.start_ip == "0.0.0.0" and rule.end_ip == "0.0.0.0"

--- a/prowler/providers/azure/services/postgresql/postgresql_flexible_server_connection_throttling_on/postgresql_flexible_server_connection_throttling_on.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_flexible_server_connection_throttling_on/postgresql_flexible_server_connection_throttling_on.py
@@ -12,12 +12,11 @@ class postgresql_flexible_server_connection_throttling_on(Check):
             flexible_servers,
         ) in postgresql_client.flexible_servers.items():
             for server in flexible_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription
-                report.resource_name = server.name
-                report.resource_id = server.id
                 report.status = "FAIL"
-                report.location = server.location
                 report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has connection_throttling disabled"
                 if server.connection_throttling == "ON":
                     report.status = "PASS"

--- a/prowler/providers/azure/services/postgresql/postgresql_flexible_server_enforce_ssl_enabled/postgresql_flexible_server_enforce_ssl_enabled.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_flexible_server_enforce_ssl_enabled/postgresql_flexible_server_enforce_ssl_enabled.py
@@ -12,12 +12,11 @@ class postgresql_flexible_server_enforce_ssl_enabled(Check):
             flexible_servers,
         ) in postgresql_client.flexible_servers.items():
             for server in flexible_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription
-                report.resource_name = server.name
-                report.resource_id = server.id
                 report.status = "FAIL"
-                report.location = server.location
                 report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has enforce ssl disabled"
                 if server.require_secure_transport == "ON":
                     report.status = "PASS"

--- a/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_checkpoints_on/postgresql_flexible_server_log_checkpoints_on.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_checkpoints_on/postgresql_flexible_server_log_checkpoints_on.py
@@ -12,12 +12,11 @@ class postgresql_flexible_server_log_checkpoints_on(Check):
             flexible_servers,
         ) in postgresql_client.flexible_servers.items():
             for server in flexible_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription
-                report.resource_name = server.name
-                report.resource_id = server.id
                 report.status = "FAIL"
-                report.location = server.location
                 report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has log_checkpoints disabled"
                 if server.log_checkpoints == "ON":
                     report.status = "PASS"

--- a/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_connections_on/postgresql_flexible_server_log_connections_on.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_connections_on/postgresql_flexible_server_log_connections_on.py
@@ -12,12 +12,11 @@ class postgresql_flexible_server_log_connections_on(Check):
             flexible_servers,
         ) in postgresql_client.flexible_servers.items():
             for server in flexible_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription
-                report.resource_name = server.name
-                report.resource_id = server.id
                 report.status = "FAIL"
-                report.location = server.location
                 report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has log_connections disabled"
                 if server.log_connections == "ON":
                     report.status = "PASS"

--- a/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_disconnections_on/postgresql_flexible_server_log_disconnections_on.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_disconnections_on/postgresql_flexible_server_log_disconnections_on.py
@@ -12,12 +12,11 @@ class postgresql_flexible_server_log_disconnections_on(Check):
             flexible_servers,
         ) in postgresql_client.flexible_servers.items():
             for server in flexible_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription
-                report.resource_name = server.name
-                report.resource_id = server.id
                 report.status = "FAIL"
-                report.location = server.location
                 report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has log_disconnections disabled"
                 if server.log_disconnections == "ON":
                     report.status = "PASS"

--- a/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_retention_days_greater_3/postgresql_flexible_server_log_retention_days_greater_3.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_flexible_server_log_retention_days_greater_3/postgresql_flexible_server_log_retention_days_greater_3.py
@@ -12,12 +12,11 @@ class postgresql_flexible_server_log_retention_days_greater_3(Check):
             flexible_servers,
         ) in postgresql_client.flexible_servers.items():
             for server in flexible_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=server
+                )
                 report.subscription = subscription
-                report.resource_name = server.name
-                report.resource_id = server.id
                 report.status = "FAIL"
-                report.location = server.location
                 report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has log_retention disabled"
                 if server.log_retention_days:
                     report.status_extended = f"Flexible Postgresql server {server.name} from subscription {subscription} has log_retention set to {server.log_retention_days}"


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from PostgreSQL service.

### Description

- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.