### PR TITLE
fix(migrations): Use indexes instead of constraints to define an index

### DIFF
--- a/api/src/backend/api/migrations/0007_scan_and_scan_summaries_indexes.py
+++ b/api/src/backend/api/migrations/0007_scan_and_scan_summaries_indexes.py
@@ -16,9 +16,9 @@ class Migration(migrations.Migration):
                 name="scans_prov_state_insert_idx",
             ),
         ),
-        migrations.AddConstraint(
+        migrations.AddIndex(
             model_name="scansummary",
-            constraint=models.Index(
+            index=models.Index(
                 fields=["tenant_id", "scan_id"], name="scan_summaries_tenant_scan_idx"
             ),
         ),

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -1098,15 +1098,17 @@ class ScanSummary(RowLevelSecurityProtectedModel):
                 fields=("tenant", "scan", "check_id", "service", "severity", "region"),
                 name="unique_scan_summary",
             ),
-            models.Index(
-                fields=["tenant_id", "scan_id"],
-                name="scan_summaries_tenant_scan_idx",
-            ),
             RowLevelSecurityConstraint(
                 field="tenant_id",
                 name="rls_on_%(class)s",
                 statements=["SELECT", "INSERT", "UPDATE", "DELETE"],
             ),
+        ]
+        indexes = [
+            models.Index(
+                fields=["tenant_id", "scan_id"],
+                name="scan_summaries_tenant_scan_idx",
+            )
         ]
 
     class JSONAPIMeta:


### PR DESCRIPTION
### Context

There was an error when trying to apply the latest migration.

### Description

One of the new added indexes was defined as part of the model constraints.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
