### PR TITLE
fix(fms): resource metadata could not be converted to dict

### DIFF
--- a/prowler/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant.py
+++ b/prowler/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant.py
@@ -6,9 +6,7 @@ class fms_policy_compliant(Check):
     def execute(self):
         findings = []
         if fms_client.fms_admin_account:
-            report = Check_Report_AWS(
-                metadata=self.metadata(), resource=fms_client.fms_policies
-            )
+            report = Check_Report_AWS(metadata=self.metadata(), resource={})
             report.region = fms_client.region
             report.resource_arn = fms_client.policy_arn_template
             report.resource_id = fms_client.audited_account

--- a/tests/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant_test.py
+++ b/tests/providers/aws/services/fms/fms_policy_compliant/fms_policy_compliant_test.py
@@ -97,6 +97,7 @@ class Test_fms_policy_compliant:
                 == f"arn:aws:fms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:policy"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource == fms_client.fms_policies[0]
 
     def test_fms_admin_with_compliant_policies(self):
         fms_client = mock.MagicMock
@@ -150,6 +151,7 @@ class Test_fms_policy_compliant:
                 == f"arn:aws:fms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:policy"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource == {}
 
     def test_fms_admin_with_non_and_compliant_policies(self):
         fms_client = mock.MagicMock
@@ -209,6 +211,7 @@ class Test_fms_policy_compliant:
                 == f"arn:aws:fms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:policy"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource == fms_client.fms_policies[0]
 
     def test_fms_admin_without_policies(self):
         fms_client = mock.MagicMock
@@ -246,6 +249,7 @@ class Test_fms_policy_compliant:
                 == f"arn:aws:fms:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:policy"
             )
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource == {}
 
     def test_fms_admin_with_policy_with_null_status(self):
         fms_client = mock.MagicMock
@@ -297,3 +301,4 @@ class Test_fms_policy_compliant:
             assert result[0].resource_id == "12345678901"
             assert result[0].resource_arn == "arn:aws:fms:us-east-1:12345678901"
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource == fms_client.fms_policies[0]


### PR DESCRIPTION
### Context

This PR introduces a fix for the check `fms_policy_compliant`. There’s an issue because we're assigning a list to the resource field of the resource metadata, that list cannot be converted to a dict so it's breaking the execution of the check.

### Description

Modified the line causing the problem and added tests for the resource.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
