### PR TITLE
feat: implement new functionality with inserted_at__gte in findings a…

### DIFF
--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -1,4 +1,5 @@
 import { Spacer } from "@nextui-org/react";
+import { format, subDays } from "date-fns";
 import React, { Suspense } from "react";
 
 import { getFindings, getMetadataInfo } from "@/actions/findings";
@@ -13,8 +14,6 @@ import {
 import { Header } from "@/components/ui";
 import { DataTable, DataTableFilterCustom } from "@/components/ui/table";
 import { createDict } from "@/lib";
-import { subDays, format } from "date-fns";
-
 import {
   FindingProps,
   ProviderProps,
@@ -35,10 +34,15 @@ export default async function Findings({
 
   const twoDaysAgo = format(subDays(new Date(), 2), "yyyy-MM-dd");
 
+  // Check if the searchParams contain any date or scan filter
+  const hasDateOrScanFilter = Object.keys(searchParams).some(
+    (key) => key.includes("inserted_at") || key.includes("scan__in"),
+  );
+
   // Default filters for getMetadataInfo
-  const defaultFilters = {
-    "filter[inserted_at__gte]": twoDaysAgo,
-  };
+  const defaultFilters: Record<string, string> = hasDateOrScanFilter
+    ? {} // Do not apply default filters if there are date or scan filters
+    : { "filter[inserted_at__gte]": twoDaysAgo };
 
   // Extract all filter parameters and combine with default filters
   const filters: Record<string, string> = {
@@ -156,10 +160,15 @@ const SSRDataTable = async ({
 
   const twoDaysAgo = format(subDays(new Date(), 2), "yyyy-MM-dd");
 
+  // Check if the searchParams contain any date or scan filter
+  const hasDateOrScanFilter = Object.keys(searchParams).some(
+    (key) => key.includes("inserted_at") || key.includes("scan__in"),
+  );
+
   // Default filters for getFindings
-  const defaultFilters = {
-    "filter[inserted_at__gte]": twoDaysAgo,
-  };
+  const defaultFilters: Record<string, string> = hasDateOrScanFilter
+    ? {} // Do not apply default filters if there are date or scan filters
+    : { "filter[inserted_at__gte]": twoDaysAgo };
 
   const filters: Record<string, string> = {
     ...defaultFilters,

--- a/ui/app/(prowler)/page.tsx
+++ b/ui/app/(prowler)/page.tsx
@@ -1,4 +1,5 @@
 import { Spacer } from "@nextui-org/react";
+import { format, subDays } from "date-fns";
 import { Suspense } from "react";
 
 import { getFindings } from "@/actions/findings/findings";
@@ -131,9 +132,12 @@ const SSRDataNewFindingsTable = async () => {
   const page = 1;
   const sort = "severity,-inserted_at";
 
+  const twoDaysAgo = format(subDays(new Date(), 2), "yyyy-MM-dd");
+
   const defaultFilters = {
     "filter[status__in]": "FAIL",
     "filter[delta__in]": "new",
+    "filter[inserted_at__gte]": twoDaysAgo,
   };
 
   const findingsData = await getFindings({
@@ -172,14 +176,21 @@ const SSRDataNewFindingsTable = async () => {
 
   return (
     <>
-      <div className="relative flex items-start justify-between">
-        <h3 className="mb-4 w-full text-sm font-bold uppercase">
-          Latest 10 failing findings to date by Severity
-        </h3>
+      <div className="relative flex w-full">
+        <div className="flex w-full items-center gap-2">
+          <h3 className="text-sm font-bold uppercase">
+            Latest 10 failing findings to date by Severity
+          </h3>
+          <p className="text-xs text-gray-500">
+            Showing the latest 10 failing findings by severity from the last 2
+            days.
+          </p>
+        </div>
         <div className="absolute -top-6 right-0">
           <LinkToFindings />
         </div>
       </div>
+      <Spacer y={4} />
       <DataTable
         columns={ColumnNewFindingsToDate}
         data={expandedResponse?.data || []}

--- a/ui/components/filters/custom-date-picker.tsx
+++ b/ui/components/filters/custom-date-picker.tsx
@@ -16,7 +16,7 @@ export const CustomDatePicker = () => {
   const searchParams = useSearchParams();
 
   const [value, setValue] = React.useState(() => {
-    const dateParam = searchParams.get("filter[updated_at]");
+    const dateParam = searchParams.get("filter[inserted_at]");
     return dateParam ? today(getLocalTimeZone()) : null;
   });
 
@@ -30,9 +30,9 @@ export const CustomDatePicker = () => {
     (date: any) => {
       const params = new URLSearchParams(searchParams.toString());
       if (date) {
-        params.set("filter[updated_at]", date.toString());
+        params.set("filter[inserted_at]", date.toString());
       } else {
-        params.delete("filter[updated_at]");
+        params.delete("filter[inserted_at]");
       }
       router.push(`?${params.toString()}`, { scroll: false });
     },

--- a/ui/components/overview/new-findings-table/link-to-findings/link-to-findings.tsx
+++ b/ui/components/overview/new-findings-table/link-to-findings/link-to-findings.tsx
@@ -6,7 +6,7 @@ export const LinkToFindings = () => {
   return (
     <div className="mt-4 flex w-full items-center justify-end">
       <CustomButton
-        asLink="/findings?sort=severity,-updated_at&filter[status__in]=FAIL"
+        asLink="/findings?sort=severity,-inserted_at&filter[status__in]=FAIL&filter[delta__in]=new"
         ariaLabel="Go to Findings page"
         variant="solid"
         color="action"


### PR DESCRIPTION

### Description

#### Fix: Avoid default date filter when `inserted_at` or `scan__in` is present in the URL

### 🛠 Changes
- Updated logic to **skip the default `filter[inserted_at__gte]`** if `searchParams` contain:
  - Any key related to `inserted_at` (e.g., `filter[inserted_at__gte]`, `filter[inserted_at__lte]`, `filter[inserted_at__date]`).
  - `filter[scan__in]`.
- Used `Object.entries(searchParams).some(...)` to ensure correct detection of date-related filters.
- Ensured **no unnecessary default filters** are applied when relevant search parameters exist.

### ✅ Expected Behavior
| **URL** | **Applies Default `filter[inserted_at__gte]`?** |
|-----------------------------|------------------|
| `/findings` | ✅ **Yes** (no `inserted_at` or `scan__in`) |
| `/findings?filter[scan__in]=123` | ❌ **No** (contains `scan__in`) |
| `/findings?filter[inserted_at]=2025-02-06` | ❌ **No** (contains `inserted_at`) |
| `/findings?filter[inserted_at__gte]=2025-02-05&filter[scan__in]=123` | ❌ **No** (both filters present) |


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
