### PR TITLE
refactor(microsoft365): `CheckReportMicrosoft365` and `resource metadata`

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -547,8 +547,8 @@ class CheckReportMicrosoft365(Check_Report):
         self,
         metadata: Dict,
         resource: Any,
-        resource_name: str = "",
-        resource_id: str = "",
+        resource_name: str,
+        resource_id: str,
         resource_location: str = "global",
     ) -> None:
         """Initialize the Microsoft365 Check's finding information.

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -536,26 +536,34 @@ class Check_Report_Kubernetes(Check_Report):
 
 
 @dataclass
-class Check_Report_Microsoft365(Check_Report):
+class CheckReportMicrosoft365(Check_Report):
     """Contains the Microsoft365 Check's finding information."""
 
     resource_name: str
     resource_id: str
     location: str
 
-    def __init__(self, metadata: Dict, resource: Any) -> None:
+    def __init__(
+        self,
+        metadata: Dict,
+        resource: Any,
+        resource_name: str = "",
+        resource_id: str = "",
+        resource_location: str = "global",
+    ) -> None:
         """Initialize the Microsoft365 Check's finding information.
 
         Args:
             metadata: The metadata of the check.
             resource: Basic information about the resource. Defaults to None.
+            resource_name: The name of the resource related with the finding.
+            resource_id: The id of the resource related with the finding.
+            resource_location: The location of the resource related with the finding.
         """
         super().__init__(metadata, resource)
-        self.resource_name = getattr(
-            resource, "name", getattr(resource, "resource_name", "")
-        )
-        self.resource_id = getattr(resource, "id", getattr(resource, "resource_id", ""))
-        self.location = getattr(resource, "location", "global")
+        self.resource_name = resource_name
+        self.resource_id = resource_id
+        self.location = resource_location
 
 
 # Testing Pending

--- a/prowler/providers/microsoft365/lib/mutelist/mutelist.py
+++ b/prowler/providers/microsoft365/lib/mutelist/mutelist.py
@@ -1,4 +1,4 @@
-from prowler.lib.check.models import Check_Report_Microsoft365
+from prowler.lib.check.models import CheckReportMicrosoft365
 from prowler.lib.mutelist.mutelist import Mutelist
 from prowler.lib.outputs.utils import unroll_dict, unroll_tags
 
