### PR TITLE
fix(aws): ecs_task_definitions_no_environment_secrets.metadata.json

### DIFF
--- a/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.metadata.json
+++ b/prowler/providers/aws/services/ecs/ecs_task_definitions_no_environment_secrets/ecs_task_definitions_no_environment_secrets.metadata.json
@@ -12,7 +12,7 @@
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
   "Severity": "critical",
   "ResourceType": "AwsEcsTaskDefinition",
-  "Description": "Check if secrets exists in ECS task definitions environment variables. If a secret is detected, the line number shown in the finding matches with the environment variable \"Name\" attribute starting to count at the \"environment\" key from the ECS Task Definition in JSON format.",
+  "Description": "Check if secrets exists in ECS task definitions environment variables.",
   "Risk": "The use of a hard-coded password increases the possibility of password guessing. If hard-coded passwords are used, it is possible that malicious users gain access through the account in question.",
   "RelatedUrl": "",
   "Remediation": {


### PR DESCRIPTION
### Context

Since the check `ecs_task_definitions_no_environment_secrets` shows no longer the line number of the found potential secret, its metadata was confusing because it was still referring to the line number.

### Description

I just removed the part from the metadata where the line number was still mentioned.
See also [PR#6710](https://github.com/prowler-cloud/prowler/pull/6710) where I could/should have done it already.

### Checklist

- Are there new checks included in this PR?  No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
