### PR TITLE
chore: Update Google Analytics ID across all docs.prowler.com sites

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,7 +124,7 @@ extra:
       make our documentation better.
   analytics:
     provider: google
-    property: G-H5TFH6WJRQ
+    property: G-KBKV70W5Y2
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/prowler-cloud


### PR DESCRIPTION
**Context**

Internal/Housekeeping - Consistent Google Analytics ID across all docs.prowler.com generated pages.
Requires this change as the ./docs part of the OSS prowler repo contributes pages to the site.

**Description**

mkdocs analytics ID change.

**Checklist**
    Are there new checks included in this PR? YNo
        If so, do we need to update permissions for the provider? Please review this carefully.
    [N/A] Review if the code is being covered by tests.
    [N/A] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
    [NO] Review if backport is needed.
    [NO] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

**License**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.