@@ -6,7 +6,7 @@ from prowler.lib.outputs.utils import unroll_dict, unroll_tags
 class Microsoft365Mutelist(Mutelist):
     def is_finding_muted(
         self,
-        finding: Check_Report_Microsoft365,
+        finding: CheckReportMicrosoft365,
     ) -> bool:
         return self.is_muted(
             finding.tenant_id,

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility.metadata.json
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "high",
-  "ResourceType": "Microsoft365Group",
+  "ResourceType": "Active teams & groups",
   "Description": "Ensure that only organizationally managed and approved public groups exist to prevent unauthorized access to sensitive group resources like SharePoint, Teams, or other shared assets.",
   "Risk": "Unmanaged public groups can allow unauthorized access to organizational resources, posing a risk of data leakage or misuse through easily guessable SharePoint URLs or self-adding to groups via the Azure portal.",
   "RelatedUrl": "https://learn.microsoft.com/en-us/microsoft-365/admin/create-groups/manage-groups?view=o365-worldwide",
@@ -15,7 +15,7 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "1. Navigate to Microsoft 365 admin center https://admin.microsoft.com. 2. Click to expand Teams & groups select Active teams & groups. 3. On the Active teams and groups page, select the group's name that is public. 4. On the popup groups name page, select Settings. 5. Under Privacy, select Private.",
       "Terraform": ""
     },
     "Recommendation": {

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility.py
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility.py
@@ -1,16 +1,38 @@
-from prowler.lib.check.models import Check, Check_Report_Microsoft365
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportMicrosoft365
 from prowler.providers.microsoft365.services.admincenter.admincenter_client import (
     admincenter_client,
 )
 
 
 class admincenter_groups_not_public_visibility(Check):
-    def execute(self) -> Check_Report_Microsoft365:
+    """Check if groups in Microsoft Admin Center have public visibility.
+
+    This check verifies whether the visibility of groups in Microsoft Admin Center
+    is set to 'Private'. If any group has a 'Public' visibility, the check fails.
+
+    Attributes:
+        metadata: Metadata associated with the check (inherited from Check).
+    """
+
+    def execute(self) -> List[CheckReportMicrosoft365]:
+        """Execute the check for groups with public visibility.
+
+        This method iterates through all groups in Microsoft Admin Center and checks
+        if any group has 'Public' visibility. If so, the check fails for that group.
+
+        Returns:
+            List[CheckReportMicrosoft365]: A list containing the results of the check for each group.
+        """
         findings = []
         for group in admincenter_client.groups.values():
-            report = Check_Report_Microsoft365(metadata=self.metadata(), resource=group)
-            report.resource_id = group.id
-            report.resource_name = group.name
+            report = CheckReportMicrosoft365(
+                metadata=self.metadata(),
+                resource=group,
+                resource_name=group.name,
+                resource_id=group.id,
+            )
             report.status = "FAIL"
             report.status_extended = f"Group {group.name} has {group.visibility} visibility and should be Private."
 

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire.metadata.json
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire.metadata.json
@@ -15,7 +15,7 @@
     "Code": {
       "CLI": "Set-MsolUser -UserPrincipalName <user> -PasswordNeverExpires $true",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "1. Navigate to Microsoft 365 admin center https://admin.microsoft.com. 2. Click to expand Settings select Org Settings. 3. Click on Security & privacy. 4. Check the Set passwords to never expire (recommended) box. 5. Click Save.",
       "Terraform": ""
     },
     "Recommendation": {

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire.metadata.json
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "Microsoft365Domain",
+  "ResourceType": "Security & privacy settings",
   "Description": "This control ensures that the password expiration policy is set to 'Set passwords to never expire (recommended)'. This aligns with modern recommendations to enhance security by avoiding arbitrary password changes and focusing on supplementary controls like MFA.",
   "Risk": "Arbitrary password expiration policies can lead to weaker passwords due to frequent changes. Users may adopt insecure habits such as using simple, memorable passwords.",
   "RelatedUrl": "https://www.cisecurity.org/insights/white-papers/cis-password-policy-guide",

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire.py
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire.py
@@ -1,15 +1,40 @@
-from prowler.lib.check.models import Check, Check_Report_Microsoft365
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportMicrosoft365
 from prowler.providers.microsoft365.services.admincenter.admincenter_client import (
     admincenter_client,
 )
 
 
 class admincenter_settings_password_never_expire(Check):
-    def execute(self) -> Check_Report_Microsoft365:
+    """Check if domains have a 'Password never expires' policy.
+
+    This check verifies whether the password policy for each domain is set to never expire.
+    If the domain password validity period is set to `2147483647`, the policy is considered to
+    have 'password never expires'.
+
+    Attributes:
+        metadata: Metadata associated with the check (inherited from Check).
+    """
+
+    def execute(self) -> List[CheckReportMicrosoft365]:
+        """Execute the check for password never expires policy.
+
+        This method iterates over all domains and checks if the password validity period is set
+        to `2147483647`, indicating that passwords for users in the domain never expire.
+
+        Returns:
+            List[CheckReportMicrosoft365]: A list of reports indicating whether the domain's password
+            policy is set to never expire.
+        """
         findings = []
         for domain in admincenter_client.domains.values():
-            report = Check_Report_Microsoft365(self.metadata(), resource=domain)
-            report.resource_name = domain.id
+            report = CheckReportMicrosoft365(
+                self.metadata(),
+                resource=domain,
+                resource_name=domain.id,
+                resource_id=domain.id,
+            )
             report.status = "FAIL"
             report.status_extended = (
                 f"Domain {domain.id} does not have a Password never expires policy."

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.metadata.json
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.metadata.json
@@ -15,7 +15,7 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "1. Navigate to Microsoft 365 admin center https://admin.microsoft.com. 2. Click to expand Users select Active users. 3. Click Add a user. 4. Fill out the appropriate fields for Name, user, etc. 5. When prompted to assign licenses select as needed Microsoft Entra ID P1 or Microsoft Entra ID P2, then click Next. 6. Under the Option settings screen you may choose from several types of privileged roles. Choose Admin center access followed by the appropriate role then click Next. 7. Select Finish adding.",
       "Terraform": ""
     },
     "Recommendation": {

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.metadata.json
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AdministrativeAccount",
+  "ResourceType": "Active users",
   "Description": "Administrative accounts must use licenses with a reduced application footprint, such as Microsoft Entra ID P1 or P2, or avoid licenses entirely when possible. This minimizes the attack surface associated with privileged identities.",
   "Risk": "Licensing administrative accounts with applications like email or collaborative tools increases their exposure to social engineering attacks and malicious content, putting privileged accounts at risk.",
   "RelatedUrl": "https://learn.microsoft.com/en-us/microsoft-365/enterprise/protect-your-global-administrator-accounts?view=o365-worldwide",

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.py
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.py
@@ -46,7 +46,7 @@ class admincenter_users_admins_reduced_license_footprint(Check):
                     resource_id=user.id,
                 )
                 report.status = "FAIL"
-                report.status_extended = f"User {user.name} has administrative roles {admin_roles} and an invalid license {user.license if user.license else ''}."
+                report.status_extended = f"User {user.name} has administrative roles {admin_roles} and an invalid license: {user.license if user.license else None}."
 
                 if user.license in allowed_licenses:
                     report.status = "PASS"

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.py
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.py
@@ -1,11 +1,32 @@
-from prowler.lib.check.models import Check, Check_Report_Microsoft365
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportMicrosoft365
 from prowler.providers.microsoft365.services.admincenter.admincenter_client import (
     admincenter_client,
 )
 
 
 class admincenter_users_admins_reduced_license_footprint(Check):
-    def execute(self) -> Check_Report_Microsoft365:
+    """Check if users with administrative roles have a reduced license footprint.
+
+    This check ensures that users with administrative roles (like Global Administrator)
+    have valid licenses, specifically one of the allowed licenses. If a user with
+    administrative roles has an invalid license, the check fails.
+
+    Attributes:
+        metadata: Metadata associated with the check (inherited from Check).
+    """
+
+    def execute(self) -> List[CheckReportMicrosoft365]:
+        """Execute the check for users with administrative roles and their licenses.
+
+        This method iterates over all users and checks if those with administrative roles
+        have an allowed license. If a user has a valid license (AAD_PREMIUM or AAD_PREMIUM_P2),
+        the check passes; otherwise, it fails.
+
+        Returns:
+            List[CheckReportMicrosoft365]: A list containing the result of the check for each user.
+        """
         findings = []
         allowed_licenses = ["AAD_PREMIUM", "AAD_PREMIUM_P2"]
         for user in admincenter_client.users.values():
@@ -13,16 +34,17 @@ class admincenter_users_admins_reduced_license_footprint(Check):
                 [
                     role
                     for role in user.directory_roles
-                    if "Administrator" in role or "Globar Reader" in role
+                    if "Administrator" in role or "Global Reader" in role
                 ]
             )
 
             if admin_roles:
-                report = Check_Report_Microsoft365(
-                    metadata=self.metadata(), resource=user
+                report = CheckReportMicrosoft365(
+                    metadata=self.metadata(),
+                    resource=user,
+                    resource_name=user.name,
+                    resource_id=user.id,
                 )
-                report.resource_id = user.id
-                report.resource_name = user.name
                 report.status = "FAIL"
                 report.status_extended = f"User {user.name} has administrative roles {admin_roles} and an invalid license {user.license if user.license else ''}."
 

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.py
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint.py
@@ -46,11 +46,15 @@ class admincenter_users_admins_reduced_license_footprint(Check):
                     resource_id=user.id,
                 )
                 report.status = "FAIL"
-                report.status_extended = f"User {user.name} has administrative roles {admin_roles} and an invalid license: {user.license if user.license else None}."
+                report.status_extended = f"User {user.name} has administrative roles {admin_roles} and does not have a license."
 
-                if user.license in allowed_licenses:
-                    report.status = "PASS"
-                    report.status_extended = f"User {user.name} has administrative roles {admin_roles} and a valid license: {user.license}."
+                if user.license:
+                    if user.license not in allowed_licenses:
+                        report.status = "FAIL"
+                        report.status_extended = f"User {user.name} has administrative roles {admin_roles} and an invalid license: {user.license}."
+                    else:
+                        report.status = "PASS"
+                        report.status_extended = f"User {user.name} has administrative roles {admin_roles} and a valid license: {user.license}."
 
                 findings.append(report)
 

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins.metadata.json
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AdministrativeRole",
+  "ResourceType": "Active users",
   "Description": "Ensure that there are between two and four global administrators designated in your tenant. This ensures monitoring, redundancy, and reduces the risk associated with having too many privileged accounts.",
   "Risk": "Having only one global administrator increases the risk of unmonitored actions and operational disruptions if that administrator is unavailable. Having more than four increases the likelihood of a breach through one of these highly privileged accounts.",
   "RelatedUrl": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices#5-limit-the-number-of-global-administrators-to-less-than-5",

--- a/prowler/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins.metadata.json
+++ b/prowler/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins.metadata.json
@@ -15,7 +15,7 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "1. Navigate to the Microsoft 365 admin center https://admin.microsoft.com 2. Select Users > Active Users. 3. In the Search field enter the name of the user to be made a Global Administrator. 4. To create a new Global Admin: 1. Select the user's name. 2. A window will appear to the right. 3. Select Manage roles. 4. Select Admin center access. 5. Check Global Administrator. 6. Click Save changes. 5. To remove Global Admins: 1. Select User. 2. Under Roles select Manage roles. 3. De-Select the appropriate role. 4. Click Save changes.",
       "Terraform": ""
     },
     "Recommendation": {

--- a/prowler/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed.metadata.json
+++ b/prowler/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed.metadata.json
@@ -15,11 +15,11 @@
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "",
+      "Other": "1. From Entra select the Portal Menu 2. Select Azure Active Directory 3. Select Users 4. Select User settings 5. Ensure that Users can register applications is set to No",
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "1. From Entra select the Portal Menu 2. Select Azure Active Directory 3. Select Users 4. Select User settings 5. Ensure that Users can register applications is set to No",
+      "Text": "Disable third-party integrated application permissions unless explicitly required. If third-party applications are necessary, implement strict approval processes and security controls to mitigate risks associated with external integrations.",
       "Url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/delegate-app-roles#restrict-who-can-create-applications"
     }
   },

