### PR TITLE
fix(aws): add default session_duration

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -104,10 +104,10 @@ class AwsProvider(Provider):
     def __init__(
         self,
         retries_max_attempts: int = 3,
-        role_arn: str = "",
+        role_arn: str = None,
         session_duration: int = 3600,
         external_id: str = None,
-        role_session_name: str = "",
+        role_session_name: str = None,
         mfa: bool = False,
         profile: str = None,
         regions: set = set(),

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -238,8 +238,6 @@ class AwsProvider(Provider):
             profile_region=profile_region,
         )
         ########
-        role_arn = ""
-        role_session_name = ""
         ######## AWS Session with Assume Role (if needed)
         if role_arn:
             # Validate the input role
@@ -533,7 +531,7 @@ class AwsProvider(Provider):
         """
         try:
             logger.debug("Creating original session ...")
-            print("lo que llega de mfa es: ", mfa)
+
             session_arguments = {}
             if profile:
                 session_arguments["profile_name"] = profile

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -105,7 +105,7 @@ class AwsProvider(Provider):
         self,
         retries_max_attempts: int = 3,
         role_arn: str = None,
-        session_duration: int = None,
+        session_duration: int = 3600,
         external_id: str = None,
         role_session_name: str = None,
         mfa: bool = None,

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -104,11 +104,11 @@ class AwsProvider(Provider):
     def __init__(
         self,
         retries_max_attempts: int = 3,
-        role_arn: str = None,
+        role_arn: str = "",
         session_duration: int = 3600,
         external_id: str = None,
-        role_session_name: str = None,
-        mfa: bool = None,
+        role_session_name: str = "",
+        mfa: bool = False,
         profile: str = None,
         regions: set = set(),
         organizations_role_arn: str = None,
@@ -238,7 +238,8 @@ class AwsProvider(Provider):
             profile_region=profile_region,
         )
         ########
-
+        role_arn = ""
+        role_session_name = ""
         ######## AWS Session with Assume Role (if needed)
         if role_arn:
             # Validate the input role
@@ -532,7 +533,7 @@ class AwsProvider(Provider):
         """
         try:
             logger.debug("Creating original session ...")
-
+            print("lo que llega de mfa es: ", mfa)
             session_arguments = {}
             if profile:
                 session_arguments["profile_name"] = profile


### PR DESCRIPTION
### Description

This PR sets the default value for `session_duration` inside `aws_provider` (3600)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
