### PR TITLE
fix(aws) wording of report.status_extended in awslambda_function_not_publicly_accessible

### DIFF
--- a/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.py
@@ -10,14 +10,14 @@ class awslambda_function_not_publicly_accessible(Check):
             report = Check_Report_AWS(metadata=self.metadata(), resource=function)
 
             report.status = "PASS"
-            report.status_extended = f"Lambda function {function.name} has a policy resource-based policy not public."
+            report.status_extended = f"Lambda function {function.name} has a resource-based policy without public access."
             if is_policy_public(
                 function.policy,
                 awslambda_client.audited_account,
                 is_cross_account_allowed=True,
             ):
                 report.status = "FAIL"
-                report.status_extended = f"Lambda function {function.name} has a policy resource-based policy with public access."
+                report.status_extended = f"Lambda function {function.name} has a resource-based policy with public access."
 
             findings.append(report)
 

--- a/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
+++ b/tests/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_test.py
@@ -107,7 +107,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Lambda function {function_name} has a policy resource-based policy with public access."
+                == f"Lambda function {function_name} has a resource-based policy with public access."
             )
             assert result[0].resource_tags == [{"tag1": "value1", "tag2": "value2"}]
 
@@ -184,7 +184,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Lambda function {function_name} has a policy resource-based policy not public."
+                == f"Lambda function {function_name} has a resource-based policy without public access."
             )
             assert result[0].resource_tags == [{"tag1": "value1", "tag2": "value2"}]
 
@@ -260,7 +260,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Lambda function {function_name} has a policy resource-based policy not public."
+                == f"Lambda function {function_name} has a resource-based policy without public access."
             )
             assert result[0].resource_tags == [{"tag1": "value1", "tag2": "value2"}]
 
@@ -319,7 +319,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Lambda function {function_name} has a policy resource-based policy with public access."
+                == f"Lambda function {function_name} has a resource-based policy with public access."
             )
             assert result[0].resource_tags == []
 
@@ -492,7 +492,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "Lambda function test-public-lambda has a policy resource-based policy with public access."
+                == "Lambda function test-public-lambda has a resource-based policy with public access."
             )
             assert result[0].resource_tags == [{"tag1": "value1", "tag2": "value2"}]
 
@@ -552,7 +552,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Lambda function {function_name} has a policy resource-based policy not public."
+                == f"Lambda function {function_name} has a resource-based policy without public access."
             )
             assert result[0].resource_tags == []
 
@@ -612,7 +612,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Lambda function {function_name} has a policy resource-based policy not public."
+                == f"Lambda function {function_name} has a resource-based policy without public access."
             )
             assert result[0].resource_tags == []
 
@@ -681,7 +681,7 @@ class Test_awslambda_function_not_publicly_accessible:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Lambda function {function_name} has a policy resource-based policy with public access."
+                == f"Lambda function {function_name} has a resource-based policy with public access."
             )
             assert result[0].resource_id == function_name
             assert result[0].resource_arn == function_arn


### PR DESCRIPTION
### Context

The wording of `report.status_extended` in the check `awslambda_function_not_publicly_accessible` was just "broken".

### Description

This PR fixes it.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