--- a/prowler/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed.metadata.json
+++ b/prowler/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "high",
-  "ResourceType": "",
+  "ResourceType": "User settings",
   "Description": "Require administrators or appropriately delegated users to register third-party applications.",
   "Risk": "It is recommended to only allow an administrator to register custom-developed applications. This ensures that the application undergoes a formal security review and approval process prior to exposing Azure Active Directory data. Certain users like developers or other high-request users may also be delegated permissions to prevent them from waiting on an administrative user. Your organization should review your policies and decide your needs.",
   "RelatedUrl": "https://learn.microsoft.com/en-us/entra/identity-platform/how-applications-are-added#who-has-permission-to-add-applications-to-my-microsoft-entra-instance",

--- a/tests/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
@@ -67,6 +67,7 @@ class Test_admincenter_groups_not_public_visibility:
             }
             assert result[0].resource_name == "Group1"
             assert result[0].resource_id == id_group1
+            assert result[0].location == "global"
 
     def test_admincenter_user_admin_compliant_license(self):
         admincenter_client = mock.MagicMock
@@ -105,3 +106,4 @@ class Test_admincenter_groups_not_public_visibility:
             }
             assert result[0].resource_name == "Group1"
             assert result[0].resource_id == id_group1
+            assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
@@ -60,6 +60,11 @@ class Test_admincenter_groups_not_public_visibility:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == "Group Group1 has Private visibility."
+            assert result[0].resource == {
+                "id": id_group1,
+                "name": "Group1",
+                "visibility": "Private",
+            }
             assert result[0].resource_name == "Group1"
             assert result[0].resource_id == id_group1
 
