### PR TITLE
fix(vm): handle `Nonetype is not iterable` for extensions

### DIFF
--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -62,15 +62,9 @@ class VirtualMachines(AzureService):
                                 storage_profile=(
                                     StorageProfile(
                                         os_disk=OSDisk(
-                                            name=(
-                                                getattr(os_disk, "name", None)
-                                                if os_disk
-                                                else None
-                                            ),
-                                            managed_disk=(
-                                                getattr(os_disk, "managed_disk", None)
-                                                if os_disk
-                                                else None
+                                            name=getattr(os_disk, "name", None),
+                                            managed_disk=getattr(
+                                                os_disk, "managed_disk", None
                                             ),
                                         ),
                                         data_disks=data_disks,

--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -32,10 +32,7 @@ class VirtualMachines(AzureService):
                     )
 
                     data_disks = []
-                    if (
-                        storage_profile
-                        and getattr(storage_profile, "data_disks", [])
-                    ):
+                    if storage_profile and getattr(storage_profile, "data_disks", []):
                         data_disks = [
                             DataDisk(
                                 lun=data_disk.lun,
@@ -69,7 +66,8 @@ class VirtualMachines(AzureService):
                                         ),
                                         data_disks=data_disks,
                                     )
-                                    if getattr(vm, "storage_profile", None)
+                                    if storage_profile
+                                    else None
                                 ),
                                 location=vm.location,
                                 security_profile=getattr(vm, "security_profile", None),

--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -34,7 +34,7 @@ class VirtualMachines(AzureService):
                     data_disks = []
                     if (
                         storage_profile
-                        and getattr(storage_profile, "data_disks", []) is not None
+                        and getattr(storage_profile, "data_disks", [])
                     ):
                         data_disks = [
                             DataDisk(
@@ -43,15 +43,15 @@ class VirtualMachines(AzureService):
                                 managed_disk=data_disk.managed_disk,
                             )
                             for data_disk in getattr(storage_profile, "data_disks", [])
-                            if data_disk is not None
+                            if data_disk
                         ]
 
                     extensions = []
-                    if getattr(vm, "resources", []) is not None:
+                    if getattr(vm, "resources", []):
                         extensions = [
                             VirtualMachineExtension(id=extension.id)
                             for extension in getattr(vm, "resources", [])
-                            if extension is not None
+                            if extension
                         ]
 
                     virtual_machines[subscription_name].update(
@@ -69,8 +69,7 @@ class VirtualMachines(AzureService):
                                         ),
                                         data_disks=data_disks,
                                     )
-                                    if storage_profile
-                                    else None
+                                    if getattr(vm, "storage_profile", None)
                                 ),
                                 location=vm.location,
                                 security_profile=getattr(vm, "security_profile", None),

--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -24,6 +24,36 @@ class VirtualMachines(AzureService):
                 virtual_machines.update({subscription_name: {}})
 
                 for vm in virtual_machines_list:
+                    storage_profile = getattr(vm, "storage_profile", None)
+                    os_disk = (
+                        getattr(storage_profile, "os_disk", None)
+                        if storage_profile
+                        else None
+                    )
+
+                    data_disks = []
+                    if (
+                        storage_profile
+                        and getattr(storage_profile, "data_disks", []) is not None
+                    ):
+                        data_disks = [
+                            DataDisk(
+                                lun=data_disk.lun,
+                                name=data_disk.name,
+                                managed_disk=data_disk.managed_disk,
+                            )
+                            for data_disk in getattr(storage_profile, "data_disks", [])
+                            if data_disk is not None
+                        ]
+
+                    extensions = []
+                    if getattr(vm, "resources", []) is not None:
+                        extensions = [
+                            VirtualMachineExtension(id=extension.id)
+                            for extension in getattr(vm, "resources", [])
+                            if extension is not None
+                        ]
+
                     virtual_machines[subscription_name].update(
                         {
                             vm.id: VirtualMachine(
@@ -32,29 +62,25 @@ class VirtualMachines(AzureService):
                                 storage_profile=(
                                     StorageProfile(
                                         os_disk=OSDisk(
-                                            name=vm.storage_profile.os_disk.name,
-                                            managed_disk=vm.storage_profile.os_disk.managed_disk,
+                                            name=(
+                                                getattr(os_disk, "name", None)
+                                                if os_disk
+                                                else None
+                                            ),
+                                            managed_disk=(
+                                                getattr(os_disk, "managed_disk", None)
+                                                if os_disk
+                                                else None
+                                            ),
                                         ),
-                                        data_disks=[
-                                            DataDisk(
-                                                lun=data_disk.lun,
-                                                name=data_disk.name,
-                                                managed_disk=data_disk.managed_disk,
-                                            )
-                                            for data_disk in getattr(
-                                                vm.storage_profile, "data_disks", []
-                                            )
-                                        ],
+                                        data_disks=data_disks,
                                     )
-                                    if getattr(vm, "storage_profile", None)
+                                    if storage_profile
                                     else None
                                 ),
                                 location=vm.location,
                                 security_profile=vm.security_profile,
-                                extensions=[
-                                    VirtualMachineExtension(id=extension.id)
-                                    for extension in getattr(vm, "resources", [])
-                                ],
+                                extensions=extensions,
                             )
                         }
                     )
