### PR TITLE
fix(detect-secrets): add case for non utf-8 values

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py
@@ -40,7 +40,7 @@ class awslambda_function_no_secrets_in_variables(Check):
                 if detect_secrets_output:
                     secrets_string = ", ".join(
                         [
-                            f"{secret['type']} in variable {original_env_vars[secret['hashed_secret']]}"
+                            f"{secret['type']} in variable {original_env_vars.get(secret['hashed_secret'], 'UNKNOWN')}"
                             for secret in detect_secrets_output
                         ]
                     )

--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py
@@ -47,7 +47,7 @@ class ecs_task_definitions_no_environment_secrets(Check):
                     if detect_secrets_output:
                         secrets_string = ", ".join(
                             [
-                                f"{secret['type']} on the environment variable {original_env_vars[secret['hashed_secret']]}"
+                                f"{secret['type']} on the environment variable {original_env_vars.get(secret['hashed_secret'], 'UNKNOWN')}"
                                 for secret in detect_secrets_output
                             ]
                         )

--- a/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py
@@ -121,6 +121,51 @@ class Test_awslambda_function_no_secrets_in_variables:
             )
             assert result[0].resource_tags == []
 
+    def test_function_secrets_in_variables_unknown(self):
+        lambda_client = mock.MagicMock
+        function_name = "test-lambda"
+        function_runtime = "nodejs4.3"
+        function_arn = f"arn:aws:lambda:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:function/{function_name}"
+
+        lambda_client.audit_config = {"secrets_ignore_patterns": []}
+
+        lambda_client.functions = {
+            "function_name": Function(
+                name=function_name,
+                security_groups=[],
+                arn=function_arn,
+                region=AWS_REGION_US_EAST_1,
+                runtime=function_runtime,
+                environment={"db_password": "password¿€œ"},
+            )
+        }
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider(),
+        ), mock.patch(
+            "prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables.awslambda_client",
+            new=lambda_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.awslambda.awslambda_function_no_secrets_in_variables.awslambda_function_no_secrets_in_variables import (
+                awslambda_function_no_secrets_in_variables,
+            )
+
+            check = awslambda_function_no_secrets_in_variables()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == function_name
+            assert result[0].resource_arn == function_arn
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Potential secret found in Lambda function {function_name} variables -> Secret Keyword in variable UNKNOWN."
+            )
+            assert result[0].resource_tags == []
+
     def test_function_secrets_in_variables_telegram_token(self):
         lambda_client = mock.MagicMock
         function_name = "test-lambda"

--- a/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
+++ b/tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py
@@ -138,3 +138,55 @@ class Test_ecs_task_definitions_no_environment_secrets:
             assert result[0].resource_arn == task_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_container_env_var_with_secrets_none_value(self):
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+
+        task_arn = ecs_client.register_task_definition(
+            family=TASK_NAME,
+            containerDefinitions=[
+                {
+                    "name": CONTAINER_NAME,
+                    "image": "ubuntu",
+                    "memory": 128,
+                    "readonlyRootFilesystem": True,
+                    "privileged": False,
+                    "user": "appuser",
+                    "environment": [
+                        {
+                            "name": ENV_VAR_NAME_WITH_SECRETS,
+                            "value": "password¿€œ",
+                        }
+                    ],
+                }
+            ],
+        )["taskDefinition"]["taskDefinitionArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=mocked_aws_provider,
+        ), patch(
+            "prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets.ecs_client",
+            new=ECS(mocked_aws_provider),
+        ):
+            from prowler.providers.aws.services.ecs.ecs_task_definitions_no_environment_secrets.ecs_task_definitions_no_environment_secrets import (
+                ecs_task_definitions_no_environment_secrets,
+            )
+
+            check = ecs_task_definitions_no_environment_secrets()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Potential secrets found in ECS task definition {TASK_NAME} with revision {TASK_REVISION}: Secrets in container test-container -> Secret Keyword on the environment variable UNKNOWN."
+            )
+            assert result[0].resource_id == f"{TASK_NAME}:{TASK_REVISION}"
+            assert result[0].resource_arn == task_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []


### PR DESCRIPTION
### Context

Partially Fixes #6728

### Description

This pull request includes updates to handle cases where environment variables containing secrets are not found, by providing a default value of 'UNKNOWN'. Additionally, new test cases have been added to verify these changes.

Error handling improvements:

* [`prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.py`](diffhunk://#diff-8a9eb1deb37463f293870557962773a42cd8e8a2cb30c48936c4154d807c03b4L43-R43): Updated the secret detection logic to return 'UNKNOWN' if the environment variable is not found.
* [`prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.py`](diffhunk://#diff-5353e40aed8f8c1af2be914e108489efac4f61b8195a57599de713b25e99a75bL50-R50): Modified the secret detection logic to return 'UNKNOWN' if the environment variable is not found.

New test cases:

* [`tests/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables_test.py`](diffhunk://#diff-3c654d9d1a3aac9de7eb368e5b73f672053d7525163ffd8c44c4d06d0a1e5759R124-R168): Added a test case to ensure that 'UNKNOWN' is returned when the environment variable is not found.
* [`tests/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets_test.py`](diffhunk://#diff-edd897bed953cb4c23610cc8ea8883e46bad66ae71930579a9b7686f6f74bebaR141-R192): Added a test case to verify that 'UNKNOWN' is returned when the environment variable is not found.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
