### PR TITLE
fix(aws): remove `SHA-1` from ACM insecure key algorithms

### DIFF
--- a/contrib/k8s/helm/prowler-api/values.yaml
+++ b/contrib/k8s/helm/prowler-api/values.yaml
@@ -399,7 +399,6 @@ mainConfig:
       [
         "RSA-1024",
         "P-192",
-        "SHA-1",
       ]
 
     # AWS EKS Configuration

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -327,7 +327,6 @@ aws:
     [
       "RSA-1024",
       "P-192",
-      "SHA-1",
     ]
 
   # AWS EKS Configuration

--- a/prowler/providers/aws/services/acm/acm_certificates_with_secure_key_algorithms/acm_certificates_with_secure_key_algorithms.py
+++ b/prowler/providers/aws/services/acm/acm_certificates_with_secure_key_algorithms/acm_certificates_with_secure_key_algorithms.py
@@ -14,7 +14,7 @@ class acm_certificates_with_secure_key_algorithms(Check):
                 report.status = "PASS"
                 report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} uses a secure key algorithm ({certificate.key_algorithm})."
                 if certificate.key_algorithm in acm_client.audit_config.get(
-                    "insecure_key_algorithms", ["RSA-1024", "P-192", "SHA-1"]
+                    "insecure_key_algorithms", ["RSA-1024", "P-192"]
                 ):
                     report.status = "FAIL"
                     report.status_extended = f"ACM Certificate {certificate.id} for {certificate.name} does not use a secure key algorithm ({certificate.key_algorithm})."

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -297,7 +297,6 @@ config_aws = {
     "insecure_key_algorithms": [
         "RSA-1024",
         "P-192",
-        "SHA-1",
     ],
     "eks_required_log_types": [
         "api",

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -317,7 +317,6 @@ aws:
     [
       "RSA-1024",
       "P-192",
-      "SHA-1",
     ]
 
   # AWS EKS Configuration


### PR DESCRIPTION
### Context

Listing a hash function gives the impression that one could check the hashing algorithm of a cert's signature.

But this is not possible, the code only ever compares to `certificate.key_algorithm`, which is either RSA or a curve.

### Description

Remove SHA-1 from default insecure key algorithms.

### Checklist

- Are there new checks included in this PR? → No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. → **Not quite sure if this qualifies as a "change to the Prowler SDK".**

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.