### PR TITLE
feat(api): restrict the deletion of users, only the user of the request can be deleted

### DIFF
--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -5381,8 +5381,8 @@ paths:
           description: ''
     delete:
       operationId: users_destroy
-      description: Remove a user account from the system.
-      summary: Delete a user account
+      description: Remove the current user account from the system.
+      summary: Delete the user account
       parameters:
       - in: path
         name: id

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -261,6 +261,16 @@ class TestUserViewSet:
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert not User.objects.filter(id=create_test_user.id).exists()
 
+    def test_users_destroy_other_user(
+        self, authenticated_client, create_test_user, users_fixture
+    ):
+        user = users_fixture[2]
+        response = authenticated_client.delete(
+            reverse("user-detail", kwargs={"pk": str(user.id)})
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert User.objects.filter(id=create_test_user.id).exists()
+
     def test_users_destroy_invalid_user(self, authenticated_client, create_test_user):
         another_user = User.objects.create_user(
             password="otherpassword", email="other@example.com"
@@ -268,7 +278,7 @@ class TestUserViewSet:
         response = authenticated_client.delete(
             reverse("user-detail", kwargs={"pk": another_user.id})
         )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert User.objects.filter(id=another_user.id).exists()
 
     @pytest.mark.parametrize(

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -277,8 +277,8 @@ class SchemaView(SpectacularAPIView):
     ),
     destroy=extend_schema(
         tags=["User"],
-        summary="Delete a user account",
-        description="Remove a user account from the system.",
+        summary="Delete the user account",
+        description="Remove the current user account from the system.",
     ),
     me=extend_schema(
         tags=["User"],
@@ -341,6 +341,12 @@ class UserViewSet(BaseUserViewset):
             data=serializer.data,
             status=status.HTTP_200_OK,
         )
+
+    def destroy(self, request, *args, **kwargs):
+        if kwargs["pk"] != str(self.request.user.id):
+            raise ValidationError("Only the current user can be deleted.")
+
+        return super().destroy(request, *args, **kwargs)
 
     @extend_schema(
         parameters=[


### PR DESCRIPTION
### Description

In this PR we have added a restriction to the user deletion endpoint:
- Only the user making the request will be able to delete himself, this means that no user will be able to delete another user's account, only his own.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
