### PR TITLE
fix(aws): key error for detect-secrets

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 
 from prowler.lib.check.models import Check, Check_Report_AWS

--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
@@ -28,19 +28,13 @@ class awslambda_function_no_secrets_in_variables(Check):
                         "detect_secrets_plugins",
                     ),
                 )
-                original_env_vars = {}
+                original_env_vars = []
                 for name, value in function.environment.items():
-                    original_env_vars.update(
-                        {
-                            hashlib.sha1(  # nosec B324 SHA1 is used here for non-security-critical unique identifiers
-                                value.encode("utf-8")
-                            ).hexdigest(): name
-                        }
-                    )
+                    original_env_vars.append(name)
                 if detect_secrets_output:
                     secrets_string = ", ".join(
                         [
-                            f"{secret['type']} in variable {original_env_vars[secret['hashed_secret']]}"
+                            f"{secret['type']} in variable {original_env_vars[secret['line_number'] - 2]}"
                             for secret in detect_secrets_output
                         ]
                     )

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -1,4 +1,3 @@
-import hashlib
 from json import dumps
 
 from prowler.lib.check.models import Check, Check_Report_AWS
@@ -25,16 +24,10 @@ class ecs_task_definitions_no_environment_secrets(Check):
 
                 if container.environment:
                     dump_env_vars = {}
-                    original_env_vars = {}
+                    original_env_vars = []
                     for env_var in container.environment:
                         dump_env_vars.update({env_var.name: env_var.value})
-                        original_env_vars.update(
-                            {
-                                hashlib.sha1(  # nosec B324 SHA1 is used here for non-security-critical unique identifiers
-                                    env_var.value.encode("utf-8")
-                                ).hexdigest(): env_var.name
-                            }
-                        )
+                        original_env_vars.append(env_var.name)
 
                     env_data = dumps(dump_env_vars, indent=2)
                     detect_secrets_output = detect_secrets_scan(
@@ -47,7 +40,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
                     if detect_secrets_output:
                         secrets_string = ", ".join(
                             [
-                                f"{secret['type']} on the environment variable {original_env_vars[secret['hashed_secret']]}"
+                                f"{secret['type']} on the environment variable {original_env_vars[secret['line_number'] - 2]}"
                                 for secret in detect_secrets_output
                             ]
                         )

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
@@ -76,7 +76,7 @@ class Test_awslambda_function_no_secrets_in_variables:
             )
             assert result[0].resource_tags == []
 
-    def test_function_secrets_in_variables(self):
+    def test_function_secrets_in_keyword(self):
         lambda_client = mock.MagicMock
         function_name = "test-lambda"
         function_runtime = "nodejs4.3"
@@ -118,6 +118,51 @@ class Test_awslambda_function_no_secrets_in_variables:
             assert (
                 result[0].status_extended
                 == f"Potential secret found in Lambda function {function_name} variables -> Secret Keyword in variable db_password."
+            )
+            assert result[0].resource_tags == []
+
+    def test_function_secrets_in_keyword_and_variable(self):
+        lambda_client = mock.MagicMock
+        function_name = "test-lambda"
+        function_runtime = "nodejs4.3"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
+
+        lambda_client.audit_config = {"secrets_ignore_patterns": []}
+
+        lambda_client.functions = {
+            "function_name": Function(
+                name=function_name,
+                security_groups=[],
+                arn=function_arn,
+                region=AWS_REGION_US_EAST_1,
+                runtime=function_runtime,
+                environment={"db_password": "srv://admin:pass@db"},
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables.awslambda_client",
+            new=lambda_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables import (
+                awslambda_function_no_secrets_in_variables,
+            )
+
+            check = awslambda_function_no_secrets_in_variables()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == function_name
+            assert result[0].resource_arn == function_arn
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Potential secret found in Lambda function {function_name} variables -> Secret Keyword in variable db_password, Basic Auth Credentials in variable db_password."
             )
             assert result[0].resource_tags == []
 

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -266,7 +266,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
                         {
                             "name": ENV_VAR_NAME_NO_SECRETS,
                             "value": ENV_VAR_VALUE_WITH_SECRETS2,
-                        }
+                        },
                     ],
                 }
             ],
@@ -322,7 +322,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
                         {
                             "name": ENV_VAR_NAME_WITH_KEYWORD2,
                             "value": ENV_VAR_VALUE_WITH_SECRETS2,
-                        }
+                        },
                     ],
                 }
             ],

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from boto3 import client
 from moto import mock_aws
-
 from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
 
 TASK_NAME = "test-task"
@@ -140,7 +139,6 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].resource_arn == task_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
-
 
     @mock_aws
     def test_container_env_var_with_keyword(self):

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -10,8 +10,10 @@ TASK_REVISION = "1"
 CONTAINER_NAME = "test-container"
 ENV_VAR_NAME_NO_SECRETS = "host"
 ENV_VAR_VALUE_NO_SECRETS = "localhost:1234"
