### PR TITLE
fix(ecs): ensure unique finding id in ECS checks

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -115,6 +115,7 @@ class ECS(AWSService):
                     service_arn = service_desc["serviceArn"]
                     service_obj = Service(
                         name=sub(":.*", "", service_arn.split("/")[-1]),
+                        id=f"{sub(':.*', '', service_arn.split('/')[-2])}/{sub(':.*', '', service_arn.split('/')[-1])}",
                         arn=service_arn,
                         region=cluster.region,
                         assign_public_ip=(
@@ -212,6 +213,7 @@ class TaskDefinition(BaseModel):
 
 class Service(BaseModel):
     name: str
+    id: str
     arn: str
     region: str
     launch_type: str = ""

--- a/tests/providers/aws/services/ecs/ecs_service_fargate_latest_platform_version/ecs_service_fargate_latest_platform_version_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_fargate_latest_platform_version/ecs_service_fargate_latest_platform_version_test.py
@@ -128,12 +128,15 @@ class Test_ecs_service_fargate_latest_platform_version:
 
         mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=mocked_aws_provider,
-        ), patch(
-            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
-            new=ECS(mocked_aws_provider),
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=mocked_aws_provider,
+            ),
+            patch(
+                "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+                new=ECS(mocked_aws_provider),
+            ),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -162,12 +165,15 @@ class Test_ecs_service_fargate_latest_platform_version:
 
         mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=mocked_aws_provider,
-        ), patch(
-            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
-            new=ECS(mocked_aws_provider),
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=mocked_aws_provider,
+            ),
+            patch(
+                "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+                new=ECS(mocked_aws_provider),
+            ),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -199,12 +205,15 @@ class Test_ecs_service_fargate_latest_platform_version:
 
         mocked_ecs_client = ECS(mocked_aws_provider)
 
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=mocked_aws_provider,
-        ), patch(
-            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
-            new=mocked_ecs_client,
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=mocked_aws_provider,
+            ),
+            patch(
+                "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+                new=mocked_ecs_client,
+            ),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -217,7 +226,7 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert result[0].status_extended == (
                 "ECS Service test-latest-linux-service is using latest FARGATE Linux version 1.4.0."
             )
-            assert result[0].resource_id == "test-latest-linux-service"
+            assert result[0].resource_id == "test-cluster/test-latest-linux-service"
             assert (
                 result[0].resource_arn
                 == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-linux-service"
@@ -249,12 +258,15 @@ class Test_ecs_service_fargate_latest_platform_version:
 
         mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=mocked_aws_provider,
-        ), patch(
-            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
-            new=ECS(mocked_aws_provider),
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=mocked_aws_provider,
+            ),
+            patch(
+                "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+                new=ECS(mocked_aws_provider),
+            ),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -267,7 +279,7 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert result[0].status_extended == (
                 "ECS Service test-latest-windows-service is using latest FARGATE Windows version 1.0.0."
             )
-            assert result[0].resource_id == "test-latest-windows-service"
+            assert result[0].resource_id == "test-cluster/test-latest-windows-service"
             assert (
                 result[0].resource_arn
                 == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-latest-windows-service"
@@ -295,12 +307,15 @@ class Test_ecs_service_fargate_latest_platform_version:
 
         mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=mocked_aws_provider,
-        ), patch(
-            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
-            new=ECS(mocked_aws_provider),
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=mocked_aws_provider,
+            ),
+            patch(
+                "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+                new=ECS(mocked_aws_provider),
+            ),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -313,7 +328,7 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert result[0].status_extended == (
                 "ECS Service test-no-latest-linux-service is not using latest FARGATE Linux version 1.4.0, currently using 1.2.0."
             )
-            assert result[0].resource_id == "test-no-latest-linux-service"
+            assert result[0].resource_id == "test-cluster/test-no-latest-linux-service"
             assert (
                 result[0].resource_arn
                 == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-linux-service"
@@ -341,12 +356,15 @@ class Test_ecs_service_fargate_latest_platform_version:
 
         mocked_aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
 
-        with patch(
-            "prowler.providers.common.provider.Provider.get_global_provider",
-            return_value=mocked_aws_provider,
-        ), patch(
-            "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
-            new=ECS(mocked_aws_provider),
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=mocked_aws_provider,
+            ),
+            patch(
+                "prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version.ecs_client",
+                new=ECS(mocked_aws_provider),
+            ),
         ):
             from prowler.providers.aws.services.ecs.ecs_service_fargate_latest_platform_version.ecs_service_fargate_latest_platform_version import (
                 ecs_service_fargate_latest_platform_version,
@@ -359,7 +377,9 @@ class Test_ecs_service_fargate_latest_platform_version:
             assert result[0].status_extended == (
                 "ECS Service test-no-latest-windows-service is not using latest FARGATE Windows version 1.0.0, currently using 0.9.0."
             )
-            assert result[0].resource_id == "test-no-latest-windows-service"
+            assert (
+                result[0].resource_id == "test-cluster/test-no-latest-windows-service"
+            )
             assert (
                 result[0].resource_arn
                 == f"arn:aws:ecs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:service/test-cluster/test-no-latest-windows-service"

--- a/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
+++ b/tests/providers/aws/services/ecs/ecs_service_no_assign_public_ip/ecs_service_no_assign_public_ip_test.py
@@ -155,7 +155,7 @@ class Test_ecs_service_no_assign_public_ip:
                 result[0].status_extended
                 == "ECS Service service-with-no-public-ip does not have automatic public IP assignment."
             )
-            assert result[0].resource_id == "service-with-no-public-ip"
+            assert result[0].resource_id == "sample-cluster/service-with-no-public-ip"
             assert result[0].resource_arn == service_arn
             assert result[0].resource_tags == []
             assert result[0].region == AWS_REGION_US_EAST_1
@@ -221,7 +221,7 @@ class Test_ecs_service_no_assign_public_ip:
                 result[0].status_extended
                 == "ECS Service service-with-public-ip has automatic public IP assignment."
             )
-            assert result[0].resource_id == "service-with-public-ip"
+            assert result[0].resource_id == "sample-cluster/service-with-public-ip"
             assert result[0].resource_arn == service_arn
             assert result[0].resource_tags == []
             assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

Fix #7050

### Description

Ensure Prowler creates unique Finding UIDs in ECS by using also the cluster name inside the service ID.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
