### PR TITLE
chore(actions): Bump Prowler version on release

### DIFF
--- a/.github/workflows/sdk-bump-version.yml
+++ b/.github/workflows/sdk-bump-version.yml
@@ -1,0 +1,94 @@
+name: SDK - Bump Version
+
+on:
+  release:
+    types: [published]
+
+
+env:
+  PROWLER_VERSION: ${{ github.event.release.tag_name }}
+  BASE_BRANCH: master
+
+jobs:
+  bump-version:
+    name: Bump Version
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get Prowler version
+        shell: bash
+        run: |
+          if [[ $PROWLER_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR_VERSION=${BASH_REMATCH[1]}
+            MINOR_VERSION=${BASH_REMATCH[2]}
+            FIX_VERSION=${BASH_REMATCH[3]}
+
+            if (( MAJOR_VERSION == 5 )); then
+                if (( FIX_VERSION == 0 )); then
+                  echo "Minor Release: $PROWLER_VERSION"
+
+                  BUMP_VERSION_TO=${MAJOR_VERSION}.$((MINOR_VERSION + 1)).${FIX_VERSION}
+                  echo "BUMP_VERSION_TO=${BUMP_VERSION_TO}" >> "${GITHUB_ENV}"
+
+                  TARGET_BRANCH=${BASE_BRANCH}
+                  echo "TARGET_BRANCH=${TARGET_BRANCH}" >> "${GITHUB_ENV}"
+
+                  echo "Bumping to next minor version: ${BUMP_VERSION_TO} in branch ${TARGET_BRANCH}"
+                else
+                  echo "Patch Release: $PROWLER_VERSION"
+
+                  BUMP_VERSION_TO=${MAJOR_VERSION}.${MINOR_VERSION}.$((FIX_VERSION + 1))
+                  echo "BUMP_VERSION_TO=${BUMP_VERSION_TO}" >> "${GITHUB_ENV}"
+
+                  TARGET_BRANCH=v${MAJOR_VERSION}.${MINOR_VERSION}
+                  echo "TARGET_BRANCH=${TARGET_BRANCH}" >> "${GITHUB_ENV}"
+
+                  echo "Bumping to next patch version: ${BUMP_VERSION_TO} in branch ${TARGET_BRANCH}"
+                fi
+            else
+                echo "Releasing another Prowler major version, aborting..."
+                exit 1
+            fi
+          else
+            echo "Invalid version syntax: '$PROWLER_VERSION' (must be N.N.N)" >&2
+            exit 1
+          fi
+
+      - name: Bump versions in files
+        run: |
+            echo "Using PROWLER_VERSION=$PROWLER_VERSION"
+            echo "Using BUMP_VERSION_TO=$BUMP_VERSION_TO"
+
+            set -e
+
+            echo "Bumping version in pyproject.toml ..."
+            sed -i "s|version = \"${PROWLER_VERSION}\"|version = \"${BUMP_VERSION_TO}\"|" pyproject.toml
+
+            echo "Bumping version in prowler/config/config.py ..."
+            sed -i "s|prowler_version = \"${PROWLER_VERSION}\"|prowler_version = \"${BUMP_VERSION_TO}\"|" prowler/config/config.py
+
+            echo "Bumping version in .env ..."
+            sed -i "s|NEXT_PUBLIC_PROWLER_RELEASE_VERSION=v${PROWLER_VERSION}|NEXT_PUBLIC_PROWLER_RELEASE_VERSION=v${BUMP_VERSION_TO}|" .env
+
+            git --no-pager diff
+
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+            author: prowler-bot <179230569+prowler-bot@users.noreply.github.com>
+            token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
+            base: ${{ env.TARGET_BRANCH }}
+            commit-message: "chore(release): Bump version to v${{ env.BUMP_VERSION_TO }}"
+            branch: "version-bump-to-v${{ env.BUMP_VERSION_TO }}"
+            title: "chore(release): Bump version to v${{ env.BUMP_VERSION_TO }}"
+            body: |
+              ### Description
+
+              Bump Prowler version to v${{ env.BUMP_VERSION_TO }}
+
+              ### License
+
+              By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
### Context

As part of our release procedure, we want to automate as much as possible.

### Description

Automatically bump Prowler version after each release.

### Tests

* https://github.com/prowler-cloud/test-actions/pull/16 bump to 5.0.11 from 5.0.10 just in `v5.0` branch
* https://github.com/prowler-cloud/test-actions/pull/17 bump 5.3.0 from 5.2.0 in `main` branch

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
