### PR TITLE
fix(storagegateway): describe smb/nfs share per region

### DIFF
--- a/prowler/providers/aws/services/storagegateway/storagegateway_service.py
+++ b/prowler/providers/aws/services/storagegateway/storagegateway_service.py
@@ -51,7 +51,10 @@ class StorageGateway(AWSService):
         logger.info("StorageGateway - Describe NFS FileShares...")
         try:
             for fileshare in self.fileshares:
-                if fileshare.fs_type == "NFS":
+                if (
+                    fileshare.region == regional_client.region
+                    and fileshare.fs_type == "NFS"
+                ):
                     response = regional_client.describe_nfs_file_shares(
                         FileShareARNList=[fileshare.arn]
                     )
@@ -70,7 +73,10 @@ class StorageGateway(AWSService):
         logger.info("StorageGateway - Describe SMB FileShares...")
         try:
             for fileshare in self.fileshares:
-                if fileshare.fs_type == "SMB":
+                if (
+                    fileshare.region == regional_client.region
+                    and fileshare.fs_type == "SMB"
+                ):
                     response = regional_client.describe_smb_file_shares(
                         FileShareARNList=[fileshare.arn]
                     )


### PR DESCRIPTION
### Description
This solves the issue of trying to access all fileshares in each region, using each regional client to access the fileshares of its own region.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
