### PR TITLE
fix(route53): solve false positive in `route53_public_hosted_zones_cloudwatch_logging_enabled`

### DIFF
--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -86,13 +86,14 @@ class Route53(AWSService):
                 )
                 for page in list_query_logging_configs_paginator.paginate():
                     for logging_config in page["QueryLoggingConfigs"]:
-                        self.hosted_zones[hosted_zone.id].logging_config = (
-                            LoggingConfig(
-                                cloudwatch_log_group_arn=logging_config[
-                                    "CloudWatchLogsLogGroupArn"
-                                ]
+                        if logging_config["HostedZoneId"] == hosted_zone.id:
+                            self.hosted_zones[hosted_zone.id].logging_config = (
+                                LoggingConfig(
+                                    cloudwatch_log_group_arn=logging_config[
+                                        "CloudWatchLogsLogGroupArn"
+                                    ]
+                                )
                             )
-                        )
 
         except Exception as error:
             logger.error(

--- a/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
+++ b/tests/providers/aws/services/route53/route53_public_hosted_zones_cloudwatch_logging_enabled/route53_public_hosted_zones_cloudwatch_logging_enabled_test.py
@@ -108,6 +108,65 @@ class Test_route53_public_hosted_zones_cloudwatch_logging_enabled:
                 == f"Route53 Public Hosted Zone {hosted_zone_id} has query logging disabled."
             )
 
+    def test_two_hosted_zone_public_one_logging_enabled_other_disabled(self):
+        route53 = mock.MagicMock
+        hosted_zone_name = "test-domain.com"
+        hosted_zone_id = "ABCDEF12345678"
+        log_group_name = "test-log-group"
+        log_group_arn = f"rn:aws:logs:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:log-group:{log_group_name}"
+
+        hosted_zone_name_disabled = "test-domain-disabled.com"
+        hosted_zone_id_disabled = "ABCDEF123456789"
+
+        route53.hosted_zones = {
+            hosted_zone_name: HostedZone(
+                name=hosted_zone_name,
+                arn=f"arn:aws:route53:::{hosted_zone_id}",
+                id=hosted_zone_id,
+                private_zone=False,
+                region=AWS_REGION_US_EAST_1,
+                logging_config=LoggingConfig(cloudwatch_log_group_arn=log_group_arn),
+            ),
+            hosted_zone_name_disabled: HostedZone(
+                name=hosted_zone_name_disabled,
+                arn=f"arn:aws:route53:::{hosted_zone_id_disabled}",
+                id=hosted_zone_id_disabled,
+                private_zone=False,
+                region=AWS_REGION_US_EAST_1,
+            ),
+        }
+
+        with mock.patch(
+            "prowler.providers.aws.services.route53.route53_service.Route53",
+            new=route53,
+        ), mock.patch(
+            "prowler.providers.aws.services.route53.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_client",
+            new=route53,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.route53.route53_public_hosted_zones_cloudwatch_logging_enabled.route53_public_hosted_zones_cloudwatch_logging_enabled import (
+                route53_public_hosted_zones_cloudwatch_logging_enabled,
+            )
+
+            check = route53_public_hosted_zones_cloudwatch_logging_enabled()
+            result = check.execute()
+
+            assert len(result) == 2
+            assert result[0].resource_id == hosted_zone_id
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Route53 Public Hosted Zone {hosted_zone_id} has query logging enabled in Log Group {log_group_arn}."
+            )
+            assert result[1].resource_id == hosted_zone_id_disabled
+            assert result[1].region == AWS_REGION_US_EAST_1
+            assert result[1].status == "FAIL"
+            assert (
+                result[1].status_extended
+                == f"Route53 Public Hosted Zone {hosted_zone_id_disabled} has query logging disabled."
+            )
+
     def test_hosted_zone__private(self):
         route53 = mock.MagicMock
         hosted_zone_name = "test-domain.com"


### PR DESCRIPTION
### Context

This PR fixes a problem in Route53. When you have more than one zone and one of them have logging enabled, we return all of the zones a PASS instead of having FAIL or PASS depending on the state for each zone. 

The problem was that we were assigning the last Logging Config to every Hosted Zone, so if there was just one Logging Config every Hosted Zone will return a PASS, so the solution was to add a condition and only assign the Logging Config to the Hosted Zone if they are matching IDs.

Fix #7173 

### Description

Modified Route53 service and test it on infra.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
