### PR TITLE
fix(microsoft365): typo `Microsoft365NotTenantIdButClientIdAndClienSecretError`

### DIFF
--- a/prowler/providers/microsoft365/exceptions/exceptions.py
+++ b/prowler/providers/microsoft365/exceptions/exceptions.py
@@ -90,7 +90,7 @@ class Microsoft365BaseException(ProwlerException):
             "message": "Microsoft365 tenant ID error: browser authentication flag (--browser-auth) not found",
             "remediation": "To use browser authentication, ensure the tenant ID is properly set.",
         },
-        (6021, "Microsoft365NotTenantIdButClientIdAndClienSecretError"): {
+        (6021, "Microsoft365NotTenantIdButClientIdAndClientSecretError"): {
             "message": "Tenant Id is required for Microsoft365 static credentials. Make sure you are using the correct credentials.",
             "remediation": "Check the Microsoft365 Tenant ID and ensure it is properly set up.",
         },
@@ -270,7 +270,7 @@ class Microsoft365BrowserAuthNoFlagError(Microsoft365CredentialsError):
         )
 
 
-class Microsoft365NotTenantIdButClientIdAndClienSecretError(
+class Microsoft365NotTenantIdButClientIdAndClientSecretError(
     Microsoft365CredentialsError
 ):
     def __init__(self, file=None, original_exception=None, message=None):

--- a/prowler/providers/microsoft365/microsoft365_provider.py
+++ b/prowler/providers/microsoft365/microsoft365_provider.py
@@ -40,7 +40,7 @@ from prowler.providers.microsoft365.exceptions.exceptions import (
     Microsoft365InteractiveBrowserCredentialError,
     Microsoft365InvalidProviderIdError,
     Microsoft365NoAuthenticationMethodError,
-    Microsoft365NotTenantIdButClientIdAndClienSecretError,
+    Microsoft365NotTenantIdButClientIdAndClientSecretError,
     Microsoft365NotValidClientIdError,
     Microsoft365NotValidClientSecretError,
     Microsoft365NotValidTenantIdError,
@@ -281,7 +281,7 @@ class Microsoft365Provider(Provider):
                 )
         else:
             if not tenant_id:
-                raise Microsoft365NotTenantIdButClientIdAndClienSecretError(
+                raise Microsoft365NotTenantIdButClientIdAndClientSecretError(
                     file=os.path.basename(__file__),
                     message="Tenant Id is required for Microsoft365 static credentials. Make sure you are using the correct credentials.",
                 )


### PR DESCRIPTION
### Context

There is a typo in Microsoft365 provider exception `Microsoft365NotTenantIdButClientIdAndClienSecretError`.

### Description

`Microsoft365NotTenantIdButClientIdAndClienSecretError` has been renamed to `Microsoft365NotTenantIdButClientIdAndClientSecretError`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
