### PR TITLE
chore(scans): properly enable link to findings when scan is completed

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -13,12 +13,12 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Accepted invitations can no longer be edited. [(#7198)](https://github.com/prowler-cloud/prowler/pull/7198)
 - Added download column in scans table to download reports for completed scans. [(#7353)](https://github.com/prowler-cloud/prowler/pull/7353)
 
-
 #### 🔄 Changed
 
 - Tweak styles for compliance cards. [(#7148)](https://github.com/prowler-cloud/prowler/pull/7148).
 - Upgrade Next.js to v14.2.25 to fix a middleware authorization vulnerability. [(#7339)](https://github.com/prowler-cloud/prowler/pull/7339)
 - Apply default filter to show only failed items when coming from scan table. [(#7356)](https://github.com/prowler-cloud/prowler/pull/7356)
+- Fix link behavior in scan cards: only disable "View Findings" when scan is not completed or executing. [(#7368)](https://github.com/prowler-cloud/prowler/pull/7368)
 
 ---
 

--- a/ui/components/scans/link-to-findings-from-scan.tsx
+++ b/ui/components/scans/link-to-findings-from-scan.tsx
@@ -4,16 +4,22 @@ import { CustomButton } from "@/components/ui/custom";
 
 interface LinkToFindingsProps {
   scanId?: string;
+  isDisabled?: boolean;
 }
 
-export const LinkToFindingsFromScan = ({ scanId }: LinkToFindingsProps) => {
+export const LinkToFindingsFromScan = ({
+  scanId,
+  isDisabled,
+}: LinkToFindingsProps) => {
   return (
     <CustomButton
       asLink={`/findings?filter[scan__in]=${scanId}&filter[status__in]=FAIL`}
       ariaLabel="Go to Findings page"
-      variant="solid"
-      color="action"
+      variant="ghost"
+      className="text-xs font-medium text-default-500 hover:text-primary disabled:opacity-30"
+      // color="action"
       size="sm"
+      isDisabled={isDisabled}
     >
       See Findings
     </CustomButton>

--- a/ui/components/scans/table/scans/column-get-scans.tsx
+++ b/ui/components/scans/table/scans/column-get-scans.tsx
@@ -107,7 +107,13 @@ export const ColumnGetScans: ColumnDef<ScanProps>[] = [
     header: "Findings",
     cell: ({ row }) => {
       const { id } = getScanData(row);
-      return <LinkToFindingsFromScan scanId={id} />;
+      const scanState = row.original.attributes?.state;
+      return (
+        <LinkToFindingsFromScan
+          scanId={id}
+          isDisabled={!["completed", "executing"].includes(scanState)}
+        />
+      );
     },
   },
   {


### PR DESCRIPTION


### Description

- Fix link to findings: only disable when scan is neither completed nor executing


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
