### PR TITLE
chore(sentry): use exceptions instead of logger.error to handle check exceptions

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -235,6 +235,7 @@ To view the logs for any component (e.g., Django, Celery worker), you can use th
 
 ```console
 docker logs -f $(docker ps --format "{{.Names}}" | grep 'api-')
+```
 
 ## Applying migrations
 

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -1,5 +1,8 @@
+import logging
+
 import sentry_sdk
 from config.env import env
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 IGNORED_EXCEPTIONS = [
     # Provider is not connected due to credentials errors
@@ -68,27 +71,27 @@ IGNORED_EXCEPTIONS = [
 ]
 
 
-def before_send(event, hint):
-    """
-    before_send handles the Sentry events in order to sent them or not
-    """
-    # Ignore logs with the ignored_exceptions
-    # https://docs.python.org/3/library/logging.html#logrecord-objects
-    if "log_record" in hint:
-        log_msg = hint["log_record"].msg
-        log_lvl = hint["log_record"].levelno
+# def before_send(event, hint):
+#     """
+#     before_send handles the Sentry events in order to sent them or not
+#     """
+#     # Ignore logs with the ignored_exceptions
+#     # https://docs.python.org/3/library/logging.html#logrecord-objects
+#     if "log_record" in hint:
+#         log_msg = hint["log_record"].msg
+#         log_lvl = hint["log_record"].levelno
 
-        # Handle Error events and discard the rest
-        if log_lvl == 40 and any(ignored in log_msg for ignored in IGNORED_EXCEPTIONS):
-            return
-    return event
+#         # Handle Error events and discard the rest
+#         if log_lvl == 40 and any(ignored in log_msg for ignored in IGNORED_EXCEPTIONS):
+#             return
+#     return event
 
 
 sentry_sdk.init(
     dsn=env.str("DJANGO_SENTRY_DSN", ""),
     # Add data like request headers and IP for users,
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    before_send=before_send,
+    # before_send=before_send,
     send_default_pii=True,
     _experiments={
         # Set continuous_profiling_auto_start to True
@@ -96,4 +99,10 @@ sentry_sdk.init(
         # possible.
         "continuous_profiling_auto_start": True,
     },
+    integrations=[
+        LoggingIntegration(
+            level=logging.ERROR,  # Capture info and above as breadcrumbs
+            event_level=logging.ERROR,  # Send records as events
+        ),
+    ],
 )

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -1,8 +1,5 @@
-import logging
-
 import sentry_sdk
 from config.env import env
-from sentry_sdk.integrations.logging import LoggingIntegration
 
 IGNORED_EXCEPTIONS = [
     # Provider is not connected due to credentials errors
@@ -100,10 +97,4 @@ sentry_sdk.init(
         "continuous_profiling_auto_start": True,
     },
     ignore_errors=IGNORED_EXCEPTIONS,
-    integrations=[
-        LoggingIntegration(
-            level=logging.ERROR,  # Capture info and above as breadcrumbs
-            event_level=logging.ERROR,  # Send records as events
-        ),
-    ],
 )

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -71,27 +71,27 @@ IGNORED_EXCEPTIONS = [
 ]
 
 
-# def before_send(event, hint):
-#     """
-#     before_send handles the Sentry events in order to sent them or not
-#     """
-#     # Ignore logs with the ignored_exceptions
-#     # https://docs.python.org/3/library/logging.html#logrecord-objects
-#     if "log_record" in hint:
-#         log_msg = hint["log_record"].msg
-#         log_lvl = hint["log_record"].levelno
+def before_send(event, hint):
+    """
+    before_send handles the Sentry events in order to sent them or not
+    """
+    # Ignore logs with the ignored_exceptions
+    # https://docs.python.org/3/library/logging.html#logrecord-objects
+    if "log_record" in hint:
+        log_msg = hint["log_record"].msg
+        log_lvl = hint["log_record"].levelno
 
-#         # Handle Error events and discard the rest
-#         if log_lvl == 40 and any(ignored in log_msg for ignored in IGNORED_EXCEPTIONS):
-#             return
-#     return event
+        # Handle Error events and discard the rest
+        if log_lvl == 40 and any(ignored in log_msg for ignored in IGNORED_EXCEPTIONS):
+            return
+    return event
 
 
 sentry_sdk.init(
     dsn=env.str("DJANGO_SENTRY_DSN", ""),
     # Add data like request headers and IP for users,
     # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
-    # before_send=before_send,
+    before_send=before_send,
     send_default_pii=True,
     _experiments={
         # Set continuous_profiling_auto_start to True
@@ -99,6 +99,7 @@ sentry_sdk.init(
         # possible.
         "continuous_profiling_auto_start": True,
     },
+    ignore_errors=IGNORED_EXCEPTIONS,
     integrations=[
         LoggingIntegration(
             level=logging.ERROR,  # Capture info and above as breadcrumbs

--- a/docs/developer-guide/services.md
+++ b/docs/developer-guide/services.md
@@ -113,7 +113,7 @@ class <Service>(ServiceParentClass):
                                 )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{<provider_specific_field>} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
@@ -124,7 +124,7 @@ class <Service>(ServiceParentClass):
             # - GCP: project_id and location
             # - Azure: subscription
 
-            logger.error(
+            logger.exception(
                 f"{<provider_specific_field>} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -161,7 +161,7 @@ class <Service>(ServiceParentClass):
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{<provider_specific_field>} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     continue
@@ -173,7 +173,7 @@ class <Service>(ServiceParentClass):
             # - GCP: project_id and location
             # - Azure: subscription
 
-            logger.error(
+            logger.exception(
                 f"{<item>.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ Prowler App can be installed in different ways, depending on your environment:
         You can change the environment variables in the `.env` file. Note that it is not recommended to use the default values in production environments.
 
     ???+ note
-        There is a development mode available, you can use the file https://github.com/prowler-cloud/prowler/blob/master/docker-compose.dev.yml to run the app in development mode.
+        There is a development mode available, you can use the file https://github.com/prowler-cloud/prowler/blob/master/docker-compose-dev.yml to run the app in development mode.
 
     ???+ warning
         Google and GitHub authentication is only available in [Prowler Cloud](https://prowler.com).

--- a/docs/tutorials/fixer.md
+++ b/docs/tutorials/fixer.md
@@ -48,7 +48,7 @@ def fixer(region):
             "EbsEncryptionByDefault"
         ]
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False
@@ -87,7 +87,7 @@ def fixer(resource_id: str) -> bool:
             },
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -745,7 +745,7 @@ class AwsProvider(Provider):
 
             return regional_clients
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -914,7 +914,7 @@ class AwsProvider(Provider):
                         for resource in page["ResourceTagMappingList"]:
                             tagged_resources.append(resource["ResourceARN"])
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
@@ -1105,7 +1105,7 @@ class AwsProvider(Provider):
 
             return enabled_regions
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return set()
@@ -1161,7 +1161,7 @@ class AwsProvider(Provider):
                 region=aws_region,
             )
         except ClientError as client_error:
-            logger.error(
+            logger.exception(
                 f"{client_error.__class__.__name__}[{client_error.__traceback__.tb_lineno}]: {client_error}"
             )
             if client_error.response["Error"]["Code"] == "InvalidClientTokenId":
@@ -1295,7 +1295,7 @@ class AwsProvider(Provider):
             )
 
         except AWSSetUpSessionError as setup_session_error:
-            logger.error(
+            logger.exception(
                 f"{setup_session_error.__class__.__name__}[{setup_session_error.__traceback__.tb_lineno}]: {setup_session_error}"
             )
             if raise_on_exception:
@@ -1303,7 +1303,7 @@ class AwsProvider(Provider):
             return Connection(error=setup_session_error)
 
         except AWSArgumentTypeValidationError as validation_error:
-            logger.error(
+            logger.exception(
                 f"{validation_error.__class__.__name__}[{validation_error.__traceback__.tb_lineno}]: {validation_error}"
             )
             if raise_on_exception:
@@ -1311,7 +1311,7 @@ class AwsProvider(Provider):
             return Connection(error=validation_error)
 
         except AWSIAMRoleARNRegionNotEmtpyError as arn_region_not_empty_error:
-            logger.error(
+            logger.exception(
                 f"{arn_region_not_empty_error.__class__.__name__}[{arn_region_not_empty_error.__traceback__.tb_lineno}]: {arn_region_not_empty_error}"
             )
             if raise_on_exception:
@@ -1319,7 +1319,7 @@ class AwsProvider(Provider):
             return Connection(error=arn_region_not_empty_error)
 
         except AWSIAMRoleARNPartitionEmptyError as arn_partition_empty_error:
-            logger.error(
+            logger.exception(
                 f"{arn_partition_empty_error.__class__.__name__}[{arn_partition_empty_error.__traceback__.tb_lineno}]: {arn_partition_empty_error}"
             )
             if raise_on_exception:
@@ -1327,7 +1327,7 @@ class AwsProvider(Provider):
             return Connection(error=arn_partition_empty_error)
 
         except AWSIAMRoleARNServiceNotIAMnorSTSError as arn_service_not_iam_sts_error:
-            logger.error(
+            logger.exception(
                 f"{arn_service_not_iam_sts_error.__class__.__name__}[{arn_service_not_iam_sts_error.__traceback__.tb_lineno}]: {arn_service_not_iam_sts_error}"
             )
             if raise_on_exception:
@@ -1335,7 +1335,7 @@ class AwsProvider(Provider):
             return Connection(error=arn_service_not_iam_sts_error)
 
         except AWSIAMRoleARNInvalidAccountIDError as arn_invalid_account_id_error:
-            logger.error(
+            logger.exception(
                 f"{arn_invalid_account_id_error.__class__.__name__}[{arn_invalid_account_id_error.__traceback__.tb_lineno}]: {arn_invalid_account_id_error}"
             )
             if raise_on_exception:
@@ -1343,7 +1343,7 @@ class AwsProvider(Provider):
             return Connection(error=arn_invalid_account_id_error)
 
         except AWSIAMRoleARNInvalidResourceTypeError as arn_invalid_resource_type_error:
-            logger.error(
+            logger.exception(
                 f"{arn_invalid_resource_type_error.__class__.__name__}[{arn_invalid_resource_type_error.__traceback__.tb_lineno}]: {arn_invalid_resource_type_error}"
             )
             if raise_on_exception:
@@ -1351,7 +1351,7 @@ class AwsProvider(Provider):
             return Connection(error=arn_invalid_resource_type_error)
 
         except AWSIAMRoleARNEmptyResourceError as arn_empty_resource_error:
-            logger.error(
+            logger.exception(
                 f"{arn_empty_resource_error.__class__.__name__}[{arn_empty_resource_error.__traceback__.tb_lineno}]: {arn_empty_resource_error}"
             )
             if raise_on_exception:
@@ -1359,7 +1359,7 @@ class AwsProvider(Provider):
             return Connection(error=arn_empty_resource_error)
 
         except AWSAssumeRoleError as assume_role_error:
-            logger.error(
+            logger.exception(
                 f"{assume_role_error.__class__.__name__}[{assume_role_error.__traceback__.tb_lineno}]: {assume_role_error}"
             )
             if raise_on_exception:
@@ -1367,7 +1367,7 @@ class AwsProvider(Provider):
             return Connection(error=assume_role_error)
 
         except ClientError as client_error:
-            logger.error(
+            logger.exception(
                 f"AWSClientError[{client_error.__traceback__.tb_lineno}]: {client_error}"
             )
             if raise_on_exception:
@@ -1377,7 +1377,7 @@ class AwsProvider(Provider):
             return Connection(error=client_error)
 
         except ProfileNotFound as profile_not_found_error:
-            logger.error(
+            logger.exception(
                 f"AWSProfileNotFoundError[{profile_not_found_error.__traceback__.tb_lineno}]: {profile_not_found_error}"
             )
             if raise_on_exception:
@@ -1388,7 +1388,7 @@ class AwsProvider(Provider):
             return Connection(error=profile_not_found_error)
 
         except NoCredentialsError as no_credentials_error:
-            logger.error(
+            logger.exception(
                 f"AWSNoCredentialsError[{no_credentials_error.__traceback__.tb_lineno}]: {no_credentials_error}"
             )
             if raise_on_exception:
@@ -1399,7 +1399,7 @@ class AwsProvider(Provider):
             return Connection(error=no_credentials_error)
 
         except AWSAccessKeyIDInvalidError as access_key_id_invalid_error:
-            logger.error(
+            logger.exception(
                 f"{access_key_id_invalid_error.__class__.__name__}[{access_key_id_invalid_error.__traceback__.tb_lineno}]: {access_key_id_invalid_error}"
             )
             if raise_on_exception:
@@ -1407,7 +1407,7 @@ class AwsProvider(Provider):
             return Connection(error=access_key_id_invalid_error)
 
         except AWSSecretAccessKeyInvalidError as secret_access_key_invalid_error:
-            logger.error(
+            logger.exception(
                 f"{secret_access_key_invalid_error.__class__.__name__}[{secret_access_key_invalid_error.__traceback__.tb_lineno}]: {secret_access_key_invalid_error}"
             )
             if raise_on_exception:
@@ -1415,7 +1415,7 @@ class AwsProvider(Provider):
             return Connection(error=secret_access_key_invalid_error)
 
         except AWSInvalidProviderIdError as invalid_account_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{invalid_account_credentials_error.__class__.__name__}[{invalid_account_credentials_error.__traceback__.tb_lineno}]: {invalid_account_credentials_error}"
             )
             if raise_on_exception:
@@ -1423,7 +1423,7 @@ class AwsProvider(Provider):
             return Connection(error=invalid_account_credentials_error)
 
         except AWSSessionTokenExpiredError as session_token_expired:
-            logger.error(
+            logger.exception(
                 f"{session_token_expired.__class__.__name__}[{session_token_expired.__traceback__.tb_lineno}]: {session_token_expired}"
             )
             if raise_on_exception:
@@ -1503,7 +1503,7 @@ class AwsProvider(Provider):
 
             return regions
         except ValueError as value_error:
-            logger.error(
+            logger.exception(
                 f"{value_error.__class__.__name__}[{value_error.__traceback__.tb_lineno}]: {value_error}"
             )
             raise AWSInvalidPartitionError(
@@ -1511,7 +1511,7 @@ class AwsProvider(Provider):
                 file=os.path.basename(__file__),
             )
         except KeyError as key_error:
-            logger.error(
+            logger.exception(
                 f"{key_error.__class__.__name__}[{key_error.__traceback__.tb_lineno}]: {key_error}"
             )
             raise AWSInvalidPartitionError(
@@ -1519,7 +1519,7 @@ class AwsProvider(Provider):
                 file=os.path.basename(__file__),
             )
         except Exception as error:
-            logger.error(f"{error.__class__.__name__}: {error}")
+            logger.exception(f"{error.__class__.__name__}: {error}")
             raise error
 
 

--- a/prowler/providers/aws/lib/mutelist/mutelist.py
+++ b/prowler/providers/aws/lib/mutelist/mutelist.py
@@ -66,7 +66,7 @@ class AWSMutelist(Mutelist):
             )["Mutelist"]
             return mutelist
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
             )
             return {}
@@ -83,7 +83,7 @@ class AWSMutelist(Mutelist):
 
             return mutelist
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
             )
             return {}
@@ -131,7 +131,7 @@ class AWSMutelist(Mutelist):
                     ] = item["Exceptions"]
                 return mutelist
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__} -- {error}[{error.__traceback__.tb_lineno}]"
             )
             return {}

--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -90,7 +90,7 @@ def quick_inventory(provider: AwsProvider, args):
                                             }
                                         )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     bar()
@@ -99,7 +99,7 @@ def quick_inventory(provider: AwsProvider, args):
                     bar.text = f"-> Found {Fore.GREEN}{len(resources_in_region)}{Style.RESET_ALL} resources in {region}"
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                     bar()
@@ -127,7 +127,7 @@ def quick_inventory(provider: AwsProvider, args):
 
         create_output(resources, provider, args)
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
 
@@ -221,7 +221,7 @@ def create_inventory_table(resources: list, resources_in_region: dict) -> dict:
 
         return inventory_table
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
 
@@ -330,7 +330,7 @@ def create_output(resources: list, provider: AwsProvider, args):
                 f"{bucket_remote_dir}/{output_file + json_file_suffix}",
             )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
 
@@ -356,7 +356,7 @@ def get_regional_buckets(provider: AwsProvider, region: str) -> list:
                 except ClientError as error:
                     bucket_tags = []
                     if error.response["Error"]["Code"] != "NoSuchTagSet":
-                        logger.error(
+                        logger.exception(
                             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 bucket_arn = (
@@ -364,7 +364,7 @@ def get_regional_buckets(provider: AwsProvider, region: str) -> list:
                 )
                 regional_buckets.append({"arn": bucket_arn, "tags": bucket_tags})
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
     return regional_buckets
@@ -381,7 +381,7 @@ def get_iam_resources(session) -> list:
                 if "aws-service-role" not in role["Arn"]:
                     iam_resources.append({"arn": role["Arn"], "tags": role.get("Tags")})
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
     try:
@@ -390,7 +390,7 @@ def get_iam_resources(session) -> list:
             for user in page["Users"]:
                 iam_resources.append({"arn": user["Arn"], "tags": user.get("Tags")})
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
     try:
@@ -399,7 +399,7 @@ def get_iam_resources(session) -> list:
             for group in page["Groups"]:
                 iam_resources.append({"arn": group["Arn"], "tags": []})
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
     try:
@@ -408,14 +408,14 @@ def get_iam_resources(session) -> list:
             for policy in page["Policies"]:
                 iam_resources.append({"arn": policy["Arn"], "tags": policy.get("Tags")})
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
     try:
         for saml_provider in iam_client.list_saml_providers()["SAMLProviderList"]:
             iam_resources.append({"arn": saml_provider["Arn"], "tags": []})
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
 

--- a/prowler/providers/aws/lib/resource_api_tagging/resource_api_tagging.py
+++ b/prowler/providers/aws/lib/resource_api_tagging/resource_api_tagging.py
@@ -25,7 +25,7 @@ def get_tagged_resources(input_resource_tags: list, provider):
                     for resource in page["ResourceTagMappingList"]:
                         tagged_resources.append(resource["ResourceARN"])
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
     except Exception as error:

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -140,7 +140,7 @@ class S3:
                                 output.file_extension: [object_name]
                             }
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         if output.file_extension in uploaded_objects["failure"]:
@@ -153,7 +153,7 @@ class S3:
                             }
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
             )
         return uploaded_objects

--- a/prowler/providers/aws/lib/security_hub/security_hub.py
+++ b/prowler/providers/aws/lib/security_hub/security_hub.py
@@ -122,7 +122,7 @@ class SecurityHub:
                 # Include that finding within their region
                 findings_per_region[region].append(finding)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__} -- [{error.__traceback__.tb_lineno}]: {error}"
             )
         return findings_per_region
@@ -180,11 +180,11 @@ class SecurityHub:
                         f"{client_error.__class__.__name__} -- [{client_error.__traceback__.tb_lineno}]: {client_error}"
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{client_error.__class__.__name__} -- [{client_error.__traceback__.tb_lineno}]: {client_error}"
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__} -- [{error.__traceback__.tb_lineno}]: {error}"
                 )
         return enabled_regions
@@ -215,7 +215,7 @@ class SecurityHub:
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__} -- [{error.__traceback__.tb_lineno}]:{error} in region {region}"
             )
         return success_count
@@ -269,7 +269,7 @@ class SecurityHub:
                     region,
                 )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__} -- [{error.__traceback__.tb_lineno}]:{error} in region {region}"
                 )
         return success_count
@@ -299,13 +299,13 @@ class SecurityHub:
                 )
                 if batch_import["FailedCount"] > 0:
                     failed_import = batch_import["FailedFindings"][0]
-                    logger.error(
+                    logger.exception(
                         f"Failed to send findings to AWS Security Hub -- {failed_import['ErrorCode']} -- {failed_import['ErrorMessage']}"
                     )
                 success_count += batch_import["SuccessCount"]
             return success_count
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__} -- [{error.__traceback__.tb_lineno}]:{error} in region {region}"
             )
             return success_count
@@ -406,7 +406,7 @@ class SecurityHub:
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             raise error

--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_enabled/accessanalyzer_enabled_fixer.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_enabled/accessanalyzer_enabled_fixer.py
@@ -34,7 +34,7 @@ def fixer(region):
             ).get("AnalyzerType", "ACCOUNT_UNUSED_ACCESS"),
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
+++ b/prowler/providers/aws/services/accessanalyzer/accessanalyzer_service.py
@@ -54,7 +54,7 @@ class AccessAnalyzer(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -82,7 +82,7 @@ class AccessAnalyzer(AWSService):
                             continue
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -109,15 +109,15 @@ class AccessAnalyzer(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/account/account_service.py
+++ b/prowler/providers/aws/services/account/account_service.py
@@ -54,12 +54,12 @@ class Account(AWSService):
             )
         except Exception as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 return None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 return Contact(type="PRIMARY")
@@ -91,7 +91,7 @@ class Account(AWSService):
             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return Contact(

--- a/prowler/providers/aws/services/acm/acm_service.py
+++ b/prowler/providers/aws/services/acm/acm_service.py
@@ -22,8 +22,6 @@ class ACM(AWSService):
     def _list_certificates(self, regional_client):
         logger.info("ACM - Listing Certificates...")
         try:
-            logger.info("Testing Sentry integration...")
-            raise Exception("error from Andoni")
             includes = {
                 "keyTypes": [
                     "RSA_1024",
@@ -76,6 +74,7 @@ class ACM(AWSService):
     def _describe_certificates(self, certificate):
         logger.info("ACM - Describing Certificates...")
         try:
+            raise Exception(f"No Shodan API Key for Andoni")
             regional_client = self.regional_clients[certificate.region]
             response = regional_client.describe_certificate(
                 CertificateArn=certificate.arn
@@ -86,7 +85,7 @@ class ACM(AWSService):
             ):
                 certificate.transparency_logging = True
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{certificate.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -99,7 +98,7 @@ class ACM(AWSService):
             )["Tags"]
             certificate.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{certificate.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/acm/acm_service.py
+++ b/prowler/providers/aws/services/acm/acm_service.py
@@ -22,6 +22,8 @@ class ACM(AWSService):
     def _list_certificates(self, regional_client):
         logger.info("ACM - Listing Certificates...")
         try:
+            logger.info("Testing Sentry integration...")
+            raise Exception("error from Andoni")
             includes = {
                 "keyTypes": [
                     "RSA_1024",
@@ -67,7 +69,7 @@ class ACM(AWSService):
                             region=regional_client.region,
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/acm/acm_service.py
+++ b/prowler/providers/aws/services/acm/acm_service.py
@@ -74,7 +74,6 @@ class ACM(AWSService):
     def _describe_certificates(self, certificate):
         logger.info("ACM - Describing Certificates...")
         try:
-            raise Exception(f"No Shodan API Key for Andoni")
             regional_client = self.regional_clients[certificate.region]
             response = regional_client.describe_certificate(
                 CertificateArn=certificate.arn

--- a/prowler/providers/aws/services/apigateway/apigateway_service.py
+++ b/prowler/providers/aws/services/apigateway/apigateway_service.py
@@ -39,7 +39,7 @@ class APIGateway(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -61,16 +61,16 @@ class APIGateway(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -89,16 +89,16 @@ class APIGateway(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -151,16 +151,16 @@ class APIGateway(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -204,17 +204,17 @@ class APIGateway(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
+++ b/prowler/providers/aws/services/apigatewayv2/apigatewayv2_service.py
@@ -37,7 +37,7 @@ class ApiGatewayV2(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -50,7 +50,7 @@ class ApiGatewayV2(AWSService):
                 if authorizers:
                     api.authorizer = True
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -77,11 +77,11 @@ class ApiGatewayV2(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 

--- a/prowler/providers/aws/services/appstream/appstream_service.py
+++ b/prowler/providers/aws/services/appstream/appstream_service.py
@@ -45,7 +45,7 @@ class AppStream(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -59,7 +59,7 @@ class AppStream(AWSService):
                 )["Tags"]
                 fleet.tags = [response]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/appsync/appsync_service.py
+++ b/prowler/providers/aws/services/appsync/appsync_service.py
@@ -45,7 +45,7 @@ class AppSync(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/athena/athena_service.py
+++ b/prowler/providers/aws/services/athena/athena_service.py
@@ -35,11 +35,11 @@ class Athena(AWSService):
                             region=regional_client.region,
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -80,7 +80,7 @@ class Athena(AWSService):
                 "PublishCloudWatchMetricsEnabled", False
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -97,11 +97,11 @@ class Athena(AWSService):
                     if queries:
                         workgroup.queries = True
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -115,11 +115,11 @@ class Athena(AWSService):
                         ResourceARN=workgroup.arn
                     ).get("Tags", [])
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{workgroup.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration.py
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_find_secrets_ec2_launch_configuration/autoscaling_find_secrets_ec2_launch_configuration.py
@@ -37,7 +37,7 @@ class autoscaling_find_secrets_ec2_launch_configuration(Check):
                     )
                     continue
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{configuration.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                     continue

--- a/prowler/providers/aws/services/autoscaling/autoscaling_service.py
+++ b/prowler/providers/aws/services/autoscaling/autoscaling_service.py
@@ -48,7 +48,7 @@ class AutoScaling(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -104,7 +104,7 @@ class AutoScaling(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -147,7 +147,7 @@ class ApplicationAutoScaling(AWSService):
                                 )
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible_fixer.py
@@ -53,7 +53,7 @@ def fixer(resource_id: str, region: str) -> bool:
         )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/awslambda/awslambda_service.py
+++ b/prowler/providers/aws/services/awslambda/awslambda_service.py
@@ -56,7 +56,7 @@ class Lambda(AWSService):
                             self.functions[lambda_arn].environment = lambda_environment
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -79,7 +79,7 @@ class Lambda(AWSService):
                 if function_code:
                     yield function, function_code
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{function.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -97,7 +97,7 @@ class Lambda(AWSService):
                     code_zip=zipfile.ZipFile(io.BytesIO(raw_code_zip)),
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             raise
@@ -119,7 +119,7 @@ class Lambda(AWSService):
                             self.functions[function.arn].policy = {}
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -148,7 +148,7 @@ class Lambda(AWSService):
                             self.functions[function.arn].url_config = None
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -167,7 +167,7 @@ class Lambda(AWSService):
                         function.tags = []
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/backup/backup_service.py
+++ b/prowler/providers/aws/services/backup/backup_service.py
@@ -66,14 +66,14 @@ class Backup(AWSService):
                             )
                         )
         except ClientError as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             if error.response["Error"]["Code"] == "AccessDeniedException":
                 if not self.backup_vaults:
                     self.backup_vaults = None
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -108,7 +108,7 @@ class Backup(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -141,7 +141,7 @@ class Backup(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -163,11 +163,11 @@ class Backup(AWSService):
                             )
 
         except ClientError as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -179,7 +179,7 @@ class Backup(AWSService):
                 )["Tags"]
                 resource.tags = [tags] if tags else []
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -209,11 +209,11 @@ class Backup(AWSService):
                                     )
                                 )
         except ClientError as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/bedrock/bedrock_service.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_service.py
@@ -48,7 +48,7 @@ class Bedrock(AWSService):
                     LoggingConfiguration(enabled=False)
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -66,7 +66,7 @@ class Bedrock(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -85,7 +85,7 @@ class Bedrock(AWSService):
                         "inputStrength", "NONE"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{guardrail.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -98,7 +98,7 @@ class Bedrock(AWSService):
                 .get("tags", [])
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{guardrail.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -145,7 +145,7 @@ class BedrockAgent(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -160,7 +160,7 @@ class BedrockAgent(AWSService):
             if agent_tags:
                 resource.tags = [agent_tags]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/cloudformation/cloudformation_service.py
+++ b/prowler/providers/aws/services/cloudformation/cloudformation_service.py
@@ -42,7 +42,7 @@ class CloudFormation(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -70,7 +70,7 @@ class CloudFormation(AWSService):
                     )
                     continue
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{stack.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/aws/services/cloudfront/cloudfront_service.py
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_service.py
@@ -82,7 +82,7 @@ class CloudFront(AWSService):
                             self.distributions[distribution_id] = distribution
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -136,7 +136,7 @@ class CloudFront(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -149,7 +149,7 @@ class CloudFront(AWSService):
                 ]
                 distribution.tags = response.get("Items")
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_logs_s3_bucket_is_not_publicly_accessible/cloudtrail_logs_s3_bucket_is_not_publicly_accessible_fixer.py
@@ -44,7 +44,7 @@ def fixer(resource_id: str, region: str) -> bool:
                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_fixer.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled_fixer.py
@@ -51,7 +51,7 @@ def fixer(region):
             args["KmsKeyId"] = cloudtrail_fixer_config.get("KmsKeyId")
         regional_client.create_trail(**args)
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_service.py
@@ -76,17 +76,17 @@ class Cloudtrail(AWSService):
                 )
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 if not self.trails:
                     self.trails = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -104,7 +104,7 @@ class Cloudtrail(AWSService):
                             ]
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -137,7 +137,7 @@ class Cloudtrail(AWSService):
                                 trail.data_events.append(event_selector)
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -173,11 +173,11 @@ class Cloudtrail(AWSService):
                                     f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                             else:
-                                logger.error(
+                                logger.exception(
                                     f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                             continue
@@ -187,7 +187,7 @@ class Cloudtrail(AWSService):
                             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -203,7 +203,7 @@ class Cloudtrail(AWSService):
             )
             return response.get("Events")
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -223,11 +223,11 @@ class Cloudtrail(AWSService):
                         )["ResourceTagList"][0]
                         trail.tags = response.get("TagsList")
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration_fixer.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration_fixer.py
@@ -65,7 +65,7 @@ def fixer(resource_arn: str) -> bool:
         return True
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_llm_jacking/cloudtrail_threat_detection_llm_jacking_fixer.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_llm_jacking/cloudtrail_threat_detection_llm_jacking_fixer.py
@@ -65,7 +65,7 @@ def fixer(resource_arn: str) -> bool:
         return True
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_privilege_escalation/cloudtrail_threat_detection_privilege_escalation_fixer.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_privilege_escalation/cloudtrail_threat_detection_privilege_escalation_fixer.py
@@ -65,7 +65,7 @@ def fixer(resource_arn: str) -> bool:
         return True
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_service.py
@@ -49,17 +49,17 @@ class CloudWatch(AWSService):
                         )
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDenied":
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 if not self.metric_alarms:
                     self.metric_alarms = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -73,7 +73,7 @@ class CloudWatch(AWSService):
                 )["Tags"]
                 metric_alarm.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -135,17 +135,17 @@ class Logs(AWSService):
                         )
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 if not self.metric_filters:
                     self.metric_filters = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -178,17 +178,17 @@ class Logs(AWSService):
                         )
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 if not self.log_groups:
                     self.log_groups = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -217,7 +217,7 @@ class Logs(AWSService):
                         f"CloudWatch Logs - Retrieved log events for {count}/{total_log_groups} log groups in {regional_client.region}..."
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         logger.info(
@@ -243,16 +243,16 @@ class Logs(AWSService):
                     )
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 self.resource_policies[regional_client.region] = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -270,7 +270,7 @@ class Logs(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled_fixer.py
@@ -51,7 +51,7 @@ def fixer(resource_id: str, region: str) -> bool:
                         )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/codeartifact/codeartifact_service.py
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_service.py
@@ -45,7 +45,7 @@ class CodeArtifact(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -162,7 +162,7 @@ class CodeArtifact(AWSService):
                     continue
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} --"
                     f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                     f" {error}"
@@ -178,7 +178,7 @@ class CodeArtifact(AWSService):
                 )["tags"]
                 repository.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/codebuild/codebuild_service.py
+++ b/prowler/providers/aws/services/codebuild/codebuild_service.py
@@ -40,7 +40,7 @@ class Codebuild(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -54,7 +54,7 @@ class Codebuild(AWSService):
             if len(build_ids) > 0:
                 project.last_build = Build(id=build_ids[0])
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{project.region}: {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -69,7 +69,7 @@ class Codebuild(AWSService):
                 if len(builds_by_id) > 0:
                     project.last_invoked_time = builds_by_id[0].get("endTime")
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region}: {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -121,7 +121,7 @@ class Codebuild(AWSService):
             )
             project.tags = project_info.get("tags", [])
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -142,7 +142,7 @@ class Codebuild(AWSService):
                             region=regional_client.region,
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -175,7 +175,7 @@ class Codebuild(AWSService):
 
             report_group.tags = report_group_info.get("tags", [])
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/cognito/cognito_service.py
+++ b/prowler/providers/aws/services/cognito/cognito_service.py
@@ -42,11 +42,11 @@ class CognitoIDP(AWSService):
                                 user_pool_clients={},
                             )
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -105,11 +105,11 @@ class CognitoIDP(AWSService):
                         "UserPoolTags", []
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -134,11 +134,11 @@ class CognitoIDP(AWSService):
                             region=user_pool.region,
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -166,11 +166,11 @@ class CognitoIDP(AWSService):
                             "EnableTokenRevocation", False
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -193,11 +193,11 @@ class CognitoIDP(AWSService):
                             status=mfa_config["MfaConfiguration"],
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -251,11 +251,11 @@ class CognitoIDP(AWSService):
                             )
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{user_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -288,11 +288,11 @@ class CognitoIdentity(AWSService):
                                 region=regional_client.region,
                             )
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -316,11 +316,11 @@ class CognitoIdentity(AWSService):
                         "AllowUnauthenticatedIdentities", False
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{identity_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{identity_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -341,11 +341,11 @@ class CognitoIdentity(AWSService):
                         ),
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{identity_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{identity_pool.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/config/config_service.py
+++ b/prowler/providers/aws/services/config/config_service.py
@@ -46,7 +46,7 @@ class Config(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -69,7 +69,7 @@ class Config(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{recorder.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/datasync/datasync_service.py
+++ b/prowler/providers/aws/services/datasync/datasync_service.py
@@ -48,7 +48,7 @@ class DataSync(AWSService):
                             region=regional_client.region,
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -72,11 +72,11 @@ class DataSync(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -94,11 +94,11 @@ class DataSync(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/directconnect/directconnect_service.py
+++ b/prowler/providers/aws/services/directconnect/directconnect_service.py
@@ -50,7 +50,7 @@ class DirectConnect(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -112,11 +112,11 @@ class DirectConnect(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/directoryservice/directoryservice_service.py
+++ b/prowler/providers/aws/services/directoryservice/directoryservice_service.py
@@ -66,7 +66,7 @@ class DirectoryService(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -96,7 +96,7 @@ class DirectoryService(AWSService):
                             )
                     self.directories[directory.id].log_subscriptions = log_subscriptions
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -138,16 +138,16 @@ class DirectoryService(AWSService):
                                     f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                             else:
-                                logger.error(
+                                logger.exception(
                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -191,13 +191,13 @@ class DirectoryService(AWSService):
                                 f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                         else:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                         continue
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -232,16 +232,16 @@ class DirectoryService(AWSService):
                                 f"{directory.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                         else:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -255,7 +255,7 @@ class DirectoryService(AWSService):
                 )["Tags"]
                 directory.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/dlm/dlm_service.py
+++ b/prowler/providers/aws/services/dlm/dlm_service.py
@@ -31,7 +31,7 @@ class DLM(AWSService):
                 )
             self.lifecycle_policies[regional_client.region] = policies
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/dms/dms_service.py
+++ b/prowler/providers/aws/services/dms/dms_service.py
@@ -55,7 +55,7 @@ class DMS(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -88,7 +88,7 @@ class DMS(AWSService):
                             engine_name=endpoint["EngineName"],
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -119,7 +119,7 @@ class DMS(AWSService):
                             ),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -129,7 +129,7 @@ class DMS(AWSService):
                 resource.region
             ].list_tags_for_resource(ResourceArn=resource.arn)["TagList"]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_cluster_public_snapshot/documentdb_cluster_public_snapshot_fixer.py
@@ -34,7 +34,7 @@ def fixer(resource_id: str, region: str) -> bool:
             ValuesToRemove=["all"],
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/documentdb/documentdb_service.py
+++ b/prowler/providers/aws/services/documentdb/documentdb_service.py
@@ -57,7 +57,7 @@ class DocumentDB(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -72,7 +72,7 @@ class DocumentDB(AWSService):
                     )["TagList"]
                     cluster.tags = response
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
             for instance_arn, instance in self.db_instances.items():
@@ -83,11 +83,11 @@ class DocumentDB(AWSService):
                     )["TagList"]
                     instance.tags = response
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -133,7 +133,7 @@ class DocumentDB(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -164,7 +164,7 @@ class DocumentDB(AWSService):
                                 )
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -185,11 +185,11 @@ class DocumentDB(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/drs/drs_service.py
+++ b/prowler/providers/aws/services/drs/drs_service.py
@@ -51,11 +51,11 @@ class DRS(AWSService):
                         )
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 

--- a/prowler/providers/aws/services/dynamodb/dynamodb_service.py
+++ b/prowler/providers/aws/services/dynamodb/dynamodb_service.py
@@ -37,7 +37,7 @@ class DynamoDB(AWSService):
                             region=regional_client.region,
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -62,7 +62,7 @@ class DynamoDB(AWSService):
                     "DeletionProtectionEnabled", False
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -89,12 +89,12 @@ class DynamoDB(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     continue
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -118,12 +118,12 @@ class DynamoDB(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     continue
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -143,12 +143,12 @@ class DynamoDB(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     continue
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -195,7 +195,7 @@ class DAX(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -216,7 +216,7 @@ class DAX(AWSService):
                     continue
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_ami_public/ec2_ami_public_fixer.py
@@ -32,7 +32,7 @@ def fixer(resource_id: str, region: str) -> bool:
             LaunchPermission={"Remove": [{"Group": "all"}]},
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_default_encryption/ec2_ebs_default_encryption_fixer.py
@@ -28,7 +28,7 @@ def fixer(region):
             "EbsEncryptionByDefault"
         ]
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_public_snapshot/ec2_ebs_public_snapshot_fixer.py
@@ -33,7 +33,7 @@ def fixer(resource_id: str, region: str) -> bool:
             GroupNames=["all"],
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_ebs_snapshot_account_block_public_access/ec2_ebs_snapshot_account_block_public_access_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_ebs_snapshot_account_block_public_access/ec2_ebs_snapshot_account_block_public_access_fixer.py
@@ -32,7 +32,7 @@ def fixer(region):
             == state
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan.py
+++ b/prowler/providers/aws/services/ec2/ec2_elastic_ip_shodan/ec2_elastic_ip_shodan.py
@@ -30,10 +30,10 @@ class ec2_elastic_ip_shodan(Check):
                             findings.append(report)
                             continue
                         else:
-                            logger.error(f"Unknown Shodan API Error: {error.value}")
+                            logger.exception(f"Unknown Shodan API Error: {error.value}")
 
         else:
-            logger.error(
+            logger.exception(
                 "No Shodan API Key -- Please input a Shodan API Key with -N/--shodan or in config.yaml"
             )
         return findings

--- a/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled_fixer.py
@@ -29,7 +29,7 @@ def fixer(region):
             "Return"
         ]
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_cassandra_exposed_to_internet/ec2_instance_port_cassandra_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_cifs_exposed_to_internet/ec2_instance_port_cifs_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_elasticsearch_kibana_exposed_to_internet/ec2_instance_port_elasticsearch_kibana_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ftp_exposed_to_internet/ec2_instance_port_ftp_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_kafka_exposed_to_internet/ec2_instance_port_kafka_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_kerberos_exposed_to_internet/ec2_instance_port_kerberos_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ldap_exposed_to_internet/ec2_instance_port_ldap_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_memcached_exposed_to_internet/ec2_instance_port_memcached_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_mongodb_exposed_to_internet/ec2_instance_port_mongodb_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_mysql_exposed_to_internet/ec2_instance_port_mysql_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_oracle_exposed_to_internet/ec2_instance_port_oracle_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_postgresql_exposed_to_internet/ec2_instance_port_postgresql_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_rdp_exposed_to_internet/ec2_instance_port_rdp_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_redis_exposed_to_internet/ec2_instance_port_redis_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_sqlserver_exposed_to_internet/ec2_instance_port_sqlserver_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_ssh_exposed_to_internet/ec2_instance_port_ssh_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_port_telnet_exposed_to_internet/ec2_instance_port_telnet_exposed_to_internet_fixer.py
@@ -43,7 +43,7 @@ def fixer(resource_id: str, region: str) -> bool:
                                 )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_secrets_user_data/ec2_instance_secrets_user_data.py
@@ -32,7 +32,7 @@ class ec2_instance_secrets_user_data(Check):
                         )
                         continue
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{instance.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                         continue

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_no_secrets/ec2_launch_template_no_secrets.py
@@ -37,7 +37,7 @@ class ec2_launch_template_no_secrets(Check):
                     )
                     continue
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{template.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                     continue

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports/ec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports_fixer.py
@@ -44,7 +44,7 @@ def fixer(resource_id: str, region: str) -> bool:
                         )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ec2/ec2_service.py
+++ b/prowler/providers/aws/services/ec2/ec2_service.py
@@ -113,7 +113,7 @@ class EC2(AWSService):
                                 )
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -148,7 +148,7 @@ class EC2(AWSService):
                         if sg["GroupName"] != "default":
                             self.regions_with_sgs.append(regional_client.region)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -183,7 +183,7 @@ class EC2(AWSService):
                             default=nacl["IsDefault"],
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -216,7 +216,7 @@ class EC2(AWSService):
             # Store that the region has at least one snapshot
             self.regions_with_snapshots[regional_client.region] = snapshots_in_region
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -239,7 +239,7 @@ class EC2(AWSService):
                     f" {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -312,7 +312,7 @@ class EC2(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -325,7 +325,7 @@ class EC2(AWSService):
                     if security_group.id == sg["GroupId"]:
                         security_group.network_interfaces.append(interface)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -343,7 +343,7 @@ class EC2(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -365,7 +365,7 @@ class EC2(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -390,7 +390,7 @@ class EC2(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -421,7 +421,7 @@ class EC2(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -441,7 +441,7 @@ class EC2(AWSService):
                 )
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -461,7 +461,7 @@ class EC2(AWSService):
                 )
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -481,7 +481,7 @@ class EC2(AWSService):
                 )
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -508,7 +508,7 @@ class EC2(AWSService):
                 "has_volumes": has_volumes,
             }
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -536,7 +536,7 @@ class EC2(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -581,7 +581,7 @@ class EC2(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -608,7 +608,7 @@ class EC2(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -641,7 +641,7 @@ class EC2(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/ecr/ecr_repositories_not_publicly_accessible/ecr_repositories_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/ecr/ecr_repositories_not_publicly_accessible/ecr_repositories_not_publicly_accessible_fixer.py
@@ -30,7 +30,7 @@ def fixer(resource_id: str, region: str) -> bool:
         regional_client.delete_repository_policy(repositoryName=resource_id)
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/ecr/ecr_service.py
+++ b/prowler/providers/aws/services/ecr/ecr_service.py
@@ -63,7 +63,7 @@ class ECR(AWSService):
             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -91,7 +91,7 @@ class ECR(AWSService):
 
         except Exception as error:
             if "RepositoryPolicyNotFoundException" not in str(error):
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -119,7 +119,7 @@ class ECR(AWSService):
                             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -201,7 +201,7 @@ class ECR(AWSService):
                                                 )
                                                 continue
                                             except Exception as error:
-                                                logger.error(
+                                                logger.exception(
                                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                                 )
                                                 continue
@@ -247,7 +247,7 @@ class ECR(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -275,7 +275,7 @@ class ECR(AWSService):
                             )
                             continue
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -306,12 +306,12 @@ class ECR(AWSService):
                 self.registries[regional_client.region].scan_type = "BASIC"
                 self.registries[regional_client.region].rules = []
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -348,7 +348,7 @@ class ECR(AWSService):
 
             return artifact_media_type in scannable_artifact_media_types
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return False

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -42,7 +42,7 @@ class ECS(AWSService):
                             environment_variables=[],
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -89,7 +89,7 @@ class ECS(AWSService):
                 "networkMode", "bridge"
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -144,7 +144,7 @@ class ECS(AWSService):
                     cluster.services[service_arn] = service_obj
                     self.services[service_arn] = service_obj
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -163,7 +163,7 @@ class ECS(AWSService):
                             region=regional_client.region,
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -180,7 +180,7 @@ class ECS(AWSService):
             cluster.settings = response["clusters"][0].get("settings", [])
             cluster.tags = response["clusters"][0].get("tags", [])
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/efs/efs_service.py
+++ b/prowler/providers/aws/services/efs/efs_service.py
@@ -44,7 +44,7 @@ class EFS(AWSService):
                             tags=efs.get("Tags"),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -63,7 +63,7 @@ class EFS(AWSService):
                         f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
             try:
@@ -79,11 +79,11 @@ class EFS(AWSService):
                         f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -111,7 +111,7 @@ class EFS(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -142,7 +142,7 @@ class EFS(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/eks/eks_service.py
+++ b/prowler/providers/aws/services/eks/eks_service.py
@@ -34,7 +34,7 @@ class EKS(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -87,7 +87,7 @@ class EKS(AWSService):
                 cluster.version = describe_cluster["cluster"].get("version", "")
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/elasticache/elasticache_service.py
+++ b/prowler/providers/aws/services/elasticache/elasticache_service.py
@@ -47,11 +47,11 @@ class ElastiCache(AWSService):
                             ),
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -74,11 +74,11 @@ class ElastiCache(AWSService):
 
                             cluster.subnets = subnets
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -126,11 +126,11 @@ class ElastiCache(AWSService):
                             engine_version=engine_version,
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -154,7 +154,7 @@ class ElastiCache(AWSService):
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
             for repl_group in self.replication_groups.values():
@@ -176,11 +176,11 @@ class ElastiCache(AWSService):
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/elasticbeanstalk/elasticbeanstalk_service.py
+++ b/prowler/providers/aws/services/elasticbeanstalk/elasticbeanstalk_service.py
@@ -40,7 +40,7 @@ class ElasticBeanstalk(AWSService):
                             region=regional_client.region,
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -72,7 +72,7 @@ class ElasticBeanstalk(AWSService):
                 ):
                     environment.cloudwatch_stream_logs = option.get("Value", "false")
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -85,11 +85,11 @@ class ElasticBeanstalk(AWSService):
             ]
             resource.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/elb/elb_service.py
+++ b/prowler/providers/aws/services/elb/elb_service.py
@@ -52,7 +52,7 @@ class ELB(AWSService):
                             availability_zones=set(elb.get("AvailabilityZones", [])),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -77,7 +77,7 @@ class ELB(AWSService):
                     load_balancer.desync_mitigation_mode = attribute["Value"]
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{load_balancer.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -93,7 +93,7 @@ class ELB(AWSService):
             load_balancer.tags = tags
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{load_balancer.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/elbv2/elbv2_service.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_service.py
@@ -55,7 +55,7 @@ class ELBv2(AWSService):
                             },
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -86,11 +86,11 @@ class ELBv2(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -122,11 +122,11 @@ class ELBv2(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -152,11 +152,11 @@ class ELBv2(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -174,11 +174,11 @@ class ELBv2(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/emr/emr_service.py
+++ b/prowler/providers/aws/services/emr/emr_service.py
@@ -47,7 +47,7 @@ class EMR(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -124,7 +124,7 @@ class EMR(AWSService):
                     cluster.tags = cluster_info["Cluster"].get("Tags")
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -146,7 +146,7 @@ class EMR(AWSService):
                 )
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"

--- a/prowler/providers/aws/services/eventbridge/eventbridge_service.py
+++ b/prowler/providers/aws/services/eventbridge/eventbridge_service.py
@@ -34,7 +34,7 @@ class EventBridge(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -48,11 +48,11 @@ class EventBridge(AWSService):
                         bus.kms_key_id = response.get("KmsKeyIdentifier")
                         bus.policy = json.loads(response.get("Policy", "{}"))
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -73,7 +73,7 @@ class EventBridge(AWSService):
                         ),
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -92,15 +92,15 @@ class EventBridge(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -148,7 +148,7 @@ class Schema(AWSService):
                         tags=[registry["Tags"]],
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -172,15 +172,15 @@ class Schema(AWSService):
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                         else:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/firehose/firehose_service.py
+++ b/prowler/providers/aws/services/firehose/firehose_service.py
@@ -38,7 +38,7 @@ class Firehose(AWSService):
                         region=regional_client.region,
                     )
         except ClientError as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -51,7 +51,7 @@ class Firehose(AWSService):
                 .get("Tags", [])
             )
         except ClientError as error:
-            logger.error(
+            logger.exception(
                 f"{stream.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -69,7 +69,7 @@ class Firehose(AWSService):
             )
             stream.kms_key_arn = encryption_config.get("KeyARN", "")
         except ClientError as error:
-            logger.error(
+            logger.exception(
                 f"{stream.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/fms/fms_service.py
+++ b/prowler/providers/aws/services/fms/fms_service.py
@@ -54,12 +54,12 @@ class FMS(AWSService):
                         # FMS is not enabled in this account
                         self.fms_admin_account = False
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                         )
                         self.fms_admin_account = None
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -90,7 +90,7 @@ class FMS(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 

--- a/prowler/providers/aws/services/fsx/fsx_service.py
+++ b/prowler/providers/aws/services/fsx/fsx_service.py
@@ -56,7 +56,7 @@ class FSx(AWSService):
                             tags=file_system.get("Tags", []),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/glacier/glacier_service.py
+++ b/prowler/providers/aws/services/glacier/glacier_service.py
@@ -37,7 +37,7 @@ class Glacier(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -59,7 +59,7 @@ class Glacier(AWSService):
                         if e.response["Error"]["Code"] == "ResourceNotFoundException":
                             self.vaults[vault.arn].access_policy = {}
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -75,7 +75,7 @@ class Glacier(AWSService):
                 ]
                 vault.tags = [response]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer.py
+++ b/prowler/providers/aws/services/glacier/glacier_vaults_policy_public_access/glacier_vaults_policy_public_access_fixer.py
@@ -30,7 +30,7 @@ def fixer(resource_id: str, region: str) -> bool:
         regional_client.delete_vault_access_policy(vaultName=resource_id)
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
+++ b/prowler/providers/aws/services/globalaccelerator/globalaccelerator_service.py
@@ -44,7 +44,7 @@ class GlobalAccelerator(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -57,7 +57,7 @@ class GlobalAccelerator(AWSService):
             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/glue/glue_service.py
+++ b/prowler/providers/aws/services/glue/glue_service.py
@@ -56,7 +56,7 @@ class Glue(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -89,11 +89,11 @@ class Glue(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -117,7 +117,7 @@ class Glue(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -157,7 +157,7 @@ class Glue(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -179,7 +179,7 @@ class Glue(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -209,7 +209,7 @@ class Glue(AWSService):
                 encryption_settings=catalog_encryption_settings,
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -221,7 +221,7 @@ class Glue(AWSService):
                 )["Tags"]
             ]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -245,7 +245,7 @@ class Glue(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -262,11 +262,11 @@ class Glue(AWSService):
                     f"{data_catalog.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{data_catalog.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{data_catalog.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_fixer.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_is_enabled/guardduty_is_enabled_fixer.py
@@ -25,7 +25,7 @@ def fixer(region):
         regional_client = guardduty_client.regional_clients[region]
         regional_client.create_detector(Enable=True)
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/guardduty/guardduty_service.py
+++ b/prowler/providers/aws/services/guardduty/guardduty_service.py
@@ -51,7 +51,7 @@ class GuardDuty(AWSService):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -108,7 +108,7 @@ class GuardDuty(AWSService):
                         detector.eks_runtime_monitoring = True
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -132,13 +132,13 @@ class GuardDuty(AWSService):
                                 detector_administrator_account.get("AccountId")
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                         continue
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -158,12 +158,12 @@ class GuardDuty(AWSService):
                             for member in page["Members"]:
                                 detector.member_accounts.append(member.get("AccountId"))
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                         continue
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -197,7 +197,7 @@ class GuardDuty(AWSService):
                             detector.findings.append(finding)
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -212,7 +212,7 @@ class GuardDuty(AWSService):
                     )["Tags"]
                     detector.tags = [response]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 

--- a/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_expires_passwords_within_90_days_or_less/iam_password_policy_expires_passwords_within_90_days_or_less_fixer.py
@@ -37,7 +37,7 @@ def fixer(resource_id: str) -> bool:
             HardExpiry=iam_client.password_policy.hard_expiry,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_lowercase/iam_password_policy_lowercase_fixer.py
@@ -37,7 +37,7 @@ def fixer(resource_id: str) -> bool:
             HardExpiry=iam_client.password_policy.hard_expiry,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_minimum_length_14/iam_password_policy_minimum_length_14_fixer.py
@@ -37,7 +37,7 @@ def fixer(resource_id: str) -> bool:
             HardExpiry=iam_client.password_policy.hard_expiry,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_number/iam_password_policy_number_fixer.py
@@ -37,7 +37,7 @@ def fixer(resource_id: str) -> bool:
             HardExpiry=iam_client.password_policy.hard_expiry,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_reuse_24/iam_password_policy_reuse_24_fixer.py
@@ -37,7 +37,7 @@ def fixer(resource_id: str) -> bool:
             HardExpiry=iam_client.password_policy.hard_expiry,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_symbol/iam_password_policy_symbol_fixer.py
@@ -37,7 +37,7 @@ def fixer(resource_id: str) -> bool:
             HardExpiry=iam_client.password_policy.hard_expiry,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase_fixer.py
+++ b/prowler/providers/aws/services/iam/iam_password_policy_uppercase/iam_password_policy_uppercase_fixer.py
@@ -37,7 +37,7 @@ def fixer(resource_id: str) -> bool:
             HardExpiry=iam_client.password_policy.hard_expiry,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -41,7 +41,7 @@ def is_service_role(role):
                 ):
                     return True
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
     return False
@@ -138,16 +138,16 @@ class IAM(AWSService):
                         )
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDenied":
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 roles = None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -176,11 +176,11 @@ class IAM(AWSService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -199,7 +199,7 @@ class IAM(AWSService):
                         groups.append(Group(name=group["GroupName"], arn=group["Arn"]))
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -210,7 +210,7 @@ class IAM(AWSService):
         try:
             account_summary = self.client.get_account_summary()
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             account_summary = None
@@ -268,17 +268,17 @@ class IAM(AWSService):
                 )
             elif error.response["Error"]["Code"] == "AccessDenied":
                 # User does not have permission to get password policy
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 stored_password_policy = None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -303,7 +303,7 @@ class IAM(AWSService):
                             user_login_profile = None
                         except Exception as error:
                             user_login_profile = None
-                            logger.error(
+                            logger.exception(
                                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
 
@@ -316,7 +316,7 @@ class IAM(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -334,7 +334,7 @@ class IAM(AWSService):
                 for mfa_device in page["VirtualMFADevices"]:
                     mfa_devices.append(mfa_device)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -357,11 +357,11 @@ class IAM(AWSService):
 
                     group.attached_policies = attached_group_policies
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -387,7 +387,7 @@ class IAM(AWSService):
                             )
                 group.users = group_users
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -419,16 +419,16 @@ class IAM(AWSService):
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -455,16 +455,16 @@ class IAM(AWSService):
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -491,17 +491,17 @@ class IAM(AWSService):
                                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                         else:
-                            logger.error(
+                            logger.exception(
                                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
 
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -541,11 +541,11 @@ class IAM(AWSService):
                                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                             else:
-                                logger.error(
+                                logger.exception(
                                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                 user.inline_policies = inline_user_policies
@@ -555,11 +555,11 @@ class IAM(AWSService):
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -599,12 +599,12 @@ class IAM(AWSService):
                                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                             else:
-                                logger.error(
+                                logger.exception(
                                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
 
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                 group.inline_policies = inline_group_policies
@@ -614,12 +614,12 @@ class IAM(AWSService):
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -660,12 +660,12 @@ class IAM(AWSService):
                                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                     )
                                 else:
-                                    logger.error(
+                                    logger.exception(
                                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                     )
 
                             except Exception as error:
-                                logger.error(
+                                logger.exception(
                                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
 
@@ -677,12 +677,12 @@ class IAM(AWSService):
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
@@ -696,16 +696,16 @@ class IAM(AWSService):
             return roles
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDenied":
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 roles = None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -734,16 +734,16 @@ class IAM(AWSService):
             return entities
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDenied":
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 entities = None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -774,7 +774,7 @@ class IAM(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -795,12 +795,12 @@ class IAM(AWSService):
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     continue
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -818,13 +818,13 @@ class IAM(AWSService):
                         name=provider["Arn"].split("/")[-1], arn=provider["Arn"]
                     )
         except ClientError as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             if error.response["Error"]["Code"] == "AccessDenied":
                 saml_providers = None
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -849,7 +849,7 @@ class IAM(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         finally:
@@ -880,7 +880,7 @@ class IAM(AWSService):
                     SAMLProviderArn=resource.arn
                 ).get("Tags", [])
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -909,16 +909,16 @@ class IAM(AWSService):
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -939,15 +939,15 @@ class IAM(AWSService):
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -980,7 +980,7 @@ class IAM(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -1016,11 +1016,11 @@ class IAM(AWSService):
                 )
                 self.organization_features = None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.py
+++ b/prowler/providers/aws/services/iam/iam_user_two_active_access_key/iam_user_two_active_access_key.py
@@ -33,6 +33,6 @@ class iam_user_two_active_access_key(Check):
                     )
                 findings.append(report)
         except Exception as error:
-            logger.error(f"{error.__class__.__name__} -- {error}")
+            logger.exception(f"{error.__class__.__name__} -- {error}")
         finally:
             return findings

--- a/prowler/providers/aws/services/iam/lib/policy.py
+++ b/prowler/providers/aws/services/iam/lib/policy.py
@@ -99,9 +99,9 @@ def is_condition_restricting_from_private_ip(condition_statement: dict) -> bool:
                     is_from_private_ip = True
 
     except ValueError:
-        logger.error(f"Invalid IP: {ip}")
+        logger.exception(f"Invalid IP: {ip}")
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
 

--- a/prowler/providers/aws/services/iam/lib/privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/lib/privilege_escalation.py
@@ -163,7 +163,7 @@ def find_privilege_escalation_combinations(
                                 if api == "*":
                                     policies_combination.add(val)
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
 

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -35,7 +35,7 @@ class Inspector2(AWSService):
                 )
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -55,7 +55,7 @@ class Inspector2(AWSService):
             inspector.active_findings = len(active_findings.get("findings")) > 0
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/kafka/kafka_service.py
+++ b/prowler/providers/aws/services/kafka/kafka_service.py
@@ -67,7 +67,7 @@ class Kafka(AWSService):
                             ),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -86,7 +86,7 @@ class Kafka(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -143,7 +143,7 @@ class KafkaConnect(AWSService):
                             ).get("encryptionType", "PLAINTEXT"),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/kinesis/kinesis_service.py
+++ b/prowler/providers/aws/services/kinesis/kinesis_service.py
@@ -34,7 +34,7 @@ class Kinesis(AWSService):
                             status=StreamStatus(stream.get("StreamStatus", "ACTIVE")),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -51,7 +51,7 @@ class Kinesis(AWSService):
             )
             stream.retention_period = stream_description.get("RetentionPeriodHours", 24)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{stream.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -64,7 +64,7 @@ class Kinesis(AWSService):
                 .get("Tags", [])
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{stream.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_fixer.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_not_deleted_unintentionally/kms_cmk_not_deleted_unintentionally_fixer.py
@@ -28,7 +28,7 @@ def fixer(resource_id: str, region: str) -> bool:
         regional_client = kms_client.regional_clients[region]
         regional_client.cancel_key_deletion(KeyId=resource_id)
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_fixer.py
+++ b/prowler/providers/aws/services/kms/kms_cmk_rotation_enabled/kms_cmk_rotation_enabled_fixer.py
@@ -26,7 +26,7 @@ def fixer(resource_id: str, region: str) -> bool:
         regional_client = kms_client.regional_clients[region]
         regional_client.enable_key_rotation(KeyId=resource_id)
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/kms/kms_service.py
+++ b/prowler/providers/aws/services/kms/kms_service.py
@@ -38,11 +38,11 @@ class KMS(AWSService):
                                 )
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -59,11 +59,11 @@ class KMS(AWSService):
                     key.spec = response["KeyMetadata"]["CustomerMasterKeySpec"]
                     key.multi_region = response["KeyMetadata"]["MultiRegion"]
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -83,11 +83,11 @@ class KMS(AWSService):
                             KeyId=key.id
                         )["KeyRotationEnabled"]
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -106,11 +106,11 @@ class KMS(AWSService):
                             )["Policy"]
                         )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -128,11 +128,11 @@ class KMS(AWSService):
                         )["Tags"]
                         key.tags = response
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 

--- a/prowler/providers/aws/services/lightsail/lightsail_service.py
+++ b/prowler/providers/aws/services/lightsail/lightsail_service.py
@@ -84,7 +84,7 @@ class Lightsail(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -123,7 +123,7 @@ class Lightsail(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -157,7 +157,7 @@ class Lightsail(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/macie/macie_service.py
+++ b/prowler/providers/aws/services/macie/macie_service.py
@@ -36,7 +36,7 @@ class Macie(AWSService):
                     )
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -52,7 +52,7 @@ class Macie(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/memorydb/memorydb_service.py
+++ b/prowler/providers/aws/services/memorydb/memorydb_service.py
@@ -46,11 +46,11 @@ class MemoryDB(AWSService):
                                 snapshot_limit=cluster["SnapshotRetentionLimit"],
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/mq/mq_service.py
+++ b/prowler/providers/aws/services/mq/mq_service.py
@@ -32,7 +32,7 @@ class MQ(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -62,7 +62,7 @@ class MQ(AWSService):
             broker.tags = [describe_broker.get("Tags", {})]
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{broker.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/neptune/neptune_cluster_public_snapshot/neptune_cluster_public_snapshot_fixer.py
+++ b/prowler/providers/aws/services/neptune/neptune_cluster_public_snapshot/neptune_cluster_public_snapshot_fixer.py
@@ -32,7 +32,7 @@ def fixer(resource_id: str, region: str) -> bool:
             ValuesToRemove=["all"],
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/neptune/neptune_service.py
+++ b/prowler/providers/aws/services/neptune/neptune_service.py
@@ -54,7 +54,7 @@ class Neptune(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -74,12 +74,12 @@ class Neptune(AWSService):
 
                         cluster.subnets = subnets
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -93,11 +93,11 @@ class Neptune(AWSService):
                         ResourceName=cluster.arn
                     )["TagList"]
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -128,7 +128,7 @@ class Neptune(AWSService):
                                 )
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -149,11 +149,11 @@ class Neptune(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_service.py
@@ -44,7 +44,7 @@ class NetworkFirewall(AWSService):
                             name=network_firewall.get("FirewallName"),
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -74,7 +74,7 @@ class NetworkFirewall(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -101,7 +101,7 @@ class NetworkFirewall(AWSService):
                 "StatelessFragmentDefaultActions", []
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -134,7 +134,7 @@ class NetworkFirewall(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 

--- a/prowler/providers/aws/services/opensearch/opensearch_service.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service.py
@@ -31,7 +31,7 @@ class OpenSearchService(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -116,7 +116,7 @@ class OpenSearchService(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -129,7 +129,7 @@ class OpenSearchService(AWSService):
             )["TagList"]
             domain.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/opensearch/opensearch_service_domains_not_publicly_accessible/opensearch_service_domains_not_publicly_accessible_fixer.py
@@ -35,7 +35,7 @@ def fixer(resource_id: str, region: str) -> bool:
         )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/organizations/organizations_service.py
+++ b/prowler/providers/aws/services/organizations/organizations_service.py
@@ -50,7 +50,7 @@ class Organizations(AWSService):
                         master_id="",
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
             else:
@@ -74,7 +74,7 @@ class Organizations(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -113,12 +113,12 @@ class Organizations(AWSService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -140,7 +140,7 @@ class Organizations(AWSService):
 
             return policy_content
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return {}
@@ -158,7 +158,7 @@ class Organizations(AWSService):
             return targets_for_policy
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return []
@@ -188,7 +188,7 @@ class Organizations(AWSService):
                 self.delegated_administrators = None
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_fixer.py
+++ b/prowler/providers/aws/services/rds/rds_instance_no_public_access/rds_instance_no_public_access_fixer.py
@@ -32,7 +32,7 @@ def fixer(resource_id: str, region: str) -> bool:
             ApplyImmediately=True,
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/rds/rds_service.py
+++ b/prowler/providers/aws/services/rds/rds_service.py
@@ -111,7 +111,7 @@ class RDS(AWSService):
                                 ],
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -131,12 +131,12 @@ class RDS(AWSService):
                                 for parameter in page["Parameters"]:
                                     instance.parameters.append(parameter)
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -175,12 +175,12 @@ class RDS(AWSService):
                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
                             else:
-                                logger.error(
+                                logger.exception(
                                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -208,7 +208,7 @@ class RDS(AWSService):
                                 )
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -230,7 +230,7 @@ class RDS(AWSService):
                     )
                     continue
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -290,15 +290,15 @@ class RDS(AWSService):
                                     # We must use a unique value as the dict key to have unique keys
                                     self.db_clusters[db_cluster_arn] = db_cluster
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -339,15 +339,15 @@ class RDS(AWSService):
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                         else:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -378,7 +378,7 @@ class RDS(AWSService):
                                 )
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -399,11 +399,11 @@ class RDS(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -433,7 +433,7 @@ class RDS(AWSService):
                         ].engine_versions.append(engine["EngineVersion"])
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -469,7 +469,7 @@ class RDS(AWSService):
                             )
                             events_exist = True
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
             if not events_exist:
@@ -489,7 +489,7 @@ class RDS(AWSService):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -502,7 +502,7 @@ class RDS(AWSService):
                     .get("TagList", [])
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer.py
+++ b/prowler/providers/aws/services/rds/rds_snapshots_public_access/rds_snapshots_public_access_fixer.py
@@ -52,7 +52,7 @@ def fixer(resource_id: str, region: str) -> bool:
             )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/redshift/redshift_service.py
+++ b/prowler/providers/aws/services/redshift/redshift_service.py
@@ -60,7 +60,7 @@ class Redshift(AWSService):
                         )
                         self.clusters.append(cluster_to_append)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -80,7 +80,7 @@ class Redshift(AWSService):
                 ]
                 cluster.subnets = subnets
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -100,7 +100,7 @@ class Redshift(AWSService):
                 cluster.bucket = cluster_attributes["BucketName"]
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -115,7 +115,7 @@ class Redshift(AWSService):
                 cluster.cluster_snapshots = True
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -132,7 +132,7 @@ class Redshift(AWSService):
                         cluster.require_ssl = True
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
+++ b/prowler/providers/aws/services/resourceexplorer2/resourceexplorer2_service.py
@@ -34,17 +34,17 @@ class ResourceExplorer2(AWSService):
                         )
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 if not self.indexes:
                     self.indexes = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/route53/route53_service.py
+++ b/prowler/providers/aws/services/route53/route53_service.py
@@ -41,7 +41,7 @@ class Route53(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -73,7 +73,7 @@ class Route53(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -96,7 +96,7 @@ class Route53(AWSService):
                             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -109,7 +109,7 @@ class Route53(AWSService):
                 )["ResourceTagSet"]
                 hosted_zone.tags = response.get("Tags")
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -166,7 +166,7 @@ class Route53Domains(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -179,7 +179,7 @@ class Route53Domains(AWSService):
                 self.domains[domain.name].status_list = domain_detail.get("StatusList")
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -192,7 +192,7 @@ class Route53Domains(AWSService):
                 )["TagList"]
                 domain.tags = response
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_account_level_public_access_blocks/s3_account_level_public_access_blocks_fixer.py
@@ -33,7 +33,7 @@ def fixer(resource_id: str) -> bool:
             },
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_policy_public_write_access/s3_bucket_policy_public_write_access_fixer.py
@@ -30,7 +30,7 @@ def fixer(resource_id: str, region: str) -> bool:
         regional_client.delete_bucket_policy(Bucket=resource_id)
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_public_access/s3_bucket_public_access_fixer.py
@@ -38,7 +38,7 @@ def fixer(resource_id: str, region: str) -> bool:
             },
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_public_list_acl/s3_bucket_public_list_acl_fixer.py
@@ -32,7 +32,7 @@ def fixer(resource_id: str, region: str) -> bool:
         regional_client = s3_client.regional_clients[region]
         regional_client.put_bucket_acl(Bucket=resource_id, ACL="private")
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/s3/s3_bucket_public_write_acl/s3_bucket_public_write_acl_fixer.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_public_write_acl/s3_bucket_public_write_acl_fixer.py
@@ -28,7 +28,7 @@ def fixer(resource_id: str, region: str) -> bool:
         regional_client = s3_client.regional_clients[region]
         regional_client.put_bucket_acl(Bucket=resource_id, ACL="private")
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/s3/s3_service.py
+++ b/prowler/providers/aws/services/s3/s3_service.py
@@ -76,11 +76,11 @@ class S3(AWSService):
                             f"{bucket['Name']} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{bucket['Name']} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{bucket['Name']} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except ClientError as error:
@@ -89,11 +89,11 @@ class S3(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -116,16 +116,16 @@ class S3(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if bucket.region:
-                logger.error(
+                logger.exception(
                     f"{bucket.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -146,18 +146,18 @@ class S3(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if "ServerSideEncryptionConfigurationNotFoundError" in str(error):
                 bucket.encryption = None
             elif regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -177,16 +177,16 @@ class S3(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -220,16 +220,16 @@ class S3(AWSService):
                     restrict_public_buckets=False,
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -257,16 +257,16 @@ class S3(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -285,16 +285,16 @@ class S3(AWSService):
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -313,16 +313,16 @@ class S3(AWSService):
             elif error.response["Error"]["Code"] == "OwnershipControlsNotFoundError":
                 bucket.ownership = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -348,11 +348,11 @@ class S3(AWSService):
                     )
             else:
                 if regional_client:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
@@ -372,16 +372,16 @@ class S3(AWSService):
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
             if regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -434,16 +434,16 @@ class S3(AWSService):
             ):
                 bucket.replication = None
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
             if regional_client:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -476,11 +476,11 @@ class S3(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -497,12 +497,12 @@ class S3(AWSService):
                 return False
             else:
                 # Bucket exists but we don't have access to it
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 return True
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -545,7 +545,7 @@ class S3Control(AWSService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -564,7 +564,7 @@ class S3Control(AWSService):
                     region=regional_client.region,
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -606,7 +606,7 @@ class S3Control(AWSService):
                     ),
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -631,7 +631,7 @@ class S3Control(AWSService):
                 ).get("RestrictPublicBuckets", False),
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/sagemaker/sagemaker_service.py
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_service.py
@@ -54,7 +54,7 @@ class SageMaker(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -75,7 +75,7 @@ class SageMaker(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -100,7 +100,7 @@ class SageMaker(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -132,7 +132,7 @@ class SageMaker(AWSService):
             if "KmsKeyId" in describe_notebook_instance:
                 notebook_instance.kms_key_id = describe_notebook_instance["KmsKeyId"]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -149,7 +149,7 @@ class SageMaker(AWSService):
             ):
                 model.vpc_config_subnets = describe_model["VpcConfig"]["Subnets"]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -183,7 +183,7 @@ class SageMaker(AWSService):
                     "Subnets"
                 ]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -195,7 +195,7 @@ class SageMaker(AWSService):
                 response = regional_client.list_tags(ResourceArn=model.arn)["Tags"]
                 model.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         try:
@@ -204,7 +204,7 @@ class SageMaker(AWSService):
                 response = regional_client.list_tags(ResourceArn=instance.arn)["Tags"]
                 instance.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         try:
@@ -213,7 +213,7 @@ class SageMaker(AWSService):
                 response = regional_client.list_tags(ResourceArn=job.arn)["Tags"]
                 job.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         try:
@@ -222,7 +222,7 @@ class SageMaker(AWSService):
                 response = regional_client.list_tags(ResourceArn=endpoint.arn)["Tags"]
                 endpoint.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -247,7 +247,7 @@ class SageMaker(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -270,7 +270,7 @@ class SageMaker(AWSService):
                 )
             endpoint_config.production_variants = production_variants
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
+++ b/prowler/providers/aws/services/secretsmanager/secretsmanager_service.py
@@ -53,7 +53,7 @@ class SecretsManager(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -68,7 +68,7 @@ class SecretsManager(AWSService):
             if secret_policy.get("ResourcePolicy"):
                 secret.policy = json.loads(secret_policy["ResourcePolicy"])
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"

--- a/prowler/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_fixer.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_enabled/securityhub_enabled_fixer.py
@@ -31,7 +31,7 @@ def fixer(region):
             ).get("EnableDefaultStandards", True)
         )
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/securityhub/securityhub_service.py
+++ b/prowler/providers/aws/services/securityhub/securityhub_service.py
@@ -87,7 +87,7 @@ class SecurityHub(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -100,7 +100,7 @@ class SecurityHub(AWSService):
                     )["Tags"]
                 ]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/servicecatalog/servicecatalog_service.py
+++ b/prowler/providers/aws/services/servicecatalog/servicecatalog_service.py
@@ -41,7 +41,7 @@ class ServiceCatalog(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -62,16 +62,16 @@ class ServiceCatalog(AWSService):
                         portfolio.shares.append(portfolio_share)
                 except Exception as error:
                     if error.response["Error"]["Code"] == "AccessDeniedException":
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                         portfolio.shares = None
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -84,11 +84,11 @@ class ServiceCatalog(AWSService):
                     Id=portfolio.id,
                 )["Tags"]
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/ses/ses_service.py
+++ b/prowler/providers/aws/services/ses/ses_service.py
@@ -34,7 +34,7 @@ class SES(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -51,11 +51,11 @@ class SES(AWSService):
                 identity.tags = identity_attributes["Tags"]
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/shield/shield_service.py
+++ b/prowler/providers/aws/services/shield/shield_service.py
@@ -23,7 +23,7 @@ class Shield(AWSService):
                 else False
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -47,7 +47,7 @@ class Shield(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/sns/sns_service.py
+++ b/prowler/providers/aws/services/sns/sns_service.py
@@ -38,7 +38,7 @@ class SNS(AWSService):
                             )
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -57,7 +57,7 @@ class SNS(AWSService):
                         "KmsMasterKeyId"
                     ]
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -73,11 +73,11 @@ class SNS(AWSService):
                     f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: Resource {resource.arn} not found while listing tags"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -103,11 +103,11 @@ class SNS(AWSService):
                     ]
                     topic.subscriptions = subscriptions
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
+++ b/prowler/providers/aws/services/sqs/sqs_queues_not_publicly_accessible/sqs_queues_not_publicly_accessible_fixer.py
@@ -56,7 +56,7 @@ def fixer(resource_id: str, region: str) -> bool:
         )
 
     except Exception as error:
-        logger.error(
+        logger.exception(
             f"{region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
         )
         return False

--- a/prowler/providers/aws/services/sqs/sqs_service.py
+++ b/prowler/providers/aws/services/sqs/sqs_service.py
@@ -44,7 +44,7 @@ class SQS(AWSService):
                                 )
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -81,15 +81,15 @@ class SQS(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -112,16 +112,16 @@ class SQS(AWSService):
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/ssm/ssm_service.py
+++ b/prowler/providers/aws/services/ssm/ssm_service.py
@@ -55,7 +55,7 @@ class SSM(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -81,7 +81,7 @@ class SSM(AWSService):
                     continue
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} --"
                     f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                     f" {error}"
@@ -100,7 +100,7 @@ class SSM(AWSService):
                     ]
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -129,7 +129,7 @@ class SSM(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"
@@ -156,7 +156,7 @@ class SSM(AWSService):
                 time.sleep(0.1)
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"

--- a/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
+++ b/prowler/providers/aws/services/ssmincidents/ssmincidents_service.py
@@ -46,17 +46,17 @@ class SSMIncidents(AWSService):
                         ]
         except ClientError as error:
             if error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
                 if not self.replication_set:
                     self.replication_set = None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -90,12 +90,12 @@ class SSMIncidents(AWSService):
                         # The replication set is not in this region, we continue to the next region
                         continue
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -115,7 +115,7 @@ class SSMIncidents(AWSService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -130,7 +130,7 @@ class SSMIncidents(AWSService):
                 response_plan.tags = response
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 

--- a/prowler/providers/aws/services/stepfunctions/stepfunctions_service.py
+++ b/prowler/providers/aws/services/stepfunctions/stepfunctions_service.py
@@ -209,11 +209,11 @@ class StepFunctions(AWSService):
 
                             self.state_machines[arn] = state_machine
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -279,11 +279,11 @@ class StepFunctions(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -311,10 +311,10 @@ class StepFunctions(AWSService):
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/aws/services/storagegateway/storagegateway_service.py
+++ b/prowler/providers/aws/services/storagegateway/storagegateway_service.py
@@ -43,7 +43,7 @@ class StorageGateway(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -65,7 +65,7 @@ class StorageGateway(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -87,7 +87,7 @@ class StorageGateway(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -114,7 +114,7 @@ class StorageGateway(AWSService):
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/transfer/transfer_service.py
+++ b/prowler/providers/aws/services/transfer/transfer_service.py
@@ -32,7 +32,7 @@ class Transfer(AWSService):
                             region=regional_client.region,
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -48,7 +48,7 @@ class Transfer(AWSService):
                 server.protocols.append(Protocol(protocol))
             server.tags = server_description.get("Tags", [])
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{server.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
+++ b/prowler/providers/aws/services/trustedadvisor/trustedadvisor_service.py
@@ -53,11 +53,11 @@ class TrustedAdvisor(AWSService):
                     f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -81,7 +81,7 @@ class TrustedAdvisor(AWSService):
                                 f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -105,21 +105,21 @@ class TrustedAdvisor(AWSService):
                     f" {error}"
                 )
             elif error.response["Error"]["Code"] == "AccessDeniedException":
-                logger.error(
+                logger.exception(
                     f"{self.region} --"
                     f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                     f" {error}"
                 )
                 self.premium_support = None
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} --"
                     f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                     f" {error}"
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} --"
                 f" {error.__class__.__name__}[{error.__traceback__.tb_lineno}]:"
                 f" {error}"

--- a/prowler/providers/aws/services/vpc/vpc_service.py
+++ b/prowler/providers/aws/services/vpc/vpc_service.py
@@ -58,11 +58,11 @@ class VPC(AWSService):
                                 tags=vpc.get("Tags"),
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -97,11 +97,11 @@ class VPC(AWSService):
                                 )
                             )
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -140,11 +140,11 @@ class VPC(AWSService):
                             )
                         )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -167,11 +167,11 @@ class VPC(AWSService):
                     if flow_logs:
                         vpc.flow_log = True
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -207,11 +207,11 @@ class VPC(AWSService):
                         if enis:
                             subnet.in_use = True
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -247,11 +247,11 @@ class VPC(AWSService):
                                 )
                             )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -280,11 +280,11 @@ class VPC(AWSService):
                                     )
                                 )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -311,7 +311,7 @@ class VPC(AWSService):
                             f"{service.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}:{error.__traceback__.tb_lineno} -- {error}"
             )
 
@@ -394,11 +394,11 @@ class VPC(AWSService):
                                 if vpc.id == subnet["VpcId"]:
                                     vpc.subnets.append(object)
                         except Exception as error:
-                            logger.error(
+                            logger.exception(
                                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -428,7 +428,7 @@ class VPC(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/waf/waf_service.py
+++ b/prowler/providers/aws/services/waf/waf_service.py
@@ -43,7 +43,7 @@ class WAF(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -61,7 +61,7 @@ class WAF(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{rule.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -78,7 +78,7 @@ class WAF(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -94,7 +94,7 @@ class WAF(AWSService):
                 rule_group.rules.append(self.rules[rule_arn])
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{rule_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -115,7 +115,7 @@ class WAF(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -133,7 +133,7 @@ class WAF(AWSService):
                     acl.rules.append(self.rules[rule_arn])
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -150,7 +150,7 @@ class WAF(AWSService):
             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -184,7 +184,7 @@ class WAFRegional(AWSService):
                     name=rule.get("Name", ""),
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -201,7 +201,7 @@ class WAFRegional(AWSService):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{rule.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -218,7 +218,7 @@ class WAFRegional(AWSService):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -236,7 +236,7 @@ class WAFRegional(AWSService):
                 rule_group.rules.append(self.rules[rule_arn])
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{rule_group.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -257,7 +257,7 @@ class WAFRegional(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -275,7 +275,7 @@ class WAFRegional(AWSService):
                     acl.rules.append(self.rules[rule_arn])
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -290,7 +290,7 @@ class WAFRegional(AWSService):
                         acl.albs.append(resource)
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/wafv2/wafv2_service.py
+++ b/prowler/providers/aws/services/wafv2/wafv2_service.py
@@ -45,7 +45,7 @@ class WAFv2(AWSService):
                         region=self.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -67,7 +67,7 @@ class WAFv2(AWSService):
                         region=regional_client.region,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -88,11 +88,11 @@ class WAFv2(AWSService):
                     f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -119,7 +119,7 @@ class WAFv2(AWSService):
                     acl.user_pools.append(resource)
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -167,12 +167,12 @@ class WAFv2(AWSService):
                         )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{acl.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -190,7 +190,7 @@ class WAFv2(AWSService):
                     .get("TagList", [])
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{resource.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
+++ b/prowler/providers/aws/services/wellarchitected/wellarchitected_service.py
@@ -36,7 +36,7 @@ class WellArchitected(AWSService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -55,11 +55,11 @@ class WellArchitected(AWSService):
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/aws/services/workspaces/workspaces_service.py
+++ b/prowler/providers/aws/services/workspaces/workspaces_service.py
@@ -46,7 +46,7 @@ class WorkSpaces(AWSService):
                         self.workspaces.append(workspace_to_append)
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -60,7 +60,7 @@ class WorkSpaces(AWSService):
                 ]
                 workspace.tags = response
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{regional_client.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -408,7 +408,7 @@ class AzureProvider(Provider):
                 credential_scopes=config["credential_scopes"],
             )
         except ArgumentTypeError as validation_error:
-            logger.error(
+            logger.exception(
                 f"{validation_error.__class__.__name__}[{validation_error.__traceback__.tb_lineno}]: {validation_error}"
             )
             raise AzureArgumentTypeValidationError(
@@ -416,7 +416,7 @@ class AzureProvider(Provider):
                 original_exception=validation_error,
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             raise AzureSetUpRegionConfigError(
@@ -506,21 +506,21 @@ class AzureProvider(Provider):
                         )
                         return credentials
                     except ClientAuthenticationError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise AzureClientAuthenticationError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                     except CredentialUnavailableError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise AzureCredentialsUnavailableError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise AzureConfigCredentialsError(
@@ -544,14 +544,14 @@ class AzureProvider(Provider):
                             authority=region_config.authority,
                         )
                     except ClientAuthenticationError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise AzureClientAuthenticationError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                     except CredentialUnavailableError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise AzureCredentialsUnavailableError(
@@ -691,33 +691,33 @@ class AzureProvider(Provider):
             return Connection(is_connected=True)
         # Exceptions from validate_arguments
         except AzureNoAuthenticationMethodError as no_auth_method_error:
-            logger.error(
+            logger.exception(
                 f"{no_auth_method_error.__class__.__name__}[{no_auth_method_error.__traceback__.tb_lineno}]: {no_auth_method_error}"
             )
             if raise_on_exception:
                 raise no_auth_method_error
             return Connection(error=no_auth_method_error)
         except AzureBrowserAuthNoTenantIDError as browser_no_tenant_error:
-            logger.error(
+            logger.exception(
                 f"{browser_no_tenant_error.__class__.__name__}[{browser_no_tenant_error.__traceback__.tb_lineno}]: {browser_no_tenant_error}"
             )
             if raise_on_exception:
                 raise browser_no_tenant_error
             return Connection(error=browser_no_tenant_error)
         except AzureTenantIDNoBrowserAuthError as tenant_no_browser_error:
-            logger.error(
+            logger.exception(
                 f"{tenant_no_browser_error.__class__.__name__}[{tenant_no_browser_error.__traceback__.tb_lineno}]: {tenant_no_browser_error}"
             )
         # Exceptions from setup_region_config
         except AzureArgumentTypeValidationError as type_validation_error:
-            logger.error(
+            logger.exception(
                 f"{type_validation_error.__class__.__name__}[{type_validation_error.__traceback__.tb_lineno}]: {type_validation_error}"
             )
             if raise_on_exception:
                 raise type_validation_error
             return Connection(error=type_validation_error)
         except AzureSetUpRegionConfigError as region_config_error:
-            logger.error(
+            logger.exception(
                 f"{region_config_error.__class__.__name__}[{region_config_error.__traceback__.tb_lineno}]: {region_config_error}"
             )
             if raise_on_exception:
@@ -725,49 +725,49 @@ class AzureProvider(Provider):
             return Connection(error=region_config_error)
         # Exceptions from setup_session
         except AzureEnvironmentVariableError as environment_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{environment_credentials_error.__class__.__name__}[{environment_credentials_error.__traceback__.tb_lineno}]: {environment_credentials_error}"
             )
             if raise_on_exception:
                 raise environment_credentials_error
             return Connection(error=environment_credentials_error)
         except AzureDefaultAzureCredentialError as default_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{default_credentials_error.__class__.__name__}[{default_credentials_error.__traceback__.tb_lineno}]: {default_credentials_error}"
             )
             if raise_on_exception:
                 raise default_credentials_error
             return Connection(error=default_credentials_error)
         except AzureInteractiveBrowserCredentialError as interactive_browser_error:
-            logger.error(
+            logger.exception(
                 f"{interactive_browser_error.__class__.__name__}[{interactive_browser_error.__traceback__.tb_lineno}]: {interactive_browser_error}"
             )
             if raise_on_exception:
                 raise interactive_browser_error
             return Connection(error=interactive_browser_error)
         except AzureConfigCredentialsError as config_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{config_credentials_error.__class__.__name__}[{config_credentials_error.__traceback__.tb_lineno}]: {config_credentials_error}"
             )
             if raise_on_exception:
                 raise config_credentials_error
             return Connection(error=config_credentials_error)
         except AzureClientAuthenticationError as client_auth_error:
-            logger.error(
+            logger.exception(
                 f"{client_auth_error.__class__.__name__}[{client_auth_error.__traceback__.tb_lineno}]: {client_auth_error}"
             )
             if raise_on_exception:
                 raise client_auth_error
             return Connection(error=client_auth_error)
         except AzureCredentialsUnavailableError as credential_unavailable_error:
-            logger.error(
+            logger.exception(
                 f"{credential_unavailable_error.__class__.__name__}[{credential_unavailable_error.__traceback__.tb_lineno}]: {credential_unavailable_error}"
             )
             if raise_on_exception:
                 raise credential_unavailable_error
             return Connection(error=credential_unavailable_error)
         except AzureDefaultAzureCredentialError as default_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{default_credentials_error.__class__.__name__}[{default_credentials_error.__traceback__.tb_lineno}]: {default_credentials_error}"
             )
             if raise_on_exception:
@@ -776,7 +776,7 @@ class AzureProvider(Provider):
         except (
             AzureClientIdAndClientSecretNotBelongingToTenantIdError
         ) as tenant_id_error:
-            logger.error(
+            logger.exception(
                 f"{tenant_id_error.__class__.__name__}[{tenant_id_error.__traceback__.tb_lineno}]: {tenant_id_error}"
             )
             if raise_on_exception:
@@ -785,7 +785,7 @@ class AzureProvider(Provider):
         except (
             AzureTenantIdAndClientSecretNotBelongingToClientIdError
         ) as client_id_error:
-            logger.error(
+            logger.exception(
                 f"{client_id_error.__class__.__name__}[{client_id_error.__traceback__.tb_lineno}]: {client_id_error}"
             )
             if raise_on_exception:
@@ -794,7 +794,7 @@ class AzureProvider(Provider):
         except (
             AzureTenantIdAndClientIdNotBelongingToClientSecretError
         ) as client_secret_error:
-            logger.error(
+            logger.exception(
                 f"{client_secret_error.__class__.__name__}[{client_secret_error.__traceback__.tb_lineno}]: {client_secret_error}"
             )
             if raise_on_exception:
@@ -802,7 +802,7 @@ class AzureProvider(Provider):
             return Connection(error=client_secret_error)
         # Exceptions from provider_id validation
         except AzureInvalidProviderIdError as invalid_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{invalid_credentials_error.__class__.__name__}[{invalid_credentials_error.__traceback__.tb_lineno}]: {invalid_credentials_error}"
             )
             if raise_on_exception:
@@ -810,7 +810,7 @@ class AzureProvider(Provider):
             return Connection(error=invalid_credentials_error)
         # Exceptions from SubscriptionClient
         except HttpResponseError as http_response_error:
-            logger.error(
+            logger.exception(
                 f"{http_response_error.__class__.__name__}[{http_response_error.__traceback__.tb_lineno}]: {http_response_error}"
             )
             if raise_on_exception:
@@ -899,7 +899,7 @@ class AzureProvider(Provider):
                             identity.tenant_domain = domain_result.value[0].id
 
                 except HttpResponseError as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                     )
                     raise AzureHTTPResponseError(
@@ -907,7 +907,7 @@ class AzureProvider(Provider):
                         original_exception=error,
                     )
                 except ClientAuthenticationError as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                     )
                     raise AzureGetTokenIdentityError(
@@ -915,7 +915,7 @@ class AzureProvider(Provider):
                         original_exception=error,
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                     )
                 # since that exception is not considered as critical, we keep filling another identity fields
@@ -940,7 +940,7 @@ class AzureProvider(Provider):
                                 identity.identity_id = me.user_principal_name
 
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
 
@@ -1121,7 +1121,7 @@ class AzureProvider(Provider):
                 "client_secret": client_secret,
             }
         except AzureNotValidTenantIdError as tenant_id_error:
-            logger.error(
+            logger.exception(
                 f"{tenant_id_error.__class__.__name__}[{tenant_id_error.__traceback__.tb_lineno}]: {tenant_id_error}"
             )
             raise AzureClientIdAndClientSecretNotBelongingToTenantIdError(
@@ -1129,7 +1129,7 @@ class AzureProvider(Provider):
                 message="The provided Azure Client ID and Client Secret do not belong to the specified Tenant ID.",
             )
         except AzureNotValidClientIdError as client_id_error:
-            logger.error(
+            logger.exception(
                 f"{client_id_error.__class__.__name__}[{client_id_error.__traceback__.tb_lineno}]: {client_id_error}"
             )
             raise AzureTenantIdAndClientSecretNotBelongingToClientIdError(
@@ -1137,7 +1137,7 @@ class AzureProvider(Provider):
                 message="The provided Azure Tenant ID and Client Secret do not belong to the specified Client ID.",
             )
         except AzureNotValidClientSecretError as client_secret_error:
-            logger.error(
+            logger.exception(
                 f"{client_secret_error.__class__.__name__}[{client_secret_error.__traceback__.tb_lineno}]: {client_secret_error}"
             )
             raise AzureTenantIdAndClientIdNotBelongingToClientSecretError(

--- a/prowler/providers/azure/lib/service/service.py
+++ b/prowler/providers/azure/lib/service/service.py
@@ -38,7 +38,7 @@ class AzureService:
                         }
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         else:

--- a/prowler/providers/azure/services/aisearch/aisearch_service.py
+++ b/prowler/providers/azure/services/aisearch/aisearch_service.py
@@ -35,7 +35,7 @@ class AISearch(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return aisearch_services

--- a/prowler/providers/azure/services/aks/aks_service.py
+++ b/prowler/providers/azure/services/aks/aks_service.py
@@ -59,7 +59,7 @@ class AKS(AzureService):
                             }
                         )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/azure/services/app/app_service.py
+++ b/prowler/providers/azure/services/app/app_service.py
@@ -105,7 +105,7 @@ class App(AzureService):
                             }
                         )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -173,7 +173,7 @@ class App(AzureService):
                             }
                         )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -204,7 +204,7 @@ class App(AzureService):
                 monitor_client.clients[subscription],
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {self.subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return monitor_diagnostics_settings

--- a/prowler/providers/azure/services/appinsights/appinsights_service.py
+++ b/prowler/providers/azure/services/appinsights/appinsights_service.py
@@ -34,7 +34,7 @@ class AppInsights(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/azure/services/containerregistry/containerregistry_service.py
+++ b/prowler/providers/azure/services/containerregistry/containerregistry_service.py
@@ -63,7 +63,7 @@ class ContainerRegistry(AzureService):
                         },
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return registries
@@ -86,7 +86,7 @@ class ContainerRegistry(AzureService):
                 monitor_client.clients[subscription],
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {self.subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return monitor_diagnostics_settings

--- a/prowler/providers/azure/services/cosmosdb/cosmosdb_service.py
+++ b/prowler/providers/azure/services/cosmosdb/cosmosdb_service.py
@@ -42,7 +42,7 @@ class CosmosDB(AzureService):
                         )
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return accounts

--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -57,11 +57,11 @@ class Defender(AzureService):
                     )
             except ResourceNotFoundError as error:
                 if "Subscription Not Registered" in error.message:
-                    logger.error(
+                    logger.exception(
                         f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: Subscription Not Registered - Please register to Microsoft.Security in order to view your security status"
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return pricings
@@ -86,11 +86,11 @@ class Defender(AzureService):
                     )
             except ClientAuthenticationError as error:
                 if "Subscription Not Registered" in error.message:
-                    logger.error(
+                    logger.exception(
                         f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: Subscription Not Registered - Please register to Microsoft.Security in order to view your security status"
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return auto_provisioning
@@ -115,7 +115,7 @@ class Defender(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return assessments
@@ -140,11 +140,11 @@ class Defender(AzureService):
                     )
             except ClientAuthenticationError as error:
                 if "Subscription Not Registered" in error.message:
-                    logger.error(
+                    logger.exception(
                         f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: Subscription Not Registered - Please register to Microsoft.Security in order to view your security status"
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return settings
@@ -188,11 +188,11 @@ class Defender(AzureService):
                         }
                     )
                 else:
-                    logger.error(
+                    logger.exception(
                         f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return security_contacts
@@ -217,7 +217,7 @@ class Defender(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return iot_security_solutions

--- a/prowler/providers/azure/services/entra/entra_service.py
+++ b/prowler/providers/azure/services/entra/entra_service.py
@@ -70,11 +70,11 @@ class Entra(AzureService):
                 error.__class__.__name__ == "ODataError"
                 and error.__dict__.get("response_status_code", None) == 403
             ):
-                logger.error(
+                logger.exception(
                     "You need 'UserAuthenticationMethod.Read.All' permission to access this information. It only can be granted through Service Principal authentication."
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -150,7 +150,7 @@ class Entra(AzureService):
                     }
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -181,7 +181,7 @@ class Entra(AzureService):
                         }
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -205,7 +205,7 @@ class Entra(AzureService):
                     }
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -237,7 +237,7 @@ class Entra(AzureService):
                         }
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -270,7 +270,7 @@ class Entra(AzureService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return directory_roles_with_members
@@ -348,7 +348,7 @@ class Entra(AzureService):
                         }
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/azure/services/iam/iam_service.py
+++ b/prowler/providers/azure/services/iam/iam_service.py
@@ -56,8 +56,8 @@ class IAM(AzureService):
                             )
                         )
             except Exception as error:
-                logger.error(f"Subscription name: {subscription}")
-                logger.error(
+                logger.exception(f"Subscription name: {subscription}")
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return builtin_roles, custom_roles
@@ -84,8 +84,8 @@ class IAM(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(f"Subscription name: {subscription}")
-                logger.error(
+                logger.exception(f"Subscription name: {subscription}")
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return role_assignments

--- a/prowler/providers/azure/services/keyvault/keyvault_service.py
+++ b/prowler/providers/azure/services/keyvault/keyvault_service.py
@@ -79,7 +79,7 @@ class KeyVault(AzureService):
                         )
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return key_vaults
@@ -106,7 +106,7 @@ class KeyVault(AzureService):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -166,7 +166,7 @@ class KeyVault(AzureService):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return secrets
@@ -183,7 +183,7 @@ class KeyVault(AzureService):
                 monitor_client.clients[subscription],
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {self.subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return monitor_diagnostics_settings

--- a/prowler/providers/azure/services/monitor/monitor_service.py
+++ b/prowler/providers/azure/services/monitor/monitor_service.py
@@ -28,7 +28,7 @@ class Monitor(AzureService):
                 )
                 diagnostics_settings.update({subscription: diagnostics_settings_list})
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return diagnostics_settings
@@ -59,7 +59,7 @@ class Monitor(AzureService):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription id: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return diagnostics_settings
@@ -92,7 +92,7 @@ class Monitor(AzureService):
                         )
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return alert_rules

--- a/prowler/providers/azure/services/mysql/mysql_service.py
+++ b/prowler/providers/azure/services/mysql/mysql_service.py
@@ -35,7 +35,7 @@ class MySQL(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return servers
@@ -58,7 +58,7 @@ class MySQL(AzureService):
                     }
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Server name: {server_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return configurations

--- a/prowler/providers/azure/services/network/network_public_ip_shodan/network_public_ip_shodan.py
+++ b/prowler/providers/azure/services/network/network_public_ip_shodan/network_public_ip_shodan.py
@@ -29,10 +29,10 @@ class network_public_ip_shodan(Check):
                             findings.append(report)
                             continue
                         else:
-                            logger.error(f"Unknown Shodan API Error: {error.value}")
+                            logger.exception(f"Unknown Shodan API Error: {error.value}")
 
         else:
-            logger.error(
+            logger.exception(
                 "No Shodan API Key -- Please input a Shodan API Key with -N/--shodan or in config.yaml"
             )
         return findings

--- a/prowler/providers/azure/services/network/network_service.py
+++ b/prowler/providers/azure/services/network/network_service.py
@@ -53,7 +53,7 @@ class Network(AzureService):
                     )
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return security_groups
@@ -95,7 +95,7 @@ class Network(AzureService):
                     )
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return network_watchers
@@ -105,7 +105,7 @@ class Network(AzureService):
         client = self.clients[subscription]
         match = re.search(r"/resourceGroups/(?P<rg>[^/]+)/", network_watcher_id)
         if not match:
-            logger.error(
+            logger.exception(
                 f"Could not extract resource group from ID: {network_watcher_id}"
             )
             return []
@@ -119,7 +119,7 @@ class Network(AzureService):
             )
             return []
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return []
@@ -141,7 +141,7 @@ class Network(AzureService):
                     )
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return bastion_hosts
@@ -164,7 +164,7 @@ class Network(AzureService):
                     )
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return public_ip_addresses

--- a/prowler/providers/azure/services/policy/policy_service.py
+++ b/prowler/providers/azure/services/policy/policy_service.py
@@ -32,7 +32,7 @@ class Policy(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/azure/services/postgresql/postgresql_service.py
+++ b/prowler/providers/azure/services/postgresql/postgresql_service.py
@@ -61,7 +61,7 @@ class PostgreSQL(AzureService):
                         )
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return flexible_servers

--- a/prowler/providers/azure/services/sqlserver/sqlserver_service.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_service.py
@@ -71,7 +71,7 @@ class SQLServer(AzureService):
                         )
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return sql_servers
@@ -140,7 +140,7 @@ class SQLServer(AzureService):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return databases

--- a/prowler/providers/azure/services/storage/storage_service.py
+++ b/prowler/providers/azure/services/storage/storage_service.py
@@ -70,7 +70,7 @@ class Storage(AzureService):
                         )
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return storage_accounts
@@ -113,12 +113,12 @@ class Storage(AzureService):
                                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                             )
                             continue
-                        logger.error(
+                        logger.exception(
                             f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/azure/services/vm/vm_service.py
+++ b/prowler/providers/azure/services/vm/vm_service.py
@@ -76,7 +76,7 @@ class VirtualMachines(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -111,7 +111,7 @@ class VirtualMachines(AzureService):
                         }
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"Subscription name: {subscription_name} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -264,6 +264,6 @@ class Provider(ABC):
 
             return audit_config
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
             )

--- a/prowler/providers/gcp/gcp_provider.py
+++ b/prowler/providers/gcp/gcp_provider.py
@@ -483,7 +483,7 @@ class GcpProvider(Provider):
         """
         try:
             if not provider_id:
-                logger.error("Provider ID is required.")
+                logger.exception("Provider ID is required.")
                 raise GCPInvalidProviderIdError(
                     file=__file__, message="Provider ID is required."
                 )
@@ -660,11 +660,11 @@ class GcpProvider(Provider):
                         )
                 except HttpError as http_error:
                     if "Cloud Asset API has not been used" in str(http_error):
-                        logger.error(
+                        logger.exception(
                             f"Projects cannot be retrieved from the Organization since Cloud Asset API has not been used before or it is disabled [{http_error.__traceback__.tb_lineno}]. Enable it by visiting https://console.developers.google.com/apis/api/cloudasset.googleapis.com/ then retry."
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error}"
                         )
             else:
@@ -723,11 +723,11 @@ class GcpProvider(Provider):
                     if "Cloud Resource Manager API has not been used" in str(
                         http_error
                     ):
-                        logger.error(
+                        logger.exception(
                             f"Project information cannot be retrieved since Cloud Resource Manager API has not been used before or it is disabled [{http_error.__traceback__.tb_lineno}]. Enable it by visiting https://console.developers.google.com/apis/api/cloudresourcemanager.googleapis.com/ then retry."
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error}"
                         )
             if not projects:
@@ -790,15 +790,15 @@ class GcpProvider(Provider):
 
         except HttpError as http_error:
             if http_error.status_code == 403 and "organizations" in http_error.uri:
-                logger.error(
+                logger.exception(
                     f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error.error_details} to get Organizations display name."
                 )
             else:
-                logger.error(
+                logger.exception(
                     f"{http_error.__class__.__name__}[{http_error.__traceback__.tb_lineno}]: {http_error}"
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -908,13 +908,13 @@ class GcpProvider(Provider):
                     for region in response.get("items", []):
                         regions.add(region["name"])
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
                     continue
             return regions
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return set()

--- a/prowler/providers/gcp/lib/service/service.py
+++ b/prowler/providers/gcp/lib/service/service.py
@@ -65,11 +65,11 @@ class GCPService:
                 if response.get("state") != "DISABLED":
                     project_ids.append(project_id)
                 else:
-                    logger.error(
+                    logger.exception(
                         f"{self.service} API has not been used in project {project_id} before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/{self.service}.googleapis.com/overview?project={project_id} then retry."
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
         return project_ids
@@ -83,6 +83,6 @@ class GCPService:
         try:
             return discovery.build(service, api_version, credentials=credentials)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/gcp/services/apikeys/apikeys_service.py
+++ b/prowler/providers/gcp/services/apikeys/apikeys_service.py
@@ -44,7 +44,7 @@ class APIKeys(GCPService):
                         .list_next(previous_request=request, previous_response=response)
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/bigquery/bigquery_service.py
+++ b/prowler/providers/gcp/services/bigquery/bigquery_service.py
@@ -54,7 +54,7 @@ class BigQuery(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -94,7 +94,7 @@ class BigQuery(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/cloudresourcemanager/cloudresourcemanager_service.py
+++ b/prowler/providers/gcp/services/cloudresourcemanager/cloudresourcemanager_service.py
@@ -36,7 +36,7 @@ class CloudResourceManager(GCPService):
                         )
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -51,7 +51,7 @@ class CloudResourceManager(GCPService):
                         )
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_service.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_service.py
@@ -51,7 +51,7 @@ class CloudSQL(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/cloudstorage/cloudstorage_service.py
+++ b/prowler/providers/gcp/services/cloudstorage/cloudstorage_service.py
@@ -48,7 +48,7 @@ class CloudStorage(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/compute/compute_public_address_shodan/compute_public_address_shodan.py
+++ b/prowler/providers/gcp/services/compute/compute_public_address_shodan/compute_public_address_shodan.py
@@ -30,10 +30,10 @@ class compute_public_address_shodan(Check):
                             findings.append(report)
                             continue
                         else:
-                            logger.error(f"Unknown Shodan API Error: {error.value}")
+                            logger.exception(f"Unknown Shodan API Error: {error.value}")
 
         else:
-            logger.error(
+            logger.exception(
                 "No Shodan API Key -- Please input a Shodan API Key with -N/--shodan or in config.yaml"
             )
         return findings

--- a/prowler/providers/gcp/services/compute/compute_service.py
+++ b/prowler/providers/gcp/services/compute/compute_service.py
@@ -42,7 +42,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -60,7 +60,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -76,7 +76,7 @@ class Compute(GCPService):
                     Project(id=project_id, enable_oslogin=enable_oslogin)
                 )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -135,7 +135,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{zone} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -166,7 +166,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -196,7 +196,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -226,7 +226,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -253,7 +253,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -278,7 +278,7 @@ class Compute(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
             try:
@@ -303,7 +303,7 @@ class Compute(GCPService):
                             previous_request=request, previous_response=response
                         )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -338,7 +338,7 @@ class Compute(GCPService):
                         "enable", False
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
 

--- a/prowler/providers/gcp/services/dataproc/dataproc_service.py
+++ b/prowler/providers/gcp/services/dataproc/dataproc_service.py
@@ -44,7 +44,7 @@ class Dataproc(GCPService):
                         .list_next(previous_request=request, previous_response=response)
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/dns/dns_service.py
+++ b/prowler/providers/gcp/services/dns/dns_service.py
@@ -39,7 +39,7 @@ class DNS(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -68,7 +68,7 @@ class DNS(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/gke/gke_service.py
+++ b/prowler/providers/gcp/services/gke/gke_service.py
@@ -29,7 +29,7 @@ class GKE(GCPService):
                     )
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -65,7 +65,7 @@ class GKE(GCPService):
                     project_id=location.project_id,
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/gcp/services/iam/iam_service.py
+++ b/prowler/providers/gcp/services/iam/iam_service.py
@@ -45,7 +45,7 @@ class IAM(GCPService):
                         .list_next(previous_request=request, previous_response=response)
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -81,7 +81,7 @@ class IAM(GCPService):
                     )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -123,7 +123,7 @@ class AccessApproval(GCPService):
                 )
 
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -159,7 +159,7 @@ class EssentialContacts(GCPService):
                     )
                 )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/kms/kms_service.py
+++ b/prowler/providers/gcp/services/kms/kms_service.py
@@ -40,7 +40,7 @@ class KMS(GCPService):
                         .list_next(previous_request=request, previous_response=response)
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -67,7 +67,7 @@ class KMS(GCPService):
                     .list_next(previous_request=request, previous_response=response)
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -105,7 +105,7 @@ class KMS(GCPService):
                         .list_next(previous_request=request, previous_response=response)
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -124,7 +124,7 @@ class KMS(GCPService):
                 for binding in response.get("bindings", []):
                     key.members.extend(binding.get("members", []))
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/logging/logging_service.py
+++ b/prowler/providers/gcp/services/logging/logging_service.py
@@ -34,7 +34,7 @@ class Logging(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -65,7 +65,7 @@ class Logging(GCPService):
                         .list_next(previous_request=request, previous_response=response)
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/gcp/services/monitoring/monitoring_service.py
+++ b/prowler/providers/gcp/services/monitoring/monitoring_service.py
@@ -50,7 +50,7 @@ class Monitoring(GCPService):
                         .list_next(previous_request=request, previous_response=response)
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 
@@ -91,11 +91,11 @@ class Monitoring(GCPService):
                             self.sa_keys_metrics.add(key_id)
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -138,11 +138,11 @@ class Monitoring(GCPService):
                             )
 
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/gcp/services/serviceusage/serviceusage_service.py
+++ b/prowler/providers/gcp/services/serviceusage/serviceusage_service.py
@@ -33,7 +33,7 @@ class ServiceUsage(GCPService):
                         previous_request=request, previous_response=response
                     )
             except Exception as error:
-                logger.error(
+                logger.exception(
                     f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                 )
 

--- a/prowler/providers/kubernetes/kubernetes_provider.py
+++ b/prowler/providers/kubernetes/kubernetes_provider.py
@@ -511,13 +511,13 @@ class KubernetesProvider(Provider):
             logger.info("Context user roles retrieved successfully.")
             return roles
         except ApiException as api_error:
-            logger.error(
+            logger.exception(
                 f"ApiException[{api_error.__traceback__.tb_lineno}]: {api_error}"
             )
         except KubernetesError as error:
             raise error
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -580,7 +580,7 @@ class KubernetesProvider(Provider):
             ) as f:
                 return f.read().strip()
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return "default"

--- a/prowler/providers/kubernetes/services/apiserver/apiserver_service.py
+++ b/prowler/providers/kubernetes/services/apiserver/apiserver_service.py
@@ -21,6 +21,6 @@ class APIServer(KubernetesService):
                     apiserver_pods.append(pod)
             return apiserver_pods
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/kubernetes/services/controllermanager/controllermanager_service.py
+++ b/prowler/providers/kubernetes/services/controllermanager/controllermanager_service.py
@@ -21,6 +21,6 @@ class ControllerManager(KubernetesService):
                     controllermanager_pods.append(pod)
             return controllermanager_pods
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/kubernetes/services/core/core_service.py
+++ b/prowler/providers/kubernetes/services/core/core_service.py
@@ -88,7 +88,7 @@ class Core(KubernetesService):
                         containers=pod_containers,
                     )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -105,7 +105,7 @@ class Core(KubernetesService):
                     annotations=cm.metadata.annotations,
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -132,7 +132,7 @@ class Core(KubernetesService):
                 )
                 self.nodes[node.metadata.uid] = node_model
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -144,7 +144,7 @@ class Core(KubernetesService):
                     node.inside = True
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 

--- a/prowler/providers/kubernetes/services/etcd/etcd_service.py
+++ b/prowler/providers/kubernetes/services/etcd/etcd_service.py
@@ -19,6 +19,6 @@ class Etcd(KubernetesService):
                     etcd_pods.append(pod)
             return etcd_pods
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/kubernetes/services/kubelet/kubelet_service.py
+++ b/prowler/providers/kubernetes/services/kubelet/kubelet_service.py
@@ -24,6 +24,6 @@ class Kubelet(KubernetesService):
                     kubelet_config_maps.append(cm)
             return kubelet_config_maps
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/kubernetes/services/rbac/rbac_service.py
+++ b/prowler/providers/kubernetes/services/rbac/rbac_service.py
@@ -47,7 +47,7 @@ class Rbac(KubernetesService):
                 bindings[binding.metadata.uid] = ClusterRoleBinding(**formatted_binding)
             return bindings
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return {}
@@ -76,7 +76,7 @@ class Rbac(KubernetesService):
                 role_bindings[binding.metadata.uid] = RoleBinding(**formatted_binding)
             return role_bindings
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return {}
@@ -101,7 +101,7 @@ class Rbac(KubernetesService):
                 roles[role.metadata.uid] = Role(**formatted_role)
             return roles
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return {}
@@ -130,7 +130,7 @@ class Rbac(KubernetesService):
                 cluster_roles[role.metadata.uid] = ClusterRole(**formatted_role)
             return cluster_roles
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return {}

--- a/prowler/providers/kubernetes/services/scheduler/scheduler_service.py
+++ b/prowler/providers/kubernetes/services/scheduler/scheduler_service.py
@@ -21,6 +21,6 @@ class Scheduler(KubernetesService):
                     scheduler_pods.append(pod)
             return scheduler_pods
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )

--- a/prowler/providers/m365/m365_provider.py
+++ b/prowler/providers/m365/m365_provider.py
@@ -344,7 +344,7 @@ class M365Provider(Provider):
                 credential_scopes=config["credential_scopes"],
             )
         except ArgumentTypeError as validation_error:
-            logger.error(
+            logger.exception(
                 f"{validation_error.__class__.__name__}[{validation_error.__traceback__.tb_lineno}]: {validation_error}"
             )
             raise M365ArgumentTypeValidationError(
@@ -352,7 +352,7 @@ class M365Provider(Provider):
                 original_exception=validation_error,
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             raise M365SetUpRegionConfigError(
@@ -494,21 +494,21 @@ class M365Provider(Provider):
                         )
                         return credentials
                     except ClientAuthenticationError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise M365ClientAuthenticationError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                     except CredentialUnavailableError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise M365CredentialsUnavailableError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise M365ConfigCredentialsError(
@@ -535,21 +535,21 @@ class M365Provider(Provider):
                             authority=region_config.authority,
                         )
                     except ClientAuthenticationError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise M365ClientAuthenticationError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                     except CredentialUnavailableError as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise M365CredentialsUnavailableError(
                             file=os.path.basename(__file__), original_exception=error
                         )
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
                         raise M365DefaultAzureCredentialError(
@@ -674,14 +674,14 @@ class M365Provider(Provider):
 
         # Exceptions from setup_region_config
         except M365ArgumentTypeValidationError as type_validation_error:
-            logger.error(
+            logger.exception(
                 f"{type_validation_error.__class__.__name__}[{type_validation_error.__traceback__.tb_lineno}]: {type_validation_error}"
             )
             if raise_on_exception:
                 raise type_validation_error
             return Connection(error=type_validation_error)
         except M365SetUpRegionConfigError as region_config_error:
-            logger.error(
+            logger.exception(
                 f"{region_config_error.__class__.__name__}[{region_config_error.__traceback__.tb_lineno}]: {region_config_error}"
             )
             if raise_on_exception:
@@ -689,28 +689,28 @@ class M365Provider(Provider):
             return Connection(error=region_config_error)
         # Exceptions from setup_session
         except M365EnvironmentVariableError as environment_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{environment_credentials_error.__class__.__name__}[{environment_credentials_error.__traceback__.tb_lineno}]: {environment_credentials_error}"
             )
             if raise_on_exception:
                 raise environment_credentials_error
             return Connection(error=environment_credentials_error)
         except M365ConfigCredentialsError as config_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{config_credentials_error.__class__.__name__}[{config_credentials_error.__traceback__.tb_lineno}]: {config_credentials_error}"
             )
             if raise_on_exception:
                 raise config_credentials_error
             return Connection(error=config_credentials_error)
         except M365ClientAuthenticationError as client_auth_error:
-            logger.error(
+            logger.exception(
                 f"{client_auth_error.__class__.__name__}[{client_auth_error.__traceback__.tb_lineno}]: {client_auth_error}"
             )
             if raise_on_exception:
                 raise client_auth_error
             return Connection(error=client_auth_error)
         except M365CredentialsUnavailableError as credential_unavailable_error:
-            logger.error(
+            logger.exception(
                 f"{credential_unavailable_error.__class__.__name__}[{credential_unavailable_error.__traceback__.tb_lineno}]: {credential_unavailable_error}"
             )
             if raise_on_exception:
@@ -719,7 +719,7 @@ class M365Provider(Provider):
         except (
             M365ClientIdAndClientSecretNotBelongingToTenantIdError
         ) as tenant_id_error:
-            logger.error(
+            logger.exception(
                 f"{tenant_id_error.__class__.__name__}[{tenant_id_error.__traceback__.tb_lineno}]: {tenant_id_error}"
             )
             if raise_on_exception:
@@ -728,7 +728,7 @@ class M365Provider(Provider):
         except (
             M365TenantIdAndClientSecretNotBelongingToClientIdError
         ) as client_id_error:
-            logger.error(
+            logger.exception(
                 f"{client_id_error.__class__.__name__}[{client_id_error.__traceback__.tb_lineno}]: {client_id_error}"
             )
             if raise_on_exception:
@@ -737,7 +737,7 @@ class M365Provider(Provider):
         except (
             M365TenantIdAndClientIdNotBelongingToClientSecretError
         ) as client_secret_error:
-            logger.error(
+            logger.exception(
                 f"{client_secret_error.__class__.__name__}[{client_secret_error.__traceback__.tb_lineno}]: {client_secret_error}"
             )
             if raise_on_exception:
@@ -745,7 +745,7 @@ class M365Provider(Provider):
             return Connection(error=client_secret_error)
         # Exceptions from provider_id validation
         except M365InvalidProviderIdError as invalid_credentials_error:
-            logger.error(
+            logger.exception(
                 f"{invalid_credentials_error.__class__.__name__}[{invalid_credentials_error.__traceback__.tb_lineno}]: {invalid_credentials_error}"
             )
             if raise_on_exception:
@@ -753,7 +753,7 @@ class M365Provider(Provider):
             return Connection(error=invalid_credentials_error)
         # Exceptions from SubscriptionClient
         except HttpResponseError as http_response_error:
-            logger.error(
+            logger.exception(
                 f"{http_response_error.__class__.__name__}[{http_response_error.__traceback__.tb_lineno}]: {http_response_error}"
             )
             if raise_on_exception:
@@ -841,7 +841,7 @@ class M365Provider(Provider):
                             identity.tenant_domain = domain_result.value[0].id
 
                 except HttpResponseError as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                     )
                     raise M365HTTPResponseError(
@@ -849,7 +849,7 @@ class M365Provider(Provider):
                         original_exception=error,
                     )
                 except ClientAuthenticationError as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                     )
                     raise M365GetTokenIdentityError(
@@ -857,7 +857,7 @@ class M365Provider(Provider):
                         original_exception=error,
                     )
                 except Exception as error:
-                    logger.error(
+                    logger.exception(
                         f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                     )
                 # since that exception is not considered as critical, we keep filling another identity fields
@@ -882,7 +882,7 @@ class M365Provider(Provider):
                                 identity.identity_id = me.user_principal_name
 
                     except Exception as error:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}] -- {error}"
                         )
 
@@ -949,7 +949,7 @@ class M365Provider(Provider):
                 "client_secret": client_secret,
             }
         except M365NotValidTenantIdError as tenant_id_error:
-            logger.error(
+            logger.exception(
                 f"{tenant_id_error.__class__.__name__}[{tenant_id_error.__traceback__.tb_lineno}]: {tenant_id_error}"
             )
             raise M365ClientIdAndClientSecretNotBelongingToTenantIdError(
@@ -957,7 +957,7 @@ class M365Provider(Provider):
                 message="The provided M365 Client ID and Client Secret do not belong to the specified Tenant ID.",
             )
         except M365NotValidClientIdError as client_id_error:
-            logger.error(
+            logger.exception(
                 f"{client_id_error.__class__.__name__}[{client_id_error.__traceback__.tb_lineno}]: {client_id_error}"
             )
             raise M365TenantIdAndClientSecretNotBelongingToClientIdError(
@@ -965,7 +965,7 @@ class M365Provider(Provider):
                 message="The provided M365 Tenant ID and Client Secret do not belong to the specified Client ID.",
             )
         except M365NotValidClientSecretError as client_secret_error:
-            logger.error(
+            logger.exception(
                 f"{client_secret_error.__class__.__name__}[{client_secret_error.__traceback__.tb_lineno}]: {client_secret_error}"
             )
             raise M365TenantIdAndClientIdNotBelongingToClientSecretError(

--- a/prowler/providers/m365/services/admincenter/admincenter_service.py
+++ b/prowler/providers/m365/services/admincenter/admincenter_service.py
@@ -51,7 +51,7 @@ class AdminCenter(M365Service):
                             f"MailboxNotEnabledForRESTAPI for user {user.id}"
                         )
                     else:
-                        logger.error(
+                        logger.exception(
                             f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
                         )
                 users.update(
@@ -68,7 +68,7 @@ class AdminCenter(M365Service):
                     }
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -104,7 +104,7 @@ class AdminCenter(M365Service):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return directory_roles_with_members
@@ -127,7 +127,7 @@ class AdminCenter(M365Service):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return groups
@@ -149,7 +149,7 @@ class AdminCenter(M365Service):
                 )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return domains

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -91,7 +91,7 @@ class Entra(M365Service):
                 guest_user_role_id=auth_policy.guest_user_role_id,
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return authorization_policy
@@ -287,7 +287,7 @@ class Entra(M365Service):
                     ),
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return conditional_access_policies
@@ -304,7 +304,7 @@ class Entra(M365Service):
                 duration_in_days=policy.request_duration_in_days,
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return admin_consent_policy
@@ -324,7 +324,7 @@ class Entra(M365Service):
                     )
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return groups
@@ -348,7 +348,7 @@ class Entra(M365Service):
                 )
                 organizations.append(organization)
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
@@ -387,7 +387,7 @@ class Entra(M365Service):
                     directory_roles_ids=user_roles_map.get(user.id, []),
                 )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return users

--- a/prowler/providers/m365/services/purview/purview_service.py
+++ b/prowler/providers/m365/services/purview/purview_service.py
@@ -23,7 +23,7 @@ class Purview(M365Service):
                 )
             )
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return audit_log_config

--- a/prowler/providers/m365/services/sharepoint/sharepoint_service.py
+++ b/prowler/providers/m365/services/sharepoint/sharepoint_service.py
@@ -41,12 +41,12 @@ class SharePoint(M365Service):
             )
 
         except ODataError as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return None
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
             return None

--- a/prowler/providers/m365/services/teams/teams_service.py
+++ b/prowler/providers/m365/services/teams/teams_service.py
@@ -27,7 +27,7 @@ class Teams(M365Service):
             )
 
         except Exception as error:
-            logger.error(
+            logger.exception(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
         return teams_settings

--- a/prowler/providers/nhn/nhn_provider.py
+++ b/prowler/providers/nhn/nhn_provider.py
@@ -248,7 +248,7 @@ class NhnProvider(Provider):
                 error_msg = (
                     "NHN test_connection error: missing username/password/tenant_id"
                 )
-                logger.error(error_msg)
+                logger.exception(error_msg)
                 raise ValueError(error_msg)
 
             # 2) Request Keystone token
@@ -268,7 +268,7 @@ class NhnProvider(Provider):
             if resp.status_code != 200:
                 # Fail
                 error_msg = f"Failed to get token. Status: {resp.status_code}, Body: {resp.text}"
-                logger.error(error_msg)
+                logger.exception(error_msg)
                 if raise_on_exception:
                     raise Exception(error_msg)
                 return Connection(error=Exception(error_msg))
@@ -296,7 +296,7 @@ class NhnProvider(Provider):
                 return Connection(is_connected=True)
             else:
                 error_msg = f"/servers call failed. Status: {servers_resp.status_code}, Body: {servers_resp.text}"
-                logger.error(error_msg)
+                logger.exception(error_msg)
                 if raise_on_exception:
                     raise Exception(error_msg)
                 return Connection(error=Exception(error_msg))

--- a/prowler/providers/nhn/services/compute/compute_service.py
+++ b/prowler/providers/nhn/services/compute/compute_service.py
@@ -21,7 +21,7 @@ class NHNComputeService:
             data = response.json()
             return data.get("servers", [])
         except Exception as e:
-            logger.error(f"Error listing servers: {e}")
+            logger.exception(f"Error listing servers: {e}")
             return []
 
     def _get_server_detail(self, server_id: str) -> dict:
@@ -31,7 +31,7 @@ class NHNComputeService:
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            logger.error(f"Error getting server detail {server_id}: {e}")
+            logger.exception(f"Error getting server detail {server_id}: {e}")
             return {}
 
     def _check_public_ip(self, server_info: dict) -> bool:

--- a/prowler/providers/nhn/services/network/network_service.py
+++ b/prowler/providers/nhn/services/network/network_service.py
@@ -33,7 +33,7 @@ class NHNNetworkService:
             data = response.json()
             return data.get("vpcs", [])
         except Exception as e:
-            logger.error(f"Error listing vpcs: {e}")
+            logger.exception(f"Error listing vpcs: {e}")
             return []
 
     def _get_vpc_detail(self, vpc_id: str) -> dict:
@@ -43,7 +43,7 @@ class NHNNetworkService:
             response.raise_for_status()
             return response.json()
         except Exception as e:
-            logger.error(f"Error getting vpc detail {vpc_id}: {e}")
+            logger.exception(f"Error getting vpc detail {vpc_id}: {e}")
             return {}
 
     def _check_has_empty_routingtables(self, vpc_info: dict) -> bool:


### PR DESCRIPTION
### Context

Sending exceptions as a log error means we lose valuable info when reviewing those exceptions, like the trace pointing to where exactly the exception happened in the code.

### Description

- Replace all `logger.error` with `logger.exception` inside `prowler/providers`.
  - Important to remember to start using `logger.exception` from now on.
- Add `ignore_errors` to sentry configuration so it honors the same ignore list we already had.
- Minor fixes in the docs.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
