### PR TITLE
fix(test-connection): Handle provider without secret

### DIFF
--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -149,12 +149,11 @@ class TestProwlerProviderConnectionTest:
         self, mock_return_prowler_provider, providers_fixture
     ):
         mock_return_prowler_provider.return_value = MagicMock()
-        with pytest.raises(Provider.secret.RelatedObjectDoesNotExist) as error:
-            connection = prowler_provider_connection_test(providers_fixture[0])
-            assert connection.is_connected is False
-            raise connection.error
+        connection = prowler_provider_connection_test(providers_fixture[0])
 
-        assert str(error.value) == "Provider has no secret."
+        assert connection.is_connected is False
+        assert isinstance(connection.error, Provider.secret.RelatedObjectDoesNotExist)
+        assert str(connection.error) == "Provider has no secret."
 
 
 class TestGetProwlerProviderKwargs:

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -148,7 +148,7 @@ class TestProwlerProviderConnectionTest:
         self, mock_return_prowler_provider
     ):
         provider = MagicMock()
-        provider.uid = "1234567890"
+        provider.uid = "111122223333"
         mock_return_prowler_provider.return_value = MagicMock()
 
         connection = prowler_provider_connection_test(provider)
@@ -160,7 +160,7 @@ class TestProwlerProviderConnectionTest:
         self, mock_return_prowler_provider
     ):
         provider = MagicMock()
-        provider.uid = "1234567890"
+        provider.uid = "333322221111"
         exception = Exception("test exception")
         mock_return_prowler_provider.side_effect = exception
 

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -150,6 +150,7 @@ class TestProwlerProviderConnectionTest:
         provider = MagicMock()
         provider.uid = "111122223333"
         mock_return_prowler_provider.return_value = MagicMock()
+        provider.secret = None
 
         connection = prowler_provider_connection_test(provider)
         assert connection.is_connected is False
@@ -160,7 +161,7 @@ class TestProwlerProviderConnectionTest:
         self, mock_return_prowler_provider
     ):
         provider = MagicMock()
-        provider.uid = "333322221111"
+        provider.uid = "1234567890"
         exception = Exception("test exception")
         mock_return_prowler_provider.side_effect = exception
 

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -151,7 +151,9 @@ class TestProwlerProviderConnectionTest:
         mock_return_prowler_provider.return_value = MagicMock()
         connection = prowler_provider_connection_test(providers_fixture[0])
         assert connection.is_connected is False
-        assert connection.error == Provider.secret.RelatedObjectDoesNotExist()
+        assert connection.error == Provider.secret.RelatedObjectDoesNotExist(
+            "Provider has no secret."
+        )
 
 
 class TestGetProwlerProviderKwargs:

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -151,7 +151,7 @@ class TestProwlerProviderConnectionTest:
         mock_return_prowler_provider.return_value = MagicMock()
         connection = prowler_provider_connection_test(providers_fixture[0])
         assert connection.is_connected is False
-        assert connection.error == Provider.secret.RelatedObjectDoesNotExist
+        assert connection.error == Provider.secret.RelatedObjectDoesNotExist()
 
 
 class TestGetProwlerProviderKwargs:

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -149,11 +149,12 @@ class TestProwlerProviderConnectionTest:
         self, mock_return_prowler_provider, providers_fixture
     ):
         mock_return_prowler_provider.return_value = MagicMock()
-        connection = prowler_provider_connection_test(providers_fixture[0])
-        assert connection.is_connected is False
-        assert connection.error == Provider.secret.RelatedObjectDoesNotExist(
-            "Provider has no secret."
-        )
+        with pytest.raises(Provider.secret.RelatedObjectDoesNotExist) as error:
+            connection = prowler_provider_connection_test(providers_fixture[0])
+            assert connection.is_connected is False
+            raise connection.error
+
+        assert str(error.value) == "Provider has no secret."
 
 
 class TestGetProwlerProviderKwargs:

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -156,19 +156,6 @@ class TestProwlerProviderConnectionTest:
         assert connection.is_connected is False
         assert connection.error == Provider.secret.RelatedObjectDoesNotExist
 
-    @patch("api.utils.return_prowler_provider")
-    def test_prowler_provider_connection_test_generic_exception(
-        self, mock_return_prowler_provider
-    ):
-        provider = MagicMock()
-        provider.uid = "1234567890"
-        exception = Exception("test exception")
-        mock_return_prowler_provider.side_effect = exception
-
-        connection = prowler_provider_connection_test(provider)
-        assert connection.is_connected is False
-        assert connection.error == exception
-
 
 class TestGetProwlerProviderKwargs:
     @pytest.mark.parametrize(

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -143,6 +143,7 @@ class TestProwlerProviderConnectionTest:
             key="value", provider_id="1234567890", raise_on_exception=False
         )
 
