### PR TITLE
refactor(microsoft365): resource metadata assertions

### DIFF
--- a/tests/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
@@ -60,11 +60,7 @@ class Test_admincenter_groups_not_public_visibility:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == "Group Group1 has Private visibility."
-            assert result[0].resource == {
-                "id": id_group1,
-                "name": "Group1",
-                "visibility": "Private",
-            }
+            assert result[0].resource == admincenter_client.groups[id_group1].dict()
             assert result[0].resource_name == "Group1"
             assert result[0].resource_id == id_group1
             assert result[0].location == "global"
@@ -99,11 +95,7 @@ class Test_admincenter_groups_not_public_visibility:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == "Group Group1 has Private visibility."
-            assert result[0].resource == {
-                "id": id_group1,
-                "name": "Group1",
-                "visibility": "Private",
-            }
+            assert result[0].resource == admincenter_client.groups[id_group1].dict()
             assert result[0].resource_name == "Group1"
             assert result[0].resource_id == id_group1
             assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_settings_password_never_expire/admincenter_settings_password_never_expire_test.py
@@ -69,10 +69,7 @@ class Test_admincenter_settings_password_never_expire:
                 result[0].status_extended
                 == f"Domain {id_domain} does not have a Password never expires policy."
             )
-            assert result[0].resource == {
-                "id": id_domain,
-                "password_validity_period": 5,
-            }
+            assert result[0].resource == admincenter_client.domains[id_domain].dict()
             assert result[0].resource_name == id_domain
             assert result[0].resource_id == id_domain
             assert result[0].location == "global"
@@ -113,10 +110,7 @@ class Test_admincenter_settings_password_never_expire:
                 result[0].status_extended
                 == f"Domain {id_domain} Password policy is set to never expire."
             )
-            assert result[0].resource == {
-                "id": id_domain,
-                "password_validity_period": 2147483647,
-            }
+            assert result[0].resource == admincenter_client.domains[id_domain].dict()
             assert result[0].resource_name == id_domain
             assert result[0].resource_id == id_domain
             assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_users_admins_reduced_license_footprint/admincenter_users_admins_reduced_license_footprint_test.py
@@ -111,13 +111,7 @@ class Test_admincenter_users_admins_reduced_license_footprint:
                 result[0].status_extended
                 == "User User1 has administrative roles Global Administrator and a valid license: AAD_PREMIUM."
             )
-            assert result[0].resource == {
-                "id": id_user1,
-                "name": "User1",
-                "directory_roles": ["Global Administrator"],
-                "license": "AAD_PREMIUM",
-                "user_type": None,
-            }
+            assert result[0].resource == admincenter_client.users[id_user1].dict()
             assert result[0].resource_name == "User1"
             assert result[0].resource_id == id_user1
             assert result[0].location == "global"
@@ -163,13 +157,7 @@ class Test_admincenter_users_admins_reduced_license_footprint:
                 result[0].status_extended
                 == "User User1 has administrative roles Global Administrator and an invalid license: O365 BUSINESS."
             )
-            assert result[0].resource == {
-                "id": id_user1,
-                "name": "User1",
-                "directory_roles": ["Global Administrator"],
-                "license": "O365 BUSINESS",
-                "user_type": None,
-            }
+            assert result[0].resource == admincenter_client.users[id_user1].dict()
             assert result[0].resource_name == "User1"
             assert result[0].resource_id == id_user1
             assert result[0].location == "global"
@@ -215,13 +203,7 @@ class Test_admincenter_users_admins_reduced_license_footprint:
                 result[0].status_extended
                 == "User User1 has administrative roles Global Administrator and does not have a license."
             )
-            assert result[0].resource == {
-                "id": id_user1,
-                "name": "User1",
-                "directory_roles": ["Global Administrator"],
-                "license": None,
-                "user_type": None,
-            }
+            assert result[0].resource == admincenter_client.users[id_user1].dict()
             assert result[0].resource_name == "User1"
             assert result[0].resource_id == id_user1
             assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins_test.py
