### PR TITLE
fix: add detector and line number of potential secret

### DIFF
--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
@@ -49,7 +49,13 @@ class ec2_launch_template_no_secrets(Check):
                 )
 
                 if version_secrets:
-                    versions_with_secrets.append(str(version.version_number))
+                    secrets_string = ", ".join(
+                        [
+                            f"{secret['type']} on line {secret['line_number']}"
+                            for secret in version_secrets
+                        ]
+                    )
+                    versions_with_secrets.append(f"Version {version.version_number}: {secrets_string}")
 
             if len(versions_with_secrets) > 0:
                 report.status = "FAIL"

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
@@ -55,7 +55,9 @@ class ec2_launch_template_no_secrets(Check):
                             for secret in version_secrets
                         ]
                     )
-                    versions_with_secrets.append(f"Version {version.version_number}: {secrets_string}")
+                    versions_with_secrets.append(
+                        f"Version {version.version_number}: {secrets_string}"
+                    )
 
             if len(versions_with_secrets) > 0:
                 report.status = "FAIL"

--- a/tests/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets_test.py
+++ b/tests/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets_test.py
@@ -155,7 +155,7 @@ class Test_ec2_launch_template_no_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "Potential secret found in User Data for EC2 Launch Template tester1 in template versions: 123."
+                == "Potential secret found in User Data for EC2 Launch Template tester1 in template versions: Version 123: Secret Keyword on line 1."
             )
             assert result[0].resource_id == "lt-1234567890"
             assert result[0].region == AWS_REGION_US_EAST_1
@@ -223,7 +223,7 @@ class Test_ec2_launch_template_no_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name} in template versions: 1, 2."
+                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name} in template versions: Version 1: Secret Keyword on line 1, Hex High Entropy String on line 3, Secret Keyword on line 3, Secret Keyword on line 4, Version 2: Secret Keyword on line 1, Hex High Entropy String on line 3, Secret Keyword on line 3, Secret Keyword on line 4."
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
@@ -297,7 +297,7 @@ class Test_ec2_launch_template_no_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name} in template versions: 1."
+                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name} in template versions: Version 1: Secret Keyword on line 1, Hex High Entropy String on line 3, Secret Keyword on line 3, Secret Keyword on line 4."
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
@@ -361,7 +361,7 @@ class Test_ec2_launch_template_no_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name} in template versions: 1."
+                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name} in template versions: Version 1: Secret Keyword on line 1, Hex High Entropy String on line 3, Secret Keyword on line 3, Secret Keyword on line 4."
             )
             assert result[0].resource_id == launch_template_id
             assert result[0].region == AWS_REGION_US_EAST_1
@@ -502,7 +502,7 @@ class Test_ec2_launch_template_no_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name1} in template versions: 1."
+                == f"Potential secret found in User Data for EC2 Launch Template {launch_template_name1} in template versions: Version 1: Secret Keyword on line 1, Hex High Entropy String on line 3, Secret Keyword on line 3, Secret Keyword on line 4."
             )
             assert result[0].resource_id == launch_template_id1
             assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

Until now it was hard to locate the potential secret found by the check `ec2_launch_template_no_secrets` because neither the detector nor the line number was indicated in prowlers report.

### Description

This PR adds the detector and the line number of the potential secret found by the check `ec2_launch_template_no_secrets`.
Doing so, it also aligns to the other prowler checks which search for potential secrets. 

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