+    @pytest.mark.django_db
     @patch("api.utils.return_prowler_provider")
     def test_prowler_provider_connection_test_without_secret(
         self, mock_return_prowler_provider, providers_fixture

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -1,25 +1,24 @@
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+from rest_framework.exceptions import NotFound, ValidationError
+
+from api.db_router import MainRouter
+from api.exceptions import InvitationTokenExpiredException
+from api.models import Invitation, Provider
+from api.utils import (
+    get_prowler_provider_kwargs,
+    initialize_prowler_provider,
+    merge_dicts,
+    prowler_provider_connection_test,
+    return_prowler_provider,
+    validate_invitation,
+)
 from prowler.providers.aws.aws_provider import AwsProvider
 from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.gcp.gcp_provider import GcpProvider
 from prowler.providers.kubernetes.kubernetes_provider import KubernetesProvider
-from rest_framework.exceptions import ValidationError, NotFound
-
-from api.db_router import MainRouter
-from api.exceptions import InvitationTokenExpiredException
-from api.models import Invitation
-from api.models import Provider
-from api.utils import (
-    merge_dicts,
-    return_prowler_provider,
-    initialize_prowler_provider,
-    prowler_provider_connection_test,
-    get_prowler_provider_kwargs,
-)
-from api.utils import validate_invitation
 
 
 class TestMergeDicts:
@@ -143,6 +142,31 @@ class TestProwlerProviderConnectionTest:
         mock_return_prowler_provider.return_value.test_connection.assert_called_once_with(
             key="value", provider_id="1234567890", raise_on_exception=False
         )
+
+    @patch("api.utils.return_prowler_provider")
+    def test_prowler_provider_connection_test_without_secret(
+        self, mock_return_prowler_provider
+    ):
+        provider = MagicMock()
+        provider.uid = "1234567890"
+        mock_return_prowler_provider.return_value = MagicMock()
+
+        connection = prowler_provider_connection_test(provider)
+        assert connection.is_connected is False
+        assert connection.error == Provider.secret.RelatedObjectDoesNotExist
+
+    @patch("api.utils.return_prowler_provider")
+    def test_prowler_provider_connection_test_generic_exception(
+        self, mock_return_prowler_provider
+    ):
+        provider = MagicMock()
+        provider.uid = "1234567890"
+        exception = Exception("test exception")
+        mock_return_prowler_provider.side_effect = exception
+
+        connection = prowler_provider_connection_test(provider)
+        assert connection.is_connected is False
+        assert connection.error == exception
 
 
 class TestGetProwlerProviderKwargs:

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -145,14 +145,10 @@ class TestProwlerProviderConnectionTest:
 
     @patch("api.utils.return_prowler_provider")
     def test_prowler_provider_connection_test_without_secret(
-        self, mock_return_prowler_provider
+        self, mock_return_prowler_provider, providers_fixture
     ):
-        provider = MagicMock()
-        provider.uid = "111122223333"
         mock_return_prowler_provider.return_value = MagicMock()
-        provider.secret = None
-
-        connection = prowler_provider_connection_test(provider)
+        connection = prowler_provider_connection_test(providers_fixture[0])
         assert connection.is_connected is False
         assert connection.error == Provider.secret.RelatedObjectDoesNotExist
 

--- a/api/src/backend/api/utils.py
+++ b/api/src/backend/api/utils.py
@@ -129,9 +129,8 @@ def prowler_provider_connection_test(provider: Provider) -> Connection:
     Returns:
         Connection: A connection object representing the result of the connection test for the specified provider.
     """
-
+    prowler_provider = return_prowler_provider(provider)
     try:
-        prowler_provider = return_prowler_provider(provider)
         prowler_provider_kwargs = provider.secret.secret
     except Provider.secret.RelatedObjectDoesNotExist as secret_error:
         return Connection(is_connected=False, error=secret_error)

--- a/api/src/backend/api/utils.py
+++ b/api/src/backend/api/utils.py
@@ -134,8 +134,6 @@ def prowler_provider_connection_test(provider: Provider) -> Connection:
         prowler_provider_kwargs = provider.secret.secret
     except Provider.secret.RelatedObjectDoesNotExist as secret_error:
         return Connection(is_connected=False, error=secret_error)
-    except Exception as error:
-        return Connection(is_connected=False, error=error)
     return prowler_provider.test_connection(
         **prowler_provider_kwargs, provider_id=provider.uid, raise_on_exception=False
     )

--- a/api/src/backend/api/utils.py
+++ b/api/src/backend/api/utils.py
@@ -129,8 +129,14 @@ def prowler_provider_connection_test(provider: Provider) -> Connection:
     Returns:
         Connection: A connection object representing the result of the connection test for the specified provider.
     """
-    prowler_provider = return_prowler_provider(provider)
-    prowler_provider_kwargs = provider.secret.secret
+
+    try:
+        prowler_provider = return_prowler_provider(provider)
+        prowler_provider_kwargs = provider.secret.secret
+    except Provider.secret.RelatedObjectDoesNotExist as secret_error:
+        return Connection(is_connected=False, error=secret_error)
+    except Exception as error:
+        return Connection(is_connected=False, error=error)
     return prowler_provider.test_connection(
         **prowler_provider_kwargs, provider_id=provider.uid, raise_on_exception=False
     )


### PR DESCRIPTION
### Description

Handle provider without secret instead of raising an exception.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
