### PR TITLE
feat(sqlserver): extract SQL Server resource metadata automated

### DIFF
--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_enabled/sqlserver_auditing_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_enabled/sqlserver_auditing_enabled.py
@@ -7,13 +7,12 @@ class sqlserver_auditing_enabled(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
                 report.status = "PASS"
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has a auditing policy configured."
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
-                report.location = sql_server.location
                 for auditing_policy in sql_server.auditing_policies:
                     if auditing_policy.state == "Disabled":
                         report.status = "FAIL"

--- a/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_auditing_retention_90_days/sqlserver_auditing_retention_90_days.py
@@ -7,11 +7,10 @@ class sqlserver_auditing_retention_90_days(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
-                report.location = sql_server.location
                 has_failed = False
                 has_policy = False
                 for policy in sql_server.auditing_policies:

--- a/prowler/providers/azure/services/sqlserver/sqlserver_azuread_administrator_enabled/sqlserver_azuread_administrator_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_azuread_administrator_enabled/sqlserver_azuread_administrator_enabled.py
@@ -7,13 +7,12 @@ class sqlserver_azuread_administrator_enabled(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
                 report.status = "PASS"
-                report.location = sql_server.location
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has an Active Directory administrator."
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
 
                 if (
                     sql_server.administrators is None

--- a/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_microsoft_defender_enabled/sqlserver_microsoft_defender_enabled.py
@@ -8,12 +8,11 @@ class sqlserver_microsoft_defender_enabled(Check):
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
                 if sql_server.security_alert_policies:
-                    report = Check_Report_Azure(self.metadata())
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=sql_server
+                    )
                     report.subscription = subscription
-                    report.resource_name = sql_server.name
-                    report.resource_id = sql_server.id
                     report.status = "FAIL"
-                    report.location = sql_server.location
                     report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has microsoft defender disabled."
                     if sql_server.security_alert_policies.state == "Enabled":
                         report.status = "PASS"

--- a/prowler/providers/azure/services/sqlserver/sqlserver_recommended_minimal_tls_version/sqlserver_recommended_minimal_tls_version.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_recommended_minimal_tls_version/sqlserver_recommended_minimal_tls_version.py
@@ -12,12 +12,11 @@ class sqlserver_recommended_minimal_tls_version(Check):
         )
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
                 report.status = "FAIL"
-                report.location = sql_server.location
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} is using TLS version {sql_server.minimal_tls_version} as minimal accepted which is not recommended. Please use one of the recommended versions: {', '.join(recommended_minimal_tls_versions)}."
                 if sql_server.minimal_tls_version in recommended_minimal_tls_versions:
                     report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} is using version {sql_server.minimal_tls_version} as minimal accepted which is recommended."

--- a/prowler/providers/azure/services/sqlserver/sqlserver_service.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_service.py
@@ -16,7 +16,6 @@ from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.lib.service.service import AzureService
 
 
-########################## SQLServer
 class SQLServer(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(SqlManagementClient, provider)

--- a/prowler/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk.py
@@ -11,11 +11,10 @@ class sqlserver_tde_encrypted_with_cmk(Check):
                     sql_server.databases if sql_server.databases is not None else []
                 )
                 if len(databases) > 0:
-                    report = Check_Report_Azure(self.metadata())
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=sql_server
+                    )
                     report.subscription = subscription
-                    report.resource_name = sql_server.name
-                    report.resource_id = sql_server.id
-                    report.location = sql_server.location
                     found_disabled = False
                     if (
                         sql_server.encryption_protector.server_key_type

--- a/prowler/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_tde_encryption_enabled/sqlserver_tde_encryption_enabled.py
@@ -14,11 +14,10 @@ class sqlserver_tde_encryption_enabled(Check):
                     for database in databases:
                         if database.name.lower() == "master":
                             continue
-                        report = Check_Report_Azure(self.metadata())
+                        report = Check_Report_Azure(
+                            metadata=self.metadata(), resource_metadata=database
+                        )
                         report.subscription = subscription
-                        report.resource_name = database.name
-                        report.resource_id = database.id
-                        report.location = sql_server.location
                         if database.tde_encryption.status == "Enabled":
                             report.status = "PASS"
                             report.status_extended = f"Database {database.name} from SQL Server {sql_server.name} from subscription {subscription} has TDE enabled"

--- a/prowler/providers/azure/services/sqlserver/sqlserver_unrestricted_inbound_access/sqlserver_unrestricted_inbound_access.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_unrestricted_inbound_access/sqlserver_unrestricted_inbound_access.py
@@ -7,13 +7,12 @@ class sqlserver_unrestricted_inbound_access(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
                 report.status = "PASS"
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} does not have firewall rules allowing 0.0.0.0-255.255.255.255."
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
-                report.location = sql_server.location
                 for firewall_rule in sql_server.firewall_rules:
                     if (
                         firewall_rule.start_ip_address == "0.0.0.0"

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_emails_notifications_admins_enabled/sqlserver_va_emails_notifications_admins_enabled.py
@@ -7,12 +7,11 @@ class sqlserver_va_emails_notifications_admins_enabled(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
                 report.status = "FAIL"
-                report.location = sql_server.location
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment disabled."
                 if (
                     sql_server.vulnerability_assessment

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_periodic_recurring_scans_enabled/sqlserver_va_periodic_recurring_scans_enabled.py
@@ -7,12 +7,11 @@ class sqlserver_va_periodic_recurring_scans_enabled(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
                 report.status = "FAIL"
-                report.location = sql_server.location
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment disabled."
                 if (
                     sql_server.vulnerability_assessment

--- a/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_va_scan_reports_configured/sqlserver_va_scan_reports_configured.py
@@ -7,12 +7,11 @@ class sqlserver_va_scan_reports_configured(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
                 report.status = "FAIL"
-                report.location = sql_server.location
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment disabled."
                 if (
                     sql_server.vulnerability_assessment

--- a/prowler/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled/sqlserver_vulnerability_assessment_enabled.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_vulnerability_assessment_enabled/sqlserver_vulnerability_assessment_enabled.py
@@ -7,12 +7,11 @@ class sqlserver_vulnerability_assessment_enabled(Check):
         findings = []
         for subscription, sql_servers in sqlserver_client.sql_servers.items():
             for sql_server in sql_servers:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=sql_server
+                )
                 report.subscription = subscription
-                report.resource_name = sql_server.name
-                report.resource_id = sql_server.id
                 report.status = "FAIL"
-                report.location = sql_server.location
                 report.status_extended = f"SQL Server {sql_server.name} from subscription {subscription} has vulnerability assessment disabled."
                 if (
                     sql_server.vulnerability_assessment


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from SQL Server service.

### Description

- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.