### PR TITLE
fix(gcp): Correct false positive when `sslMode=ENCRYPTED_ONLY` in CloudSQL

### DIFF
--- a/prowler/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections.py
@@ -11,12 +11,13 @@ class cloudsql_instance_ssl_connections(Check):
             report.status_extended = (
                 f"Database Instance {instance.name} requires SSL connections."
             )
-            if (
-                not instance.require_ssl
-                or instance.ssl_mode == "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
+
+            if (instance.ssl_mode == "ALLOW_UNENCRYPTED_AND_ENCRYPTED") or (
+                instance.ssl_mode == "SSL_MODE_UNSPECIFIED" and not instance.require_ssl
             ):
                 report.status = "FAIL"
                 report.status_extended = f"Database Instance {instance.name} does not require SSL connections."
+
             findings.append(report)
 
         return findings

--- a/tests/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections_test.py
+++ b/tests/providers/gcp/services/cloudsql/cloudsql_instance_ssl_connections/cloudsql_instance_ssl_connections_test.py
@@ -74,6 +74,52 @@ class Test_cloudsql_instance_ssl_connections:
             assert result[0].location == GCP_EU1_LOCATION
             assert result[0].project_id == GCP_PROJECT_ID
 
+    def test_cloudsql_instance_ssl_connections_disabled_and_ssl_mode_encrypted(self):
+        cloudsql_client = mock.MagicMock()
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_gcp_provider(),
+        ), mock.patch(
+            "prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections.cloudsql_client",
+            new=cloudsql_client,
+        ):
+            from prowler.providers.gcp.services.cloudsql.cloudsql_instance_ssl_connections.cloudsql_instance_ssl_connections import (
+                cloudsql_instance_ssl_connections,
+            )
+            from prowler.providers.gcp.services.cloudsql.cloudsql_service import (
+                Instance,
+            )
+
+            cloudsql_client.instances = [
+                Instance(
+                    name="instance1",
+                    version="POSTGRES_15",
+                    ip_addresses=[],
+                    region=GCP_EU1_LOCATION,
+                    public_ip=False,
+                    require_ssl=False,
+                    ssl_mode="ENCRYPTED_ONLY",
+                    automated_backups=True,
+                    authorized_networks=[],
+                    flags=[],
+                    project_id=GCP_PROJECT_ID,
+                )
+            ]
+
+            check = cloudsql_instance_ssl_connections()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Database Instance instance1 requires SSL connections."
+            )
+            assert result[0].resource_id == "instance1"
+            assert result[0].resource_name == "instance1"
+            assert result[0].location == GCP_EU1_LOCATION
+            assert result[0].project_id == GCP_PROJECT_ID
+
     def test_cloudsql_instance_ssl_connections_enabled_and_ssl_mode_not_encrypted(self):
         cloudsql_client = mock.MagicMock()
 


### PR DESCRIPTION

### Context

The cloudsql_instance_ssl_connections check in Prowler incorrectly marks Cloud SQL instances as non-compliant when sslMode is set to ENCRYPTED_ONLY and requireSsl is False.

According to the [Google Cloud SQL documentation](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1/instances#sslmode), sslMode takes precedence over requireSsl. When sslMode=ENCRYPTED_ONLY, SSL connections are enforced regardless of the requireSsl setting. However, Prowler currently flags these instances as FAIL instead of PASS.

### Description

Fix #6916

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
