### PR TITLE
chore(github): add compliance to PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -92,3 +92,9 @@ component/api:
 component/ui:
   - changed-files:
       - any-glob-to-any-file: "ui/**"
+
+compliance:
+  - changed-files:
+      - any-glob-to-any-file: "prowler/compliance/**"
+      - any-glob-to-any-file: "prowler/lib/outputs/compliance/**"
+      - any-glob-to-any-file: "tests/lib/outputs/compliance/**"


### PR DESCRIPTION
### Description

This pull request includes a change to the `.github/labeler.yml` file to add a new section for compliance-related files. This helps in automatically labeling pull requests that modify compliance-related files.

Changes in `component/api`:

* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR95-R100): Added a new section for `compliance` to label changes in the `prowler/compliance`, `prowler/lib/outputs/compliance`, and `tests/lib/outputs/compliance` directories.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