-ENV_VAR_NAME_WITH_SECRETS = "DB_PASSWORD"
-ENV_VAR_VALUE_WITH_SECRETS = "pass-12343"
+ENV_VAR_NAME_WITH_KEYWORD = "DB_PASSWORD"
+ENV_VAR_VALUE_WITH_SECRETS = "srv://admin:pass@db"
+ENV_VAR_NAME_WITH_KEYWORD2 = "DATABASE_PASSWORD"
+ENV_VAR_VALUE_WITH_SECRETS2 = "srv://admin:password@database"
 
 
 class Test_ecs_task_definitions_no_environment_secrets:
@@ -88,7 +90,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].resource_tags == []
 
     @mock_aws
-    def test_container_env_var_with_secrets(self):
+    def test_container_env_var_with_secret(self):
         ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
 
         task_arn = ecs_client.register_task_definition(
@@ -103,7 +105,7 @@ class Test_ecs_task_definitions_no_environment_secrets:
                     "user": "appuser",
                     "environment": [
                         {
-                            "name": ENV_VAR_NAME_WITH_SECRETS,
+                            "name": ENV_VAR_NAME_NO_SECRETS,
                             "value": ENV_VAR_VALUE_WITH_SECRETS,
                         }
                     ],
@@ -132,7 +134,224 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Basic Auth Credentials on the environment variable host."
+            )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
+
+
+    @mock_aws
+    def test_container_env_var_with_keyword(self):
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [
+                        {
+                            "name": ENV_VAR_NAME_WITH_KEYWORD,
+                            "value": ENV_VAR_VALUE_NO_SECRETS,
+                        }
+                    ],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
+                ecs_task_definitions_no_environment_secrets,
+            )
+
+            check = ecs_task_definitions_no_environment_secrets()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
                 == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on the environment variable DB_PASSWORD."
+            )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_container_env_var_with_keyword_and_secret(self):
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [
+                        {
+                            "name": ENV_VAR_NAME_WITH_KEYWORD,
+                            "value": ENV_VAR_VALUE_WITH_SECRETS,
+                        }
+                    ],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
+                ecs_task_definitions_no_environment_secrets,
+            )
+
+            check = ecs_task_definitions_no_environment_secrets()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on the environment variable DB_PASSWORD, Basic Auth Credentials on the environment variable DB_PASSWORD."
+            )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_container_multiple_env_vars_with_keyword_and_secret(self):
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [
+                        {
+                            "name": ENV_VAR_NAME_WITH_KEYWORD,
+                            "value": ENV_VAR_VALUE_WITH_SECRETS,
+                        },
+                        {
+                            "name": ENV_VAR_NAME_NO_SECRETS,
+                            "value": ENV_VAR_VALUE_WITH_SECRETS2,
+                        }
+                    ],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
+                ecs_task_definitions_no_environment_secrets,
+            )
+
+            check = ecs_task_definitions_no_environment_secrets()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on the environment variable DB_PASSWORD, Basic Auth Credentials on the environment variable DB_PASSWORD, Basic Auth Credentials on the environment variable host."
+            )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_container_all_env_vars_with_keyword_and_secret(self):
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [
+                        {
+                            "name": ENV_VAR_NAME_WITH_KEYWORD,
+                            "value": ENV_VAR_VALUE_WITH_SECRETS,
+                        },
+                        {
+                            "name": ENV_VAR_NAME_WITH_KEYWORD2,
+                            "value": ENV_VAR_VALUE_WITH_SECRETS2,
+                        }
+                    ],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
+                ecs_task_definitions_no_environment_secrets,
+            )
+
+            check = ecs_task_definitions_no_environment_secrets()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on the environment variable DB_PASSWORD, Basic Auth Credentials on the environment variable DB_PASSWORD, Basic Auth Credentials on the environment variable DATABASE_PASSWORD, Secret Keyword on the environment variable DATABASE_PASSWORD."
             )
             assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
             assert result[0].resource_arn == task_arn


### PR DESCRIPTION
### Context

PR #6537 introduced a bug which this PR will fix.

### Description

Both prowler checks `ecs_task_definitions_no_environment_secrets` and `awslambda_function_no_secrets_in_variables` will throw a key error if the potential secret is not the **whole** but only a **part** of the value. 
Since PR #6537, the **whole** value was sha1 hashed and associated to its variable name in order to get the variable name back by passing the found potential secret which was also sha1 hashed by detect-secrets. However, detect-secrets hashes only the **part** of the value which was detected to be a potential secret but not the **whole** value as PR #6537 did.
For example, if the value is `srv://admin:pass@db`, detect-secrets will hash only `pass` and not the whole value. Therefore, the hash will differ from the hash computed by PR #6537 and as such it will not be retrievable, leading to a key error and therefore **missing the finding**. 

As you see in this PR, the fix consists in associating the line number with the variable name. Since detect-secrets returns the line number, we are still able to get the variable name for easy spotting the potential secret.
The line number is off by 2 because the array `original_env_vars` starts at 0 while the json, passed to detect-secrets, starts with a curly bracket in line 1.
I added some more unit tests to cover cases with secrets found on different lines in different order with different detectors.

### Checklist

- Are there new checks included in this PR? Yes 
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
