### PR TITLE
fix: update Azure CIS with existing App checks

### DIFF
--- a/prowler/compliance/azure/cis_2.1_azure.json
+++ b/prowler/compliance/azure/cis_2.1_azure.json
@@ -3115,7 +3115,9 @@
     {
       "Id": "9.4",
       "Description": "Ensure that Register with Entra ID is enabled on App Service",
-      "Checks": [],
+      "Checks": [
+        "app_register_with_identity"
+      ],
       "Attributes": [
         {
           "Section": "9. AppService",

--- a/prowler/compliance/azure/cis_3.0_azure.json
+++ b/prowler/compliance/azure/cis_3.0_azure.json
@@ -3220,7 +3220,9 @@
     {
       "Id": "9.1",
       "Description": "Ensure 'HTTPS Only' is set to `On`",
-      "Checks": [],
+      "Checks": [
+        "app_ensure_http_is_redirected_to_https"
+      ],
       "Attributes": [
         {
           "Section": "9. AppService",
@@ -3262,7 +3264,9 @@
     {
       "Id": "9.3",
       "Description": "Ensure 'FTP State' is set to 'FTPS Only' or 'Disabled'",
-      "Checks": [],
+      "Checks": [
+        "app_ftp_deployment_disabled"
+      ],
       "Attributes": [
         {
           "Section": "9. AppService",
@@ -3304,7 +3308,9 @@
     {
       "Id": "9.5",
       "Description": "Ensure that Register with Entra ID is enabled on App Service",
-      "Checks": [],
+      "Checks": [
+        "app_register_with_identity"
+      ],
       "Attributes": [
         {
           "Section": "9. AppService",


### PR DESCRIPTION
### Context

Some checks for CIS 2.1 and 3.0 was not added when it exists in App service.

### Description

Add missing checks for App service

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
