### PR TITLE
fix(azure): handle account not supporting Blob 

### DIFF
--- a/prowler/providers/azure/services/storage/storage_service.py
+++ b/prowler/providers/azure/services/storage/storage_service.py
@@ -105,7 +105,10 @@ class Storage(AzureService):
                             ),
                         )
                     except Exception as error:
-                        if "Blob is not supported for the account." in str(error).strip():
+                        if (
+                            "Blob is not supported for the account."
+                            in str(error).strip()
+                        ):
                             logger.warning(
                                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )


### PR DESCRIPTION
### Context

This PR fixes an issue where the `_get_blob_properties` method stops processing storage accounts when encountering an account that doesn’t support blobs (e.g., FileStorage). Now, if the error message contains "Blob is not supported for the account.", a warning is logged and the loop continues processing subsequent accounts.

Fix #7047 

### Description

Updated exception handling in _get_blob_properties to check the error message and continue the loop when the unsupported blob error is detected.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
