### PR TITLE
chore(tests): Split by provider in the SDK

### DIFF
--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           files: ./**
           files_ignore: |
-            # .github/**
+            .github/**
             docs/**
             permissions/**
             api/**

--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -119,6 +119,13 @@ jobs:
         run: |
           poetry run pytest -n auto --cov=./prowler/providers/aws --cov-report=xml tests/providers/aws
 
+      - name: AWS - Upload coverage to Codecov
+        if: steps.aws-changed-files.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
+
       # Test Azure
       - name: Azure - Check if any file has changed
         id: azure-changed-files
@@ -130,6 +137,13 @@ jobs:
         if: steps.azure-changed-files.outputs.any_changed == 'true'
         run: |
           poetry run pytest -n auto --cov=./prowler/providers/azure --cov-report=xml tests/providers/azure
+
+      - name: Azure - Upload coverage to Codecov
+        if: steps.azure-changed-files.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
 
       # Test GCP
       - name: GCP - Check if any file has changed
@@ -143,6 +157,13 @@ jobs:
         run: |
           poetry run pytest -n auto --cov=./prowler/providers/gcp --cov-report=xml tests/providers/gcp
 
+      - name: GCP - Upload coverage to Codecov
+        if: steps.gcp-changed-files.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
+
       # Test Kubernetes
       - name: Kubernetes - Check if any file has changed
         id: kubernetes-changed-files
@@ -154,6 +175,13 @@ jobs:
         if: steps.kubernetes-changed-files.outputs.any_changed == 'true'
         run: |
           poetry run pytest -n auto --cov=./prowler/providers/kubernetes --cov-report=xml tests/providers/kubernetes
+
+      - name: Kubernetes - Upload coverage to Codecov
+        if: steps.kubernetes-changed-files.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
 
       # Test NHN
       - name: NHN - Check if any file has changed
@@ -167,6 +195,12 @@ jobs:
         run: |
           poetry run pytest -n auto --cov=./prowler/providers/nhn --cov-report=xml tests/providers/nhn
 
+      - name: NHN - Upload coverage to Codecov
+        if: steps.nhn-changed-files.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
 
       # Test M365
       - name: M365 - Check if any file has changed
@@ -180,14 +214,37 @@ jobs:
         run: |
           poetry run pytest -n auto --cov=./prowler/providers/m365 --cov-report=xml tests/providers/m365
 
+      - name: M365 - Upload coverage to Codecov
+        if: steps.m365-changed-files.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
+
       # Common Tests
       - name: Lib - Test
+        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |
           poetry run pytest -n auto --cov=./prowler/lib --cov-report=xml tests/lib
 
+      - name: Lib - Upload coverage to Codecov
+        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
+
       - name: Config - Test
+        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |
           poetry run pytest -n auto --cov=./prowler/config --cov-report=xml tests/config
+
+      - name: Config - Upload coverage to Codecov
+        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: prowler
 
       # Codecov
       - name: Upload coverage reports to Codecov
@@ -197,5 +254,3 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: prowler
-
-

--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -112,7 +112,9 @@ jobs:
         id: aws-changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          files: ./prowler/providers/aws
+          files: |
+            ./prowler/providers/aws
+            ./tests/providers/aws
 
       - name: AWS - Test
         if: steps.aws-changed-files.outputs.any_changed == 'true'
@@ -124,7 +126,9 @@ jobs:
         id: azure-changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          files: ./prowler/providers/azure
+          files: |
+            ./prowler/providers/azure
+            ./tests/providers/azure
 
       - name: Azure - Test
         if: steps.azure-changed-files.outputs.any_changed == 'true'
@@ -136,7 +140,9 @@ jobs:
         id: gcp-changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          files: ./prowler/providers/gcp
+          files: |
+            ./prowler/providers/gcp
+            ./tests/providers/gcp
 
       - name: GCP - Test
         if: steps.gcp-changed-files.outputs.any_changed == 'true'
@@ -148,7 +154,9 @@ jobs:
         id: kubernetes-changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          files: ./prowler/providers/kubernetes
+          files: |
+            ./prowler/providers/kubernetes
+            ./tests/providers/kubernetes
 
       - name: Kubernetes - Test
         if: steps.kubernetes-changed-files.outputs.any_changed == 'true'
@@ -160,7 +168,9 @@ jobs:
         id: nhn-changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          files: ./prowler/providers/nhn
+          files: |
+            ./prowler/providers/nhn
+            ./tests/providers/nhn
 
       - name: NHN - Test
         if: steps.nhn-changed-files.outputs.any_changed == 'true'
@@ -172,7 +182,9 @@ jobs:
         id: m365-changed-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         with:
-          files: ./prowler/providers/m365
+          files: |
+            ./prowler/providers/m365
+            ./tests/providers/m365
 
       - name: M365 - Test
         if: steps.m365-changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           files: ./**
           files_ignore: |
-            .github/**
+            # .github/**
             docs/**
             permissions/**
             api/**
@@ -107,11 +107,89 @@ jobs:
         run: |
           /tmp/hadolint Dockerfile --ignore=DL3013
 
-      - name: Test with pytest
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
-        run: |
-          poetry run pytest -n auto --cov=./prowler --cov-report=xml tests
+      # Test AWS
+      - name: AWS - Check if any file has changed
+        id: aws-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: ./prowler/providers/aws
 
+      - name: AWS - Test
+        if: steps.aws-changed-files.outputs.any_changed == 'true'
+        run: |
+          poetry run pytest -n auto --cov=./prowler/providers/aws --cov-report=xml tests/providers/aws
+
+      # Test Azure
+      - name: Azure - Check if any file has changed
+        id: azure-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: ./prowler/providers/azure
+
+      - name: Azure - Test
+        if: steps.azure-changed-files.outputs.any_changed == 'true'
+        run: |
+          poetry run pytest -n auto --cov=./prowler/providers/azure --cov-report=xml tests/providers/azure
+
+      # Test GCP
+      - name: GCP - Check if any file has changed
+        id: gcp-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: ./prowler/providers/gcp
+
+      - name: GCP - Test
+        if: steps.gcp-changed-files.outputs.any_changed == 'true'
+        run: |
+          poetry run pytest -n auto --cov=./prowler/providers/gcp --cov-report=xml tests/providers/gcp
+
+      # Test Kubernetes
+      - name: Kubernetes - Check if any file has changed
+        id: kubernetes-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: ./prowler/providers/kubernetes
+
+      - name: Kubernetes - Test
+        if: steps.kubernetes-changed-files.outputs.any_changed == 'true'
+        run: |
+          poetry run pytest -n auto --cov=./prowler/providers/kubernetes --cov-report=xml tests/providers/kubernetes
+
+      # Test NHN
+      - name: NHN - Check if any file has changed
+        id: nhn-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: ./prowler/providers/nhn
+
+      - name: NHN - Test
+        if: steps.nhn-changed-files.outputs.any_changed == 'true'
+        run: |
+          poetry run pytest -n auto --cov=./prowler/providers/nhn --cov-report=xml tests/providers/nhn
+
+
+      # Test M365
+      - name: M365 - Check if any file has changed
+        id: m365-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: ./prowler/providers/m365
+
+      - name: M365 - Test
+        if: steps.m365-changed-files.outputs.any_changed == 'true'
+        run: |
+          poetry run pytest -n auto --cov=./prowler/providers/m365 --cov-report=xml tests/providers/m365
+
+      # Common Tests
+      - name: Lib - Test
+        run: |
+          poetry run pytest -n auto --cov=./prowler/lib --cov-report=xml tests/lib
+
+      - name: Config - Test
+        run: |
+          poetry run pytest -n auto --cov=./prowler/config --cov-report=xml tests/config
+
+      # Codecov
       - name: Upload coverage reports to Codecov
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         uses: codecov/codecov-action@ad3126e916f78f00edff4ed0317cf185271ccc2d # v5.4.2
@@ -119,3 +197,5 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: prowler
+
+

--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -117,14 +117,7 @@ jobs:
       - name: AWS - Test
         if: steps.aws-changed-files.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/providers/aws --cov-report=xml tests/providers/aws
-
-      - name: AWS - Upload coverage to Codecov
-        if: steps.aws-changed-files.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/providers/aws --cov-report=xml:aws_coverage.xml tests/providers/aws
 
       # Test Azure
       - name: Azure - Check if any file has changed
@@ -136,14 +129,7 @@ jobs:
       - name: Azure - Test
         if: steps.azure-changed-files.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/providers/azure --cov-report=xml tests/providers/azure
-
-      - name: Azure - Upload coverage to Codecov
-        if: steps.azure-changed-files.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/providers/azure --cov-report=xml:azure_coverage.xml tests/providers/azure
 
       # Test GCP
       - name: GCP - Check if any file has changed
@@ -155,14 +141,7 @@ jobs:
       - name: GCP - Test
         if: steps.gcp-changed-files.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/providers/gcp --cov-report=xml tests/providers/gcp
-
-      - name: GCP - Upload coverage to Codecov
-        if: steps.gcp-changed-files.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/providers/gcp --cov-report=xml:gcp_coverage.xml tests/providers/gcp
 
       # Test Kubernetes
       - name: Kubernetes - Check if any file has changed
@@ -174,14 +153,7 @@ jobs:
       - name: Kubernetes - Test
         if: steps.kubernetes-changed-files.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/providers/kubernetes --cov-report=xml tests/providers/kubernetes
-
-      - name: Kubernetes - Upload coverage to Codecov
-        if: steps.kubernetes-changed-files.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/providers/kubernetes --cov-report=xml:kubernetes_coverage.xml tests/providers/kubernetes
 
       # Test NHN
       - name: NHN - Check if any file has changed
@@ -193,14 +165,7 @@ jobs:
       - name: NHN - Test
         if: steps.nhn-changed-files.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/providers/nhn --cov-report=xml tests/providers/nhn
-
-      - name: NHN - Upload coverage to Codecov
-        if: steps.nhn-changed-files.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/providers/nhn --cov-report=xml:nhn_coverage.xml tests/providers/nhn
 
       # Test M365
       - name: M365 - Check if any file has changed
@@ -212,39 +177,18 @@ jobs:
       - name: M365 - Test
         if: steps.m365-changed-files.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/providers/m365 --cov-report=xml tests/providers/m365
-
-      - name: M365 - Upload coverage to Codecov
-        if: steps.m365-changed-files.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/providers/m365 --cov-report=xml:m365_coverage.xml tests/providers/m365
 
       # Common Tests
       - name: Lib - Test
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/lib --cov-report=xml tests/lib
-
-      - name: Lib - Upload coverage to Codecov
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/lib --cov-report=xml:lib_coverage.xml tests/lib
 
       - name: Config - Test
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
         run: |
-          poetry run pytest -n auto --cov=./prowler/config --cov-report=xml tests/config
-
-      - name: Config - Upload coverage to Codecov
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: prowler
+          poetry run pytest -n auto --cov=./prowler/config --cov-report=xml:config_coverage.xml tests/config
 
       # Codecov
       - name: Upload coverage reports to Codecov
@@ -254,3 +198,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           flags: prowler
+          files: ./aws_coverage.xml,./azure_coverage.xml,./gcp_coverage.xml,./kubernetes_coverage.xml,./nhn_coverage.xml,./m365_coverage.xml,./lib_coverage.xml,./config_coverage.xml


### PR DESCRIPTION
### Context

We want to speed up tests execution since AWS took more than 40' in each run and we are running AWS tests even when there are no modifications under `prowler/providers/aws`

### Description

Split tests by provider in the SDK.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
