### PR TITLE
fix(scan): handle cloud provider errors and ignore expected sentry noise

### DIFF
--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -39,6 +39,9 @@ IGNORED_EXCEPTIONS = [
     "RequestExpired",
     "ConnectionClosedError",
     "MaxRetryError",
+    "AWSAccessKeyIDInvalidError",
+    "AWSSessionTokenExpiredError",
+    "EndpointConnectionError",  # AWS Service is not available in a region
     "Pool is closed",  # The following comes from urllib3: eu-west-1 -- HTTPClientError[126]: An HTTP Client raised an unhandled exception: AWSHTTPSConnectionPool(host='hostname.s3.eu-west-1.amazonaws.com', port=443): Pool is closed.
     # Authentication Errors from GCP
     "ClientAuthenticationError",
@@ -63,8 +66,6 @@ IGNORED_EXCEPTIONS = [
     "AzureClientIdAndClientSecretNotBelongingToTenantIdError",
     "AzureHTTPResponseError",
     "Error with credentials provided",
-    # AWS Service is not available in a region
-    "EndpointConnectionError",
 ]
 
 

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
@@ -37,6 +37,7 @@ class cloudtrail_multi_region_enabled(Check):
                     report.status_extended = (
                         "No CloudTrail trails enabled with logging were found."
                     )
+                    report.region = region
                     report.resource_arn = cloudtrail_client._get_trail_arn_template(
                         region
                     )

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_multi_region_enabled/cloudtrail_multi_region_enabled.py
@@ -29,6 +29,10 @@ class cloudtrail_multi_region_enabled(Check):
                             break
                 # If there are no trails logging it is needed to store the FAIL once all the trails have been checked
                 if not trail_is_logging:
+                    report = Check_Report_AWS(
+                        metadata=self.metadata(),
+                        resource={},
+                    )
                     report.status = "FAIL"
                     report.status_extended = (
                         "No CloudTrail trails enabled with logging were found."

--- a/prowler/providers/aws/services/iam/iam_service.py
+++ b/prowler/providers/aws/services/iam/iam_service.py
@@ -880,9 +880,14 @@ class IAM(AWSService):
                     SAMLProviderArn=resource.arn
                 ).get("Tags", [])
         except Exception as error:
-            logger.error(
-                f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
-            )
+            if error.response["Error"]["Code"] == "NoSuchEntityException":
+                logger.warning(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
+            else:
+                logger.error(
+                    f"{self.region} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                )
 
     def _get_last_accessed_services(self):
         logger.info("IAM - Getting Last Accessed Services ...")

--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -161,7 +161,7 @@ class Defender(AzureService):
                     {
                         security_contact_default.name: SecurityContacts(
                             resource_id=security_contact_default.id,
-                            name=security_contact_default.get("name", "default"),
+                            name=getattr(security_contact_default, "name", "default"),
                             emails=security_contact_default.emails,
                             phone=security_contact_default.phone,
                             alert_notifications_minimal_severity=security_contact_default.alert_notifications.minimal_severity,

--- a/prowler/providers/gcp/services/cloudsql/cloudsql_service.py
+++ b/prowler/providers/gcp/services/cloudsql/cloudsql_service.py
@@ -30,18 +30,18 @@ class CloudSQL(GCPService):
                                 region=instance["region"],
                                 ip_addresses=instance.get("ipAddresses", []),
                                 public_ip=public_ip,
-                                require_ssl=instance["settings"]["ipConfiguration"].get(
-                                    "requireSsl", False
-                                ),
-                                ssl_mode=instance["settings"]["ipConfiguration"].get(
-                                    "sslMode", "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
-                                ),
+                                require_ssl=instance["settings"]
+                                .get("ipConfiguration", {})
+                                .get("requireSsl", False),
+                                ssl_mode=instance["settings"]
+                                .get("ipConfiguration", {})
+                                .get("sslMode", "ALLOW_UNENCRYPTED_AND_ENCRYPTED"),
                                 automated_backups=instance["settings"][
                                     "backupConfiguration"
                                 ]["enabled"],
-                                authorized_networks=instance["settings"][
-                                    "ipConfiguration"
-                                ]["authorizedNetworks"],
+                                authorized_networks=instance["settings"]
+                                .get("ipConfiguration", {})
+                                .get("authorizedNetworks", []),
                                 flags=instance["settings"].get("databaseFlags", []),
                                 project_id=project_id,
                             )


### PR DESCRIPTION
## Context
Multiple errors were reported across AWS, Azure, and GCP during scheduled scans. Some were caused by missing attributes or configurations, while others were expected transient errors that shouldn't trigger alerts in Sentry.

## Description

### Fixes
- **Azure**: Replaced `.get()` with `getattr()` for `SecurityContact` objects to avoid `AttributeError`.
- **GCP**: Used `.get("ipConfiguration", {})` to prevent `KeyError` when the config is missing in Cloud SQL instances.
- **AWS**:
  - Fixed `UnboundLocalError` in `cloudtrail_multi_region_enabled` by initializing `report` when no matching trail is found.
  - Handled `NoSuchEntityException` when calling `ListRoles` in unsupported or misconfigured regions.

### Sentry Ignore Rules
Added to the ignore list in Sentry:
- `AWSAccessKeyIDInvalidError[1013]`
- `AWSSessionTokenExpiredError[1016]`
- `MaxRetryError[541]` (e.g., HTTPSConnectionPool)

These are known, expected, and do not require reporting.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
