### PR TITLE
fix(network): handle `Nonetype is not iterable` for security groups

### DIFF
--- a/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
@@ -18,9 +18,8 @@ class network_http_internet_access_restricted(Check):
                         rule.destination_port_range == "80"
                         or (
                             (
-                                "-" in rule.destination_port_range
-                                if rule.destination_port_range is not None
-                                else False
+                                rule.destination_port_range
+                                and "-" in rule.destination_port_range
                             )
                             and int(rule.destination_port_range.split("-")[0]) <= 80
                             and int(rule.destination_port_range.split("-")[1]) >= 80

--- a/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
@@ -5,32 +5,33 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_http_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        for subscription, security_groups in network_client.security_groups.items():
-            for security_group in security_groups:
-                report = Check_Report_Azure(
-                    metadata=self.metadata(), resource=security_group
-                )
-                report.subscription = subscription
-                report.status = "PASS"
-                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access restricted."
-                rule_fail_condition = any(
-                    (
-                        rule.destination_port_range == "80"
-                        or (
-                            "-" in rule.destination_port_range
-                            and int(rule.destination_port_range.split("-")[0]) <= 80
-                            and int(rule.destination_port_range.split("-")[1]) >= 80
-                        )
+        if network_client.security_groups is not None:
+            for subscription, security_groups in network_client.security_groups.items():
+                for security_group in security_groups:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=security_group
                     )
-                    and rule.protocol in ["TCP", "Tcp", "*"]
-                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                    and rule.access == "Allow"
-                    and rule.direction == "Inbound"
-                    for rule in security_group.security_rules
-                )
-                if rule_fail_condition:
-                    report.status = "FAIL"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access allowed."
-                findings.append(report)
+                    report.subscription = subscription
+                    report.status = "PASS"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access restricted."
+                    rule_fail_condition = any(
+                        (
+                            rule.destination_port_range == "80"
+                            or (
+                                "-" in rule.destination_port_range
+                                and int(rule.destination_port_range.split("-")[0]) <= 80
+                                and int(rule.destination_port_range.split("-")[1]) >= 80
+                            )
+                        )
+                        and rule.protocol in ["TCP", "Tcp", "*"]
+                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                        and rule.access == "Allow"
+                        and rule.direction == "Inbound"
+                        for rule in security_group.security_rules
+                    )
+                    if rule_fail_condition:
+                        report.status = "FAIL"
+                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access allowed."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
@@ -17,9 +17,11 @@ class network_http_internet_access_restricted(Check):
                     (
                         rule.destination_port_range == "80"
                         or (
-                            "-" in rule.destination_port_range
-                            if rule.destination_port_range is not None
-                            else False
+                            (
+                                "-" in rule.destination_port_range
+                                if rule.destination_port_range is not None
+                                else False
+                            )
                             and int(rule.destination_port_range.split("-")[0]) <= 80
                             and int(rule.destination_port_range.split("-")[1]) >= 80
                         )

--- a/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
@@ -18,6 +18,8 @@ class network_http_internet_access_restricted(Check):
                         rule.destination_port_range == "80"
                         or (
                             "-" in rule.destination_port_range
+                            if rule.destination_port_range is not None
+                            else False
                             and int(rule.destination_port_range.split("-")[0]) <= 80
                             and int(rule.destination_port_range.split("-")[1]) >= 80
                         )

--- a/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted.py
@@ -5,33 +5,32 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_http_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        if network_client.security_groups is not None:
-            for subscription, security_groups in network_client.security_groups.items():
-                for security_group in security_groups:
-                    report = Check_Report_Azure(
-                        metadata=self.metadata(), resource=security_group
-                    )
-                    report.subscription = subscription
-                    report.status = "PASS"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access restricted."
-                    rule_fail_condition = any(
-                        (
-                            rule.destination_port_range == "80"
-                            or (
-                                "-" in rule.destination_port_range
-                                and int(rule.destination_port_range.split("-")[0]) <= 80
-                                and int(rule.destination_port_range.split("-")[1]) >= 80
-                            )
+        for subscription, security_groups in network_client.security_groups.items():
+            for security_group in security_groups:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource=security_group
+                )
+                report.subscription = subscription
+                report.status = "PASS"
+                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access restricted."
+                rule_fail_condition = any(
+                    (
+                        rule.destination_port_range == "80"
+                        or (
+                            "-" in rule.destination_port_range
+                            and int(rule.destination_port_range.split("-")[0]) <= 80
+                            and int(rule.destination_port_range.split("-")[1]) >= 80
                         )
-                        and rule.protocol in ["TCP", "Tcp", "*"]
-                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                        and rule.access == "Allow"
-                        and rule.direction == "Inbound"
-                        for rule in security_group.security_rules
                     )
-                    if rule_fail_condition:
-                        report.status = "FAIL"
-                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access allowed."
-                    findings.append(report)
+                    and rule.protocol in ["TCP", "Tcp", "*"]
+                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                    and rule.access == "Allow"
+                    and rule.direction == "Inbound"
+                    for rule in security_group.security_rules
+                )
+                if rule_fail_condition:
+                    report.status = "FAIL"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has HTTP internet access allowed."
+                findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
@@ -5,35 +5,32 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_rdp_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        if network_client.security_groups is not None:
-            for subscription, security_groups in network_client.security_groups.items():
-                for security_group in security_groups:
-                    report = Check_Report_Azure(
-                        metadata=self.metadata(), resource=security_group
-                    )
-                    report.subscription = subscription
-                    report.status = "PASS"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access restricted."
-                    rule_fail_condition = any(
-                        (
-                            rule.destination_port_range == "3389"
-                            or (
-                                "-" in rule.destination_port_range
-                                and int(rule.destination_port_range.split("-")[0])
-                                <= 3389
-                                and int(rule.destination_port_range.split("-")[1])
-                                >= 3389
-                            )
+        for subscription, security_groups in network_client.security_groups.items():
+            for security_group in security_groups:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource=security_group
+                )
+                report.subscription = subscription
+                report.status = "PASS"
+                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access restricted."
+                rule_fail_condition = any(
+                    (
+                        rule.destination_port_range == "3389"
+                        or (
+                            "-" in rule.destination_port_range
+                            and int(rule.destination_port_range.split("-")[0]) <= 3389
+                            and int(rule.destination_port_range.split("-")[1]) >= 3389
                         )
-                        and rule.protocol in ["TCP", "Tcp", "*"]
-                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                        and rule.access == "Allow"
-                        and rule.direction == "Inbound"
-                        for rule in security_group.security_rules
                     )
-                    if rule_fail_condition:
-                        report.status = "FAIL"
-                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access allowed."
-                    findings.append(report)
+                    and rule.protocol in ["TCP", "Tcp", "*"]
+                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                    and rule.access == "Allow"
+                    and rule.direction == "Inbound"
+                    for rule in security_group.security_rules
+                )
+                if rule_fail_condition:
+                    report.status = "FAIL"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access allowed."
+                findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
@@ -17,9 +17,11 @@ class network_rdp_internet_access_restricted(Check):
                     (
                         rule.destination_port_range == "3389"
                         or (
-                            "-" in rule.destination_port_range
-                            if rule.destination_port_range is not None
-                            else False
+                            (
+                                "-" in rule.destination_port_range
+                                if rule.destination_port_range is not None
+                                else False
+                            )
                             and int(rule.destination_port_range.split("-")[0]) <= 3389
                             and int(rule.destination_port_range.split("-")[1]) >= 3389
                         )

--- a/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
@@ -18,6 +18,8 @@ class network_rdp_internet_access_restricted(Check):
                         rule.destination_port_range == "3389"
                         or (
                             "-" in rule.destination_port_range
+                            if rule.destination_port_range is not None
+                            else False
                             and int(rule.destination_port_range.split("-")[0]) <= 3389
                             and int(rule.destination_port_range.split("-")[1]) >= 3389
                         )

--- a/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
@@ -5,32 +5,35 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_rdp_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        for subscription, security_groups in network_client.security_groups.items():
-            for security_group in security_groups:
-                report = Check_Report_Azure(
-                    metadata=self.metadata(), resource=security_group
-                )
-                report.subscription = subscription
-                report.status = "PASS"
-                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access restricted."
-                rule_fail_condition = any(
-                    (
-                        rule.destination_port_range == "3389"
-                        or (
-                            "-" in rule.destination_port_range
-                            and int(rule.destination_port_range.split("-")[0]) <= 3389
-                            and int(rule.destination_port_range.split("-")[1]) >= 3389
-                        )
+        if network_client.security_groups is not None:
+            for subscription, security_groups in network_client.security_groups.items():
+                for security_group in security_groups:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=security_group
                     )
-                    and rule.protocol in ["TCP", "Tcp", "*"]
-                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                    and rule.access == "Allow"
-                    and rule.direction == "Inbound"
-                    for rule in security_group.security_rules
-                )
-                if rule_fail_condition:
-                    report.status = "FAIL"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access allowed."
-                findings.append(report)
+                    report.subscription = subscription
+                    report.status = "PASS"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access restricted."
+                    rule_fail_condition = any(
+                        (
+                            rule.destination_port_range == "3389"
+                            or (
+                                "-" in rule.destination_port_range
+                                and int(rule.destination_port_range.split("-")[0])
+                                <= 3389
+                                and int(rule.destination_port_range.split("-")[1])
+                                >= 3389
+                            )
+                        )
+                        and rule.protocol in ["TCP", "Tcp", "*"]
+                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                        and rule.access == "Allow"
+                        and rule.direction == "Inbound"
+                        for rule in security_group.security_rules
+                    )
+                    if rule_fail_condition:
+                        report.status = "FAIL"
+                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has RDP internet access allowed."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted.py
@@ -18,9 +18,8 @@ class network_rdp_internet_access_restricted(Check):
                         rule.destination_port_range == "3389"
                         or (
                             (
-                                "-" in rule.destination_port_range
-                                if rule.destination_port_range is not None
-                                else False
+                                rule.destination_port_range
+                                and "-" in rule.destination_port_range
                             )
                             and int(rule.destination_port_range.split("-")[0]) <= 3389
                             and int(rule.destination_port_range.split("-")[1]) >= 3389

--- a/prowler/providers/azure/services/network/network_service.py
+++ b/prowler/providers/azure/services/network/network_service.py
@@ -34,6 +34,7 @@ class Network(AzureService):
                                     id=rule.id,
                                     name=rule.name,
                                     destination_port_range=rule.destination_port_range,
+                                    source_address_prefix=rule.source_address_prefix,
                                     protocol=rule.protocol,
                                     access=rule.access,
                                     direction=rule.direction,

--- a/prowler/providers/azure/services/network/network_service.py
+++ b/prowler/providers/azure/services/network/network_service.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from azure.mgmt.network import NetworkManagementClient
 
@@ -33,15 +33,10 @@ class Network(AzureService):
                                 SecurityRule(
                                     id=rule.id,
                                     name=rule.name,
-                                    destination_port_range=getattr(
-                                        rule, "destination_port_range", ""
-                                    ),
-                                    protocol=getattr(rule, "protocol", ""),
-                                    source_address_prefix=getattr(
-                                        rule, "source_address_prefix", ""
-                                    ),
-                                    access=getattr(rule, "access", "Allow"),
-                                    direction=getattr(rule, "direction", "Inbound"),
+                                    destination_port_range=rule.destination_port_range,
+                                    protocol=rule.protocol,
+                                    access=rule.access,
+                                    direction=rule.direction,
                                 )
                                 for rule in getattr(
                                     security_group, "security_rules", []
@@ -168,11 +163,11 @@ class NetworkWatcher:
 class SecurityRule:
     id: str
     name: str
-    destination_port_range: str
-    protocol: str
-    source_address_prefix: str
-    access: str
-    direction: str
+    destination_port_range: Optional[str]
+    protocol: Optional[str]
+    source_address_prefix: Optional[str]
+    access: Optional[str]
+    direction: Optional[str]
 
 
 @dataclass

--- a/prowler/providers/azure/services/network/network_service.py
+++ b/prowler/providers/azure/services/network/network_service.py
@@ -33,11 +33,15 @@ class Network(AzureService):
                                 SecurityRule(
                                     id=rule.id,
                                     name=rule.name,
-                                    destination_port_range=rule.destination_port_range,
-                                    source_address_prefix=rule.source_address_prefix,
-                                    protocol=rule.protocol,
-                                    access=rule.access,
-                                    direction=rule.direction,
+                                    destination_port_range=getattr(
+                                        rule, "destination_port_range", ""
+                                    ),
+                                    protocol=getattr(rule, "protocol", ""),
+                                    source_address_prefix=getattr(
+                                        rule, "source_address_prefix", ""
+                                    ),
+                                    access=getattr(rule, "access", "Allow"),
+                                    direction=getattr(rule, "direction", "Inbound"),
                                 )
                                 for rule in getattr(
                                     security_group, "security_rules", []

--- a/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
@@ -18,9 +18,8 @@ class network_ssh_internet_access_restricted(Check):
                         rule.destination_port_range == "22"
                         or (
                             (
-                                "-" in rule.destination_port_range
-                                if rule.destination_port_range is not None
-                                else False
+                                rule.destination_port_range
+                                and "-" in rule.destination_port_range
                             )
                             and int(rule.destination_port_range.split("-")[0]) <= 22
                             and int(rule.destination_port_range.split("-")[1]) >= 22

--- a/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
@@ -17,9 +17,11 @@ class network_ssh_internet_access_restricted(Check):
                     (
                         rule.destination_port_range == "22"
                         or (
-                            "-" in rule.destination_port_range
-                            if rule.destination_port_range is not None
-                            else False
+                            (
+                                "-" in rule.destination_port_range
+                                if rule.destination_port_range is not None
+                                else False
+                            )
                             and int(rule.destination_port_range.split("-")[0]) <= 22
                             and int(rule.destination_port_range.split("-")[1]) >= 22
                         )

--- a/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
@@ -5,32 +5,33 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_ssh_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        for subscription, security_groups in network_client.security_groups.items():
-            for security_group in security_groups:
-                report = Check_Report_Azure(
-                    metadata=self.metadata(), resource=security_group
-                )
-                report.subscription = subscription
-                report.status = "PASS"
-                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access restricted."
-                rule_fail_condition = any(
-                    (
-                        rule.destination_port_range == "22"
-                        or (
-                            "-" in rule.destination_port_range
-                            and int(rule.destination_port_range.split("-")[0]) <= 22
-                            and int(rule.destination_port_range.split("-")[1]) >= 22
-                        )
+        if network_client.security_groups is not None:
+            for subscription, security_groups in network_client.security_groups.items():
+                for security_group in security_groups:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=security_group
                     )
-                    and rule.protocol in ["TCP", "Tcp", "*"]
-                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                    and rule.access == "Allow"
-                    and rule.direction == "Inbound"
-                    for rule in security_group.security_rules
-                )
-                if rule_fail_condition:
-                    report.status = "FAIL"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access allowed."
-                findings.append(report)
+                    report.subscription = subscription
+                    report.status = "PASS"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access restricted."
+                    rule_fail_condition = any(
+                        (
+                            rule.destination_port_range == "22"
+                            or (
+                                "-" in rule.destination_port_range
+                                and int(rule.destination_port_range.split("-")[0]) <= 22
+                                and int(rule.destination_port_range.split("-")[1]) >= 22
+                            )
+                        )
+                        and rule.protocol in ["TCP", "Tcp", "*"]
+                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                        and rule.access == "Allow"
+                        and rule.direction == "Inbound"
+                        for rule in security_group.security_rules
+                    )
+                    if rule_fail_condition:
+                        report.status = "FAIL"
+                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access allowed."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
@@ -18,6 +18,8 @@ class network_ssh_internet_access_restricted(Check):
                         rule.destination_port_range == "22"
                         or (
                             "-" in rule.destination_port_range
+                            if rule.destination_port_range is not None
+                            else False
                             and int(rule.destination_port_range.split("-")[0]) <= 22
                             and int(rule.destination_port_range.split("-")[1]) >= 22
                         )

--- a/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted.py
@@ -5,33 +5,32 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_ssh_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        if network_client.security_groups is not None:
-            for subscription, security_groups in network_client.security_groups.items():
-                for security_group in security_groups:
-                    report = Check_Report_Azure(
-                        metadata=self.metadata(), resource=security_group
-                    )
-                    report.subscription = subscription
-                    report.status = "PASS"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access restricted."
-                    rule_fail_condition = any(
-                        (
-                            rule.destination_port_range == "22"
-                            or (
-                                "-" in rule.destination_port_range
-                                and int(rule.destination_port_range.split("-")[0]) <= 22
-                                and int(rule.destination_port_range.split("-")[1]) >= 22
-                            )
+        for subscription, security_groups in network_client.security_groups.items():
+            for security_group in security_groups:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource=security_group
+                )
+                report.subscription = subscription
+                report.status = "PASS"
+                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access restricted."
+                rule_fail_condition = any(
+                    (
+                        rule.destination_port_range == "22"
+                        or (
+                            "-" in rule.destination_port_range
+                            and int(rule.destination_port_range.split("-")[0]) <= 22
+                            and int(rule.destination_port_range.split("-")[1]) >= 22
                         )
-                        and rule.protocol in ["TCP", "Tcp", "*"]
-                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                        and rule.access == "Allow"
-                        and rule.direction == "Inbound"
-                        for rule in security_group.security_rules
                     )
-                    if rule_fail_condition:
-                        report.status = "FAIL"
-                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access allowed."
-                    findings.append(report)
+                    and rule.protocol in ["TCP", "Tcp", "*"]
+                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                    and rule.access == "Allow"
+                    and rule.direction == "Inbound"
+                    for rule in security_group.security_rules
+                )
+                if rule_fail_condition:
+                    report.status = "FAIL"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has SSH internet access allowed."
+                findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
@@ -14,10 +14,14 @@ class network_udp_internet_access_restricted(Check):
                 report.status = "PASS"
                 report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access restricted."
                 rule_fail_condition = any(
-                    rule.protocol in ["UDP", "Udp"]
-                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                    and rule.access == "Allow"
-                    and rule.direction == "Inbound"
+                    (
+                        rule.protocol in ["UDP", "Udp"]
+                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                        if rule.source_address_prefix is not None
+                        else False
+                        and rule.access == "Allow"
+                        and rule.direction == "Inbound"
+                    )
                     for rule in security_group.security_rules
                 )
                 if rule_fail_condition:

--- a/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
@@ -17,9 +17,9 @@ class network_udp_internet_access_restricted(Check):
                     (
                         rule.protocol in ["UDP", "Udp"]
                         and (
-                            rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                            if rule.source_address_prefix is not None
-                            else False
+                            rule.source_address_prefix
+                            and rule.source_address_prefix
+                            in ["Internet", "*", "0.0.0.0/0"]
                         )
                         and rule.access == "Allow"
                         and rule.direction == "Inbound"

--- a/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
@@ -5,24 +5,25 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_udp_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        for subscription, security_groups in network_client.security_groups.items():
-            for security_group in security_groups:
-                report = Check_Report_Azure(
-                    metadata=self.metadata(), resource=security_group
-                )
-                report.subscription = subscription
-                report.status = "PASS"
-                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access restricted."
-                rule_fail_condition = any(
-                    rule.protocol in ["UDP", "Udp"]
-                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                    and rule.access == "Allow"
-                    and rule.direction == "Inbound"
-                    for rule in security_group.security_rules
-                )
-                if rule_fail_condition:
-                    report.status = "FAIL"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access allowed."
-                findings.append(report)
+        if network_client.security_groups is not None:
+            for subscription, security_groups in network_client.security_groups.items():
+                for security_group in security_groups:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=security_group
+                    )
+                    report.subscription = subscription
+                    report.status = "PASS"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access restricted."
+                    rule_fail_condition = any(
+                        rule.protocol in ["UDP", "Udp"]
+                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                        and rule.access == "Allow"
+                        and rule.direction == "Inbound"
+                        for rule in security_group.security_rules
+                    )
+                    if rule_fail_condition:
+                        report.status = "FAIL"
+                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access allowed."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
@@ -16,9 +16,11 @@ class network_udp_internet_access_restricted(Check):
                 rule_fail_condition = any(
                     (
                         rule.protocol in ["UDP", "Udp"]
-                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                        if rule.source_address_prefix is not None
-                        else False
+                        and (
+                            rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                            if rule.source_address_prefix is not None
+                            else False
+                        )
                         and rule.access == "Allow"
                         and rule.direction == "Inbound"
                     )

--- a/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
+++ b/prowler/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted.py
@@ -5,25 +5,24 @@ from prowler.providers.azure.services.network.network_client import network_clie
 class network_udp_internet_access_restricted(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        if network_client.security_groups is not None:
-            for subscription, security_groups in network_client.security_groups.items():
-                for security_group in security_groups:
-                    report = Check_Report_Azure(
-                        metadata=self.metadata(), resource=security_group
-                    )
-                    report.subscription = subscription
-                    report.status = "PASS"
-                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access restricted."
-                    rule_fail_condition = any(
-                        rule.protocol in ["UDP", "Udp"]
-                        and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
-                        and rule.access == "Allow"
-                        and rule.direction == "Inbound"
-                        for rule in security_group.security_rules
-                    )
-                    if rule_fail_condition:
-                        report.status = "FAIL"
-                        report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access allowed."
-                    findings.append(report)
+        for subscription, security_groups in network_client.security_groups.items():
+            for security_group in security_groups:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource=security_group
+                )
+                report.subscription = subscription
+                report.status = "PASS"
+                report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access restricted."
+                rule_fail_condition = any(
+                    rule.protocol in ["UDP", "Udp"]
+                    and rule.source_address_prefix in ["Internet", "*", "0.0.0.0/0"]
+                    and rule.access == "Allow"
+                    and rule.direction == "Inbound"
+                    for rule in security_group.security_rules
+                )
+                if rule_fail_condition:
+                    report.status = "FAIL"
+                    report.status_extended = f"Security Group {security_group.name} from subscription {subscription} has UDP internet access allowed."
+                findings.append(report)
 
         return findings

--- a/tests/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted_test.py
@@ -37,7 +37,7 @@ class Test_network_http_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
-    def test_network_security_groups_no_security_rules(self):
+    def test_network_security_groups_none_destination_port_range(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"
         security_group_id = str(uuid4())
@@ -48,7 +48,15 @@ class Test_network_http_internet_access_restricted:
                     id=security_group_id,
                     name=security_group_name,
                     location="location",
-                    security_rules=[],
+                    security_rules=[
+                        SecurityRule(
+                            destination_port_range=None,
+                            protocol="TCP",
+                            source_address_prefix="Internet",
+                            access="Allow",
+                            direction="Inbound",
+                        )
+                    ],
                 )
             ]
         }

--- a/tests/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted_test.py
@@ -37,6 +37,34 @@ class Test_network_http_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
+    def test_none_security_groups(self):
+        network_client = mock.MagicMock
+        network_client.security_groups = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.network.network_service.Network",
+                new=network_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.azure.services.network.network_client.network_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
+                network_http_internet_access_restricted,
+            )
+
+            network_client.security_groups = None
+
+            check = network_http_internet_access_restricted()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_http_internet_access_restricted/network_http_internet_access_restricted_test.py
@@ -37,34 +37,6 @@ class Test_network_http_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
-    def test_none_security_groups(self):
-        network_client = mock.MagicMock
-        network_client.security_groups = {}
-
-        with (
-            mock.patch(
-                "prowler.providers.common.provider.Provider.get_global_provider",
-                return_value=set_mocked_azure_provider(),
-            ),
-            mock.patch(
-                "prowler.providers.azure.services.network.network_service.Network",
-                new=network_client,
-            ) as service_client,
-            mock.patch(
-                "prowler.providers.azure.services.network.network_client.network_client",
-                new=service_client,
-            ),
-        ):
-            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
-                network_http_internet_access_restricted,
-            )
-
-            network_client.security_groups = None
-
-            check = network_http_internet_access_restricted()
-            result = check.execute()
-            assert len(result) == 0
-
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted_test.py
@@ -37,6 +37,61 @@ class Test_network_rdp_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
+    def test_network_security_groups_none_destination_port_range(self):
+        network_client = mock.MagicMock
+        security_group_name = "Security Group Name"
+        security_group_id = str(uuid4())
+
+        network_client.security_groups = {
+            AZURE_SUBSCRIPTION_ID: [
+                SecurityGroup(
+                    id=security_group_id,
+                    name=security_group_name,
+                    location="location",
+                    security_rules=[
+                        SecurityRule(
+                            destination_port_range=None,
+                            protocol="TCP",
+                            source_address_prefix="Internet",
+                            access="Allow",
+                            direction="Inbound",
+                        )
+                    ],
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.network.network_service.Network",
+                new=network_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.azure.services.network.network_client.network_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
+                network_http_internet_access_restricted,
+            )
+
+            check = network_http_internet_access_restricted()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Security Group {security_group_name} from subscription {AZURE_SUBSCRIPTION_ID} has HTTP internet access restricted."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == security_group_name
+            assert result[0].resource_id == security_group_id
+            assert result[0].location == "location"
+
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted_test.py
@@ -37,34 +37,6 @@ class Test_network_rdp_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
-    def test_none_security_groups(self):
-        network_client = mock.MagicMock
-        network_client.security_groups = {}
-
-        with (
-            mock.patch(
-                "prowler.providers.common.provider.Provider.get_global_provider",
-                return_value=set_mocked_azure_provider(),
-            ),
-            mock.patch(
-                "prowler.providers.azure.services.network.network_service.Network",
-                new=network_client,
-            ) as service_client,
-            mock.patch(
-                "prowler.providers.azure.services.network.network_client.network_client",
-                new=service_client,
-            ),
-        ):
-            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
-                network_http_internet_access_restricted,
-            )
-
-            network_client.security_groups = None
-
-            check = network_http_internet_access_restricted()
-            result = check.execute()
-            assert len(result) == 0
-
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_rdp_internet_access_restricted/network_rdp_internet_access_restricted_test.py
@@ -37,6 +37,34 @@ class Test_network_rdp_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
+    def test_none_security_groups(self):
+        network_client = mock.MagicMock
+        network_client.security_groups = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.network.network_service.Network",
+                new=network_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.azure.services.network.network_client.network_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
+                network_http_internet_access_restricted,
+            )
+
+            network_client.security_groups = None
+
+            check = network_http_internet_access_restricted()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted_test.py
@@ -37,6 +37,34 @@ class Test_network_ssh_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
+    def test_none_security_groups(self):
+        network_client = mock.MagicMock
+        network_client.security_groups = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.network.network_service.Network",
+                new=network_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.azure.services.network.network_client.network_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
+                network_http_internet_access_restricted,
+            )
+
+            network_client.security_groups = None
+
+            check = network_http_internet_access_restricted()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted_test.py
@@ -37,6 +37,61 @@ class Test_network_ssh_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
+    def test_network_security_groups_none_destination_port_range(self):
+        network_client = mock.MagicMock
+        security_group_name = "Security Group Name"
+        security_group_id = str(uuid4())
+
+        network_client.security_groups = {
+            AZURE_SUBSCRIPTION_ID: [
+                SecurityGroup(
+                    id=security_group_id,
+                    name=security_group_name,
+                    location="location",
+                    security_rules=[
+                        SecurityRule(
+                            destination_port_range=None,
+                            protocol="TCP",
+                            source_address_prefix="Internet",
+                            access="Allow",
+                            direction="Inbound",
+                        )
+                    ],
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.network.network_service.Network",
+                new=network_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.azure.services.network.network_client.network_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
+                network_http_internet_access_restricted,
+            )
+
+            check = network_http_internet_access_restricted()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Security Group {security_group_name} from subscription {AZURE_SUBSCRIPTION_ID} has HTTP internet access restricted."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == security_group_name
+            assert result[0].resource_id == security_group_id
+            assert result[0].location == "location"
+
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_ssh_internet_access_restricted/network_ssh_internet_access_restricted_test.py
@@ -37,34 +37,6 @@ class Test_network_ssh_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
-    def test_none_security_groups(self):
-        network_client = mock.MagicMock
-        network_client.security_groups = {}
-
-        with (
-            mock.patch(
-                "prowler.providers.common.provider.Provider.get_global_provider",
-                return_value=set_mocked_azure_provider(),
-            ),
-            mock.patch(
-                "prowler.providers.azure.services.network.network_service.Network",
-                new=network_client,
-            ) as service_client,
-            mock.patch(
-                "prowler.providers.azure.services.network.network_client.network_client",
-                new=service_client,
-            ),
-        ):
-            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
-                network_http_internet_access_restricted,
-            )
-
-            network_client.security_groups = None
-
-            check = network_http_internet_access_restricted()
-            result = check.execute()
-            assert len(result) == 0
-
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted_test.py
@@ -37,34 +37,6 @@ class Test_network_udp_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
-    def test_none_security_groups(self):
-        network_client = mock.MagicMock
-        network_client.security_groups = {}
-
-        with (
-            mock.patch(
-                "prowler.providers.common.provider.Provider.get_global_provider",
-                return_value=set_mocked_azure_provider(),
-            ),
-            mock.patch(
-                "prowler.providers.azure.services.network.network_service.Network",
-                new=network_client,
-            ) as service_client,
-            mock.patch(
-                "prowler.providers.azure.services.network.network_client.network_client",
-                new=service_client,
-            ),
-        ):
-            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
-                network_http_internet_access_restricted,
-            )
-
-            network_client.security_groups = None
-
-            check = network_http_internet_access_restricted()
-            result = check.execute()
-            assert len(result) == 0
-
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted_test.py
@@ -37,6 +37,61 @@ class Test_network_udp_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
+    def test_network_security_groups_none_source_address_prefix(self):
+        network_client = mock.MagicMock
+        security_group_name = "Security Group Name"
+        security_group_id = str(uuid4())
+
+        network_client.security_groups = {
+            AZURE_SUBSCRIPTION_ID: [
+                SecurityGroup(
+                    id=security_group_id,
+                    name=security_group_name,
+                    location="location",
+                    security_rules=[
+                        SecurityRule(
+                            destination_port_range=None,
+                            protocol="TCP",
+                            source_address_prefix=None,
+                            access="Allow",
+                            direction="Inbound",
+                        )
+                    ],
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.network.network_service.Network",
+                new=network_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.azure.services.network.network_client.network_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
+                network_http_internet_access_restricted,
+            )
+
+            check = network_http_internet_access_restricted()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Security Group {security_group_name} from subscription {AZURE_SUBSCRIPTION_ID} has HTTP internet access restricted."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == security_group_name
+            assert result[0].resource_id == security_group_id
+            assert result[0].location == "location"
+
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"

--- a/tests/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted_test.py
+++ b/tests/providers/azure/services/network/network_udp_internet_access_restricted/network_udp_internet_access_restricted_test.py
@@ -37,6 +37,34 @@ class Test_network_udp_internet_access_restricted:
             result = check.execute()
             assert len(result) == 0
 
+    def test_none_security_groups(self):
+        network_client = mock.MagicMock
+        network_client.security_groups = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.network.network_service.Network",
+                new=network_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.azure.services.network.network_client.network_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.azure.services.network.network_http_internet_access_restricted.network_http_internet_access_restricted import (
+                network_http_internet_access_restricted,
+            )
+
+            network_client.security_groups = None
+
+            check = network_http_internet_access_restricted()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_network_security_groups_no_security_rules(self):
         network_client = mock.MagicMock
         security_group_name = "Security Group Name"


### PR DESCRIPTION
### Context

Several `Nonetype is not iterable` errors were happening in `Azure Network`.

### Description

Those errors have been fixed with this pull request correctly handling the `None` objects and tests were added to verify that behavior.

### Checklist

- Are there new checks included in this PR? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
