### PR TITLE
feat(teams): add new check `teams_external_domains_restricted`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Support CLOUDSDK_AUTH_ACCESS_TOKEN in GCP [(#7495)](https://github.com/prowler-cloud/prowler/pull/7495).
 - Add service Exchange to Microsoft365 with one check for Organizations Mailbox Auditing enabled [(#7408)](https://github.com/prowler-cloud/prowler/pull/7408)
 - Add check for Bypass Disable in every Mailbox for service Defender in M365 [(#7418)](https://github.com/prowler-cloud/prowler/pull/7418)
-- Add new check `teams_email_sending_to_channel_disabled` [(#7533)](https://github.com/prowler-cloud/prowler/pull/7533)
+- Add new check `teams_external_domains_restricted` [(#7557)](https://github.com/prowler-cloud/prowler/pull/7557)
+- Add new check `teams_unmanaged_communication_disabled` [(#7561)](https://github.com/prowler-cloud/prowler/pull/7561)
 
 ### Fixed
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -17,7 +17,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add service Exchange to Microsoft365 with one check for Organizations Mailbox Auditing enabled [(#7408)](https://github.com/prowler-cloud/prowler/pull/7408)
 - Add check for Bypass Disable in every Mailbox for service Defender in M365 [(#7418)](https://github.com/prowler-cloud/prowler/pull/7418)
 - Add new check `teams_external_domains_restricted` [(#7557)](https://github.com/prowler-cloud/prowler/pull/7557)
-- Add new check `teams_unmanaged_communication_disabled` [(#7561)](https://github.com/prowler-cloud/prowler/pull/7561)
 - Add new check `teams_email_sending_to_channel_disabled` [(#7533)](https://github.com/prowler-cloud/prowler/pull/7533)
 - Add new check for AllowList not used in the Connection Filter Policy from service Defender in M365 [(#7492)](https://github.com/prowler-cloud/prowler/pull/7492)
 - Add new check for SafeList not enabled in the Connection Filter Policy from service Defender in M365 [(#7492)](https://github.com/prowler-cloud/prowler/pull/7492)

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -137,6 +137,23 @@ class M365PowerShell(PowerShellSession):
         """
         return self.execute("Get-CsTeamsClientConfiguration | ConvertTo-Json")
 
+    def get_user_settings(self) -> dict:
+        """
+        Get Teams User Settings.
+
+        Retrieves the current Microsoft Teams user settings.
+
+        Returns:
+            dict: Teams user settings in JSON format.
+
+        Example:
+            >>> get_user_settings()
+            {
+                "AllowExternalAccess": true
+            }
+        """
+        return self.execute("Get-CsTenantFederationConfiguration | ConvertTo-Json")
+
     def connect_exchange_online(self) -> dict:
         """
         Connect to Exchange Online PowerShell Module.

--- a/prowler/providers/m365/services/teams/teams_external_domains_restricted/teams_external_domains_restricted.metadata.json
+++ b/prowler/providers/m365/services/teams/teams_external_domains_restricted/teams_external_domains_restricted.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "m365",
+  "CheckID": "teams_external_domains_restricted",
+  "CheckTitle": "Ensure external domains are restricted.",
+  "CheckType": [],
+  "ServiceName": "teams",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "Teams Settings",
+  "Description": "Ensure external domains are restricted from being used in Teams admin center.",
+  "Risk": "Allowing unrestricted communication with external domains in Microsoft Teams increases the risk of exposure to social engineering attacks, phishing, malware delivery (e.g., DarkGate), and exploitation tactics such as GIFShell or username enumeration.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/powershell/module/teams/set-cstenantfederationconfiguration?view=teams-ps",
+  "Remediation": {
+    "Code": {
+      "CLI": "Set-CsTenantFederationConfiguration -AllowFederatedUsers $false",
+      "NativeIaC": "",
+      "Other": "1. Navigate to Microsoft Teams admin center https://admin.teams.microsoft.com/. 2. Click to expand Users select External access. 3. Under Teams and Skype for Business users in external organizations set Choose which external domains your users have access to to one of the following: Allow only specific external domains or Block all external domains. 4. Click Save.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Restrict external collaboration by configuring Teams to either Block all external domains or Allow only specific, trusted external domains. This ensures users can only interact with vetted organizations, significantly reducing the attack surface.",
+      "Url": "https://learn.microsoft.com/en-us/powershell/module/teams/set-cstenantfederationconfiguration?view=teams-ps"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/teams/teams_external_domains_restricted/teams_external_domains_restricted.py
+++ b/prowler/providers/m365/services/teams/teams_external_domains_restricted/teams_external_domains_restricted.py
@@ -1,0 +1,40 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.teams.teams_client import teams_client
+
+
+class teams_external_domains_restricted(Check):
+    """Check if external domains are restricted from being used in Teams admin center.
+
+    Attributes:
+        metadata: Metadata associated with the check (inherited from Check).
+    """
+
+    def execute(self) -> List[CheckReportM365]:
+        """Execute the check for
+
+        This method checks if external domains are restricted from being used in Teams admin center.
+
+        Returns:
+            List[CheckReportM365]: A list of reports containing the result of the check.
+        """
+        findings = []
+        user_settings = teams_client.user_settings
+        if user_settings:
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=user_settings if user_settings else {},
+                resource_name="Teams User Settings",
+                resource_id="userSettings",
+            )
+            report.status = "FAIL"
+            report.status_extended = "Users can access external domains."
+
+            if user_settings and not user_settings.allow_external_access:
+                report.status = "PASS"
+                report.status_extended = "Users can not access external domains."
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/m365/services/teams/teams_service.py
+++ b/prowler/providers/m365/services/teams/teams_service.py
@@ -10,6 +10,7 @@ class Teams(M365Service):
         super().__init__(provider)
         self.powershell.connect_microsoft_teams()
         self.teams_settings = self._get_teams_client_configuration()
+        self.user_settings = self._get_user_settings()
         self.powershell.close()
 
     def _get_teams_client_configuration(self):
@@ -37,6 +38,21 @@ class Teams(M365Service):
             )
         return teams_settings
 
+    def _get_user_settings(self):
+        logger.info("M365 - Getting Teams user settings...")
+        user_settings = None
+        try:
+            settings = self.powershell.get_user_settings()
+            if settings:
+                user_settings = UserSettings(
+                    allow_external_access=settings.get("AllowFederatedUsers", True),
+                )
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+        return user_settings
+
 
 class CloudStorageSettings(BaseModel):
     allow_box: bool
@@ -49,3 +65,7 @@ class CloudStorageSettings(BaseModel):
 class TeamsSettings(BaseModel):
     cloud_storage_settings: CloudStorageSettings
     allow_email_into_channel: bool = True
+
+
+class UserSettings(BaseModel):
+    allow_external_access: bool = True

--- a/tests/providers/m365/services/teams/teams_external_domains_restricted/teams_external_domains_restricted_test.py
+++ b/tests/providers/m365/services/teams/teams_external_domains_restricted/teams_external_domains_restricted_test.py
@@ -1,0 +1,106 @@
+from unittest import mock
+
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_teams_external_domains_restricted:
+    def test_no_user_settings(self):
+        teams_client = mock.MagicMock()
+        teams_client.audited_tenant = "audited_tenant"
+        teams_client.audited_domain = DOMAIN
+        teams_client.user_settings = None
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_microsoft_teams"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.teams.teams_external_domains_restricted.teams_external_domains_restricted.teams_client",
+                new=teams_client,
+            ),
+        ):
+            from prowler.providers.m365.services.teams.teams_external_domains_restricted.teams_external_domains_restricted import (
+                teams_external_domains_restricted,
+            )
+
+            check = teams_external_domains_restricted()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_external_domains_allowed(self):
+        teams_client = mock.MagicMock()
+        teams_client.audited_tenant = "audited_tenant"
+        teams_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_microsoft_teams"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.teams.teams_external_domains_restricted.teams_external_domains_restricted.teams_client",
+                new=teams_client,
+            ),
+        ):
+            from prowler.providers.m365.services.teams.teams_external_domains_restricted.teams_external_domains_restricted import (
+                teams_external_domains_restricted,
+            )
+            from prowler.providers.m365.services.teams.teams_service import UserSettings
+
+            teams_client.user_settings = UserSettings(
+                allow_external_access=True,
+            )
+
+            check = teams_external_domains_restricted()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].status_extended == "Users can access external domains."
+            assert result[0].resource == teams_client.user_settings.dict()
+            assert result[0].resource_name == "Teams User Settings"
+            assert result[0].resource_id == "userSettings"
+            assert result[0].location == "global"
+
+    def test_external_domains_restricted(self):
+        teams_client = mock.MagicMock()
+        teams_client.audited_tenant = "audited_tenant"
+        teams_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_microsoft_teams"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.teams.teams_external_domains_restricted.teams_external_domains_restricted.teams_client",
+                new=teams_client,
+            ),
+        ):
+            from prowler.providers.m365.services.teams.teams_external_domains_restricted.teams_external_domains_restricted import (
+                teams_external_domains_restricted,
+            )
+            from prowler.providers.m365.services.teams.teams_service import UserSettings
+
+            teams_client.user_settings = UserSettings(
+                allow_external_access=False,
+            )
+
+            check = teams_external_domains_restricted()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].status_extended == "Users can not access external domains."
+            assert result[0].resource == teams_client.user_settings.dict()
+            assert result[0].resource_name == "Teams User Settings"
+            assert result[0].resource_id == "userSettings"
+            assert result[0].location == "global"

--- a/tests/providers/m365/services/teams/teams_service_test.py
+++ b/tests/providers/m365/services/teams/teams_service_test.py
@@ -6,6 +6,7 @@ from prowler.providers.m365.services.teams.teams_service import (
     CloudStorageSettings,
     Teams,
     TeamsSettings,
+    UserSettings,
 )
 from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
 
@@ -19,6 +20,12 @@ def mock_get_teams_client_configuration(_):
             allow_google_drive=False,
             allow_share_file=False,
         )
+    )
+
+
+def mock_get_user_settings(_):
+    return UserSettings(
+        allow_external_access=False,
     )
 
 
@@ -61,5 +68,25 @@ class Test_Teams_Service:
                     allow_google_drive=False,
                     allow_share_file=False,
                 )
+            )
+            teams_client.powershell.close()
+
+    @patch(
+        "prowler.providers.m365.services.teams.teams_service.Teams._get_user_settings",
+        new=mock_get_user_settings,
+    )
+    def test_get_user_settings(self):
+        with (
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_microsoft_teams"
+            ),
+        ):
+            teams_client = Teams(
+                set_mocked_m365_provider(
+                    identity=M365IdentityInfo(tenant_domain=DOMAIN)
+                )
+            )
+            assert teams_client.user_settings == UserSettings(
+                allow_external_access=False,
             )
             teams_client.powershell.close()


### PR DESCRIPTION
### Context

Allowing communication with external domains in `Microsoft Teams` can introduce security risks, especially when those domains are not explicitly trusted. Threat actors have exploited Teams external access features to deliver malware, conduct phishing campaigns, and perform reconnaissance on users and systems.

### Description

This check ensures that external communication in Microsoft Teams is restricted by either blocking all external domains. Configuring Teams to allow only approved external domains helps reduce exposure to external threats and enforces stricter collaboration boundaries.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
