### PR TITLE
chore(next): Remove `x-powered-by` header

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -14,6 +14,7 @@ const cspHeader = `
 `
 
 module.exports = {
+  poweredByHeader: false,  
   output: "standalone",
   async headers() {
     return [


### PR DESCRIPTION
### Description

Remove `x-powered-by` header from NextJS.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
