### PR TITLE
chore(dockerfile): add image source as docker label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.12.10-alpine3.20
 
 LABEL maintainer="https://github.com/prowler-cloud/prowler"
+LABEL org.opencontainers.image.source="https://github.com/prowler-cloud/prowler"
 
 # Update system dependencies and install essential tools
 #hadolint ignore=DL3018


### PR DESCRIPTION
### Context
Today when using Dependabot or Renovate to keep the `toniblyx/prowler` Docker image updated in a consuming repository, various information such as release notes and changelogs are not included in the pull request because these services are not aware of any associated source repository for the image. This makes it a bit tedious to figure out which changes have been made as you have to jump between repositories instead of having all of the context in one pull request.


### Description
The [OpenContainers Annotations Spec](https://specs.opencontainers.org/image-spec/annotations/) defines a label `org.opencontainers.image.source` that, among other things, is used by Dependabot and Renovate to link a specific Docker image back to a source repository in order to include release notes and changelogs in pull requests that update the image.

For this to work properly there must also exist git tags that are identical to the Docker image tags, which as far as I can tell seems to be the case for Prowler.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [X] Review if the code is being covered by tests.
- [X] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [X] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [X] Verify if API specs need to be regenerated.
- [X] Check if version updates are required (e.g., specs, Poetry, etc.).
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.