### PR TITLE
fix(gcp): fix flaky tests from dns service

### DIFF
--- a/tests/providers/gcp/services/dns/dns_dnssec_disabled/dns_dnssec_disabled_test.py
+++ b/tests/providers/gcp/services/dns/dns_dnssec_disabled/dns_dnssec_disabled_test.py
@@ -1,13 +1,18 @@
 from re import search
 from unittest import mock
 
-from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
 
 
 class Test_dns_dnssec_disabled:
     def test_dns_no_managed_zones(self):
         dns_client = mock.MagicMock()
         dns_client.managed_zones = []
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -51,6 +56,7 @@ class Test_dns_dnssec_disabled:
         dns_client = mock.MagicMock()
         dns_client.project_ids = [GCP_PROJECT_ID]
         dns_client.managed_zones = [managed_zone]
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -101,6 +107,7 @@ class Test_dns_dnssec_disabled:
         dns_client = mock.MagicMock()
         dns_client.project_ids = [GCP_PROJECT_ID]
         dns_client.managed_zones = [managed_zone]
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/gcp/services/dns/dns_rsasha1_in_use_to_key_sign_in_dnssec/dns_rsasha1_in_use_to_key_sign_in_dnssec_test.py
+++ b/tests/providers/gcp/services/dns/dns_rsasha1_in_use_to_key_sign_in_dnssec/dns_rsasha1_in_use_to_key_sign_in_dnssec_test.py
@@ -1,13 +1,18 @@
 from re import search
 from unittest import mock
 
-from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
 
 
 class Test_dns_rsasha1_in_use_to_key_sign_in_dnssec:
     def test_dns_no_managed_zones(self):
         dns_client = mock.MagicMock()
         dns_client.managed_zones = []
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -51,6 +56,7 @@ class Test_dns_rsasha1_in_use_to_key_sign_in_dnssec:
         dns_client = mock.MagicMock()
         dns_client.project_ids = [GCP_PROJECT_ID]
         dns_client.managed_zones = [managed_zone]
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -101,6 +107,7 @@ class Test_dns_rsasha1_in_use_to_key_sign_in_dnssec:
         dns_client = mock.MagicMock()
         dns_client.project_ids = [GCP_PROJECT_ID]
         dns_client.managed_zones = [managed_zone]
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",

--- a/tests/providers/gcp/services/dns/dns_rsasha1_in_use_to_zone_sign_in_dnssec/dns_rsasha1_in_use_to_zone_sign_in_dnssec_test.py
+++ b/tests/providers/gcp/services/dns/dns_rsasha1_in_use_to_zone_sign_in_dnssec/dns_rsasha1_in_use_to_zone_sign_in_dnssec_test.py
@@ -1,13 +1,18 @@
 from re import search
 from unittest import mock
 
-from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID, set_mocked_gcp_provider
+from tests.providers.gcp.gcp_fixtures import (
+    GCP_EU1_LOCATION,
+    GCP_PROJECT_ID,
+    set_mocked_gcp_provider,
+)
 
 
 class Test_dns_rsasha1_in_use_to_zone_sign_in_dnssec:
     def test_dns_no_managed_zones(self):
         dns_client = mock.MagicMock()
         dns_client.managed_zones = []
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -51,6 +56,7 @@ class Test_dns_rsasha1_in_use_to_zone_sign_in_dnssec:
         dns_client = mock.MagicMock()
         dns_client.project_ids = [GCP_PROJECT_ID]
         dns_client.managed_zones = [managed_zone]
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",
@@ -101,6 +107,7 @@ class Test_dns_rsasha1_in_use_to_zone_sign_in_dnssec:
         dns_client = mock.MagicMock()
         dns_client.project_ids = [GCP_PROJECT_ID]
         dns_client.managed_zones = [managed_zone]
+        dns_client.region = GCP_EU1_LOCATION
 
         with mock.patch(
             "prowler.providers.common.provider.Provider.get_global_provider",


### PR DESCRIPTION
### Context

Some tests from DNS are failing during some Github runnings. I've noticed that when the CheckReportGCP try to assign the region to the location of the report if the MagicMock object of the test does not have region it could fail, so I added that to all the tests of this service.

### Description

Added dns_client.region to all the unit tests of the service DNS from GCP.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
