### PR TITLE
fix(cloudwatch): handle None metric alarms

### DIFF
--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_alarm_state_configured/cloudwatch_alarm_actions_alarm_state_configured.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_alarm_state_configured/cloudwatch_alarm_actions_alarm_state_configured.py
@@ -7,12 +7,15 @@ from prowler.providers.aws.services.cloudwatch.cloudwatch_client import (
 class cloudwatch_alarm_actions_alarm_state_configured(Check):
     def execute(self):
         findings = []
-        for metric_alarm in cloudwatch_client.metric_alarms:
-            report = Check_Report_AWS(metadata=self.metadata(), resource=metric_alarm)
-            report.status = "PASS"
-            report.status_extended = f"CloudWatch metric alarm {metric_alarm.name} has actions configured for the ALARM state."
-            if not metric_alarm.alarm_actions:
-                report.status = "FAIL"
-                report.status_extended = f"CloudWatch metric alarm {metric_alarm.name} does not have actions configured for the ALARM state."
-            findings.append(report)
+        if cloudwatch_client.metric_alarms is not None:
+            for metric_alarm in cloudwatch_client.metric_alarms:
+                report = Check_Report_AWS(
+                    metadata=self.metadata(), resource=metric_alarm
+                )
+                report.status = "PASS"
+                report.status_extended = f"CloudWatch metric alarm {metric_alarm.name} has actions configured for the ALARM state."
+                if not metric_alarm.alarm_actions:
+                    report.status = "FAIL"
+                    report.status_extended = f"CloudWatch metric alarm {metric_alarm.name} does not have actions configured for the ALARM state."
+                findings.append(report)
         return findings

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_enabled/cloudwatch_alarm_actions_enabled.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_enabled/cloudwatch_alarm_actions_enabled.py
@@ -7,14 +7,17 @@ from prowler.providers.aws.services.cloudwatch.cloudwatch_client import (
 class cloudwatch_alarm_actions_enabled(Check):
     def execute(self):
         findings = []
-        for metric_alarm in cloudwatch_client.metric_alarms:
-            report = Check_Report_AWS(metadata=self.metadata(), resource=metric_alarm)
-            report.status = "PASS"
-            report.status_extended = (
-                f"CloudWatch metric alarm {metric_alarm.name} has actions enabled."
-            )
-            if not metric_alarm.actions_enabled:
-                report.status = "FAIL"
-                report.status_extended = f"CloudWatch metric alarm {metric_alarm.name} does not have actions enabled."
-            findings.append(report)
+        if cloudwatch_client.metric_alarms is not None:
+            for metric_alarm in cloudwatch_client.metric_alarms:
+                report = Check_Report_AWS(
+                    metadata=self.metadata(), resource=metric_alarm
+                )
+                report.status = "PASS"
+                report.status_extended = (
+                    f"CloudWatch metric alarm {metric_alarm.name} has actions enabled."
+                )
+                if not metric_alarm.actions_enabled:
+                    report.status = "FAIL"
+                    report.status_extended = f"CloudWatch metric alarm {metric_alarm.name} does not have actions enabled."
+                findings.append(report)
         return findings

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_alarm_state_configured/cloudwatch_alarm_actions_alarm_state_configured_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_alarm_state_configured/cloudwatch_alarm_actions_alarm_state_configured_test.py
@@ -28,10 +28,41 @@ class Test_cloudwatch_alarm_actions_alarm_state_configured:
                 new=CloudWatch(aws_provider),
             ),
         ):
-
             from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_alarm_state_configured.cloudwatch_alarm_actions_alarm_state_configured import (
                 cloudwatch_alarm_actions_alarm_state_configured,
             )
+
+            check = cloudwatch_alarm_actions_alarm_state_configured()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_none_cloudwatch_alarms(self):
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client.metric_alarms = []
+
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+            CloudWatch,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_alarm_state_configured.cloudwatch_alarm_actions_alarm_state_configured.cloudwatch_client",
+                new=CloudWatch(aws_provider),
+            ) as cloudwatch_client_mock,
+        ):
+            from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_alarm_state_configured.cloudwatch_alarm_actions_alarm_state_configured import (
+                cloudwatch_alarm_actions_alarm_state_configured,
+            )
+
+            cloudwatch_client_mock.metric_alarms = None
 
             check = cloudwatch_alarm_actions_alarm_state_configured()
             result = check.execute()
@@ -66,7 +97,6 @@ class Test_cloudwatch_alarm_actions_alarm_state_configured:
                 new=CloudWatch(aws_provider),
             ),
         ):
-
             from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_alarm_state_configured.cloudwatch_alarm_actions_alarm_state_configured import (
                 cloudwatch_alarm_actions_alarm_state_configured,
             )
@@ -116,7 +146,6 @@ class Test_cloudwatch_alarm_actions_alarm_state_configured:
                 new=CloudWatch(aws_provider),
             ),
         ):
-
             from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_alarm_state_configured.cloudwatch_alarm_actions_alarm_state_configured import (
                 cloudwatch_alarm_actions_alarm_state_configured,
             )

--- a/tests/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_enabled/cloudwatch_alarm_actions_enabled_test.py
+++ b/tests/providers/aws/services/cloudwatch/cloudwatch_alarm_actions_enabled/cloudwatch_alarm_actions_enabled_test.py
@@ -28,10 +28,40 @@ class Test_cloudwatch_alarm_actions_enabled:
                 new=CloudWatch(aws_provider),
             ),
         ):
-
             from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_enabled.cloudwatch_alarm_actions_enabled import (
                 cloudwatch_alarm_actions_enabled,
             )
+
+            check = cloudwatch_alarm_actions_enabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_none_cloudwatch_alarms(self):
+        cloudwatch_client = client("cloudwatch", region_name=AWS_REGION_US_EAST_1)
+        cloudwatch_client.metric_alarms = []
+
+        from prowler.providers.aws.services.cloudwatch.cloudwatch_service import (
+            CloudWatch,
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_enabled.cloudwatch_alarm_actions_enabled.cloudwatch_client",
+                new=CloudWatch(aws_provider),
+            ) as cloudwatch_client_mock,
+        ):
+            from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_enabled.cloudwatch_alarm_actions_enabled import (
+                cloudwatch_alarm_actions_enabled,
+            )
+
+            cloudwatch_client_mock.metric_alarms = None
 
             check = cloudwatch_alarm_actions_enabled()
             result = check.execute()
@@ -66,7 +96,6 @@ class Test_cloudwatch_alarm_actions_enabled:
                 new=CloudWatch(aws_provider),
             ),
         ):
-
             from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_enabled.cloudwatch_alarm_actions_enabled import (
                 cloudwatch_alarm_actions_enabled,
             )
@@ -116,7 +145,6 @@ class Test_cloudwatch_alarm_actions_enabled:
                 new=CloudWatch(aws_provider),
             ),
         ):
-
             from prowler.providers.aws.services.cloudwatch.cloudwatch_alarm_actions_enabled.cloudwatch_alarm_actions_enabled import (
                 cloudwatch_alarm_actions_enabled,
             )


### PR DESCRIPTION
### Description

Handle None metric alarms when there is an AccessDenied:

- `cloudwatch_alarm_actions_alarm_state_configured -- TypeError[10]: 'NoneType' object is not iterable`
- `cloudwatch_alarm_actions_enabled -- TypeError[10]: 'NoneType' object is not iterable`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
