### PR TITLE
fix(rds): handle Certificate `rds-ca-2019` not found

### DIFF
--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -170,16 +170,9 @@ class RDS(AWSService):
                                         )
                                     )
                         except ClientError as error:
-                            # If the certificate is not found and it's deprecated we show a warning and continue the execution
-                            deprecated_certs = ["rds-ca-2015", "rds-ca-2019"]
-                            if error.response["Error"][
-                                "Code"
-                            ] == "CertificateNotFound" and any(
-                                cert in error.response["Error"]["Message"]
-                                for cert in deprecated_certs
-                            ):
+                            if error.response["Error"]["Code"] == "CertificateNotFound":
                                 logger.warning(
-                                    f"{regional_client.region} -- Instance {instance.id} is using a deprecated certificate ({instance.ca_cert}) which is no longer available."
+                                    f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                             else:
                                 logger.error(


### PR DESCRIPTION
### Context

We’re having an issue when calling the DescribeCertificates operation: `Certificate rds-ca-2019 not found`

The problem here is that `rds-ca-2019` is deprecated so it’s obvious that it cannot be found, the problem is that if as user you are still using a deprecated certificated on your RDS instance without changing the error will continue here:

[Amazon Docs where appears that CA as deprecated](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html) 

So, my solution has been adding a try-except to that DescribeCertificates call and put a warning in case the certificate CA is rds-ca-2019 (deprecated in 2024) or rds-ca-2015 (deprecated in 2020)

### Description

Modified RDS service and added tests for the exception

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
