### PR TITLE
fix(aws): codebuild service threw KeyError for projects type CODEPIPELINE

### DIFF
--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -84,21 +84,13 @@ class Codebuild(AWSService):
             if project_info["source"]["type"] != "NO_SOURCE":
                 project.source = Source(
                     type=project_info["source"]["type"],
-                    location=(
-                        project_info["source"]["location"]
-                        if project_info["source"].get("location") is not None
-                        else ""
-                    ),
+                    location=project_info["source"].get("location", ""),
                 )
             project.secondary_sources = []
             for secondary_source in project_info.get("secondarySources", []):
                 source_obj = Source(
                     type=secondary_source["type"],
-                    location=(
-                        secondary_source["location"]
-                        if secondary_source.get("location") is not None
-                        else ""
-                    ),
+                    location=secondary_source.get("location", ""),
                 )
                 project.secondary_sources.append(source_obj)
             environment = project_info.get("environment", {})

--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -84,12 +84,13 @@ class Codebuild(AWSService):
             if project_info["source"]["type"] != "NO_SOURCE":
                 project.source = Source(
                     type=project_info["source"]["type"],
-                    location=project_info["source"]["location"],
+                    location=project_info["source"]["location"] if project_info["source"].get("location") is not None else ""
                 )
             project.secondary_sources = []
             for secondary_source in project_info.get("secondarySources", []):
                 source_obj = Source(
-                    type=secondary_source["type"], location=secondary_source["location"]
+                    type=secondary_source["type"],
+                    location=secondary_source["location"] if secondary_source.get("location") is not None else ""
                 )
                 project.secondary_sources.append(source_obj)
             environment = project_info.get("environment", {})

--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -84,13 +84,21 @@ class Codebuild(AWSService):
             if project_info["source"]["type"] != "NO_SOURCE":
                 project.source = Source(
                     type=project_info["source"]["type"],
-                    location=project_info["source"]["location"] if project_info["source"].get("location") is not None else ""
+                    location=(
+                        project_info["source"]["location"]
+                        if project_info["source"].get("location") is not None
+                        else ""
+                    ),
                 )
             project.secondary_sources = []
             for secondary_source in project_info.get("secondarySources", []):
                 source_obj = Source(
                     type=secondary_source["type"],
-                    location=secondary_source["location"] if secondary_source.get("location") is not None else ""
+                    location=(
+                        secondary_source["location"]
+                        if secondary_source.get("location") is not None
+                        else ""
+                    ),
                 )
                 project.secondary_sources.append(source_obj)
             environment = project_info.get("environment", {})


### PR DESCRIPTION
### Context

The `codebuild_service.py` threw the error `KeyError[87]: 'location'` for projects of type `CODEPIPELINE`.

### Description
This PR fixes it by verifying that the field `location` exists before accessing it. In case of projects of type `CODEPIPELINE`, the field `location` does not exist and is therefore set to an empty string.

See [AWS documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/codebuild/client/batch_get_projects.html) about the `location` property within the response of `batch_get_projects()` method: 

> **location** (string) –
> 
> Information about the location of the source code to be built. Valid values include:
> 
> For source code settings that are specified in the source action of a pipeline in **CodePipeline, location should not be specified.** If it is specified, CodePipeline ignores it. This is because CodePipeline uses the settings in a pipeline’s source action instead of this value.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
