### PR TITLE
fix(directoryservice): handle ClientException

### DIFF
--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -131,9 +131,15 @@ class DirectoryService(AWSService):
                             self.directories[directory.id].event_topics = event_topics
                         except ClientError as error:
                             if error.response["Error"]["Code"] == "ClientException":
-                                logger.warning(
-                                    f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                                )
+                                error_message = error.response["Error"]["Message"]
+                                if "is in Deleting state" in error_message:
+                                    logger.warning(
+                                        f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                    )
+                                else:
+                                    logger.error(
+                                        f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                    )
                             else:
                                 logger.error(
                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -221,9 +227,15 @@ class DirectoryService(AWSService):
                         )
                     except ClientError as error:
                         if error.response["Error"]["Code"] == "ClientException":
-                            logger.warning(
-                                f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                            )
+                            error_message = error.response["Error"]["Message"]
+                            if "is in Deleting state" in error_message:
+                                logger.warning(
+                                    f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
+                            else:
+                                logger.error(
+                                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
                         else:
                             logger.error(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -107,21 +107,38 @@ class DirectoryService(AWSService):
                 if directory.region == regional_client.region:
                     # Operation is not supported for Shared MicrosoftAD directories.
                     if directory.type != DirectoryType.SharedMicrosoftAD:
-                        describe_event_topics_parameters = {"DirectoryId": directory.id}
-                        event_topics = []
-                        describe_event_topics = regional_client.describe_event_topics(
-                            **describe_event_topics_parameters
-                        )
-                        for event_topic in describe_event_topics["EventTopics"]:
-                            event_topics.append(
-                                EventTopics(
-                                    topic_arn=event_topic["TopicArn"],
-                                    topic_name=event_topic["TopicName"],
-                                    status=event_topic["Status"],
-                                    created_date_time=event_topic["CreatedDateTime"],
+                        try:
+                            describe_event_topics_parameters = {
+                                "DirectoryId": directory.id
+                            }
+                            event_topics = []
+                            describe_event_topics = (
+                                regional_client.describe_event_topics(
+                                    **describe_event_topics_parameters
                                 )
                             )
-                        self.directories[directory.id].event_topics = event_topics
+                            for event_topic in describe_event_topics["EventTopics"]:
+                                event_topics.append(
+                                    EventTopics(
+                                        topic_arn=event_topic["TopicArn"],
+                                        topic_name=event_topic["TopicName"],
+                                        status=event_topic["Status"],
+                                        created_date_time=event_topic[
+                                            "CreatedDateTime"
+                                        ],
+                                    )
+                                )
+                            self.directories[directory.id].event_topics = event_topics
+                        except ClientError as error:
+                            if error.response["Error"]["Code"] == "ClientException":
+                                logger.warning(
+                                    f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
+                            else:
+                                logger.error(
+                                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
+                        continue
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -202,10 +219,16 @@ class DirectoryService(AWSService):
                                 "SnapshotLimits"
                             ]["ManualSnapshotsLimitReached"],
                         )
-                    except Exception as error:
-                        logger.error(
-                            f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                        )
+                    except ClientError as error:
+                        if error.response["Error"]["Code"] == "ClientException":
+                            logger.warning(
+                                f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                            )
+                        else:
+                            logger.error(
+                                f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                            )
+                        continue
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -141,7 +141,11 @@ class DirectoryService(AWSService):
                                 logger.error(
                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
-                        continue
+                        except Exception as error:
+                            logger.error(
+                                f"{regional_client.region} -- {error.__class__.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                            )
+
         except Exception as error:
             logger.error(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -231,7 +235,10 @@ class DirectoryService(AWSService):
                             logger.error(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
-                        continue
+                    except Exception as error:
+                        logger.error(
+                            f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                        )
 
         except Exception as error:
             logger.error(

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -130,16 +130,13 @@ class DirectoryService(AWSService):
                                 )
                             self.directories[directory.id].event_topics = event_topics
                         except ClientError as error:
-                            if error.response["Error"]["Code"] == "ClientException":
-                                error_message = error.response["Error"]["Message"]
-                                if "is in Deleting state" in error_message:
-                                    logger.warning(
-                                        f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                                    )
-                                else:
-                                    logger.error(
-                                        f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                                    )
+                            if (
+                                "is in Deleting state"
+                                in error.response["Error"]["Message"]
+                            ):
+                                logger.warning(
+                                    f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                                )
                             else:
                                 logger.error(
                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
@@ -226,16 +223,10 @@ class DirectoryService(AWSService):
                             ]["ManualSnapshotsLimitReached"],
                         )
                     except ClientError as error:
-                        if error.response["Error"]["Code"] == "ClientException":
-                            error_message = error.response["Error"]["Message"]
-                            if "is in Deleting state" in error_message:
-                                logger.warning(
-                                    f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                                )
-                            else:
-                                logger.error(
-                                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-                                )
+                        if "is in Deleting state" in error.response["Error"]["Message"]:
+                            logger.warning(
+                                f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                            )
                         else:
                             logger.error(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Context

The sentry scanner notifies us about two issues that comes from an exception that should be handle as a warning instead of an error. This happened during a calling to DescribeEventTopics and GetSnapshotLimits.

### Description

Modified those exceptions to catch the error and show it as a warning.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
