### PR TITLE
fix(cloudwatch): NoneType object is not iterable

### DIFF
--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_group_not_publicly_accessible/cloudwatch_log_group_not_publicly_accessible.py
@@ -12,18 +12,21 @@ class cloudwatch_log_group_not_publicly_accessible(Check):
             and logs_client.log_groups is not None
         ):
             for resource_policies in logs_client.resource_policies.values():
-                for resource_policy in resource_policies:
-                    if is_policy_public(
-                        resource_policy.policy, logs_client.audited_account
-                    ):
-                        for statement in resource_policy.policy.get("Statement", []):
-                            public_resources = statement.get("Resource", [])
-                            if isinstance(public_resources, str):
-                                public_resources = [public_resources]
-                            for resource in public_resources:
-                                for log_group in logs_client.log_groups.values():
-                                    if log_group.arn in resource or resource == "*":
-                                        public_log_groups.append(log_group.arn)
+                if resource_policies is not None:
+                    for resource_policy in resource_policies:
+                        if is_policy_public(
+                            resource_policy.policy, logs_client.audited_account
+                        ):
+                            for statement in resource_policy.policy.get(
+                                "Statement", []
+                            ):
+                                public_resources = statement.get("Resource", [])
+                                if isinstance(public_resources, str):
+                                    public_resources = [public_resources]
+                                for resource in public_resources:
+                                    for log_group in logs_client.log_groups.values():
+                                        if log_group.arn in resource or resource == "*":
+                                            public_log_groups.append(log_group.arn)
             for log_group in logs_client.log_groups.values():
                 report = Check_Report_AWS(metadata=self.metadata(), resource=log_group)
                 report.status = "PASS"


### PR DESCRIPTION
### Context

`cloudwatch_log_group_not_publicly_accessible` check is giving this error:

`cloudwatch_log_group_not_publicly_accessible -- TypeError[15]: 'NoneType' object is not iterable`

### Description

A validation has been added to check if the object we are going to iterate over is None or not to avoid it.

### Checklist

- Are there new checks included in this PR? No.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
