### PR TITLE
chore(aws_audit_manager_control_tower_guardrails): add checks to reqs

### DIFF
--- a/prowler/compliance/aws/aws_audit_manager_control_tower_guardrails_aws.json
+++ b/prowler/compliance/aws/aws_audit_manager_control_tower_guardrails_aws.json
@@ -28,7 +28,9 @@
           "Service": "ebs"
         }
       ],
-      "Checks": []
+      "Checks": [
+        "ec2_ebs_volume_snapshots_exists"
+      ]
     },
     {
       "Id": "1.0.3",
@@ -42,7 +44,8 @@
         }
       ],
       "Checks": [
-        "ec2_ebs_default_encryption"
+        "ec2_ebs_default_encryption",
+        "ec2_ebs_volume_encryption"
       ]
     },
     {
@@ -87,7 +90,9 @@
         }
       ],
       "Checks": [
-        "iam_user_mfa_enabled_console_access"
+        "iam_user_mfa_enabled_console_access",
+        "iam_user_hardware_mfa_enabled",
+        "iam_root_mfa_enabled"
       ]
     },
     {
@@ -102,7 +107,9 @@
         }
       ],
       "Checks": [
-        "iam_user_mfa_enabled_console_access"
+        "iam_user_mfa_enabled_console_access",
+        "iam_user_hardware_mfa_enabled",
+        "iam_root_mfa_enabled"
       ]
     },
     {
@@ -117,7 +124,9 @@
         }
       ],
       "Checks": [
-        "iam_root_mfa_enabled"
+        "iam_root_mfa_enabled",
+        "iam_root_hardware_mfa_enabled",
+        "iam_user_mfa_enabled_console_access"
       ]
     },
     {
@@ -162,7 +171,10 @@
         }
       ],
       "Checks": [
-        "rds_instance_no_public_access"
+        "rds_instance_no_public_access",
+        "s3_bucket_public_access",
+        "s3_bucket_public_list_acl",
+        "s3_account_level_public_access_blocks"
       ]
     },
     {
@@ -192,7 +204,8 @@
         }
       ],
       "Checks": [
-        "rds_instance_storage_encrypted"
+        "rds_instance_storage_encrypted",
+        "rds_instance_transport_encrypted"
       ]
     },
     {


### PR DESCRIPTION
### Description
This pull request includes updates to the `prowler/compliance/aws/aws_audit_manager_control_tower_guardrails_aws.json` file to enhance the compliance checks for various AWS services. The most important changes include adding new checks for EBS volumes, IAM users, RDS instances, and S3 buckets.

Enhancements to compliance checks:

* Added a check for EBS volume snapshots in the `ebs` service.
* Added a check for EBS volume encryption in addition to the default encryption check.
* Added checks for IAM user hardware MFA and root MFA in addition to the existing console access MFA check. [[1]](diffhunk://#diff-34aa4ec4bd27096b92e903f06f2716016cb285bd436aac1e2e63e538eaf6e459L90-R95) [[2]](diffhunk://#diff-34aa4ec4bd27096b92e903f06f2716016cb285bd436aac1e2e63e538eaf6e459L105-R112) [[3]](diffhunk://#diff-34aa4ec4bd27096b92e903f06f2716016cb285bd436aac1e2e63e538eaf6e459L120-R129)
* Added checks for S3 bucket public access and account-level public access blocks.
* Added a check for RDS instance transport encryption in addition to storage encryption.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
