### PR TITLE
fix(backport): Use container tagged version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Check labels
         id: preview_label_check
-        uses: docker://agilepathway/pull-request-label-checker:v1.6.65
+        uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5 # v1.6.65
         with:
           allow_failure: true
           prefix_mode: true

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Check labels
         id: preview_label_check
-        uses: docker://agilepathway/pull-request-label-checker:sha-c3d16ad # v1.6.65
+        uses: docker://agilepathway/pull-request-label-checker:v1.6.65
         with:
           allow_failure: true
           prefix_mode: true


### PR DESCRIPTION
### Description

Use container tagged version since SHA images are not built for `amd64`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
