### PR TITLE
fix(resources): add the correct id and names for resources

### DIFF
--- a/prowler/providers/azure/services/defender/defender_container_images_scan_enabled/defender_container_images_scan_enabled.py
+++ b/prowler/providers/azure/services/defender/defender_container_images_scan_enabled/defender_container_images_scan_enabled.py
@@ -11,7 +11,6 @@ class defender_container_images_scan_enabled(Check):
                     metadata=self.metadata(), resource=pricings["Containers"]
                 )
                 report.subscription = subscription
-                report.resource_name = "Dender plan for Containers"
                 report.status = "PASS"
                 report.status_extended = (
                     f"Container image scan is enabled in subscription {subscription}."

--- a/prowler/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on.py
@@ -11,7 +11,6 @@ class defender_ensure_defender_for_azure_sql_databases_is_on(Check):
                     metadata=self.metadata(), resource=pricings["SqlServers"]
                 )
                 report.subscription = subscription
-                report.resource_name = "Defender plan Azure SQL DB Servers"
                 report.status = "PASS"
                 report.status_extended = f"Defender plan Defender for Azure SQL DB Servers from subscription {subscription} is set to ON (pricing tier standard)."
                 if pricings["SqlServers"].pricing_tier != "Standard":

--- a/prowler/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on.py
@@ -11,7 +11,6 @@ class defender_ensure_defender_for_containers_is_on(Check):
                     metadata=self.metadata(), resource=pricings["Containers"]
                 )
                 report.subscription = subscription
-                report.resource_name = "Defender plan Container Registries"
                 report.status = "PASS"
                 report.status_extended = f"Defender plan Defender for Containers from subscription {subscription} is set to ON (pricing tier standard)."
                 if pricings["Containers"].pricing_tier != "Standard":

--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -39,6 +39,7 @@ class Defender(AzureService):
                         {
                             pricing.name: Pricing(
                                 resource_id=pricing.id,
+                                resource_name=pricing.name,
                                 pricing_tier=getattr(pricing, "pricing_tier", None),
                                 free_trial_remaining_time=pricing.free_trial_remaining_time,
                                 extensions=dict(
@@ -224,6 +225,7 @@ class Defender(AzureService):
 
 class Pricing(BaseModel):
     resource_id: str
+    resource_name: str
     pricing_tier: str
     free_trial_remaining_time: timedelta
     extensions: Dict[str, bool] = {}

--- a/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
@@ -9,6 +9,7 @@ class compute_project_os_login_enabled(Check):
             report = Check_Report_GCP(
                 metadata=self.metadata(),
                 resource=project,
+                resource_name=project.id,
                 project_id=project.id,
                 location=compute_client.region,
             )

--- a/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
+++ b/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
@@ -11,6 +11,7 @@ class iam_audit_logs_enabled(Check):
             report = Check_Report_GCP(
                 metadata=self.metadata(),
                 resource=project,
+                resource_name=project.id,
                 project_id=project.id,
                 location=cloudresourcemanager_client.region,
             )

--- a/tests/providers/azure/services/defender/defender_container_images_scan_enabled/defender_container_images_scan_enabled_test.py
+++ b/tests/providers/azure/services/defender/defender_container_images_scan_enabled/defender_container_images_scan_enabled_test.py
@@ -60,6 +60,7 @@ class Test_defender_container_images_scan_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "NotContainers": Pricing(
                     resource_id=str(uuid4()),
+                    resource_name="Defender plan Servers",
                     pricing_tier="Free",
                     free_trial_remaining_time=timedelta(days=1),
                 )
@@ -90,6 +91,7 @@ class Test_defender_container_images_scan_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "Containers": Pricing(
                     resource_id=str(uuid4()),
+                    resource_name="Defender plan for Containers",
                     pricing_tier="Free",
                     free_trial_remaining_time=timedelta(days=1),
                     extensions={},
@@ -124,7 +126,7 @@ class Test_defender_container_images_scan_enabled:
                     "Containers"
                 ].resource_id
             )
-            assert result[0].resource_name == "Dender plan for Containers"
+            assert result[0].resource_name == "Defender plan for Containers"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
 
     def test_defender_subscription_containers_container_images_scan_off(self):
@@ -133,6 +135,7 @@ class Test_defender_container_images_scan_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "Containers": Pricing(
                     resource_id=str(uuid4()),
+                    resource_name="Defender plan for Containers",
                     pricing_tier="Free",
                     free_trial_remaining_time=timedelta(days=1),
                     extensions={"ContainerRegistriesVulnerabilityAssessments": False},
@@ -167,7 +170,7 @@ class Test_defender_container_images_scan_enabled:
                     "Containers"
                 ].resource_id
             )
-            assert result[0].resource_name == "Dender plan for Containers"
+            assert result[0].resource_name == "Defender plan for Containers"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
 
     def test_defender_subscription_containers_container_images_scan_on(self):
@@ -176,6 +179,7 @@ class Test_defender_container_images_scan_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "Containers": Pricing(
                     resource_id=str(uuid4()),
+                    resource_name="Defender plan for Containers",
                     pricing_tier="Free",
                     free_trial_remaining_time=timedelta(days=1),
                     extensions={"ContainerRegistriesVulnerabilityAssessments": True},
@@ -210,5 +214,5 @@ class Test_defender_container_images_scan_enabled:
                     "Containers"
                 ].resource_id
             )
