### PR TITLE
fix(scan_id): Read the ID from the Scan object

### DIFF
--- a/ui/components/scans/table/scan-detail.tsx
+++ b/ui/components/scans/table/scan-detail.tsx
@@ -89,7 +89,7 @@ export const ScanDetail = ({
 
         <InfoField label="Scan ID" variant="simple">
           <Snippet className="bg-gray-50 py-1 dark:bg-slate-800" hideSymbol>
-            {renderValue(taskDetails?.attributes.task_args.scan_id)}
+            {scanDetails.id}
           </Snippet>
         </InfoField>
 


### PR DESCRIPTION
### Description

Read the `Scan.ID` from the `Scan` object since the scheduled scan task has not `scan_id` in `task_args` because the `scan` is created in the task.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
