### PR TITLE
feat(vm): extract VM resource metadata automated

### DIFF
--- a/prowler/providers/azure/services/vm/vm_ensure_attached_disks_encrypted_with_cmk/vm_ensure_attached_disks_encrypted_with_cmk.py
+++ b/prowler/providers/azure/services/vm/vm_ensure_attached_disks_encrypted_with_cmk/vm_ensure_attached_disks_encrypted_with_cmk.py
@@ -9,12 +9,11 @@ class vm_ensure_attached_disks_encrypted_with_cmk(Check):
         for subscription_name, disks in vm_client.disks.items():
             for disk_id, disk in disks.items():
                 if disk.vms_attached:
-                    report = Check_Report_Azure(self.metadata())
-                    report.status = "PASS"
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=disk
+                    )
                     report.subscription = subscription_name
-                    report.resource_name = disk.resource_name
-                    report.resource_id = disk.resource_id
-                    report.location = disk.location
+                    report.status = "PASS"
                     report.status_extended = f"Disk '{disk_id}' is encrypted with a customer-managed key in subscription {subscription_name}."
 
                     if (

--- a/prowler/providers/azure/services/vm/vm_ensure_unattached_disks_encrypted_with_cmk/vm_ensure_unattached_disks_encrypted_with_cmk.py
+++ b/prowler/providers/azure/services/vm/vm_ensure_unattached_disks_encrypted_with_cmk/vm_ensure_unattached_disks_encrypted_with_cmk.py
@@ -9,12 +9,11 @@ class vm_ensure_unattached_disks_encrypted_with_cmk(Check):
         for subscription_name, disks in vm_client.disks.items():
             for disk_id, disk in disks.items():
                 if not disk.vms_attached:
-                    report = Check_Report_Azure(self.metadata())
-                    report.status = "PASS"
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=disk
+                    )
                     report.subscription = subscription_name
-                    report.resource_name = disk.resource_name
-                    report.resource_id = disk.resource_id
-                    report.location = disk.location
+                    report.status = "PASS"
                     report.status_extended = f"Disk '{disk_id}' is encrypted with a customer-managed key in subscription {subscription_name}."
 
                     if (

--- a/prowler/providers/azure/services/vm/vm_ensure_using_managed_disks/vm_ensure_using_managed_disks.py
+++ b/prowler/providers/azure/services/vm/vm_ensure_using_managed_disks/vm_ensure_using_managed_disks.py
@@ -7,13 +7,12 @@ class vm_ensure_using_managed_disks(Check):
         findings = []
 
         for subscription_name, vms in vm_client.virtual_machines.items():
-            for vm_id, vm in vms.items():
-                report = Check_Report_Azure(self.metadata())
+            for vm in vms.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=vm
+                )
                 report.status = "PASS"
                 report.subscription = subscription_name
-                report.resource_name = vm.resource_name
-                report.resource_id = vm_id
-                report.location = vm.location
                 report.status_extended = f"VM {vm.resource_name} is using managed disks in subscription {subscription_name}"
 
                 using_managed_disks = (

--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -8,7 +8,6 @@ from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.azure.lib.service.service import AzureService
 
 
-########################## VirtualMachines
 class VirtualMachines(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(ComputeManagementClient, provider)
@@ -27,7 +26,7 @@ class VirtualMachines(AzureService):
                 for vm in virtual_machines_list:
                     virtual_machines[subscription_name].update(
                         {
-                            vm.vm_id: VirtualMachine(
+                            vm.id: VirtualMachine(
                                 resource_id=vm.id,
                                 resource_name=vm.name,
                                 storage_profile=getattr(vm, "storage_profile", None),

--- a/prowler/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled.py
+++ b/prowler/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled.py
@@ -7,12 +7,12 @@ class vm_trusted_launch_enabled(Check):
         findings = []
 
         for subscription_name, vms in vm_client.virtual_machines.items():
-            for vm_id, vm in vms.items():
-                report = Check_Report_Azure(self.metadata())
-                report.status = "FAIL"
+            for vm in vms.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource_metadata=vm
+                )
                 report.subscription = subscription_name
-                report.resource_name = vm.resource_name
-                report.resource_id = vm_id
+                report.status = "FAIL"
                 report.status_extended = f"VM {vm.resource_name} has trusted launch disabled in subscription {subscription_name}"
 
                 if (

--- a/tests/providers/azure/services/vm/vm_ensure_using_managed_disks/vm_ensure_using_managed_disks_test.py
+++ b/tests/providers/azure/services/vm/vm_ensure_using_managed_disks/vm_ensure_using_managed_disks_test.py
@@ -53,7 +53,7 @@ class Test_vm_ensure_using_managed_disks:
         vm_client.virtual_machines = {
             AZURE_SUBSCRIPTION_ID: {
                 vm_id: VirtualMachine(
-                    resource_id="/subscriptions/resource_id",
+                    resource_id=vm_id,
                     resource_name="VMTest",
                     location="location",
                     security_profile=mock.MagicMock(
@@ -104,7 +104,7 @@ class Test_vm_ensure_using_managed_disks:
         vm_client.virtual_machines = {
             AZURE_SUBSCRIPTION_ID: {
                 vm_id: VirtualMachine(
-                    resource_id="/subscriptions/resource_id",
+                    resource_id=vm_id,
                     resource_name="VMTest",
                     location="location",
                     security_profile=mock.MagicMock(
@@ -155,7 +155,7 @@ class Test_vm_ensure_using_managed_disks:
         vm_client.virtual_machines = {
             AZURE_SUBSCRIPTION_ID: {
                 vm_id: VirtualMachine(
-                    resource_id="/subscriptions/resource_id",
+                    resource_id=vm_id,
                     resource_name="VMTest",
                     location="location",
                     security_profile=mock.MagicMock(

--- a/tests/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled_test.py
+++ b/tests/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled_test.py
@@ -62,7 +62,7 @@ class Test_vm_trusted_launch_enabled:
             vm_client.virtual_machines = {
                 AZURE_SUBSCRIPTION_ID: {
                     vm_id: VirtualMachine(
-                        resource_id="/subscriptions/resource_id",
+                        resource_id=vm_id,
                         resource_name="VMTest",
                         location="location",
                         security_profile=mock.MagicMock(
@@ -112,7 +112,7 @@ class Test_vm_trusted_launch_enabled:
             vm_client.virtual_machines = {
                 AZURE_SUBSCRIPTION_ID: {
                     vm_id: VirtualMachine(
-                        resource_id="/subscriptions/resource_id",
+                        resource_id=vm_id,
                         resource_name="VMTest",
                         location="location",
                         security_profile=mock.MagicMock(


### PR DESCRIPTION
### Context

Due to new way of automatic extraction of basic check report information in Azure implemented in PR #6505 this PR change the way that report are generated in checks from VM service.

### Description

- Using new `Check_Report_Azure` constructor

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.