### PR TITLE
fix(m365): remove unused arguments

### DIFF
--- a/prowler/providers/m365/lib/arguments/arguments.py
+++ b/prowler/providers/m365/lib/arguments/arguments.py
@@ -39,18 +39,6 @@ def init_parser(self):
         action="store_true",
         help="Initialize Microsoft 365 PowerShell modules",
     )
-    m365_parser.add_argument(
-        "--user",
-        nargs="?",
-        default=None,
-        help="Microsoft 365 user email",
-    )
-    m365_parser.add_argument(
-        "--encypted-password",
-        nargs="?",
-        default=None,
-        help="Microsoft 365 encrypted password",
-    )
     # Regions
     m365_regions_subparser = m365_parser.add_argument_group("Regions")
     m365_regions_subparser.add_argument(


### PR DESCRIPTION
### Context

Currently, we have two arguments `--user` and `--encrypted-password`, that are not being used and won’t be used (plus one of them has a typo). 

### Description

This PR removes both arguments to avoid confusion.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
