### PR TITLE
fix(gcp): make logging sink check at project level

### DIFF
--- a/tests/providers/gcp/services/logging/logging_sink_created/logging_sink_created_test.py
+++ b/tests/providers/gcp/services/logging/logging_sink_created/logging_sink_created_test.py
@@ -146,6 +146,15 @@ class Test_logging_sink_created:
                     project_id=GCP_PROJECT_ID,
                 )
             ]
+            logging_client.projects = {
+                GCP_PROJECT_ID: GCPProject(
+                    id=GCP_PROJECT_ID,
+                    number="123456789012",
+                    name="test",
+                    labels={},
+                    lifecycle_state="ACTIVE",
+                )
+            }
 
             check = logging_sink_created()
             result = check.execute()
@@ -153,9 +162,9 @@ class Test_logging_sink_created:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == f"Sink sink1 is enabled but not exporting copies of all the log entries in project {GCP_PROJECT_ID}."
+                == f"There are no logging sinks to export copies of all the log entries in project {GCP_PROJECT_ID}."
             )
-            assert result[0].resource_id == "sink1"
-            assert result[0].resource_name == "sink1"
+            assert result[0].resource_id == GCP_PROJECT_ID
+            assert result[0].resource_name == "test"
             assert result[0].project_id == GCP_PROJECT_ID
             assert result[0].location == GCP_EU1_LOCATION


### PR DESCRIPTION
### Description

Make `logging_sink_created` to verify is there is a sink logging at project level and not by checking every sink.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
