### PR TITLE
feat(providers): add component to render a link to the documentation

### DIFF
--- a/ui/components/providers/workflow/forms/connect-account-form.tsx
+++ b/ui/components/providers/workflow/forms/connect-account-form.tsx
@@ -9,17 +9,13 @@ import * as z from "zod";
 
 import { useToast } from "@/components/ui";
 import { CustomButton, CustomInput } from "@/components/ui/custom";
-import {
-  getProviderLogo,
-  getProviderName,
-  ProviderType,
-} from "@/components/ui/entities";
+import { ProviderType } from "@/components/ui/entities";
 import { Form } from "@/components/ui/form";
 
 import { addProvider } from "../../../../actions/providers/providers";
 import { addProviderFormSchema, ApiError } from "../../../../types";
 import { RadioGroupProvider } from "../../radio-group-provider";
-
+import { ProviderTitleDocs } from "../provider-title-docs";
 export type FormValues = z.infer<typeof addProviderFormSchema>;
 
 // Helper function for labels and placeholders
@@ -170,14 +166,7 @@ export const ConnectAccountForm = () => {
         {/* Step 2: UID, alias, and credentials (if AWS) */}
         {prevStep === 2 && (
           <>
-            <div className="mb-4 flex items-center space-x-4">
-              {providerType && getProviderLogo(providerType as ProviderType)}
-              <span className="text-lg font-semibold">
-                {providerType
-                  ? getProviderName(providerType as ProviderType)
-                  : "Unknown Provider"}
-              </span>
-            </div>
+            <ProviderTitleDocs providerType={providerType as ProviderType} />
             <CustomInput
               control={form.control}
               name="providerUid"

--- a/ui/components/providers/workflow/forms/update-via-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/update-via-credentials-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Divider } from "@nextui-org/react";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Control, useForm } from "react-hook-form";
@@ -9,8 +10,6 @@ import * as z from "zod";
 import { updateCredentialsProvider } from "@/actions/providers/providers";
 import { useToast } from "@/components/ui";
 import { CustomButton } from "@/components/ui/custom";
-import { getProviderLogo } from "@/components/ui/entities";
-import { getProviderName } from "@/components/ui/entities";
 import { ProviderType } from "@/components/ui/entities";
 import { Form } from "@/components/ui/form";
 import {
@@ -22,6 +21,7 @@ import {
   KubernetesCredentials,
 } from "@/types";
 
+import { ProviderTitleDocs } from "../provider-title-docs";
 import { AWScredentialsForm } from "./via-credentials/aws-credentials-form";
 import { AzureCredentialsForm } from "./via-credentials/azure-credentials-form";
 import { GCPcredentialsForm } from "./via-credentials/gcp-credentials-form";
@@ -178,14 +178,9 @@ export const UpdateViaCredentialsForm = ({
         <input type="hidden" name="providerId" value={providerId} />
         <input type="hidden" name="providerType" value={providerType} />
 
-        <div className="mb-4 flex items-center space-x-4">
-          {providerType && getProviderLogo(providerType as ProviderType)}
-          <span className="text-lg font-semibold">
-            {providerType
-              ? getProviderName(providerType as ProviderType)
-              : "Unknown Provider"}
-          </span>
-        </div>
+        <ProviderTitleDocs providerType={providerType as ProviderType} />
+
+        <Divider />
 
         {providerType === "aws" && (
           <AWScredentialsForm

--- a/ui/components/providers/workflow/forms/via-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Divider } from "@nextui-org/divider";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Control, useForm } from "react-hook-form";
@@ -9,8 +10,6 @@ import * as z from "zod";
 import { addCredentialsProvider } from "@/actions/providers/providers";
 import { useToast } from "@/components/ui";
 import { CustomButton } from "@/components/ui/custom";
-import { getProviderLogo } from "@/components/ui/entities";
-import { getProviderName } from "@/components/ui/entities";
 import { ProviderType } from "@/components/ui/entities";
 import { Form } from "@/components/ui/form";
 import {
@@ -22,6 +21,7 @@ import {
   KubernetesCredentials,
 } from "@/types";
 
+import { ProviderTitleDocs } from "../provider-title-docs";
 import { AWScredentialsForm } from "./via-credentials/aws-credentials-form";
 import { AzureCredentialsForm } from "./via-credentials/azure-credentials-form";
 import { GCPcredentialsForm } from "./via-credentials/gcp-credentials-form";
@@ -177,14 +177,9 @@ export const ViaCredentialsForm = ({
         <input type="hidden" name="providerId" value={providerId} />
         <input type="hidden" name="providerType" value={providerType} />
 
-        <div className="mb-4 flex items-center space-x-4">
-          {providerType && getProviderLogo(providerType as ProviderType)}
-          <span className="text-lg font-semibold">
-            {providerType
-              ? getProviderName(providerType as ProviderType)
-              : "Unknown Provider"}
-          </span>
-        </div>
+        <ProviderTitleDocs providerType={providerType as ProviderType} />
+
+        <Divider />
 
         {providerType === "aws" && (
           <AWScredentialsForm

--- a/ui/components/providers/workflow/forms/via-credentials/aws-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/aws-credentials-form.tsx
@@ -10,7 +10,7 @@ export const AWScredentialsForm = ({
 }) => {
   return (
     <>
-      <div className="text-left">
+      <div className="flex flex-col">
         <div className="text-md font-bold leading-9 text-default-foreground">
           Connect via Credentials
         </div>

--- a/ui/components/providers/workflow/forms/via-credentials/aws-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/aws-credentials-form.tsx
@@ -11,10 +11,10 @@ export const AWScredentialsForm = ({
   return (
     <>
       <div className="text-left">
-        <div className="text-2xl font-bold leading-9 text-default-foreground">
+        <div className="text-md font-bold leading-9 text-default-foreground">
           Connect via Credentials
         </div>
-        <div className="py-2 text-small text-default-500">
+        <div className="text-sm text-default-500">
           Please provide the information for your AWS credentials.
         </div>
       </div>

--- a/ui/components/providers/workflow/forms/via-credentials/azure-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/azure-credentials-form.tsx
@@ -10,7 +10,7 @@ export const AzureCredentialsForm = ({
 }) => {
   return (
     <>
-      <div className="text-left">
+      <div className="flex flex-col">
         <div className="text-md font-bold leading-9 text-default-foreground">
           Connect via Credentials
         </div>

--- a/ui/components/providers/workflow/forms/via-credentials/azure-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/azure-credentials-form.tsx
@@ -11,10 +11,10 @@ export const AzureCredentialsForm = ({
   return (
     <>
       <div className="text-left">
-        <div className="text-2xl font-bold leading-9 text-default-foreground">
+        <div className="text-md font-bold leading-9 text-default-foreground">
           Connect via Credentials
         </div>
-        <div className="py-2 text-default-500">
+        <div className="text-sm text-default-500">
           Please provide the information for your Azure credentials.
         </div>
       </div>

--- a/ui/components/providers/workflow/forms/via-credentials/gcp-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/gcp-credentials-form.tsx
@@ -11,10 +11,10 @@ export const GCPcredentialsForm = ({
   return (
     <>
       <div className="text-left">
-        <div className="text-2xl font-bold leading-9 text-default-foreground">
+        <div className="text-md font-bold leading-9 text-default-foreground">
           Connect via Credentials
         </div>
-        <div className="py-2 text-default-500">
+        <div className="text-sm text-default-500">
           Please provide the information for your GCP credentials.
         </div>
       </div>

--- a/ui/components/providers/workflow/forms/via-credentials/gcp-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/gcp-credentials-form.tsx
@@ -10,7 +10,7 @@ export const GCPcredentialsForm = ({
 }) => {
   return (
     <>
-      <div className="text-left">
+      <div className="flex flex-col">
         <div className="text-md font-bold leading-9 text-default-foreground">
           Connect via Credentials
         </div>

--- a/ui/components/providers/workflow/forms/via-credentials/k8s-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/k8s-credentials-form.tsx
@@ -10,11 +10,11 @@ export const KubernetesCredentialsForm = ({
 }) => {
   return (
     <>
-      <div className="text-left">
-        <div className="text-2xl font-bold leading-9 text-default-foreground">
+      <div className="flex flex-col">
+        <div className="text-md font-bold leading-9 text-default-foreground">
           Connect via Credentials
         </div>
-        <div className="py-2 text-default-500">
+        <div className="text-sm text-default-500">
           Please provide the kubeconfig content for your Kubernetes credentials.
         </div>
       </div>

--- a/ui/components/providers/workflow/forms/via-role/aws-role-form.tsx
+++ b/ui/components/providers/workflow/forms/via-role/aws-role-form.tsx
@@ -23,11 +23,11 @@ export const AWSCredentialsRoleForm = ({
 
   return (
     <>
-      <div className="flex flex-col gap-2">
-        <div className="text-2xl font-bold leading-9 text-default-foreground">
+      <div className="flex flex-col">
+        <div className="text-md font-bold leading-9 text-default-foreground">
           Connect assuming IAM Role
         </div>
-        <div className="text-small text-default-500">
+        <div className="text-sm text-default-500">
           Please provide the information for your AWS credentials.
         </div>
       </div>

--- a/ui/components/providers/workflow/index.ts
+++ b/ui/components/providers/workflow/index.ts
@@ -1,4 +1,5 @@
 export * from "./credentials-role-helper";
+export * from "./provider-title-docs";
 export * from "./skeleton-provider-workflow";
 export * from "./vertical-steps";
 export * from "./workflow-add-provider";

--- a/ui/components/providers/workflow/provider-title-docs.tsx
+++ b/ui/components/providers/workflow/provider-title-docs.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link";
+
+import { getProviderName } from "@/components/ui/entities/get-provider-logo";
+import { ProviderType } from "@/components/ui/entities/get-provider-logo";
+import { getProviderLogo } from "@/components/ui/entities/get-provider-logo";
+
+export const ProviderTitleDocs = ({
+  providerType,
+}: {
+  providerType: ProviderType;
+}) => {
+  const getProviderHelpText = (provider: string) => {
+    switch (provider) {
+      case "aws":
+        return {
+          text: "Need help connecting your AWS account?",
+          link: "https://goto.prowler.com/provider-aws",
+        };
+      case "azure":
+        return {
+          text: "Need help connecting your Azure subscription?",
+          link: "https://goto.prowler.com/provider-azure",
+        };
+      case "gcp":
+        return {
+          text: "Need help connecting your GCP project?",
+          link: "https://goto.prowler.com/provider-gcp",
+        };
+      case "kubernetes":
+        return {
+          text: "Need help connecting your Kubernetes cluster?",
+          link: "https://goto.prowler.com/provider-k8s",
+        };
+      default:
+        return {
+          text: "How to setup a provider?",
+          link: "https://goto.prowler.com/provider-help",
+        };
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex space-x-4">
+        {providerType && getProviderLogo(providerType as ProviderType)}
+        <span className="text-lg font-semibold">
+          {providerType
+            ? getProviderName(providerType as ProviderType)
+            : "Unknown Provider"}
+        </span>
+      </div>
+      <div className="flex items-end gap-x-2">
+        <p className="text-sm text-default-500">
+          {getProviderHelpText(providerType as string).text}
+        </p>
+        <Link
+          href={getProviderHelpText(providerType as string).link}
+          target="_blank"
+          className="text-sm font-medium text-primary"
+        >
+          Read the docs
+        </Link>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION


### Description

- Added a new component to generate a link to the documentation.

![image](https://github.com/user-attachments/assets/4dcb084f-a984-45fe-815a-4ee65ee89604)

![image](https://github.com/user-attachments/assets/f503d7d8-f92b-482b-94e0-9d308e6ebe87)


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
