### PR TITLE
chore(aws-regions): remove backport to v3

### DIFF
--- a/.github/workflows/sdk-refresh-aws-services-regions.yml
+++ b/.github/workflows/sdk-refresh-aws-services-regions.yml
@@ -56,7 +56,7 @@ jobs:
           token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
           commit-message: "feat(regions_update): Update regions for AWS services"
           branch: "aws-services-regions-updated-${{ github.sha }}"
-          labels: "status/waiting-for-revision, severity/low, provider/aws, backport-to-v3"
+          labels: "status/waiting-for-revision, severity/low, provider/aws"
           title: "chore(regions_update): Changes in regions for AWS services"
           body: |
             ### Description


### PR DESCRIPTION
### Description

Remove backport to v3 in the AWS Refresh Regions.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