+++ b/tests/providers/microsoft365/services/admincenter/admincenter_users_between_two_and_four_global_admins/admincenter_users_between_two_and_four_global_admins_test.py
@@ -70,26 +70,10 @@ class Test_admincenter_users_between_two_and_four_global_admins:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == "There are 2 global administrators."
-            assert result[0].resource == {
-                "id": id,
-                "name": "Global Administrator",
-                "members": [
-                    {
-                        "id": id_user1,
-                        "name": "User1",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                    {
-                        "id": id_user2,
-                        "name": "User2",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                ],
-            }
+            assert (
+                result[0].resource
+                == admincenter_client.directory_roles["Global Administrator"].dict()
+            )
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
             assert result[0].location == "global"
@@ -145,54 +129,10 @@ class Test_admincenter_users_between_two_and_four_global_admins:
                 result[0].status_extended
                 == "There are 6 global administrators. It should be more than one and less than five."
             )
-            assert result[0].resource == {
-                "id": id,
-                "name": "Global Administrator",
-                "members": [
-                    {
-                        "id": id_user1,
-                        "name": "User1",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                    {
-                        "id": id_user2,
-                        "name": "User2",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                    {
-                        "id": id_user3,
-                        "name": "User3",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                    {
-                        "id": id_user4,
-                        "name": "User4",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                    {
-                        "id": id_user5,
-                        "name": "User5",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                    {
-                        "id": id_user6,
-                        "name": "User6",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                ],
-            }
+            assert (
+                result[0].resource
+                == admincenter_client.directory_roles["Global Administrator"].dict()
+            )
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
             assert result[0].location == "global"
@@ -238,19 +178,10 @@ class Test_admincenter_users_between_two_and_four_global_admins:
                 result[0].status_extended
                 == "There are 1 global administrators. It should be more than one and less than five."
             )
-            assert result[0].resource == {
-                "id": id,
-                "name": "Global Administrator",
-                "members": [
-                    {
-                        "id": id_user1,
-                        "name": "User1",
-                        "directory_roles": [],
-                        "license": None,
-                        "user_type": None,
-                    },
-                ],
-            }
+            assert (
+                result[0].resource
+                == admincenter_client.directory_roles["Global Administrator"].dict()
+            )
             assert result[0].resource_name == "Global Administrator"
             assert result[0].resource_id == id
             assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/entra/entra_policy_ensure_default_user_cannot_create_tenants/microsoft365_entra_policy_ensure_default_user_cannot_create_tenants_test.py
+++ b/tests/providers/microsoft365/services/entra/entra_policy_ensure_default_user_cannot_create_tenants/microsoft365_entra_policy_ensure_default_user_cannot_create_tenants_test.py
@@ -77,20 +77,7 @@ class Test_entra_policy_ensure_default_user_cannot_create_tenants:
                 result[0].status_extended
                 == "Tenant creation is not disabled for non-admin users."
             )
-            assert result[0].resource == {
-                "id": id,
-                "name": "Test",
-                "description": "Test",
-                "default_user_role_permissions": {
-                    "allowed_to_create_apps": None,
-                    "allowed_to_create_security_groups": None,
-                    "allowed_to_create_tenants": True,
-                    "allowed_to_read_bitlocker_keys_for_owned_device": None,
-                    "allowed_to_read_other_users": None,
-                    "odata_type": None,
-                    "permission_grant_policies_assigned": None,
-                },
-            }
+            assert result[0].resource == entra_client.authorization_policy.dict()
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id
             assert result[0].location == "global"
@@ -130,20 +117,7 @@ class Test_entra_policy_ensure_default_user_cannot_create_tenants:
                 result[0].status_extended
                 == "Tenant creation is disabled for non-admin users."
             )
-            assert result[0].resource == {
-                "id": id,
-                "name": "Test",
-                "description": "Test",
-                "default_user_role_permissions": {
-                    "allowed_to_create_apps": None,
-                    "allowed_to_create_security_groups": None,
-                    "allowed_to_create_tenants": False,
-                    "allowed_to_read_bitlocker_keys_for_owned_device": None,
-                    "allowed_to_read_other_users": None,
-                    "odata_type": None,
-                    "permission_grant_policies_assigned": None,
-                },
-            }
+            assert result[0].resource == entra_client.authorization_policy.dict()
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id
             assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
+++ b/tests/providers/microsoft365/services/entra/entra_thirdparty_integrated_apps_not_allowed/entra_thirdparty_integrated_apps_not_allowed_test.py
@@ -74,12 +74,7 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
                 result[0].status_extended
                 == "App creation is disabled for non-admin users."
             )
-            assert result[0].resource == {
-                "id": id,
-                "name": "Test",
-                "description": "Test",
-                "default_user_role_permissions": role_permissions,
-            }
+            assert result[0].resource == entra_client.authorization_policy.dict()
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id
             assert result[0].location == "global"
@@ -123,12 +118,7 @@ class Test_entra_thirdparty_integrated_apps_not_allowed:
                 result[0].status_extended
                 == "App creation is not disabled for non-admin users."
             )
-            assert result[0].resource == {
-                "id": id,
-                "name": "Test",
-                "description": "Test",
-                "default_user_role_permissions": role_permissions,
-            }
+            assert result[0].resource == entra_client.authorization_policy.dict()
             assert result[0].resource_name == "Test"
             assert result[0].resource_id == id
             assert result[0].location == "global"

--- a/tests/providers/microsoft365/services/sharepoint/sharepoint_external_sharing_managed/sharepoint_external_sharing_managed_test.py
+++ b/tests/providers/microsoft365/services/sharepoint/sharepoint_external_sharing_managed/sharepoint_external_sharing_managed_test.py
@@ -53,14 +53,7 @@ class Test_sharepoint_external_sharing_managed:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "none",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_allow_list_empty(self):
         """
@@ -105,14 +98,7 @@ class Test_sharepoint_external_sharing_managed:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": [],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_block_list_empty(self):
         """
@@ -157,14 +143,7 @@ class Test_sharepoint_external_sharing_managed:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": [],
-                "sharingDomainRestrictionMode": "blockList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_allow_list_non_empty(self):
         """
@@ -209,14 +188,7 @@ class Test_sharepoint_external_sharing_managed:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_block_list_non_empty(self):
         """
@@ -261,14 +233,7 @@ class Test_sharepoint_external_sharing_managed:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "blockList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_empty_settings(self):
         """

--- a/tests/providers/microsoft365/services/sharepoint/sharepoint_external_sharing_restricted/sharepoint_external_sharing_restricted_test.py
+++ b/tests/providers/microsoft365/services/sharepoint/sharepoint_external_sharing_restricted/sharepoint_external_sharing_restricted_test.py
@@ -51,14 +51,7 @@ class Test_sharepoint_external_sharing_restricted:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_external_sharing_not_restricted(self):
         """
@@ -101,14 +94,7 @@ class Test_sharepoint_external_sharing_restricted:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserAndGuestSharing",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_empty_settings(self):
         """

--- a/tests/providers/microsoft365/services/sharepoint/sharepoint_guest_sharing_restricted/sharepoint_guest_sharing_restricted_test.py
+++ b/tests/providers/microsoft365/services/sharepoint/sharepoint_guest_sharing_restricted/sharepoint_guest_sharing_restricted_test.py
@@ -52,14 +52,7 @@ class Test_sharepoint_guest_sharing_restricted:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_guest_sharing_not_restricted(self):
         """
@@ -103,14 +96,7 @@ class Test_sharepoint_guest_sharing_restricted:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserSharingOnly",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": True,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_empty_settings(self):
         """

--- a/tests/providers/microsoft365/services/sharepoint/sharepoint_modern_authentication_required/sharepoint_modern_authentication_required_test.py
+++ b/tests/providers/microsoft365/services/sharepoint/sharepoint_modern_authentication_required/sharepoint_modern_authentication_required_test.py
@@ -51,14 +51,7 @@ class Test_sharepoint_modern_authentication_required:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserAndGuestSharing",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": False,
-                "legacyAuth": False,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_sharepoint_modern_authentication_enabled(self):
         """
@@ -104,14 +97,7 @@ class Test_sharepoint_modern_authentication_required:
             assert result[0].resource_id == DOMAIN
             assert result[0].location == "global"
             assert result[0].resource_name == "SharePoint Settings"
-            assert result[0].resource == {
-                "sharingCapability": "ExternalUserAndGuestSharing",
-                "sharingAllowedDomainList": ["allowed-domain.com"],
-                "sharingBlockedDomainList": ["blocked-domain.com"],
-                "sharingDomainRestrictionMode": "allowList",
-                "resharingEnabled": False,
-                "legacyAuth": True,
-            }
+            assert result[0].resource == sharepoint_client.settings.dict()
 
     def test_sharepoint_empty_settings(self):
         """


### PR DESCRIPTION
### Context

The current approach of the `resource metadata assertions` is not optimal and results in excessive lines of code.

### Description

The goal of this pull request is to reduce the number of lines used in each section of the `resource metadata` without affecting existing code behavior.

This should have been part of #6952 but it wan’t detected at the time.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
