### PR TITLE
fix(celery): Kill celery worker process after every task to release memory

### DIFF
--- a/api/docker-entrypoint.sh
+++ b/api/docker-entrypoint.sh
@@ -28,7 +28,7 @@ start_prod_server() {
 
 start_worker() {
   echo "Starting the worker..."
-  poetry run python -m celery -A config.celery worker -l "${DJANGO_LOGGING_LEVEL:-info}" -Q celery,scans -E
+  poetry run python -m celery -A config.celery worker -l "${DJANGO_LOGGING_LEVEL:-info}" -Q celery,scans -E --max-tasks-per-child 1
 }
 
 start_worker_beat() {


### PR DESCRIPTION
### Context

Imported resources from Prowler SDK would remain in memory when deploying the Prowler App locally after running scans because Celery worker child processes were not released.

Fixes #6752

### Description

Through a configuration parameter, we are replacing each worker child process after executing a task: https://docs.celeryq.dev/en/latest/userguide/workers.html#max-tasks-per-child-setting

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
