### PR TITLE
fix(stepfunctions): `Nonetype` object has no attribute `level`

### DIFF
--- a/prowler/providers/aws/services/stepfunctions/stepfunctions_statemachine_logging_enabled/stepfunctions_statemachine_logging_enabled.py
+++ b/prowler/providers/aws/services/stepfunctions/stepfunctions_statemachine_logging_enabled/stepfunctions_statemachine_logging_enabled.py
@@ -33,7 +33,10 @@ class stepfunctions_statemachine_logging_enabled(Check):
             report.status = "PASS"
             report.status_extended = f"Step Functions state machine {state_machine.name} has logging enabled."
 
-            if state_machine.logging_configuration.level == LoggingLevel.OFF:
+            if (
+                not state_machine.logging_configuration
+                or state_machine.logging_configuration.level == LoggingLevel.OFF
+            ):
                 report.status = "FAIL"
                 report.status_extended = f"Step Functions state machine {state_machine.name} does not have logging enabled."
             findings.append(report)

--- a/tests/providers/aws/services/stepfunctions/stepfunctions_statemachine_logging_enabled/stepfunctions_statemachine_logging_enabled_test.py
+++ b/tests/providers/aws/services/stepfunctions/stepfunctions_statemachine_logging_enabled/stepfunctions_statemachine_logging_enabled_test.py
@@ -74,6 +74,15 @@ def create_state_machine(name, logging_configuration):
             },
             1,
         ),  # Logging enabled
+        (
+            {
+                STATE_MACHINE_ARN: create_state_machine(
+                    "TestStateMachine",
+                    None,
+                )
+            },
+            1,
+        ),  # Logging configuration is None
     ],
 )
 @mock_aws(config={"stepfunctions": {"execute_state_machine": True}})
@@ -104,10 +113,9 @@ def test_stepfunctions_statemachine_logging(state_machines, expected_status):
 
         # Additional assertions for specific scenarios
         if expected_status == 1:
-            if (
-                state_machines[STATE_MACHINE_ARN].logging_configuration.level
-                == LoggingLevel.OFF
-            ):
+            logging_conf = state_machines[STATE_MACHINE_ARN].logging_configuration
+
+            if logging_conf is None or logging_conf.level == LoggingLevel.OFF:
                 assert result[0].status == "FAIL"
                 assert (
                     result[0].status_extended
@@ -123,3 +131,4 @@ def test_stepfunctions_statemachine_logging(state_machines, expected_status):
             assert result[0].resource_id == STATE_MACHINE_ID
             assert result[0].resource_arn == STATE_MACHINE_ARN
             assert result[0].region == AWS_REGION_EU_WEST_1
+            assert result[0].resource == state_machines[STATE_MACHINE_ARN]


### PR DESCRIPTION
### Context

This PR introduces a fix on the check `stepfunctions_statemachine_logging_enabled` from Stepfunctions service in AWS where we're having the error `NoneType` object has no attribute `level`

This appear because StateMachine Logging Configuration is set by default to None, so if the state machine doesn’t have logging configuration in the check we’re trying to access to the variable level of a None object so it runs an error.

My solution has been to add another if among the `if state_machine.logging_configuration.level == LoggingLevel.OFF` to verify that the state machine logging configuration is not None.

### Description

Modified the check `stepfunctions_statemachine_logging_enabled` and added a test for that case.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
