### PR TITLE
build(api): Force django-allauth==65.4.1

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -5428,4 +5428,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "5892eb6b702f29a7eebff3f9dc899ea8d78cac622aa8f299ef4c662df8f5b51d"
+content-hash = "0da43d42c9cdb0b990cfd184ba776e3ce2a5ee72fbd076e980d7111c772d6000"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "celery[pytest] (>=5.4.0,<6.0.0)",
   "dj-rest-auth[with_social,jwt] (==7.0.1)",
   "django==5.1.7",
+  "django-allauth==65.4.1",
   "django-celery-beat (>=2.7.0,<3.0.0)",
   "django-celery-results (>=2.5.1,<3.0.0)",
   "django-cors-headers==4.4.0",


### PR DESCRIPTION
### Context

Previous dependencies were installing a greater minor version for `django-allauth` that was causing warnings.

### Description

<details>

<summary>API build logs</summary>

```
api-dev-1   | Applying database migrations...
api-dev-1   | Operations to perform:
api-dev-1   |   Apply all migrations: account, admin, api, auth, authtoken, contenttypes, django_celery_beat, django_celery_results, sessions, socialaccount, token_blacklist
api-dev-1   | Running migrations:
api-dev-1   |   Applying django_celery_results.0001_initial... OK
api-dev-1   |   Applying django_celery_results.0002_add_task_name_args_kwargs... OK
api-dev-1   |   Applying django_celery_results.0003_auto_20181106_1101... OK
api-dev-1   |   Applying django_celery_results.0004_auto_20190516_0412... OK
api-dev-1   |   Applying django_celery_results.0005_taskresult_worker... OK
api-dev-1   |   Applying django_celery_results.0006_taskresult_date_created... OK
api-dev-1   |   Applying django_celery_results.0007_remove_taskresult_hidden... OK
api-dev-1   |   Applying django_celery_results.0008_chordcounter... OK
api-dev-1   |   Applying django_celery_results.0009_groupresult... OK
api-dev-1   |   Applying django_celery_results.0010_remove_duplicate_indices... OK
api-dev-1   |   Applying django_celery_results.0011_taskresult_periodic_task_name... OK
api-dev-1   |   Applying contenttypes.0001_initial... OK
api-dev-1   |   Applying contenttypes.0002_remove_content_type_name... OK
api-dev-1   |   Applying auth.0001_initial... OK
api-dev-1   |   Applying auth.0002_alter_permission_name_max_length... OK
api-dev-1   |   Applying auth.0003_alter_user_email_max_length... OK
api-dev-1   |   Applying auth.0004_alter_user_username_opts... OK
api-dev-1   |   Applying auth.0005_alter_user_last_login_null... OK
api-dev-1   |   Applying auth.0006_require_contenttypes_0002... OK
api-dev-1   |   Applying auth.0007_alter_validators_add_error_messages... OK
api-dev-1   |   Applying auth.0008_alter_user_username_max_length... OK
api-dev-1   |   Applying auth.0009_alter_user_last_name_max_length... OK
api-dev-1   |   Applying auth.0010_alter_group_name_max_length... OK
api-dev-1   |   Applying auth.0011_update_proxy_permissions... OK
api-dev-1   |   Applying auth.0012_alter_user_first_name_max_length... OK
api-dev-1   |   Applying api.0001_initial... OK
api-dev-1   |   Applying account.0001_initial... OK
api-dev-1   |   Applying account.0002_email_max_length... OK
api-dev-1   |   Applying account.0003_alter_emailaddress_create_unique_verified_email... OK
api-dev-1   |   Applying account.0004_alter_emailaddress_drop_unique_email... OK
api-dev-1   |   Applying account.0005_emailaddress_idx_upper_email... OK
api-dev-1   |   Applying account.0006_emailaddress_lower... OK
api-dev-1   |   Applying account.0007_emailaddress_idx_email... OK
api-dev-1   |   Applying account.0008_emailaddress_unique_primary_email_fixup... OK
api-dev-1   |   Applying account.0009_emailaddress_unique_primary_email... OK
api-dev-1   |   Applying admin.0001_initial... OK
api-dev-1   |   Applying admin.0002_logentry_remove_auto_add... OK
api-dev-1   |   Applying admin.0003_logentry_add_action_flag_choices... OK
api-dev-1   |   Applying django_celery_beat.0001_initial... OK
api-dev-1   |   Applying django_celery_beat.0002_auto_20161118_0346... OK
api-dev-1   |   Applying django_celery_beat.0003_auto_20161209_0049... OK
api-dev-1   |   Applying django_celery_beat.0004_auto_20170221_0000... OK
api-dev-1   |   Applying django_celery_beat.0005_add_solarschedule_events_choices... OK
api-dev-1   |   Applying django_celery_beat.0006_auto_20180322_0932... OK
api-dev-1   |   Applying django_celery_beat.0007_auto_20180521_0826... OK
api-dev-1   |   Applying django_celery_beat.0008_auto_20180914_1922... OK
api-dev-1   |   Applying django_celery_beat.0006_auto_20180210_1226... OK
api-dev-1   |   Applying django_celery_beat.0006_periodictask_priority... OK
api-dev-1   |   Applying django_celery_beat.0009_periodictask_headers... OK
api-dev-1   |   Applying django_celery_beat.0010_auto_20190429_0326... OK
api-dev-1   |   Applying django_celery_beat.0011_auto_20190508_0153... OK
api-dev-1   |   Applying django_celery_beat.0012_periodictask_expire_seconds... OK
api-dev-1   |   Applying django_celery_beat.0013_auto_20200609_0727... OK
api-dev-1   |   Applying django_celery_beat.0014_remove_clockedschedule_enabled... OK
api-dev-1   |   Applying django_celery_beat.0015_edit_solarschedule_events_choices... OK
api-dev-1   |   Applying django_celery_beat.0016_alter_crontabschedule_timezone... OK
api-dev-1   |   Applying django_celery_beat.0017_alter_crontabschedule_month_of_year... OK
api-dev-1   |   Applying django_celery_beat.0018_improve_crontab_helptext... OK
api-dev-1   |   Applying django_celery_beat.0019_alter_periodictasks_options... OK
api-dev-1   |   Applying token_blacklist.0001_initial... OK
api-dev-1   |   Applying token_blacklist.0002_outstandingtoken_jti_hex... OK
api-dev-1   |   Applying token_blacklist.0003_auto_20171017_2007... OK
api-dev-1   |   Applying token_blacklist.0004_auto_20171017_2013... OK
api-dev-1   |   Applying token_blacklist.0005_remove_outstandingtoken_jti... OK
api-dev-1   |   Applying token_blacklist.0006_auto_20171017_2113... OK
api-dev-1   |   Applying token_blacklist.0007_auto_20171017_2214... OK
api-dev-1   |   Applying token_blacklist.0008_migrate_to_bigautofield... OK
api-dev-1   |   Applying token_blacklist.0010_fix_migrate_to_bigautofield... OK
api-dev-1   |   Applying token_blacklist.0011_linearizes_history... OK
api-dev-1   |   Applying token_blacklist.0012_alter_outstandingtoken_user... OK
api-dev-1   |   Applying api.0002_token_migrations... OK
api-dev-1   |   Applying api.0003_update_provider_unique_constraint_with_is_deleted... OK
api-dev-1   |   Applying api.0004_rbac... OK
api-dev-1   |   Applying api.0005_rbac_missing_admin_roles... OK
api-dev-1   |   Applying api.0006_findings_first_seen... OK
api-dev-1   |   Applying api.0007_scan_and_scan_summaries_indexes... OK
api-dev-1   |   Applying api.0008_daily_scheduled_tasks_update... OK
api-dev-1   |   Applying api.0009_increase_provider_uid_maximum_length... OK
api-dev-1   |   Applying api.0010_findings_performance_indexes_partitions... OK
api-dev-1   |   Applying api.0011_findings_performance_indexes_parent... OK
api-dev-1   |   Applying api.0012_scan_report_output... OK
api-dev-1   |   Applying authtoken.0001_initial... OK
api-dev-1   |   Applying authtoken.0002_auto_20160226_1747... OK
api-dev-1   |   Applying authtoken.0003_tokenproxy... OK
api-dev-1   |   Applying authtoken.0004_alter_tokenproxy_options... OK
api-dev-1   |   Applying sessions.0001_initial... OK
api-dev-1   |   Applying socialaccount.0001_initial... OK
api-dev-1   |   Applying socialaccount.0002_token_max_lengths... OK
api-dev-1   |   Applying socialaccount.0003_extra_data_default_dict... OK
api-dev-1   |   Applying socialaccount.0004_app_provider_id_settings... OK
api-dev-1   |   Applying socialaccount.0005_socialtoken_nullable_app... OK
api-dev-1   |   Applying socialaccount.0006_alter_socialaccount_extra_data... OK
api-dev-1   | Applying Django fixtures...
api-dev-1   | Loading api/fixtures/dev/0_dev_users.json
api-dev-1   | Installed 2 object(s) from 1 fixture(s)
api-dev-1   | Loading api/fixtures/dev/1_dev_tenants.json
api-dev-1   | Installed 5 object(s) from 1 fixture(s)
api-dev-1   | Loading api/fixtures/dev/2_dev_providers.json
api-dev-1   | Installed 13 object(s) from 1 fixture(s)
api-dev-1   | Loading api/fixtures/dev/3_dev_scans.json
api-dev-1   | Installed 12 object(s) from 1 fixture(s)
api-dev-1   | Loading api/fixtures/dev/4_dev_resources.json
api-dev-1   | Installed 20 object(s) from 1 fixture(s)
api-dev-1   | Loading api/fixtures/dev/5_dev_findings.json
api-dev-1   | Installed 78 object(s) from 1 fixture(s)
api-dev-1   | Loading api/fixtures/dev/6_dev_rbac.json
api-dev-1   | Installed 13 object(s) from 1 fixture(s)
api-dev-1   | Loading api/fixtures/dev/7_dev_compliance.json
api-dev-1   | Installed 30 object(s) from 1 fixture(s)
api-dev-1   | Managing DB partitions...
api-dev-1   | Finding:
api-dev-1   |   + 2025_mar
api-dev-1   |      name: 2025_mar
api-dev-1   |      from_values: 01954f00-b000-7356-891a-b0c5dbfd1377
api-dev-1   |      to_values: 0195eea5-d3ff-7da5-b0b3-b99e659b5b1e
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_apr
api-dev-1   |      name: 2025_apr
api-dev-1   |      from_values: 0195eea5-d400-7a7b-98d3-5a752bb30a51
api-dev-1   |      to_values: 01968924-9bff-7749-aa03-aa92fc1ecf8f
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_may
api-dev-1   |      name: 2025_may
api-dev-1   |      from_values: 01968924-9c00-791f-be62-1c158eae7f7b
api-dev-1   |      to_values: 019728c9-bfff-78ec-bdc0-5276e59163cf
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_jun
api-dev-1   |      name: 2025_jun
api-dev-1   |      from_values: 019728c9-c000-7924-aa73-624ba87545c8
api-dev-1   |      to_values: 0197c348-87ff-7b85-b220-4895d9901d9c
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_jul
api-dev-1   |      name: 2025_jul
api-dev-1   |      from_values: 0197c348-8800-7b84-b6f0-e4800f02d5fc
api-dev-1   |      to_values: 019862ed-abff-7c26-af3e-931ef28cfb8c
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_aug
api-dev-1   |      name: 2025_aug
api-dev-1   |      from_values: 019862ed-ac00-7ae1-b18b-ed06f71864c7
api-dev-1   |      to_values: 01990292-cfff-7ef1-901f-c061bd674563
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_sep
api-dev-1   |      name: 2025_sep
api-dev-1   |      from_values: 01990292-d000-73b3-ab7f-d667c0f9305a
api-dev-1   |      to_values: 01999d11-97ff-7276-b0d3-359f2f3d5e65
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   | 
api-dev-1   | ResourceFindingMapping:
api-dev-1   |   + 2025_mar
api-dev-1   |      name: 2025_mar
api-dev-1   |      from_values: 01954f00-b000-7186-8499-976de8e49667
api-dev-1   |      to_values: 0195eea5-d3ff-7e02-b5f9-df201a2f5d36
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_apr
api-dev-1   |      name: 2025_apr
api-dev-1   |      from_values: 0195eea5-d400-7dc8-b97c-7eb98dc7924f
api-dev-1   |      to_values: 01968924-9bff-7310-a04e-575c419321cb
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_may
api-dev-1   |      name: 2025_may
api-dev-1   |      from_values: 01968924-9c00-74c1-8da4-48ace44cf7ee
api-dev-1   |      to_values: 019728c9-bfff-71fb-85ed-0b78a3f0589f
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_jun
api-dev-1   |      name: 2025_jun
api-dev-1   |      from_values: 019728c9-c000-7909-8e03-0aded3ee30b1
api-dev-1   |      to_values: 0197c348-87ff-7bc7-a02c-5b053a643c04
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_jul
api-dev-1   |      name: 2025_jul
api-dev-1   |      from_values: 0197c348-8800-74c1-b08e-512bae964b5e
api-dev-1   |      to_values: 019862ed-abff-7d3a-ba4e-f150665780a1
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_aug
api-dev-1   |      name: 2025_aug
api-dev-1   |      from_values: 019862ed-ac00-7da0-818a-d55c54d60c06
api-dev-1   |      to_values: 01990292-cfff-7797-a478-406f7cd2014b
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   |   + 2025_sep
api-dev-1   |      name: 2025_sep
api-dev-1   |      from_values: 01990292-d000-7a82-9832-57fe42d36b11
api-dev-1   |      to_values: 01999d11-97ff-7eae-84e5-8299a8f7c7ec
api-dev-1   |      size_unit: months
api-dev-1   |      size_value: 1
api-dev-1   | 
api-dev-1   | 0 partitions will be deleted
api-dev-1   | 14 partitions will be created
api-dev-1   | Operations applied.
api-dev-1   | Starting the development server...
postgres-1  | 2025-03-24 16:17:55.260 UTC [56] LOG:  checkpoint starting: time
api-dev-1   | Performing system checks...
api-dev-1   | 
api-dev-1   | System check identified no issues (0 silenced).
api-dev-1   | March 24, 2025 - 16:14:19
api-dev-1   | Django version 5.1.5, using settings 'config.django.devel'
api-dev-1   | Starting development server at http://0.0.0.0:8080/
api-dev-1   | Quit the server with CONTROL-C.
api-dev-1   | 
postgres-1  | 2025-03-24 16:19:27.562 UTC [56] LOG:  checkpoint complete: wrote 890 buffers (5.4%); 1 WAL file(s) added, 0 removed, 0 recycled; write=92.218 s, sync=0.050 s, total=92.302 s; sync files=588, longest=0.003 s, average=0.001 s; distance=5694 kB, estimate=5694 kB; lsn=0/1EAA4C8, redo lsn=0/1EAA490
```

</details>

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
