### PR TITLE
fix(reports): Fix task kwargs and result

### DIFF
--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -91,7 +91,9 @@ def perform_scan_task(
 
     chain(
         perform_scan_summary_task.si(tenant_id, scan_id),
-        generate_outputs.si(scan_id, provider_id, tenant_id=tenant_id),
+        generate_outputs.si(
+            scan_id=scan_id, provider_id=provider_id, tenant_id=tenant_id
+        ),
     ).apply_async()
 
     return result
@@ -158,7 +160,9 @@ def perform_scheduled_scan_task(self, tenant_id: str, provider_id: str):
 
     chain(
         perform_scan_summary_task.si(tenant_id, scan_instance.id),
-        generate_outputs.si(str(scan_instance.id), provider_id, tenant_id=tenant_id),
+        generate_outputs.si(
+            scan_id=str(scan_instance.id), provider_id=provider_id, tenant_id=tenant_id
+        ),
     ).apply_async()
 
     return result
@@ -272,8 +276,4 @@ def generate_outputs(scan_id: str, provider_id: str, tenant_id: str):
 
     logger.info(f"Scan output files generated, output location: {output_directory}")
 
-    return {
-        "upload": uploaded,
-        "scan_id": scan_id,
-        "provider_id": provider_id,
-    }
+    return {"upload": uploaded}


### PR DESCRIPTION
### Context

Task arguments weren't properly set so failed report tasks would not provide enough information in the `/tasks` endpoint.

### Description

This issue has been fixed:

![image](https://github.com/user-attachments/assets/4ace4a15-2192-4190-a6fe-3ed697811a01)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
