### PR TITLE
fix(aws): SNS threw IndexError if SubscriptionArn is PendingConfirmation

### DIFF
--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -97,7 +97,11 @@ class SNS(AWSService):
                             owner=sub["Owner"],
                             protocol=sub["Protocol"],
                             endpoint=sub["Endpoint"],
-                            region=(sub["SubscriptionArn"].split(":")[3] if ":" in sub["SubscriptionArn"] else "unknown"),
+                            region=(
+                                sub["SubscriptionArn"].split(":")[3]
+                                if ":" in sub["SubscriptionArn"]
+                                else "unknown"
+                            ),
                         )
                         for sub in response["Subscriptions"]
                     ]

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -92,16 +92,12 @@ class SNS(AWSService):
                     )
                     subscriptions: list[Subscription] = [
                         Subscription(
-                            id=sub["SubscriptionArn"].split(":")[-1],
+                            id=(parts := sub["SubscriptionArn"].split(":"))[-1],
                             arn=sub["SubscriptionArn"],
                             owner=sub["Owner"],
                             protocol=sub["Protocol"],
                             endpoint=sub["Endpoint"],
-                            region=(
-                                sub["SubscriptionArn"].split(":")[3]
-                                if ":" in sub["SubscriptionArn"]
-                                else "unknown"
-                            ),
+                            region=parts[3] if len(parts) > 3 else "unknown",
                         )
                         for sub in response["Subscriptions"]
                     ]

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -97,7 +97,7 @@ class SNS(AWSService):
                             owner=sub["Owner"],
                             protocol=sub["Protocol"],
                             endpoint=sub["Endpoint"],
-                            region=sub["SubscriptionArn"].split(":")[3],
+                            region=(sub["SubscriptionArn"].split(":")[3] if ":" in sub["SubscriptionArn"] else "unknown"),
                         )
                         for sub in response["Subscriptions"]
                     ]


### PR DESCRIPTION
### Context

The `sns_service.py` threw the error `IndexError[100]: list index out of range` upon extracting the region from the field `SubscriptionArn` of a subscription if the field `SubscriptionArn` was not an ARN but the value `PendingConfirmation`.

### Description

This PR fixes it by verifying that the `SubscriptionArn` has at least 4 parts after the split by the character `:` in order to extract the 4th part, which is the `region`. If it doesn't, the `region` is set to `unkown`. Instead of `unknown` it could have been set also to `regional_client.region` or `topic.region` but I'm not sure if they can differ from the region of a subscription. Feel free to adapt it.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
