### PR TITLE
fix(ui): Remove UTC from timestamps in app

### DIFF
--- a/ui/components/ui/entities/date-with-time.tsx
+++ b/ui/components/ui/entities/date-with-time.tsx
@@ -23,7 +23,7 @@ export const DateWithTime: React.FC<DateWithTimeProps> = ({
     }
 
     const formattedDate = format(date, "MMM dd, yyyy");
-    const formattedTime = format(date, "p 'UTC'");
+    const formattedTime = format(date, "p");
 
     return (
       <div className="mw-fit py-[2px]">


### PR DESCRIPTION
### Context

We are currently displaying `UTC` after timestamps in the app, but this is not accurate since the timestamps are getting converted to the local (browser) timezone prior to formatting.

### Description

- Remove `UTC` from appearing after timestamps in the UI.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
