### PR TITLE
feat(scans): Optimize read queries during scans

### DIFF
--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -228,8 +228,10 @@ def perform_prowler_scan(
                     last_first_seen_at = None
                     if finding_uid not in last_status_cache:
                         most_recent_finding = (
-                            Finding.objects.filter(uid=finding_uid)
-                            .order_by("-id")
+                            Finding.all_objects.filter(
+                                tenant_id=tenant_id, uid=finding_uid
+                            )
+                            .order_by("-inserted_at")
                             .values("status", "first_seen_at")
                             .first()
                         )
@@ -378,7 +380,7 @@ def aggregate_findings(tenant_id: str, scan_id: str):
         - muted_changed: Muted findings with a delta of 'changed'.
     """
     with rls_transaction(tenant_id):
-        findings = Finding.objects.filter(scan_id=scan_id)
+        findings = Finding.objects.filter(tenant_id=tenant_id, scan_id=scan_id)
 
         aggregation = findings.values(
             "check_id",


### PR DESCRIPTION
### Context

During scans, when retrieving information from the latest common finding, we did:

```sql
SELECT "findings"."status", "findings"."first_seen_at" FROM "findings" INNER JOIN "scans" ON ("findings"."scan_id" = "scans"."id") INNER JOIN "providers" ON ("scans"."provider_id" = "providers"."id") WHERE (NOT "providers"."is_deleted" AND NOT "providers"."is_deleted" AND "findings"."uid" = ?) ORDER BY "findings"."id" DESC LIMIT ?
```


### Description

We got rid of the JOINs for that specific query and added a filter for `tenant_id`, increasing performance for that query.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