@@ -93,5 +98,10 @@ class Test_admincenter_groups_not_public_visibility:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == "Group Group1 has Private visibility."
+            assert result[0].resource == {
+                "id": id_group1,
+                "name": "Group1",
+                "visibility": "Private",
+            }
             assert result[0].resource_name == "Group1"
             assert result[0].resource_id == id_group1

--- a/tests/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire_test.py
@@ -69,6 +69,10 @@ class Test_admincenter_settings_password_never_expire:
                 result[0].status_extended
                 == f"Domain {id_domain} does not have a Password never expires policy."
             )
+            assert result[0].resource == {
+                "id": id_domain,
+                "password_validity_period": 5,
+            }
             assert result[0].resource_name == id_domain
             assert result[0].resource_id == id_domain
 
@@ -108,5 +112,9 @@ class Test_admincenter_settings_password_never_expire:
                 result[0].status_extended
                 == f"Domain {id_domain} Password policy is set to never expire."
             )
+            assert result[0].resource == {
+                "id": id_domain,
+                "password_validity_period": 2147483647,
+            }
             assert result[0].resource_name == id_domain
             assert result[0].resource_id == id_domain

--- a/tests/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire_test.py
@@ -75,6 +75,7 @@ class Test_admincenter_settings_password_never_expire:
             }
             assert result[0].resource_name == id_domain
             assert result[0].resource_id == id_domain
