### PR TITLE
fix(elasticache): improve logic in `elasticache_redis_cluster_backup_enabled`

### DIFF
--- a/docs/tutorials/configuration_file.md
+++ b/docs/tutorials/configuration_file.md
@@ -47,6 +47,7 @@ The following list includes all the AWS checks with configurable variables that 
 | `ecr_repositories_scan_vulnerabilities_in_latest_image`       | `ecr_repository_vulnerability_minimum_severity`  | String          |
 | `eks_cluster_uses_a_supported_version`                        | `eks_cluster_oldest_version_supported`           | String          |
 | `eks_control_plane_logging_all_types_enabled`                 | `eks_required_log_types`                         | List of Strings |
+| `elasticache_redis_cluster_backup_enabled`                    | `minimum_snapshot_retention_period`              | Integer         |
 | `elb_is_in_multiple_az`                                       | `elb_min_azs`                                    | Integer         |
 | `elbv2_is_in_multiple_az`                                     | `elbv2_min_azs`                                  | Integer         |
 | `guardduty_is_enabled`                                        | `mute_non_default_regions`                       | Boolean         |

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -360,6 +360,11 @@ aws:
   # Minimum number of Availability Zones that an ELBv2 must be in
   elbv2_min_azs: 2
 
+  # AWS Elasticache Configuration
+  # aws.elasticache_redis_cluster_backup_enabled
+  # Minimum number of days that a Redis cluster must have backups retention period
+  minimum_snapshot_retention_period: 7
+
 
   # AWS Secrets Configuration
   # Patterns to ignore in the secrets checks

--- a/prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.py
+++ b/prowler/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled.py
@@ -11,7 +11,7 @@ class elasticache_redis_cluster_backup_enabled(Check):
             report = Check_Report_AWS(metadata=self.metadata(), resource=repl_group)
             report.status = "FAIL"
             report.status_extended = f"Elasticache Redis cache cluster {repl_group.id} does not have automated snapshot backups enabled."
-            if repl_group.snapshot_retention > elasticache_client.audit_config.get(
+            if repl_group.snapshot_retention >= elasticache_client.audit_config.get(
                 "minimum_snapshot_retention_period", 7
             ):
                 report.status = "PASS"

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -308,6 +308,7 @@ config_aws = {
     ],
     "eks_cluster_oldest_version_supported": "1.28",
     "excluded_sensitive_environment_variables": [],
+    "minimum_snapshot_retention_period": 7,
     "elb_min_azs": 2,
     "elbv2_min_azs": 2,
     "secrets_ignore_patterns": [],

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -353,6 +353,11 @@ aws:
   # Minimum number of Availability Zones that an ELBv2 must be in
   elbv2_min_azs: 2
 
+  # AWS Elasticache Configuration
+  # aws.elasticache_redis_cluster_backup_enabled
+  # Minimum number of days that a Redis cluster must have backups retention period
+  minimum_snapshot_retention_period: 7
+
   # AWS Secrets Configuration
   # Patterns to ignore in the secrets checks
   secrets_ignore_patterns: []

--- a/tests/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled_test.py
+++ b/tests/providers/aws/services/elasticache/elasticache_redis_cluster_backup_enabled/elasticache_redis_cluster_backup_enabled_test.py
@@ -149,6 +149,54 @@ class Test_elasticache_redis_cluster_backup_enabled:
             assert result[0].resource_arn == REPLICATION_GROUP_ARN
             assert result[0].resource_tags == REPLICATION_GROUP_TAGS
 
+    def test_elasticache_redis_cluster_backup_enabled_7_days(self):
+        # Mock ElastiCache Service
+        elasticache_client = MagicMock
+        elasticache_client.replication_groups = {}
+
+        elasticache_client.replication_groups[REPLICATION_GROUP_ARN] = ReplicationGroup(
+            arn=REPLICATION_GROUP_ARN,
+            id=REPLICATION_GROUP_ID,
+            region=AWS_REGION_US_EAST_1,
+            status=REPLICATION_GROUP_STATUS,
+            snapshot_retention=7,
+            encrypted=REPLICATION_GROUP_ENCRYPTION,
+            transit_encryption=REPLICATION_GROUP_TRANSIT_ENCRYPTION,
+            multi_az=REPLICATION_GROUP_MULTI_AZ,
+            tags=REPLICATION_GROUP_TAGS,
+            auto_minor_version_upgrade=not AUTO_MINOR_VERSION_UPGRADE,
+            automatic_failover=AUTOMATIC_FAILOVER,
+            engine_version="6.0",
+            auth_token_enabled=False,
+        )
+
+        elasticache_client.audit_config = {"minimum_snapshot_retention_period": 7}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=set_mocked_aws_provider([AWS_REGION_US_EAST_1]),
+        ), mock.patch(
+            "prowler.providers.aws.services.elasticache.elasticache_service.ElastiCache",
+            new=elasticache_client,
+        ):
+            from prowler.providers.aws.services.elasticache.elasticache_redis_cluster_backup_enabled.elasticache_redis_cluster_backup_enabled import (
+                elasticache_redis_cluster_backup_enabled,
+            )
+
+            check = elasticache_redis_cluster_backup_enabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Elasticache Redis cache cluster {REPLICATION_GROUP_ID} has automated snapshot backups enabled with retention period 7 days."
+            )
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_id == REPLICATION_GROUP_ID
+            assert result[0].resource_arn == REPLICATION_GROUP_ARN
+            assert result[0].resource_tags == REPLICATION_GROUP_TAGS
+
     def test_elasticache_redis_cluster_backup_enabled_modified_retention(self):
         # Mock ElastiCache Service
         elasticache_client = MagicMock


### PR DESCRIPTION
### Context

The check from Elasticache `elasticache_redis_cluster_backup_enabled` recommends 7 or more days for a backup but the check verifies if `snapshot_retention > minimum_snapshot_retention_period` (7 by default). So for 7 days exactly it’s failing.

Additionally, reviewing the check, I’ve seen that it’s supposed to be configurable but it’s not added to the config file neither to the docs, so I needed to fix that too.

Fix #6965 

### Description

- Modify the validation (now it's >=).
- Added the check to the config file
- Made the necessary tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
