### PR TITLE
fix(aws): iam_user_with_temporary_credentials resource in OCSF

### DIFF
--- a/prowler/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials.py
+++ b/prowler/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials.py
@@ -15,7 +15,7 @@ class iam_user_with_temporary_credentials(Check):
 
             report = Check_Report_AWS(
                 metadata=self.metadata(),
-                resource=iam_client.user_temporary_credentials_usage,
+                resource=user_name,
             )
             report.resource_id = user_name
             report.resource_arn = user_arn

--- a/prowler/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials.py
+++ b/prowler/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials.py
@@ -15,7 +15,7 @@ class iam_user_with_temporary_credentials(Check):
 
             report = Check_Report_AWS(
                 metadata=self.metadata(),
-                resource={"user_name": user_name, "user_arn": user_arn},
+                resource={"name": user_name, "arn": user_arn},
             )
             report.resource_id = user_name
             report.resource_arn = user_arn

--- a/prowler/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials.py
+++ b/prowler/providers/aws/services/iam/iam_user_with_temporary_credentials/iam_user_with_temporary_credentials.py
@@ -15,7 +15,7 @@ class iam_user_with_temporary_credentials(Check):
 
             report = Check_Report_AWS(
                 metadata=self.metadata(),
-                resource=user_name,
+                resource={"user_name": user_name, "user_arn": user_arn},
             )
             report.resource_id = user_name
             report.resource_arn = user_arn


### PR DESCRIPTION
### Context

The check `user_temporary_credentials_usage` produced the following error which prevented to have any  findings for this check in prowlers report:

`{"timestamp": "2025-01-27 14:50:57,103", "filename": "ocsf.py:211", "level": "ERROR", "module": "ocsf", "message": "TypeError[207]: keys must be str, int, float, bool or None, not tuple"}` 

This is because the `resource` of the `report` was set to `iam_client.user_temporary_credentials_usage` which can be a dictionary which is not supported by the `ocsf.py`.

### Description

~~Therefore, this fix sets `resource` of the `report` to `user_name`. This aligns also with the other    ###`iam_user`-checks.~~

If `resource` of the `report` was set to `user_name` (of type `str`) prowler threw the following error:

`{"timestamp": "2025-01-29 20:50:59,693", "filename": "models.py:432", "level": "ERROR", "module": "models", "message": "Resource metadata <class 'str'> in iam_user_with_temporary_credentials could not be converted to dict"}`

Therefore,  this fix sets `resource` of the `report` to the `dict` `{"user_name": user_name, "user_arn": user_arn}`. This seems to be accepted by both files `ocsf.py` and `models.py`. 

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
