### PR TITLE
docs(installation): add warning for `poetry shell` deprecation in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ gunicorn -c config/guniconf.py config.wsgi:application
 ```
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
+>
+> Note that the command `poetry env activate` is not a direct replacement. For more information read poetry enviroment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 > Now, you can access the API documentation at http://localhost:8080/api/v1/docs.
 
@@ -213,6 +215,8 @@ python prowler.py -v
 ```
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
+>
+> Note that the command `poetry env activate` is not a direct replacement. For more information read poetry enviroment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 > If you want to clone Prowler from Windows, use `git config core.longpaths true` to allow long file paths.
 # 📐✏️ High level architecture

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ cd src/backend
 python manage.py migrate --database admin
 gunicorn -c config/guniconf.py config.wsgi:application
 ```
+> [!IMPORTANT]
+> Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 
 > Now, you can access the API documentation at http://localhost:8080/api/v1/docs.
 
@@ -209,6 +211,9 @@ poetry shell
 poetry install
 python prowler.py -v
 ```
+> [!IMPORTANT]
+> Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
+
 > If you want to clone Prowler from Windows, use `git config core.longpaths true` to allow long file paths.
 # 📐✏️ High level architecture
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ docker compose up -d
 git clone https://github.com/prowler-cloud/prowler
 cd prowler/api
 poetry install
-poetry shell
+eval $(poetry env activate)
 set -a
 source .env
 docker compose up postgres valkey -d
@@ -130,7 +130,8 @@ gunicorn -c config/guniconf.py config.wsgi:application
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 >
-> Note that the command `poetry env activate` is not a direct replacement. For more information read poetry enviroment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
+> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 > Now, you can access the API documentation at http://localhost:8080/api/v1/docs.
 
@@ -140,7 +141,7 @@ gunicorn -c config/guniconf.py config.wsgi:application
 git clone https://github.com/prowler-cloud/prowler
 cd prowler/api
 poetry install
-poetry shell
+eval $(poetry env activate)
 set -a
 source .env
 cd src/backend
@@ -153,7 +154,7 @@ python -m celery -A config.celery worker -l info -E
 git clone https://github.com/prowler-cloud/prowler
 cd prowler/api
 poetry install
-poetry shell
+eval $(poetry env activate)
 set -a
 source .env
 cd src/backend
@@ -209,14 +210,15 @@ Python >= 3.9, < 3.13 is required with pip and poetry:
 ``` console
 git clone https://github.com/prowler-cloud/prowler
 cd prowler
-poetry shell
+eval $(poetry env activate)
 poetry install
 python prowler.py -v
 ```
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 >
-> Note that the command `poetry env activate` is not a direct replacement. For more information read poetry enviroment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
+> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 > If you want to clone Prowler from Windows, use `git config core.longpaths true` to allow long file paths.
 # 📐✏️ High level architecture


### PR DESCRIPTION
### Context

Poetry removed `poetry shell` in favor of `poetry env activate`:
_Add an poetry env activate command as replacement of poetry shell (https://github.com/python-poetry/poetry/pull/9763)._

### Description

This pr includes a note in our `README.md` to help users identify this problem.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
