### PR TITLE
fix(neptune): correct service name

### DIFF
--- a/prowler/providers/aws/services/neptune/neptune_cluster_iam_authentication_enabled/neptune_cluster_iam_authentication_enabled.metadata.json
+++ b/prowler/providers/aws/services/neptune/neptune_cluster_iam_authentication_enabled/neptune_cluster_iam_authentication_enabled.metadata.json
@@ -3,7 +3,7 @@
   "CheckID": "neptune_cluster_iam_authentication_enabled",
   "CheckTitle": "Check if Neptune Clusters have IAM authentication enabled.",
   "CheckType": [],
-  "ServiceName": "rds",
+  "ServiceName": "neptune",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
   "Severity": "medium",


### PR DESCRIPTION
### Description

`neptune_cluster_iam_authentication_enabled` belongs to the `neptune` service.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