@@ -110,13 +136,13 @@ class UefiSettings:
 @dataclass
 class SecurityProfile:
     security_type: str
-    uefi_settings: UefiSettings
+    uefi_settings: Optional[UefiSettings]
 
 
 @dataclass
 class OSDisk:
-    name: str
-    managed_disk: bool
+    name: Optional[str]
+    managed_disk: Optional[bool]
 
 
 @dataclass
@@ -128,7 +154,7 @@ class DataDisk:
 
 @dataclass
 class StorageProfile:
-    os_disk: OSDisk
+    os_disk: Optional[OSDisk]
     data_disks: List[DataDisk]
 
 
@@ -142,7 +168,7 @@ class VirtualMachine:
     resource_id: str
     resource_name: str
     location: str
-    security_profile: SecurityProfile
+    security_profile: Optional[SecurityProfile]
     extensions: list[VirtualMachineExtension]
     storage_profile: Optional[StorageProfile] = None
 

--- a/tests/providers/azure/services/vm/vm_service_test.py
+++ b/tests/providers/azure/services/vm/vm_service_test.py
@@ -41,6 +41,32 @@ def mock_vm_get_virtual_machines(_):
     }
 
 
+def mock_vm_get_virtual_machines_with_none(_):
+    return {
+        AZURE_SUBSCRIPTION_ID: {
+            "vm_id-1": VirtualMachine(
+                resource_id="/subscriptions/resource_id",
+                resource_name="VMWithNoneValues",
+                location="location",
+                security_profile=None,
+                extensions=None,
+                storage_profile=None,
+            ),
+            "vm_id-2": VirtualMachine(
+                resource_id="/subscriptions/resource_id2",
+                resource_name="VMWithPartialNone",
+                location="location",
+                security_profile=None,
+                extensions=None,
+                storage_profile=StorageProfile(
+                    os_disk=None,
+                    data_disks=None,
+                ),
+            ),
+        }
+    }
+
+
 def mock_vm_get_disks(_):
     return {
         AZURE_SUBSCRIPTION_ID: {
@@ -137,3 +163,22 @@ class Test_VirtualMachines_Service:
             disks[AZURE_SUBSCRIPTION_ID]["disk_id-1"].encryption_type
             == "EncryptionAtRestWithPlatformKey"
         )
+
+
+@patch(
+    "prowler.providers.azure.services.vm.vm_service.VirtualMachines._get_virtual_machines",
+    new=mock_vm_get_virtual_machines_with_none,
+)
+class Test_VirtualMachines_NoneCases:
+    def test_virtual_machine_with_none_storage_profile(self):
+        virtual_machines = VirtualMachines(set_mocked_azure_provider())
+        vm_1 = virtual_machines.virtual_machines[AZURE_SUBSCRIPTION_ID]["vm_id-1"]
+        assert vm_1.storage_profile is None
+        assert vm_1.resource_name == "VMWithNoneValues"
+
+    def test_virtual_machine_with_partial_none_storage_profile(self):
+        virtual_machines = VirtualMachines(set_mocked_azure_provider())
+        vm_2 = virtual_machines.virtual_machines[AZURE_SUBSCRIPTION_ID]["vm_id-2"]
+        assert vm_2.storage_profile.os_disk is None
+        assert vm_2.storage_profile.data_disks is None
+        assert vm_2.resource_name == "VMWithPartialNone"


### PR DESCRIPTION
### Context

This PR introduces changes in VM service for Azure. Some checks are being affected by a failure in this service because it's trying to iterate over a Nonetype object. This is caused by the line `for extension in getattr(vm, "resources", [])` where the getattr is not working because even if there is no resources, the parameter exists but is set to “None”.

Also, I've done a similar approach with data_disks because it was done in a similar way and could get the same error.

### Description

Modified VM service and added tests for None cases.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
