### PR TITLE
docs(tutorials): update all deprecated `poetry shell` references

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ gunicorn -c config/guniconf.py config.wsgi:application
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 >
-> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> If your poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
 > In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 > Now, you can access the API documentation at http://localhost:8080/api/v1/docs.
@@ -217,7 +217,7 @@ python prowler.py -v
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 >
-> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> If your poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
 > In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 > If you want to clone Prowler from Windows, use `git config core.longpaths true` to allow long file paths.

--- a/docs/developer-guide/introduction.md
+++ b/docs/developer-guide/introduction.md
@@ -24,7 +24,7 @@ eval $(poetry env activate) \
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 >
-> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> If your poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
 > In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 ## Contributing with your code or fixes to Prowler

--- a/docs/developer-guide/introduction.md
+++ b/docs/developer-guide/introduction.md
@@ -19,8 +19,13 @@ For isolation and to avoid conflicts with other environments, we recommend using
 Then install all dependencies including the ones for developers:
 ```
 poetry install --with dev
-poetry shell
+eval $(poetry env activate) \
 ```
+> [!IMPORTANT]
+> Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
+>
+> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
 ## Contributing with your code or fixes to Prowler
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Prowler App can be installed in different ways, depending on your environment:
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/api \
     poetry install \
-    poetry shell \
+    eval $(poetry env activate) \
     set -a \
     source .env \
     docker compose up postgres valkey -d \
@@ -84,6 +84,12 @@ Prowler App can be installed in different ways, depending on your environment:
     python manage.py migrate --database admin \
     gunicorn -c config/guniconf.py config.wsgi:application
     ```
+
+    ???+ important
+        Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
+
+        If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+        In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
     > Now, you can access the API documentation at http://localhost:8080/api/v1/docs.
 
@@ -93,7 +99,7 @@ Prowler App can be installed in different ways, depending on your environment:
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/api \
     poetry install \
-    poetry shell \
+    eval $(poetry env activate) \
     set -a \
     source .env \
     cd src/backend \
@@ -106,7 +112,7 @@ Prowler App can be installed in different ways, depending on your environment:
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/api \
     poetry install \
-    poetry shell \
+    eval $(poetry env activate) \
     set -a \
     source .env \
     cd src/backend \

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ Prowler App can be installed in different ways, depending on your environment:
     ???+ important
         Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 
-        If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+        If your poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
         In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
 
     > Now, you can access the API documentation at http://localhost:8080/api/v1/docs.

--- a/docs/tutorials/aws/cloudshell.md
+++ b/docs/tutorials/aws/cloudshell.md
@@ -27,7 +27,12 @@ cd prowler
 pip install poetry
 mkdir /tmp/poetry
 poetry config cache-dir /tmp/poetry
-poetry shell
+eval $(poetry env activate)
 poetry install
 python prowler.py -v
 ```
+> [!IMPORTANT]
+> Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
+>
+> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment

--- a/docs/tutorials/aws/cloudshell.md
+++ b/docs/tutorials/aws/cloudshell.md
@@ -34,5 +34,5 @@ python prowler.py -v
 > [!IMPORTANT]
 > Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 >
-> If you poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
+> If your poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
 > In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment


### PR DESCRIPTION
### Context

Recently `poetry shell` was deprecated in favor of `poetry env activate`:
[Managing environments | Documentation | Poetry - Python dependency management and packaging made easy](https://python-poetry.org/docs/managing-environments/#bash-csh-zsh) 

### Description

This pull request updates our documentation to correctly guide users with the usage of the new command and not the deprecated one.

As the change is recent, we will also warn them that they might not be using the last version and must keep using `poetry shell`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
