### PR TITLE
fix(redshift): validation error for `Cluster.multi_az`

### DIFF
--- a/prowler/providers/aws/services/redshift/redshift_cluster_multi_az_enabled/redshift_cluster_multi_az_enabled.py
+++ b/prowler/providers/aws/services/redshift/redshift_cluster_multi_az_enabled/redshift_cluster_multi_az_enabled.py
@@ -11,7 +11,7 @@ class redshift_cluster_multi_az_enabled(Check):
             report.status_extended = (
                 f"Redshift Cluster {cluster.id} does not have Multi-AZ enabled."
             )
-            if cluster.multi_az:
+            if cluster.multi_az == "Enabled":
                 report.status = "PASS"
                 report.status_extended = (
                     f"Redshift Cluster {cluster.id} has Multi-AZ enabled."

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -45,8 +45,7 @@ class Redshift(AWSService):
                                 "AllowVersionUpgrade", False
                             ),
                             encrypted=cluster.get("Encrypted", False),
-                            multi_az=str(cluster.get("MultiAZ", False)).lower()
-                            == "true",
+                            multi_az=cluster.get("MultiAZ", ""),
                             region=regional_client.region,
                             tags=cluster.get("Tags"),
                             master_username=cluster.get("MasterUsername", ""),
@@ -146,7 +145,7 @@ class Cluster(BaseModel):
     vpc_security_groups: list = []
     public_access: bool = False
     encrypted: bool = False
-    multi_az: bool = False
+    multi_az: str = None
     master_username: str = None
     database_name: str = None
     endpoint_address: str = None

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -45,7 +45,8 @@ class Redshift(AWSService):
                                 "AllowVersionUpgrade", False
                             ),
                             encrypted=cluster.get("Encrypted", False),
-                            multi_az=cluster.get("MultiAZ", False),
+                            multi_az=str(cluster.get("MultiAZ", False)).lower()
+                            == "true",
                             region=regional_client.region,
                             tags=cluster.get("Tags"),
                             master_username=cluster.get("MasterUsername", ""),

--- a/tests/providers/aws/services/redshift/redshift_cluster_multi_az_enabled/redshift_cluster_multi_az_enabled_test.py
+++ b/tests/providers/aws/services/redshift/redshift_cluster_multi_az_enabled/redshift_cluster_multi_az_enabled_test.py
@@ -149,7 +149,7 @@ class Test_redshift_cluster_multi_az_enabled:
                     )
 
                     # Moto does not pass the multi_az parameter back.
-                    service_client.clusters[0].multi_az = 1
+                    service_client.clusters[0].multi_az = "Enabled"
                     check = redshift_cluster_multi_az_enabled()
                     result = check.execute()
 

--- a/tests/providers/aws/services/redshift/redshift_service_test.py
+++ b/tests/providers/aws/services/redshift/redshift_service_test.py
@@ -140,7 +140,8 @@ class Test_Redshift_Service:
         ]
         assert redshift.clusters[0].parameter_group_name == "default.redshift-1.0"
         assert redshift.clusters[0].encrypted
-        assert redshift.clusters[0].multi_az is False
+        # Moto does not pass the multi_az parameter back.
+        assert redshift.clusters[0].multi_az == ""
         assert redshift.clusters[0].master_username == "user"
         assert redshift.clusters[0].enhanced_vpc_routing
         assert redshift.clusters[0].database_name == "test"


### PR DESCRIPTION
### Context

This PR introduces a fix for Redshift service in AWS. We’re having a validation error:
```
us-east-1 -- ValidationError[31]: 1 validation error for Cluster
multi_az - value could not be parsed to a boolean (type=type_error.bool)
```
This comes from the api call describe cluster of Redshift service, in boto3 documentation we can see:

`MultiAZ (string) – A boolean value that, if true, indicates that the cluster is deployed in two Availability Zones.`

So, the sdk is returning a string and we assume on our code that it’s a boolean value,  I've changed it so now it'll work in both cases, for String and for Boolean. Can't added test for the string case because moto create the parameter MultiAZ as a boolean.

### Description

Modified multi_az parameter.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
