### PR TITLE
fix(cloudfront): Incorrect bucket name retrievement

### DIFF
--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_non_existent_bucket/cloudfront_distributions_s3_origin_non_existent_bucket.py
@@ -16,7 +16,7 @@ class cloudfront_distributions_s3_origin_non_existent_bucket(Check):
 
             for origin in distribution.origins:
                 if origin.s3_origin_config:
-                    bucket_name = origin.domain_name.split(".")[0]
+                    bucket_name = origin.domain_name.split(".s3")[0]
                     if not s3_client._head_bucket(bucket_name):
                         non_existent_buckets.append(bucket_name)
 

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -496,6 +496,7 @@ class S3(AWSService):
                 )
                 return False
             else:
+                # Bucket exists but we don't have access to it
                 logger.error(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )


### PR DESCRIPTION
### Context

A user reported false positives in check `cloudfront_distributions_s3_origin_non_existent_bucket` due to a naming retrievement error in buckets.

Until now, we extracted the bucket name from the `CloudFront` domain by cutting off at the first dot. However, for bucket names containing dots, like `bucket.dev`, we only captured `bucket` instead of the full `bucket.dev`.

Fix #6940

### Description

This issue has been fixed, and now bucket names are correctly extracted. Users shouldn't be facing this same problem again.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