+            assert result[0].location == "global"
 
     def test_admincenter_password_not_expire(self):
         admincenter_client = mock.MagicMock
@@ -118,3 +119,4 @@ class Test_admincenter_settings_password_never_expire:
             }
             assert result[0].resource_name == id_domain
             assert result[0].resource_id == id_domain
+            assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
@@ -161,7 +161,7 @@ class Test_admincenter_users_admins_reduced_license_footprint:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "User User1 has administrative roles Global Administrator and an invalid license O365 BUSINESS."
+                == "User User1 has administrative roles Global Administrator and an invalid license: O365 BUSINESS."
             )
             assert result[0].resource == {
                 "id": id_user1,

--- a/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
@@ -120,6 +120,7 @@ class Test_admincenter_users_admins_reduced_license_footprint:
             }
             assert result[0].resource_name == "User1"
             assert result[0].resource_id == id_user1
+            assert result[0].location == "global"
 
     def test_admincenter_user_admin_non_compliant_license(self):
         admincenter_client = mock.MagicMock
@@ -171,3 +172,4 @@ class Test_admincenter_users_admins_reduced_license_footprint:
             }
             assert result[0].resource_name == "User1"
             assert result[0].resource_id == id_user1
+            assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
@@ -111,6 +111,13 @@ class Test_admincenter_users_admins_reduced_license_footprint:
                 result[0].status_extended
                 == "User User1 has administrative roles Global Administrator and a valid license: AAD_PREMIUM."
             )
+            assert result[0].resource == {
+                "id": id_user1,
+                "name": "User1",
+                "directory_roles": ["Global Administrator"],
+                "license": "AAD_PREMIUM",
+                "user_type": None,
+            }
             assert result[0].resource_name == "User1"
             assert result[0].resource_id == id_user1
 
@@ -155,5 +162,12 @@ class Test_admincenter_users_admins_reduced_license_footprint:
                 result[0].status_extended
                 == "User User1 has administrative roles Global Administrator and an invalid license O365 BUSINESS."
             )
+            assert result[0].resource == {
+                "id": id_user1,
+                "name": "User1",
+                "directory_roles": ["Global Administrator"],
+                "license": "O365 BUSINESS",
+                "user_type": None,
+            }
             assert result[0].resource_name == "User1"
             assert result[0].resource_id == id_user1

