### PR TITLE
fix: add missing Check_Report_Azure parameters

### DIFF
--- a/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
+++ b/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
@@ -32,7 +32,10 @@ class entra_conditional_access_policy_require_mfa_for_management_api(Check):
                     )
                     break
             else:
-                report = Check_Report_Azure(self.metadata())
+                report = Check_Report_Azure(
+                    metadata=self.metadata(),
+                    resource_metadata=conditional_access_policies.values(),
+                )
                 report.subscription = f"Tenant: {tenant_name}"
                 report.resource_name = "Conditional Access Policy"
                 report.resource_id = "Conditional Access Policy"

--- a/prowler/providers/azure/services/entra/entra_non_privileged_user_has_mfa/entra_non_privileged_user_has_mfa.py
+++ b/prowler/providers/azure/services/entra/entra_non_privileged_user_has_mfa/entra_non_privileged_user_has_mfa.py
@@ -14,7 +14,9 @@ class entra_non_privileged_user_has_mfa(Check):
                 if not is_privileged_user(
                     user, entra_client.directory_roles[tenant_domain]
                 ):
-                    report = Check_Report_Azure(self.metadata(), resource_metadata=user)
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource_metadata=user
+                    )
                     report.subscription = f"Tenant: {tenant_domain}"
                     report.status = "FAIL"
                     report.status_extended = (

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
@@ -10,7 +10,9 @@ class monitor_diagnostic_settings_exists(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            report = Check_Report_Azure(self.metadata(), diagnostic_settings)
+            report = Check_Report_Azure(
+                metadata=self.metadata(), resource_metadata=diagnostic_settings
+            )
             report.subscription = subscription_name
             report.resource_name = "Diagnostic Settings"
             report.resource_id = "diagnostic_settings"


### PR DESCRIPTION
### Context

Add missing Check_Report_Azure parameters

### Description

Add missing Check_Report_Azure to checks:
- `entra_conditional_access_policy_require_mfa_for_management_api`
- `entra_non_privileged_user_has_mfa`
- `monitor_diagnostic_settings_exists`

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
