### PR TITLE
fix: force z-index componet select provider

### DIFF
--- a/ui/components/filters/custom-select-provider.tsx
+++ b/ui/components/filters/custom-select-provider.tsx
@@ -68,6 +68,7 @@ export const CustomSelectProvider: React.FC = () => {
       placeholder="Select a provider"
       classNames={{
         selectorIcon: "right-2",
+        label:"!z-0"
       }}
       label="Provider"
       labelPlacement="inside"


### PR DESCRIPTION
### Context

Navigating through the Prowler App, the vendor selector component overlaps with the nav.

https://github.com/user-attachments/assets/07feb315-9aa8-4f59-b14a-62f744f5462c

### Description

On the overview page when using scroll the label of the provider selector component overlaps with the top navigation bar. It is necessary to force the css label with !z-0 so that the index is below the upper nav.

https://github.com/user-attachments/assets/ecdd91b0-9bbc-404c-896f-2b0e2d97b2ee


### Checklist

- Are there new checks included in this PR?  No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ x] Review if the code is being covered by tests.
- [x ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ x] Review if backport is needed.
- [x ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
