### PR TITLE
fix(ocsf): Adapt for 1.4.0

### DIFF
--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -78,7 +78,6 @@ class OCSF(Output):
                         title=finding.metadata.CheckTitle,
                         uid=finding.uid,
                         name=finding.resource_name,
-                        product_uid="prowler",
                         types=finding.metadata.CheckType,
                     ),
                     time_dt=finding.timestamp,

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -62,7 +62,6 @@ class TestOCSF:
         assert output_data.finding_info.desc == findings[0].metadata.Description
         assert output_data.finding_info.title == findings[0].metadata.CheckTitle
         assert output_data.finding_info.uid == findings[0].uid
-        assert output_data.finding_info.product_uid == "prowler"
         assert output_data.finding_info.types == ["test-type"]
         assert output_data.time == int(findings[0].timestamp.timestamp())
         assert output_data.time_dt == findings[0].timestamp
@@ -199,7 +198,6 @@ class TestOCSF:
                     "created_time": int(datetime.now().timestamp()),
                     "created_time_dt": datetime.now().isoformat(),
                     "desc": "check description",
-                    "product_uid": "prowler",
                     "title": "test-check-id",
                     "uid": "test-unique-finding",
                     "types": ["test-type"],
@@ -286,7 +284,6 @@ class TestOCSF:
         assert finding_information.desc == finding_output.metadata.Description
         assert finding_information.title == finding_output.metadata.CheckTitle
         assert finding_information.uid == finding_output.uid
-        assert finding_information.product_uid == "prowler"
 
         # Event time
         assert finding_ocsf.time == int(finding_output.timestamp.timestamp())


### PR DESCRIPTION
### Description

Remove `finding_info.product_uid` from the OCSF since it is now deprecated in v1.4.0.


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. -> **not needed will release on v5.4**
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
