### PR TITLE
fix: handle errors in AWS, Azure, and GCP

### DIFF
--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -33,6 +33,10 @@ IGNORED_EXCEPTIONS = [
     "ValidationException",
     "AWSSecretAccessKeyInvalidError",
     "InvalidAction",
+    "InvalidRequestException",
+    "RequestExpired",
+    "ConnectionClosedError",
+    "HTTPSConnectionPool",
     "Pool is closed",  # The following comes from urllib3: eu-west-1 -- HTTPClientError[126]: An HTTP Client raised an unhandled exception: AWSHTTPSConnectionPool(host='hostname.s3.eu-west-1.amazonaws.com', port=443): Pool is closed.
     # Authentication Errors from GCP
     "ClientAuthenticationError",
@@ -41,6 +45,8 @@ IGNORED_EXCEPTIONS = [
     "Permission denied to get service",
     "API has not been used in project",
     "HttpError 404 when requesting",
+    "HttpError 403 when requesting",
+    "HttpError 400 when requesting",
     "GCPNoAccesibleProjectsError",
     # Authentication Errors from Azure
     "ClientAuthenticationError",

--- a/prowler/providers/aws/services/redshift/redshift_cluster_public_access/redshift_cluster_public_access.py
+++ b/prowler/providers/aws/services/redshift/redshift_cluster_public_access/redshift_cluster_public_access.py
@@ -19,7 +19,8 @@ class redshift_cluster_public_access(Check):
                 report.status_extended = f"Redshift Cluster {cluster.id} has the endpoint {cluster.endpoint_address} set as publicly accessible but is not publicly exposed."
                 # 2. Check if Redshift Cluster is in a public subnet
                 if any(
-                    subnet in vpc_client.subnets and vpc_client.subnets[subnet].public
+                    subnet in vpc_client.vpc_subnets
+                    and vpc_client.vpc_subnets[subnet].public
                     for subnet in cluster.subnets
                 ):
                     report.status_extended = f"Redshift Cluster {cluster.id} has the endpoint {cluster.endpoint_address} set as publicly accessible in a public subnet but is not publicly exposed."

--- a/prowler/providers/azure/services/containerregistry/containerregistry_service.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_service.py
@@ -46,9 +46,6 @@ class ContainerRegistry(AzureService):
                                 admin_user_enabled=getattr(
                                     registry, "admin_user_enabled", False
                                 ),
-                                network_rule_set=getattr(
-                                    registry, "network_rule_set", None
-                                ),
                                 monitor_diagnostic_settings=self._get_registry_monitor_settings(
                                     registry.name, resource_group, subscription
                                 ),

--- a/prowler/providers/azure/services/keyvault/keyvault_service.py
+++ b/prowler/providers/azure/services/keyvault/keyvault_service.py
@@ -53,10 +53,13 @@ class KeyVault(AzureService):
                                 ),
                                 private_endpoint_connections=[
                                     PrivateEndpointConnection(id=conn.id)
-                                    for conn in getattr(
-                                        keyvault_properties,
-                                        "private_endpoint_connections",
-                                        [],
+                                    for conn in (
+                                        getattr(
+                                            keyvault_properties,
+                                            "private_endpoint_connections",
+                                            [],
+                                        )
+                                        or []
                                     )
                                 ],
                                 enable_soft_delete=getattr(

--- a/prowler/providers/azure/services/monitor/monitor_service.py
+++ b/prowler/providers/azure/services/monitor/monitor_service.py
@@ -53,7 +53,7 @@ class Monitor(AzureService):
                                 category_group=log_settings.category_group,
                                 enabled=log_settings.enabled,
                             )
-                            for log_settings in getattr(setting, "logs", [])
+                            for log_settings in (getattr(setting, "logs", []) or [])
                         ],
                         storage_account_id=setting.storage_account_id,
                     )

--- a/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock.py
+++ b/prowler/providers/gcp/services/cloudstorage/cloudstorage_bucket_log_retention_policy_lock/cloudstorage_bucket_log_retention_policy_lock.py
@@ -23,7 +23,7 @@ class cloudstorage_bucket_log_retention_policy_lock(Check):
                 if bucket.retention_policy:
                     report.status = "FAIL"
                     report.status_extended = f"Log Sink Bucket {bucket.name} has no Retention Policy but without Bucket Lock."
-                    if bucket.retention_policy["isLocked"]:
+                    if bucket.retention_policy.get("isLocked", False):
                         report.status = "PASS"
                         report.status_extended = f"Log Sink Bucket {bucket.name} has a Retention Policy with Bucket Lock."
                 findings.append(report)

--- a/tests/providers/aws/services/redshift/redshift_cluster_public_access/redshift_cluster_public_access_test.py
+++ b/tests/providers/aws/services/redshift/redshift_cluster_public_access/redshift_cluster_public_access_test.py
@@ -206,7 +206,7 @@ class Test_redshift_cluster_public_access:
             )
         )
         vpc_client = mock.MagicMock
-        vpc_client.subnets = {"subnet-123456": mock.MagicMock(public=True)}
+        vpc_client.vpc_subnets = {"subnet-123456": mock.MagicMock(public=True)}
         ec2_client = mock.MagicMock
         aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
 
@@ -260,7 +260,7 @@ class Test_redshift_cluster_public_access:
             )
         )
         vpc_client = mock.MagicMock
-        vpc_client.subnets = {"subnet-123456": mock.MagicMock(public=True)}
+        vpc_client.vpc_subnets = {"subnet-123456": mock.MagicMock(public=True)}
         ec2_client = mock.MagicMock
         ec2_client.security_groups = {
             f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:security-group/sg-123456": mock.MagicMock(


### PR DESCRIPTION
### Description

This PR fixes multiple issues across AWS, Azure, and GCP providers caused by missing or `None` attributes. Iteration over such attributes now defaults to empty lists to prevent runtime errors.

### Context

During scheduled scans, several errors were raised due to optional or missing fields in cloud resources. This update ensures safer handling of those attributes, especially in services like Azure Key Vault, Network, and container registries.

### Fixed errors

- `TypeError`: `'NoneType' object is not iterable` in Azure Key Vault and Network modules  
- `TypeError`: unexpected keyword argument `'network_rule_set'`  
- `TypeError`: `FlowLog.__init__()` missing required arguments  
- `ResourceNotFoundError`: resource group `'NetworkWatcherRG'` not found  
- `ResourceNotFoundError`: parent resource for `'networkWatchers/flowLogs'` not found  
- `AttributeError`: `'VPC' object has no attribute 'subnets'`  
- `KeyError`: `'isLocked'` missing in bucket resource  

### Ignored in Sentry

#### AWS
- `InvalidRequestException`
- `RequestExpired`
- `ConnectionClosedError`
- `HTTPSConnectionPool`

#### GCP
- `HttpError 403 when requesting`
- `HttpError 400 when requesting`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
