### PR TITLE
ref(providers): Refactor provider deletion functions

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to the **Prowler API** are documented in this file.
 - HTTP Security Headers [(#7289)](https://github.com/prowler-cloud/prowler/pull/7289).
 - New endpoint to get the compliance overviews metadata [(#7333)](https://github.com/prowler-cloud/prowler/pull/7333).
 
+### Changed
+- Refactored deletion logic and implemented retry mechanism for deletion tasks [(#7349)](https://github.com/prowler-cloud/prowler/pull/7349).
+
 ---
 
 ## [v1.5.1] (Prowler v5.4.1)

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the **Prowler API** are documented in this file.
 - HTTP Security Headers [(#7289)](https://github.com/prowler-cloud/prowler/pull/7289).
 - New endpoint to get the compliance overviews metadata [(#7333)](https://github.com/prowler-cloud/prowler/pull/7333).
 
+---
+
+## [v1.5.2] (Prowler v5.4.2)
+
 ### Changed
 - Refactored deletion logic and implemented retry mechanism for deletion tasks [(#7349)](https://github.com/prowler-cloud/prowler/pull/7349).
 

--- a/api/src/backend/api/tests/test_db_utils.py
+++ b/api/src/backend/api/tests/test_db_utils.py
@@ -131,9 +131,10 @@ class TestBatchDelete:
         return provider_count
 
     @pytest.mark.django_db
-    def test_batch_delete(self, create_test_providers):
+    def test_batch_delete(self, tenants_fixture, create_test_providers):
+        tenant_id = str(tenants_fixture[0].id)
         _, summary = batch_delete(
-            Provider.objects.all(), batch_size=create_test_providers // 2
+            tenant_id, Provider.objects.all(), batch_size=create_test_providers // 2
         )
         assert Provider.objects.all().count() == 0
         assert summary == {"api.Provider": create_test_providers}

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -55,6 +55,7 @@ from tasks.tasks import (
 
 from api.base_views import BaseRLSViewSet, BaseTenantViewset, BaseUserViewset
 from api.db_router import MainRouter
+from api.db_utils import delete_related_daily_task
 from api.filters import (
     ComplianceOverviewFilter,
     FindingFilter,
@@ -1088,6 +1089,7 @@ class ProviderViewSet(BaseRLSViewSet):
         provider = get_object_or_404(Provider, pk=pk)
         provider.is_deleted = True
         provider.save()
+        delete_related_daily_task(str(provider.id))
 
         with transaction.atomic():
             task = delete_provider_task.delay(

--- a/api/src/backend/config/celery.py
+++ b/api/src/backend/config/celery.py
@@ -50,9 +50,9 @@ class RLSTask(Task):
 
         tenant_id = kwargs.get("tenant_id")
         with rls_transaction(tenant_id):
-            APITask.objects.create(
+            APITask.objects.update_or_create(
                 id=task_result_instance.task_id,
                 tenant_id=tenant_id,
-                task_runner_task=task_result_instance,
+                defaults={"task_runner_task": task_result_instance},
             )
         return result

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -44,8 +44,7 @@ def check_provider_connection_task(provider_id: str):
 
 
 @shared_task(base=RLSTask, name="provider-deletion", queue="deletion")
-@set_tenant
-def delete_provider_task(provider_id: str):
+def delete_provider_task(provider_id: str, tenant_id: str):
     """
     Task to delete a specific Provider instance.
 
@@ -53,6 +52,7 @@ def delete_provider_task(provider_id: str):
 
     Args:
         provider_id (str): The primary key of the `Provider` instance to be deleted.
+        tenant_id (str): Tenant ID the provider belongs to.
 
     Returns:
         tuple: A tuple containing:
@@ -60,7 +60,7 @@ def delete_provider_task(provider_id: str):
             - A dictionary with the count of deleted instances per model,
               including related models if cascading deletes were triggered.
     """
-    return delete_provider(pk=provider_id)
+    return delete_provider(tenant_id=tenant_id, pk=provider_id)
 
 
 @shared_task(base=RLSTask, name="scan-perform", queue="scans")

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -43,7 +43,9 @@ def check_provider_connection_task(provider_id: str):
     return check_provider_connection(provider_id=provider_id)
 
 
-@shared_task(base=RLSTask, name="provider-deletion", queue="deletion")
+@shared_task(
+    base=RLSTask, name="provider-deletion", queue="deletion", autoretry_for=(Exception,)
+)
 def delete_provider_task(provider_id: str, tenant_id: str):
     """
     Task to delete a specific Provider instance.
@@ -174,7 +176,7 @@ def perform_scan_summary_task(tenant_id: str, scan_id: str):
     return aggregate_findings(tenant_id=tenant_id, scan_id=scan_id)
 
 
-@shared_task(name="tenant-deletion", queue="deletion")
+@shared_task(name="tenant-deletion", queue="deletion", autoretry_for=(Exception,))
 def delete_tenant_task(tenant_id: str):
     return delete_tenant(pk=tenant_id)
 

--- a/api/src/backend/tasks/tests/test_deletion.py
+++ b/api/src/backend/tasks/tests/test_deletion.py
@@ -9,17 +9,19 @@ from api.models import Provider, Tenant
 class TestDeleteProvider:
     def test_delete_provider_success(self, providers_fixture):
         instance = providers_fixture[0]
-        result = delete_provider(instance.id)
+        tenant_id = str(instance.tenant_id)
+        result = delete_provider(tenant_id, instance.id)
 
         assert result
         with pytest.raises(ObjectDoesNotExist):
             Provider.objects.get(pk=instance.id)
 
-    def test_delete_provider_does_not_exist(self):
+    def test_delete_provider_does_not_exist(self, tenants_fixture):
+        tenant_id = str(tenants_fixture[0].id)
         non_existent_pk = "babf6796-cfcc-4fd3-9dcf-88d012247645"
 
         with pytest.raises(ObjectDoesNotExist):
-            delete_provider(non_existent_pk)
+            delete_provider(tenant_id, non_existent_pk)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Context

Deletion tasks, specially provider deletion tasks, were not working as expected and they would end up hanging or failing.

### Description

This PR includes 3 changes in the API tasks:
- Deletion tasks execute deletion actions under independent transactions to prevent database blocks.
- Provider daily scheduled scan configuration is deleted on `DELETE /providers/<id>` request instead of waiting for the deletion task (prevents undesired behaviors on task failures).
- Deletion tasks now have a retry mechanism.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
