### PR TITLE
chore(ui-gha): add version prefix

### DIFF
--- a/.github/workflows/ui-build-lint-push-containers.yml
+++ b/.github/workflows/ui-build-lint-push-containers.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           context: ${{ env.WORKING_DIRECTORY }}
           build-args: |
-            NEXT_PUBLIC_PROWLER_RELEASE_VERSION=${{ env.RELEASE_TAG }}
+            NEXT_PUBLIC_PROWLER_RELEASE_VERSION="v${{ env.RELEASE_TAG }}"
           push: true
           tags: |
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.RELEASE_TAG }}


### PR DESCRIPTION
### Context

Prowler version needs to be shown with a `v` prefix

### Description

Add version prefix `v`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