-            assert result[0].resource_name == "Dender plan for Containers"
+            assert result[0].resource_name == "Defender plan for Containers"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_app_services_is_on/defender_ensure_defender_for_app_services_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_app_services_is_on/defender_ensure_defender_for_app_services_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_app_services_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "AppServices": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_app_services_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "AppServices": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_arm_is_on/defender_ensure_defender_for_arm_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_arm_is_on/defender_ensure_defender_for_arm_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_arm_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "Arm": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_arm_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "Arm": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_azure_sql_databases_is_on/defender_ensure_defender_for_azure_sql_databases_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -67,7 +68,7 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
                 == f"Defender plan Defender for Azure SQL DB Servers from subscription {AZURE_SUBSCRIPTION_ID} is set to OFF (pricing tier not standard)."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Defender plan Azure SQL DB Servers"
+            assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id
 
     def test_defender_sql_databases_pricing_tier_standard(self):
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )
@@ -106,5 +108,5 @@ class Test_defender_ensure_defender_for_azure_sql_databases_is_on:
                 == f"Defender plan Defender for Azure SQL DB Servers from subscription {AZURE_SUBSCRIPTION_ID} is set to ON (pricing tier standard)."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Defender plan Azure SQL DB Servers"
+            assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_containers_is_on/defender_ensure_defender_for_containers_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_containers_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "Containers": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -67,7 +68,7 @@ class Test_defender_ensure_defender_for_containers_is_on:
                 == f"Defender plan Defender for Containers from subscription {AZURE_SUBSCRIPTION_ID} is set to OFF (pricing tier not standard)."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Defender plan Container Registries"
+            assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id
 
     def test_defender_container_registries_pricing_tier_standard(self):
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_containers_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "Containers": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )
@@ -106,5 +108,5 @@ class Test_defender_ensure_defender_for_containers_is_on:
                 == f"Defender plan Defender for Containers from subscription {AZURE_SUBSCRIPTION_ID} is set to ON (pricing tier standard)."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Defender plan Container Registries"
