### PR TITLE
fix: prevent SSR mismatch in OAuth URL generation

### DIFF
--- a/ui/app/(auth)/sign-in/page.tsx
+++ b/ui/app/(auth)/sign-in/page.tsx
@@ -1,10 +1,18 @@
 import { AuthForm } from "@/components/auth/oss";
-import { isGithubOAuthEnabled, isGoogleOAuthEnabled } from "@/lib/helper";
+import {
+  getAuthUrl,
+  isGithubOAuthEnabled,
+  isGoogleOAuthEnabled,
+} from "@/lib/helper";
 
 const SignIn = () => {
+  const GOOGLE_AUTH_URL = getAuthUrl("google");
+  const GITHUB_AUTH_URL = getAuthUrl("github");
   return (
     <AuthForm
       type="sign-in"
+      googleAuthUrl={GOOGLE_AUTH_URL}
+      githubAuthUrl={GITHUB_AUTH_URL}
       isGoogleOAuthEnabled={isGoogleOAuthEnabled}
       isGithubOAuthEnabled={isGithubOAuthEnabled}
     />

--- a/ui/components/auth/oss/auth-form.tsx
+++ b/ui/components/auth/oss/auth-form.tsx
@@ -18,19 +18,22 @@ import {
   FormField,
   FormMessage,
 } from "@/components/ui/form";
-import { getAuthUrl } from "@/lib/helper";
 import { ApiError, authFormSchema } from "@/types";
 
 export const AuthForm = ({
   type,
   invitationToken,
   isCloudEnv,
+  googleAuthUrl,
+  githubAuthUrl,
   isGoogleOAuthEnabled,
   isGithubOAuthEnabled,
 }: {
   type: string;
   invitationToken?: string | null;
   isCloudEnv?: boolean;
+  googleAuthUrl?: string;
+  githubAuthUrl?: string;
   isGoogleOAuthEnabled?: boolean;
   isGithubOAuthEnabled?: boolean;
 }) => {
@@ -326,7 +329,7 @@ export const AuthForm = ({
                       variant="bordered"
                       className="w-full"
                       as="a"
-                      href={getAuthUrl("google")}
+                      href={googleAuthUrl}
                       isDisabled={!isGoogleOAuthEnabled}
                     >
                       Continue with Google
@@ -364,7 +367,7 @@ export const AuthForm = ({
                       variant="bordered"
                       className="w-full"
                       as="a"
-                      href={getAuthUrl("github")}
+                      href={githubAuthUrl}
                       isDisabled={!isGithubOAuthEnabled}
                     >
                       Continue with Github


### PR DESCRIPTION

### Description

- Ensure OAuth URLs are only generated in the server environment.
- Prevent mismatches between SSR and client-side rendering.


![image](https://github.com/user-attachments/assets/ecaec1b6-ac60-479d-8d92-f81021d69a7f)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
