### PR TITLE
fix(azure): remove `resource_name` inside the `Check_Report`

### DIFF
--- a/prowler/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on.py
@@ -16,7 +16,6 @@ class defender_ensure_defender_for_databases_is_on(Check):
                     metadata=self.metadata(), resource=pricings["SqlServers"]
                 )
                 report.subscription = subscription
-                report.resource_name = "Defender plan Databases"
                 report.status = "PASS"
                 report.status_extended = f"Defender plan Defender for Databases from subscription {subscription} is set to ON (pricing tier standard)."
                 if (

--- a/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
@@ -8,8 +8,7 @@ class compute_project_os_login_enabled(Check):
         for project in compute_client.compute_projects:
             report = Check_Report_GCP(
                 metadata=self.metadata(),
-                resource=project,
-                resource_name=project.id,
+                resource=compute_client.projects[project.id],
                 project_id=project.id,
                 location=compute_client.region,
             )

--- a/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
+++ b/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
@@ -10,8 +10,7 @@ class iam_audit_logs_enabled(Check):
         for project in cloudresourcemanager_client.cloud_resource_manager_projects:
             report = Check_Report_GCP(
                 metadata=self.metadata(),
-                resource=project,
-                resource_name=project.id,
+                resource=cloudresourcemanager_client.projects[project.id],
                 project_id=project.id,
                 location=cloudresourcemanager_client.region,
             )

--- a/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py
@@ -214,7 +214,7 @@ class Test_defender_ensure_defender_for_databases_is_on:
                 == f"Defender plan Defender for Databases from subscription {AZURE_SUBSCRIPTION_ID} is set to ON (pricing tier standard)."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Defender plan Databases"
+            assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id
 
     def test_defender_databases_cosmosdb_not_standard(self):
@@ -272,5 +272,5 @@ class Test_defender_ensure_defender_for_databases_is_on:
                 == f"Defender plan Defender for Databases from subscription {AZURE_SUBSCRIPTION_ID} is set to OFF (pricing tier not standard)."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Defender plan Databases"
+            assert result[0].resource_name == "Defender plan Servers"
             assert result[0].resource_id == resource_id

--- a/tests/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled_test.py
@@ -75,7 +75,7 @@ class Test_compute_project_os_login_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == project.id
-            assert result[0].resource_name == project.id
+            assert result[0].resource_name == "test"
             assert result[0].location == "global"
             assert result[0].project_id == GCP_PROJECT_ID
 
@@ -125,6 +125,6 @@ class Test_compute_project_os_login_enabled:
                 result[0].status_extended,
             )
             assert result[0].resource_id == project.id
-            assert result[0].resource_name == project.id
+            assert result[0].resource_name == "test"
             assert result[0].location == "global"
             assert result[0].project_id == GCP_PROJECT_ID

--- a/tests/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled_test.py
+++ b/tests/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled_test.py
@@ -76,7 +76,7 @@ class Test_iam_audit_logs_enabled:
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID
-                assert r.resource_name == GCP_PROJECT_ID
+                assert r.resource_name == "test"
                 assert r.project_id == GCP_PROJECT_ID
                 assert r.location == cloudresourcemanager_client.region
 
@@ -126,6 +126,6 @@ class Test_iam_audit_logs_enabled:
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID
-                assert r.resource_name == GCP_PROJECT_ID
+                assert r.resource_name == "test"
                 assert r.project_id == GCP_PROJECT_ID
                 assert r.location == cloudresourcemanager_client.region


### PR DESCRIPTION
### Description
This pull request includes changes to the Azure and GCP providers to update resource names and ensure consistency in the test cases. The most important changes include modifying the resource names in the Azure Defender for Databases and GCP Compute OS Login Enabled checks.

Changes to Azure provider:

* [`prowler/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on.py`](diffhunk://#diff-073296c114b4536e12b8a8a55b4d96849635b22886b7bee1ad6cbc2cf7271271L19): Removed the hardcoded resource name "Defender plan Databases" from the report.

* [`tests/providers/azure/services/defender/defender_ensure_defender_for_databases_is_on/defender_ensure_defender_for_databases_is_on_test.py`](diffhunk://#diff-82757bdc75d1f67432777cf308ead90331e83812ab2c08eb402e3e3b24c952dcL217-R217): Updated test cases to assert the resource name as "Defender plan Servers" instead of "Defender plan Databases". [[1]](diffhunk://#diff-82757bdc75d1f67432777cf308ead90331e83812ab2c08eb402e3e3b24c952dcL217-R217) [[2]](diffhunk://#diff-82757bdc75d1f67432777cf308ead90331e83812ab2c08eb402e3e3b24c952dcL275-R275)

Changes to GCP provider:

* [`prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py`](diffhunk://#diff-e96d1504b25ba3f4ac68231a5c87e331526512d43590d4d850f6398d5852f305L11-R11): Changed the resource assignment to use `compute_client.projects[project.id]` instead of `project`.

* [`tests/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled_test.py`](diffhunk://#diff-5cad7d23a4b53f0ab76eebf4ec62044276696f39d77157fc1c544b8abd0792a4L78-R78): Updated test cases to assert the resource name as "test" instead of `project.id`. [[1]](diffhunk://#diff-5cad7d23a4b53f0ab76eebf4ec62044276696f39d77157fc1c544b8abd0792a4L78-R78) [[2]](diffhunk://#diff-5cad7d23a4b53f0ab76eebf4ec62044276696f39d77157fc1c544b8abd0792a4L128-R128)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
