### PR TITLE
fix: microsoft365 mutelist

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -541,6 +541,7 @@ class Check_Report_Microsoft365(Check_Report):
 
     resource_name: str
     resource_id: str
+    tenant_id: str
     location: str
 
     def __init__(self, metadata: Dict, resource: Any) -> None:
@@ -555,6 +556,7 @@ class Check_Report_Microsoft365(Check_Report):
             resource, "name", getattr(resource, "resource_name", "")
         )
         self.resource_id = getattr(resource, "id", getattr(resource, "resource_id", ""))
+        self.tenant_id = getattr(resource, "tenant_id", "")
         self.location = getattr(resource, "location", "global")
 
 


### PR DESCRIPTION
### Context

After modifying the `Check Report` to include `resource metadata` in `M365`, we unintentionally broke the `mutelist`. This needs to be fixed.

### Description

Check Report for `microsoft365` has been corrected to include the field `tenant_id` that was breaking the `mutelist`.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
