### PR TITLE
fix(gcp): fix wrong provider value in check

### DIFF
--- a/prowler/providers/gcp/services/compute/compute_public_address_shodan/compute_public_address_shodan.metadata.json
+++ b/prowler/providers/gcp/services/compute/compute_public_address_shodan/compute_public_address_shodan.metadata.json
@@ -1,5 +1,5 @@
 {
-  "Provider": "compute",
+  "Provider": "gcp",
   "CheckID": "compute_public_address_shodan",
   "CheckTitle": "Check if any of the Public Addresses are in Shodan (requires Shodan API KEY).",
   "CheckType": [


### PR DESCRIPTION
minor PR for fixing a wrong entry for the "provider" key in this check
value should be "gcp"
fixed