### PR TITLE
feat: add link with the service status using static icon 

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Accepted invitations can no longer be edited. [(#7198)](https://github.com/prowler-cloud/prowler/pull/7198)
 - Added download column in scans table to download reports for completed scans. [(#7353)](https://github.com/prowler-cloud/prowler/pull/7353)
 - Show muted icon when a finding is muted. [(#7378)](https://github.com/prowler-cloud/prowler/pull/7378)
+- Added static status icon with link to service status page. [(#7468)](https://github.com/prowler-cloud/prowler/pull/7468)
 
 #### 🔄 Changed
 

--- a/ui/components/ui/sidebar/menu.tsx
+++ b/ui/components/ui/sidebar/menu.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import { Divider } from "@nextui-org/react";
 import { Ellipsis, LogOut } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 import { logOut } from "@/actions/auth";
-import { AddIcon } from "@/components/icons";
+import { AddIcon, InfoIcon } from "@/components/icons";
 import { CollapseMenuButton } from "@/components/ui/sidebar/collapse-menu-button";
 import {
   Tooltip,
@@ -167,9 +168,25 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
         </TooltipProvider>
       </div>
 
-      <span className="text-muted-foreground border-border mt-2 border-t pt-2 text-center text-xs lg:mt-4">
-        {process.env.NEXT_PUBLIC_PROWLER_RELEASE_VERSION}
-      </span>
+      <div className="text-muted-foreground border-border mt-2 flex items-center justify-center gap-2 border-t pt-2 text-center text-xs">
+        <span>{process.env.NEXT_PUBLIC_PROWLER_RELEASE_VERSION}</span>
+        {process.env.NEXT_PUBLIC_IS_CLOUD_ENV === "true" && (
+          <>
+            <Divider orientation="vertical" />
+            <Link
+              href="https://status.prowler.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1"
+            >
+              <InfoIcon size={16} />
+              <span className="text-muted-foreground font-normal opacity-80 transition-opacity hover:font-bold hover:opacity-100">
+                Service Status
+              </span>
+            </Link>
+          </>
+        )}
+      </div>
     </>
   );
 };


### PR DESCRIPTION


### Description

- This PR adds a static status icon that links to the service status page.
- It's a temporary solution ahead of the 5.5 release, the icon will be updated to reflect the real-time status using the incident API.



### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
