### PR TITLE
fix(defender): add default resource name in contacts

### DIFF
--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -177,7 +177,7 @@ class Defender(AzureService):
                         {
                             "default": SecurityContacts(
                                 resource_id=f"/subscriptions/{self.subscriptions[subscription_name]}/providers/Microsoft.Security/securityContacts/default",
-                                name="",
+                                name="default",
                                 emails="",
                                 phone="",
                                 alert_notifications_minimal_severity="",


### PR DESCRIPTION
### Description
This pull request includes a small change to the `prowler/providers/azure/services/defender/defender_service.py` file. The change sets the default name for security contacts to "default" instead of an empty string.

* [`prowler/providers/azure/services/defender/defender_service.py`](diffhunk://#diff-d57627c6eec20c2ee551ce121565b24b89f0b2f9f16c927040b62fc7731f9639L180-R180): Changed the `name` field in the `SecurityContacts` dictionary to "default" in the `_get_security_contacts` method.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
