### PR TITLE
fix(scans, findings): Improve API performance ordering by inserted_at instead of id

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,7 +8,7 @@ description = "Prowler's API (Django/DRF)"
 license = "Apache-2.0"
 name = "prowler-api"
 package-mode = false
-version = "1.3.0"
+version = "1.3.1"
 
 [tool.poetry.dependencies]
 celery = {extras = ["pytest"], version = "^5.4.0"}

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Prowler API
-  version: 1.2.0
+  version: 1.3.1
   description: |-
     Prowler API specification.
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1306,9 +1306,8 @@ class FindingViewSet(BaseRLSViewSet):
     }
     http_method_names = ["get"]
     filterset_class = FindingFilter
-    ordering = ["-id"]
+    ordering = ["-inserted_at"]
     ordering_fields = [
-        "id",
         "status",
         "severity",
         "check_id",
@@ -2006,7 +2005,7 @@ class OverviewViewSet(BaseRLSViewSet):
                 uid=OuterRef("uid"),
                 scan__provider=OuterRef("scan__provider"),
             )
-            .order_by("-id")  # Most recent by id
+            .order_by("-inserted_at")  # Most recent
             .values("id")[:1]
         )
 
@@ -2075,7 +2074,7 @@ class OverviewViewSet(BaseRLSViewSet):
                 state=StateChoices.COMPLETED,
                 provider_id=OuterRef("scan__provider_id"),
             )
-            .order_by("-id")
+            .order_by("-inserted_at")
             .values("id")[:1]
         )
 
@@ -2120,7 +2119,7 @@ class OverviewViewSet(BaseRLSViewSet):
                 state=StateChoices.COMPLETED,
                 provider_id=OuterRef("scan__provider_id"),
             )
-            .order_by("-id")
+            .order_by("-inserted_at")
             .values("id")[:1]
         )
 
@@ -2156,7 +2155,7 @@ class OverviewViewSet(BaseRLSViewSet):
                 state=StateChoices.COMPLETED,
                 provider_id=OuterRef("scan__provider_id"),
             )
-            .order_by("-id")
+            .order_by("-inserted_at")
             .values("id")[:1]
         )
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -194,7 +194,7 @@ class SchemaView(SpectacularAPIView):
 
     def get(self, request, *args, **kwargs):
         spectacular_settings.TITLE = "Prowler API"
-        spectacular_settings.VERSION = "1.2.0"
+        spectacular_settings.VERSION = "1.3.1"
         spectacular_settings.DESCRIPTION = (
             "Prowler API specification.\n\nThis file is auto-generated."
         )


### PR DESCRIPTION
### Context

Postgres v16.x does not include native support for ordering UUIDv7, leading to a really bad performance when trying to order by UUID7.

### Description

Scans and findings queries will no longer order by ID. Instead, `inserted_at` will be used.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
