### PR TITLE
chore(sentry): ignore exception when aws service not available in a region

### DIFF
--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -54,6 +54,8 @@ IGNORED_EXCEPTIONS = [
     "AzureClientIdAndClientSecretNotBelongingToTenantIdError",
     "AzureHTTPResponseError",
     "Error with credentials provided",
+    # AWS Service is not available in a region
+    "EndpointConnectionError",
 ]
 
 


### PR DESCRIPTION
### Description

Ignore Sentry exception when a AWS service is not available in a region. 

We decided to ignore this error [here](https://github.com/prowler-cloud/prowler/pull/7338#issuecomment-2747832898).

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
