### PR TITLE
fix(finding): raise when generating invalid findings

### DIFF
--- a/prowler/__main__.py
+++ b/prowler/__main__.py
@@ -332,18 +332,21 @@ def prowler():
     # Outputs
     # TODO: this part is needed since the checks generates a Check_Report_XXX and the output uses Finding
     # This will be refactored for the outputs generate directly the Finding
-    finding_outputs = [
-        Finding.generate_output(global_provider, finding, output_options)
-        for finding in findings
-    ]
+    finding_outputs = []
+    for finding in findings:
+        try:
+            finding_outputs.append(
+                Finding.generate_output(global_provider, finding, output_options)
+            )
+        except Exception:
+            continue
 
     generated_outputs = {"regular": [], "compliance": []}
 
     if args.output_formats:
         for mode in args.output_formats:
             filename = (
-                f"{output_options.output_directory}/"
-                f"{output_options.output_filename}"
+                f"{output_options.output_directory}/{output_options.output_filename}"
             )
             if mode == "csv":
                 csv_output = CSV(

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from prowler.config.config import prowler_version
 from prowler.lib.check.models import Check_Report, CheckMetadata
@@ -257,7 +257,13 @@ class Finding(BaseModel):
             )
 
             return cls(**output_data)
+        except ValidationError as validation_error:
+            logger.error(
+                f"{validation_error.__class__.__name__}[{validation_error.__traceback__.tb_lineno}]: {validation_error} - {output_data}"
+            )
+            raise validation_error
         except Exception as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+            raise error

--- a/prowler/lib/scan/scan.py
+++ b/prowler/lib/scan/scan.py
@@ -296,12 +296,16 @@ class Scan:
                         self.get_completed_checks(),
                     )
 
-                    findings = [
-                        Finding.generate_output(
-                            self._provider, finding, output_options=None
-                        )
-                        for finding in check_findings
-                    ]
+                    findings = []
+                    for finding in check_findings:
+                        try:
+                            findings.append(
+                                Finding.generate_output(
+                                    self._provider, finding, output_options=None
+                                )
+                            )
+                        except Exception:
+                            continue
 
                     yield self.progress, findings
                 # If check does not exists in the provider or is from another provider


### PR DESCRIPTION
### Context

Partially fixes #6728

### Description

If during a `Finding` generation something happens we don't want to store `None` findings but skip them.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
