### PR TITLE
fix(provider): disable periodic task on views before deleting

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -16,6 +16,13 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ---
 
+## [v1.5.4] (Prowler v5.4.4)
+
+### Fixed
+- Disabled periodic task deletion at view level due to performance issues ([#7466])(https://github.com/prowler-cloud/prowler/pull/7466).
+
+---
+
 ## [v1.5.3] (Prowler v5.4.3)
 
 ### Fixed

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ## [v1.5.4] (Prowler v5.4.4)
 
 ### Fixed
-- Disabled periodic task deletion at view level due to performance issues ([#7466])(https://github.com/prowler-cloud/prowler/pull/7466).
+- Fixed a bug with periodic tasks when trying to delete a provider ([#7466])(https://github.com/prowler-cloud/prowler/pull/7466).
 
 ---
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1092,6 +1092,7 @@ class ProviderViewSet(BaseRLSViewSet):
         # Temporarily disabled due to performance issues
         # delete_related_daily_task(str(provider.id))
 
+        # TODO: Disable instead of delete, review performance
         task_name = f"scan-perform-scheduled-{str(provider.id)}"
         PeriodicTask.objects.filter(name=task_name).update(enabled=False)
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -22,6 +22,7 @@ from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
+from django_celery_beat.models import PeriodicTask
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -55,7 +56,6 @@ from tasks.tasks import (
 
 from api.base_views import BaseRLSViewSet, BaseTenantViewset, BaseUserViewset
 from api.db_router import MainRouter
-from api.db_utils import delete_related_daily_task
 from api.filters import (
     ComplianceOverviewFilter,
     FindingFilter,
@@ -1089,7 +1089,11 @@ class ProviderViewSet(BaseRLSViewSet):
         provider = get_object_or_404(Provider, pk=pk)
         provider.is_deleted = True
         provider.save()
-        delete_related_daily_task(str(provider.id))
+        # Temporarily disabled due to performance issues
+        # delete_related_daily_task(str(provider.id))
+
+        task_name = f"scan-perform-scheduled-{str(provider.id)}"
+        PeriodicTask.objects.filter(name=task_name).update(enabled=False)
 
         with transaction.atomic():
             task = delete_provider_task.delay(

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1089,10 +1089,6 @@ class ProviderViewSet(BaseRLSViewSet):
         provider = get_object_or_404(Provider, pk=pk)
         provider.is_deleted = True
         provider.save()
-        # Temporarily disabled due to performance issues
-        # delete_related_daily_task(str(provider.id))
-
-        # TODO: Disable instead of delete, review performance
         task_name = f"scan-perform-scheduled-{str(provider.id)}"
         PeriodicTask.objects.filter(name=task_name).update(enabled=False)
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1089,7 +1089,7 @@ class ProviderViewSet(BaseRLSViewSet):
         provider = get_object_or_404(Provider, pk=pk)
         provider.is_deleted = True
         provider.save()
-        task_name = f"scan-perform-scheduled-{str(provider.id)}"
+        task_name = f"scan-perform-scheduled-{pk}"
         PeriodicTask.objects.filter(name=task_name).update(enabled=False)
 
         with transaction.atomic():


### PR DESCRIPTION
### Context

Currently a user is unable to delete a provider because the API returns a 500. This is due to the deletion of periodic tasks at view level before deleting the provider itself.

### Description

In this PR we are going to disable the periodic task at the view level. After deleting the provider, we will remove the related periodic task.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