+            assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_cosmosdb_is_on/defender_ensure_defender_for_cosmosdb_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_cosmosdb_is_on/defender_ensure_defender_for_cosmosdb_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_cosmosdb_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )
@@ -69,6 +70,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )
@@ -100,6 +102,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )
@@ -131,6 +134,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )
@@ -162,21 +166,25 @@ class Test_defender_ensure_defender_for_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
@@ -216,21 +224,25 @@ class Test_defender_ensure_defender_for_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServers": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 ),
                 "CosmosDbs": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 ),

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_dns_is_on/defender_ensure_defender_for_dns_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_dns_is_on/defender_ensure_defender_for_dns_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_dns_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "Dns": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_dns_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "Dns": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_keyvault_is_on/defender_ensure_defender_for_keyvault_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_keyvault_is_on/defender_ensure_defender_for_keyvault_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "KeyVaults": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_keyvault_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "KeyVaults": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_os_relational_databases_is_on/defender_ensure_defender_for_os_relational_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_os_relational_databases_is_on/defender_ensure_defender_for_os_relational_databases_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -80,6 +81,7 @@ class Test_defender_ensure_defender_for_os_relational_databases_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "OpenSourceRelationalDatabases": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_server_is_on/defender_ensure_defender_for_server_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_server_is_on/defender_ensure_defender_for_server_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_server_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "VirtualMachines": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_server_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "VirtualMachines": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_sql_servers_is_on/defender_ensure_defender_for_sql_servers_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_sql_servers_is_on/defender_ensure_defender_for_sql_servers_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_sql_servers_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "SqlServerVirtualMachines": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_storage_is_on/defender_ensure_defender_for_storage_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_storage_is_on/defender_ensure_defender_for_storage_is_on_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_defender_for_storage_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "StorageAccounts": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Not Standard",
                     free_trial_remaining_time=0,
                 )
@@ -77,6 +78,7 @@ class Test_defender_ensure_defender_for_storage_is_on:
             AZURE_SUBSCRIPTION_ID: {
                 "StorageAccounts": Pricing(
                     resource_id=resource_id,
+                    resource_name="Defender plan Servers",
                     pricing_tier="Standard",
                     free_trial_remaining_time=0,
                 )

--- a/tests/providers/azure/services/defender/defender_service_test.py
+++ b/tests/providers/azure/services/defender/defender_service_test.py
@@ -21,6 +21,7 @@ def mock_defender_get_pricings(_):
         AZURE_SUBSCRIPTION_ID: {
             "Standard": Pricing(
                 resource_id="resource_id",
+                resource_name="resource_name",
                 pricing_tier="pricing_tier",
                 free_trial_remaining_time=timedelta(days=1),
                 extensions={},
@@ -139,6 +140,10 @@ class Test_Defender_Service:
         assert (
             defender.pricings[AZURE_SUBSCRIPTION_ID]["Standard"].resource_id
             == "resource_id"
+        )
+        assert (
+            defender.pricings[AZURE_SUBSCRIPTION_ID]["Standard"].resource_name
+            == "resource_name"
         )
         assert (
             defender.pricings[AZURE_SUBSCRIPTION_ID]["Standard"].pricing_tier

--- a/tests/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled_test.py
@@ -75,6 +75,7 @@ class Test_compute_project_os_login_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == project.id
+            assert result[0].resource_name == project.id
             assert result[0].location == "global"
             assert result[0].project_id == GCP_PROJECT_ID
 
@@ -124,5 +125,6 @@ class Test_compute_project_os_login_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == project.id
+            assert result[0].resource_name == project.id
             assert result[0].location == "global"
             assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled_test.py
+++ b/tests/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled_test.py
@@ -76,6 +76,7 @@ class Test_iam_audit_logs_enabled:
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID
+                assert r.resource_name == GCP_PROJECT_ID
                 assert r.project_id == GCP_PROJECT_ID
                 assert r.location == cloudresourcemanager_client.region
 
@@ -125,5 +126,6 @@ class Test_iam_audit_logs_enabled:
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID
+                assert r.resource_name == GCP_PROJECT_ID
                 assert r.project_id == GCP_PROJECT_ID
                 assert r.location == cloudresourcemanager_client.region


### PR DESCRIPTION
### Description

This PR fixes the incorrect names and ids from some resources for GCP and Azure.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
