### PR TITLE
fix(aws): list tags for DocumentDB clusters

### DIFF
--- a/prowler/providers/aws/services/documentdb/documentdb_service.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_service.py
@@ -64,6 +64,17 @@ class DocumentDB(AWSService):
     def _list_tags_for_resource(self):
         logger.info("DocumentDB - List Tags...")
         try:
+            for cluster_arn, cluster in self.db_clusters.items():
+                try:
+                    regional_client = self.regional_clients[cluster.region]
+                    response = regional_client.list_tags_for_resource(
+                        ResourceName=cluster_arn
+                    )["TagList"]
+                    cluster.tags = response
+                except Exception as error:
+                    logger.error(
+                        f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
             for instance_arn, instance in self.db_instances.items():
                 try:
                     regional_client = self.regional_clients[instance.region]

--- a/tests/providers/aws/services/documentdb/documentdb_service_test.py
+++ b/tests/providers/aws/services/documentdb/documentdb_service_test.py
@@ -179,7 +179,7 @@ class Test_DocumentDB_Service:
                 parameter_group="default.docdb3.6",
                 deletion_protection=True,
                 region=AWS_REGION_US_EAST_1,
-                tags=[],
+                tags=[{"Key": "environment", "Value": "test"}],
             )
         }
 


### PR DESCRIPTION
### Context

Until now, only the tags of the DocumentDB **instances** and **snapshots** were read out but not the tags of the **cluster**.

### Description

This fix lists also the tags of the cluster.

### Checklist

- Are there new checks included in this PR?  No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
