### PR TITLE
fix(iam): handle `UnboundLocalError` cannot access local variable 'report'

### DIFF
--- a/prowler/providers/azure/services/iam/iam_custom_role_has_permissions_to_administer_resource_locks/iam_custom_role_has_permissions_to_administer_resource_locks.py
+++ b/prowler/providers/azure/services/iam/iam_custom_role_has_permissions_to_administer_resource_locks/iam_custom_role_has_permissions_to_administer_resource_locks.py
@@ -29,5 +29,5 @@ class iam_custom_role_has_permissions_to_administer_resource_locks(Check):
                             report.status_extended = f"Role {custom_role.name} from subscription {subscription} has permission to administer resource locks."
                             exits_role_with_permission_over_locks = True
                             break
-            findings.append(report)
+                findings.append(report)
         return findings

--- a/tests/providers/azure/services/iam/iam_custom_role_has_permissions_to_administer_resource_locks/iam_custom_role_has_permissions_to_administer_resource_locks_test.py
+++ b/tests/providers/azure/services/iam/iam_custom_role_has_permissions_to_administer_resource_locks/iam_custom_role_has_permissions_to_administer_resource_locks_test.py
@@ -198,3 +198,25 @@ class Test_iam_custom_role_has_permissions_to_administer_resource_locks:
                 result[0].resource_id
                 == defender_client.custom_roles[AZURE_SUBSCRIPTION_ID][0].id
             )
+
+    def test_iam_custom_roles_empty_list_but_with_key(self):
+        defender_client = mock.MagicMock
+        defender_client.custom_roles = {AZURE_SUBSCRIPTION_ID: []}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.iam.iam_custom_role_has_permissions_to_administer_resource_locks.iam_custom_role_has_permissions_to_administer_resource_locks.iam_client",
+                new=defender_client,
+            ),
+        ):
+            from prowler.providers.azure.services.iam.iam_custom_role_has_permissions_to_administer_resource_locks.iam_custom_role_has_permissions_to_administer_resource_locks import (
+                iam_custom_role_has_permissions_to_administer_resource_locks,
+            )
+
+            check = iam_custom_role_has_permissions_to_administer_resource_locks()
+            result = check.execute()
+            assert len(result) == 0


### PR DESCRIPTION
### Context

This PR introduces changes in the check iam_custom_role_has_permissions_to_administer_resource_locks from IAM service in Azure. There we’re adding to the findings the variable report between the two loops, so if there is no roles there is no problem but as it's a dict if there's no roles but the key of the dict exists the report is not initialized and we’re trying to add to the findings nothing so it causes the error.

### Description

Modified the check and added a test case.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
