### PR TITLE
fix(teams): `teams_email_sending_to_channel_disabled` docstrings

### DIFF
--- a/prowler/providers/m365/services/teams/teams_email_sending_to_channel_disabled/teams_email_sending_to_channel_disabled.py
+++ b/prowler/providers/m365/services/teams/teams_email_sending_to_channel_disabled/teams_email_sending_to_channel_disabled.py
@@ -5,7 +5,7 @@ from prowler.providers.m365.services.teams.teams_client import teams_client
 
 
 class teams_email_sending_to_channel_disabled(Check):
-    """Check if
+    """Check if users can send emails to channel email addresses.
 
     Attributes:
         metadata: Metadata associated with the check (inherited from Check).
@@ -14,7 +14,7 @@ class teams_email_sending_to_channel_disabled(Check):
     def execute(self) -> List[CheckReportM365]:
         """Execute the check for
 
-        This method checks if
+        This method checks if users can send emails to channel email addresses.
 
         Returns:
             List[CheckReportM365]: A list of reports containing the result of the check.


### PR DESCRIPTION
### Context

This check does not have `docstrings` correctly fulfilled.

### Description

I have added the missing `docstrings`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
