### PR TITLE
chore(ui): update label from 'Select a scan job' to 'Select a cloud p…

### DIFF
--- a/ui/components/scans/launch-workflow/select-scan-provider.tsx
+++ b/ui/components/scans/launch-workflow/select-scan-provider.tsx
@@ -55,8 +55,8 @@ export const SelectScanProvider = <
         <>
           <FormControl>
             <Select
-              aria-label="Select a scan job"
-              placeholder="Choose a scan job"
+              aria-label="Select a cloud provider"
+              placeholder="Choose a cloud provider"
               labelPlacement="outside"
               classNames={{
                 selectorIcon: "right-2",
@@ -77,7 +77,7 @@ export const SelectScanProvider = <
                     {selectedItem.alias}
                   </div>
                 ) : (
-                  "Choose a scan job"
+                  "Choose a cloud provider"
                 );
               }}
             >


### PR DESCRIPTION


### Description

- Updated the UI label from "Select a scan job" to "Select a cloud provider" to better reflect the intended selection.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