--- a/tests/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins_test.py
@@ -70,6 +70,26 @@ class Test_admincenter_users_between_two_and_four_global_admins:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == "There are 2 global administrators."
+            assert result[0].resource == {
+                "id": id,
+                "name": "Global Administrator",
+                "members": [
+                    {
+                        "id": id_user1,
+                        "name": "User1",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                    {
+                        "id": id_user2,
+                        "name": "User2",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                ],
+            }
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
 
@@ -124,6 +144,54 @@ class Test_admincenter_users_between_two_and_four_global_admins:
                 result[0].status_extended
                 == "There are 6 global administrators. It should be more than one and less than five."
             )
+            assert result[0].resource == {
+                "id": id,
+                "name": "Global Administrator",
+                "members": [
+                    {
+                        "id": id_user1,
+                        "name": "User1",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                    {
+                        "id": id_user2,
+                        "name": "User2",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                    {
+                        "id": id_user3,
+                        "name": "User3",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                    {
+                        "id": id_user4,
+                        "name": "User4",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                    {
+                        "id": id_user5,
+                        "name": "User5",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                    {
+                        "id": id_user6,
+                        "name": "User6",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                ],
+            }
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
 
@@ -168,5 +236,18 @@ class Test_admincenter_users_between_two_and_four_global_admins:
                 result[0].status_extended
                 == "There are 1 global administrators. It should be more than one and less than five."
             )
+            assert result[0].resource == {
+                "id": id,
+                "name": "Global Administrator",
+                "members": [
+                    {
+                        "id": id_user1,
+                        "name": "User1",
+                        "directory_roles": [],
+                        "license": None,
+                        "user_type": None,
+                    },
+                ],
+            }
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id

--- a/tests/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins_test.py
@@ -92,6 +92,7 @@ class Test_admincenter_users_between_two_and_four_global_admins:
             }
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
+            assert result[0].location == "global"
 
     def test_admincenter_more_than_five_global_admins(self):
         admincenter_client = mock.MagicMock
@@ -194,6 +195,7 @@ class Test_admincenter_users_between_two_and_four_global_admins:
             }
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
+            assert result[0].location == "global"
 
     def test_admincenter_one_global_admin(self):
         admincenter_client = mock.MagicMock
@@ -251,3 +253,4 @@ class Test_admincenter_users_between_two_and_four_global_admins:
             }
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
+            assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
+++ b/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
@@ -35,6 +35,7 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
+            assert result[0].resource == {}
             assert result[0].resource_name == "Authorization Policy"
             assert result[0].resource_id == "authorizationPolicy"
             assert (
@@ -81,6 +82,12 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
                 result[0].status_extended
                 == "App creation is disabled for non-admin users."
             )
+            assert result[0].resource == {
+                "id": id,
+                "name": "Test",
+                "description": "Test",
+                "default_user_role_permissions": role_permissions,
+            }
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id
 
@@ -123,5 +130,11 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
                 result[0].status_extended
                 == "App creation is not disabled for non-admin users."
             )
+            assert result[0].resource == {
+                "id": id,
+                "name": "Test",
+                "description": "Test",
+                "default_user_role_permissions": role_permissions,
+            }
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id

--- a/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
+++ b/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
@@ -38,10 +38,7 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
             assert result[0].resource == {}
             assert result[0].resource_name == "Authorization Policy"
             assert result[0].resource_id == "authorizationPolicy"
-            assert (
-                result[0].status_extended
-                == "App creation is not disabled for non-admin users."
-            )
+            assert result[0].status_extended == "Authorization Policy was not found."
             assert result[0].location == "global"
 
     def test_entra_default_user_role_permissions_not_allowed_to_create_apps(self):

--- a/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
+++ b/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
@@ -42,6 +42,7 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
                 result[0].status_extended
                 == "App creation is not disabled for non-admin users."
             )
+            assert result[0].location == "global"
 
     def test_entra_default_user_role_permissions_not_allowed_to_create_apps(self):
         id = str(uuid4())
@@ -90,6 +91,7 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
             }
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id
+            assert result[0].location == "global"
 
     def test_entra_default_user_role_permissions_allowed_to_create_apps(self):
         id = str(uuid4())
@@ -138,3 +140,4 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
             }
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id
+            assert result[0].location == "global"


### PR DESCRIPTION
### Context

Prowler’s resource metadata structure could be improved, and this PR aims to establish a foundation for best practices in provider development, benefiting future providers as well.

### Description

Several changes have been applied to refactor the `Microsoft365` provider’s reporting model, including:

- Renaming `Check_Report_Microsoft365` → `CheckReportMicrosoft365`.
- Adding `resource_name` and `resource_id` to `__init__`.
- Updating tests accordingly.
- `Removing `report.resource_id` and `report.resource_name` from existing Microsoft365` checks.
- Adding `asserts` in check tests to verify `check_report.resource`.
- Adding `docstrings` to checks.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
