### PR TITLE
fix(vm): handle NoneType accessing security_profile

### DIFF
--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -50,7 +50,7 @@ class VirtualMachines(AzureService):
                                     else None
                                 ),
                                 location=vm.location,
-                                security_profile=vm.get("security_profile", None),
+                                security_profile=getattr(vm, "security_profile", None),
                                 extensions=[
                                     VirtualMachineExtension(id=extension.id)
                                     for extension in getattr(vm, "resources", [])

--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -50,7 +50,7 @@ class VirtualMachines(AzureService):
                                     else None
                                 ),
                                 location=vm.location,
-                                security_profile=vm.security_profile,
+                                security_profile=vm.get("security_profile", None),
                                 extensions=[
                                     VirtualMachineExtension(id=extension.id)
                                     for extension in getattr(vm, "resources", [])
@@ -142,7 +142,7 @@ class VirtualMachine:
     resource_id: str
     resource_name: str
     location: str
-    security_profile: SecurityProfile
+    security_profile: Optional[SecurityProfile]
     extensions: list[VirtualMachineExtension]
     storage_profile: Optional[StorageProfile] = None
 

--- a/prowler/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled.py
+++ b/prowler/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled.py
@@ -14,7 +14,8 @@ class vm_trusted_launch_enabled(Check):
                 report.status_extended = f"VM {vm.resource_name} has trusted launch disabled in subscription {subscription_name}"
 
                 if (
-                    vm.security_profile.security_type == "TrustedLaunch"
+                    vm.security_profile
+                    and vm.security_profile.security_type == "TrustedLaunch"
                     and vm.security_profile.uefi_settings.secure_boot_enabled
                     and vm.security_profile.uefi_settings.v_tpm_enabled
                 ):

--- a/tests/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled_test.py
+++ b/tests/providers/azure/services/vm/vm_trusted_launch_enabled/vm_trusted_launch_enabled_test.py
@@ -158,3 +158,52 @@ class Test_vm_trusted_launch_enabled:
                 result[0].status_extended
                 == f"VM VMTest has trusted launch disabled in subscription {AZURE_SUBSCRIPTION_ID}"
             )
+
+    def test_vm_no_security_profile(self):
+        vm_id = str(uuid4())
+        vm_client = mock.MagicMock
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.vm.vm_trusted_launch_enabled.vm_trusted_launch_enabled.vm_client",
+                new=vm_client,
+            ),
+        ):
+            from prowler.providers.azure.services.vm.vm_service import VirtualMachine
+            from prowler.providers.azure.services.vm.vm_trusted_launch_enabled.vm_trusted_launch_enabled import (
+                vm_trusted_launch_enabled,
+            )
+
+            vm_client.virtual_machines = {
+                AZURE_SUBSCRIPTION_ID: {
+                    vm_id: VirtualMachine(
+                        resource_id=vm_id,
+                        resource_name="VMTest",
+                        location="location",
+                        security_profile=None,
+                        extensions=[],
+                        storage_profile=mock.MagicMock(
+                            os_disk=mock.MagicMock(
+                                create_option="FromImage",
+                                managed_disk=mock.MagicMock(id="managed_disk_id"),
+                            ),
+                            data_disks=[],
+                        ),
+                    )
+                }
+            }
+
+            check = vm_trusted_launch_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == "VMTest"
+            assert result[0].resource_id == vm_id
+            assert (
+                result[0].status_extended
+                == f"VM VMTest has trusted launch disabled in subscription {AZURE_SUBSCRIPTION_ID}"
+            )


### PR DESCRIPTION
### Description
Handle NoneType accessing security_profile attributes as `vm.security_profile` can be `None`.

https://learn.microsoft.com/en-us/python/api/azure-mgmt-computefleet/azure.mgmt.computefleet.models.basevirtualmachineprofile?view=azure-python#azure-mgmt-computefleet-models-basevirtualmachineprofile-security-profile

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
