### PR TITLE
fix(s3): handle None S3 account public access block

### DIFF
--- a/prowler/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks.py
+++ b/prowler/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks.py
@@ -6,27 +6,28 @@ from prowler.providers.aws.services.s3.s3control_client import s3control_client
 class s3_account_level_public_access_blocks(Check):
     def execute(self):
         findings = []
-        report = Check_Report_AWS(
-            metadata=self.metadata(),
-            resource=s3control_client.account_public_access_block,
-        )
-        if (
-            s3control_client.account_public_access_block
-            and s3control_client.account_public_access_block.ignore_public_acls
-            and s3control_client.account_public_access_block.restrict_public_buckets
-        ):
-            report.status = "PASS"
-            report.status_extended = f"Block Public Access is configured for the account {s3control_client.audited_account}."
-            report.region = s3control_client.region
-            report.resource_id = s3control_client.audited_account
-            report.resource_arn = s3_client.account_arn_template
-            findings.append(report)
-        elif s3_client.buckets or s3_client.provider.scan_unused_services:
-            report.status = "FAIL"
-            report.status_extended = f"Block Public Access is not configured for the account {s3control_client.audited_account}."
-            report.region = s3control_client.region
-            report.resource_id = s3control_client.audited_account
-            report.resource_arn = s3_client.account_arn_template
-            findings.append(report)
+        if s3control_client.account_public_access_block is not None:
+            report = Check_Report_AWS(
+                metadata=self.metadata(),
+                resource=s3control_client.account_public_access_block,
+            )
+            if (
+                s3control_client.account_public_access_block
+                and s3control_client.account_public_access_block.ignore_public_acls
+                and s3control_client.account_public_access_block.restrict_public_buckets
+            ):
+                report.status = "PASS"
+                report.status_extended = f"Block Public Access is configured for the account {s3control_client.audited_account}."
+                report.region = s3control_client.region
+                report.resource_id = s3control_client.audited_account
+                report.resource_arn = s3_client.account_arn_template
+                findings.append(report)
+            elif s3_client.buckets or s3_client.provider.scan_unused_services:
+                report.status = "FAIL"
+                report.status_extended = f"Block Public Access is not configured for the account {s3control_client.audited_account}."
+                report.region = s3control_client.region
+                report.resource_id = s3control_client.audited_account
+                report.resource_arn = s3_client.account_arn_template
+                findings.append(report)
 
         return findings

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -511,7 +511,7 @@ class S3Control(AWSService):
     def __init__(self, provider):
         # Call AWSService's __init__
         super().__init__(__class__.__name__, provider)
-        self.account_public_access_block = self._get_public_access_block()
+        self.account_public_access_block = None
         self.access_points = {}
         self.multi_region_access_points = {}
         self.__threading_call__(self._list_access_points)
@@ -525,7 +525,7 @@ class S3Control(AWSService):
             public_access_block = self.client.get_public_access_block(
                 AccountId=self.audited_account
             )["PublicAccessBlockConfiguration"]
-            return PublicAccessBlock(
+            self.account_public_access_block = PublicAccessBlock(
                 block_public_acls=public_access_block["BlockPublicAcls"],
                 ignore_public_acls=public_access_block["IgnorePublicAcls"],
                 block_public_policy=public_access_block["BlockPublicPolicy"],
@@ -534,7 +534,7 @@ class S3Control(AWSService):
         except Exception as error:
             if "NoSuchPublicAccessBlockConfiguration" in str(error):
                 # Set all block as False
-                return PublicAccessBlock(
+                self.account_public_access_block = PublicAccessBlock(
                     block_public_acls=False,
                     ignore_public_acls=False,
                     block_public_policy=False,

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -514,6 +514,7 @@ class S3Control(AWSService):
         self.account_public_access_block = None
         self.access_points = {}
         self.multi_region_access_points = {}
+        self._get_public_access_block()
         self.__threading_call__(self._list_access_points)
         self.__threading_call__(self._get_access_point, self.access_points.values())
         if self.audited_partition == "aws":

--- a/tests/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_test.py
+++ b/tests/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_test.py
@@ -156,3 +156,33 @@ class Test_s3_account_level_public_access_blocks:
             result = check.execute()
 
             assert len(result) == 0
+
+    def test_none_bucket_account_public_block(self):
+        from prowler.providers.aws.services.s3.s3_service import S3, S3Control
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.s3.s3_account_level_public_access_blocks.s3_account_level_public_access_blocks.s3_client",
+                new=S3(aws_provider),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.s3.s3_account_level_public_access_blocks.s3_account_level_public_access_blocks.s3control_client",
+                new=S3Control(aws_provider),
+            ) as s3control_client,
+        ):
+            # Test Check
+            from prowler.providers.aws.services.s3.s3_account_level_public_access_blocks.s3_account_level_public_access_blocks import (
+                s3_account_level_public_access_blocks,
+            )
+
+            s3control_client.account_public_access_block = None
+            check = s3_account_level_public_access_blocks()
+            result = check.execute()
+
+            assert len(result) == 0


### PR DESCRIPTION
### Description

Handle None S3 account public access block to fix the following error:

`Resource metadata <class 'NoneType'> in s3_account_level_public_access_blocks could not be converted to dict`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
