### PR TITLE
chore(scan): Remove ._findings

### DIFF
--- a/prowler/lib/scan/scan.py
+++ b/prowler/lib/scan/scan.py
@@ -36,7 +36,6 @@ class Scan:
     _service_checks_to_execute: dict[str, set[str]]
     _service_checks_completed: dict[str, set[str]]
     _progress: float = 0.0
-    _findings: list = []
     _duration: int = 0
     _status: list[str] = None
 
@@ -216,10 +215,6 @@ class Scan:
     def duration(self) -> int:
         return self._duration
 
-    @property
-    def findings(self) -> list:
-        return self._findings
-
     def scan(
         self,
         custom_checks_metadata: dict = {},
@@ -281,9 +276,6 @@ class Scan:
                         for finding in check_findings:
                             if finding.status not in self._status:
                                 check_findings.remove(finding)
-
-                    # Store findings
-                    self._findings.extend(check_findings)
 
                     # Remove the executed check
                     self._service_checks_to_execute[service].remove(check_name)

--- a/tests/lib/scan/scan_test.py
+++ b/tests/lib/scan/scan_test.py
@@ -333,7 +333,6 @@ class TestScan:
         assert scan.service_checks_completed == {
             "accessanalyzer": {"accessanalyzer_enabled"},
         }
-        assert scan.findings == mock_execute.side_effect()
         mock_logger.error.assert_not_called()
 
     def test_init_invalid_severity(


### PR DESCRIPTION
### Description

Remove `Scan._findings` since it is not being used and only increases memory usage.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
