### PR TITLE
feat(ui): Page size for datatables

### DIFF
--- a/ui/actions/invitations/invitation.ts
+++ b/ui/actions/invitations/invitation.ts
@@ -15,6 +15,7 @@ export const getInvitations = async ({
   query = "",
   sort = "",
   filters = {},
+  pageSize = 10,
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -23,6 +24,7 @@ export const getInvitations = async ({
   const url = new URL(`${apiBaseUrl}/tenants/invitations`);
 
   if (page) url.searchParams.append("page[number]", page.toString());
+  if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 

--- a/ui/actions/manage-groups/manage-groups.ts
+++ b/ui/actions/manage-groups/manage-groups.ts
@@ -16,11 +16,13 @@ export const getProviderGroups = async ({
   query = "",
   sort = "",
   filters = {},
+  pageSize = 10,
 }: {
   page?: number;
   query?: string;
   sort?: string;
   filters?: Record<string, string | number>;
+  pageSize?: number;
 }): Promise<ProviderGroupsResponse | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -29,6 +31,7 @@ export const getProviderGroups = async ({
   const url = new URL(`${apiBaseUrl}/provider-groups`);
 
   if (page) url.searchParams.append("page[number]", page.toString());
+  if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 

--- a/ui/actions/providers/providers.ts
+++ b/ui/actions/providers/providers.ts
@@ -16,6 +16,7 @@ export const getProviders = async ({
   query = "",
   sort = "",
   filters = {},
+  pageSize = 10,
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -24,6 +25,7 @@ export const getProviders = async ({
   const url = new URL(`${apiBaseUrl}/providers?include=provider_groups`);
 
   if (page) url.searchParams.append("page[number]", page.toString());
+  if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 

--- a/ui/actions/roles/roles.ts
+++ b/ui/actions/roles/roles.ts
@@ -15,6 +15,7 @@ export const getRoles = async ({
   query = "",
   sort = "",
   filters = {},
+  pageSize = 10,
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -23,6 +24,7 @@ export const getRoles = async ({
   const url = new URL(`${apiBaseUrl}/roles`);
 
   if (page) url.searchParams.append("page[number]", page.toString());
+  if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 

--- a/ui/actions/scans/scans.ts
+++ b/ui/actions/scans/scans.ts
@@ -15,6 +15,7 @@ export const getScans = async ({
   query = "",
   sort = "",
   filters = {},
+  pageSize = 10,
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -23,6 +24,7 @@ export const getScans = async ({
   const url = new URL(`${apiBaseUrl}/scans`);
 
   if (page) url.searchParams.append("page[number]", page.toString());
+  if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 

--- a/ui/actions/users/users.ts
+++ b/ui/actions/users/users.ts
@@ -15,6 +15,7 @@ export const getUsers = async ({
   query = "",
   sort = "",
   filters = {},
+  pageSize = 10,
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -23,6 +24,7 @@ export const getUsers = async ({
   const url = new URL(`${apiBaseUrl}/users?include=roles`);
 
   if (page) url.searchParams.append("page[number]", page.toString());
+  if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -152,7 +152,6 @@ const SSRDataTable = async ({
   const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
   const defaultSort = "severity,status,-inserted_at";
   const sort = searchParams.sort?.toString() || defaultSort;
-  const pageSizeOptions = [10, 20, 30, 50, 100];
 
   // Make sure the sort is correctly encoded
   const encodedSort = sort.replace(/^\+/, "");
@@ -229,7 +228,6 @@ const SSRDataTable = async ({
         columns={ColumnFindings}
         data={expandedResponse?.data || []}
         metadata={findingsData?.meta}
-        pageSizeOptions={pageSizeOptions}
       />
     </>
   );

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -149,8 +149,10 @@ const SSRDataTable = async ({
   searchParams: SearchParamsProps;
 }) => {
   const page = parseInt(searchParams.page?.toString() || "1", 10);
+  const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
   const defaultSort = "severity,status,-inserted_at";
   const sort = searchParams.sort?.toString() || defaultSort;
+  const pageSizeOptions = [10, 20, 30, 50, 100];
 
   // Make sure the sort is correctly encoded
   const encodedSort = sort.replace(/^\+/, "");
@@ -186,7 +188,7 @@ const SSRDataTable = async ({
     page,
     sort: encodedSort,
     filters,
-    pageSize: 10,
+    pageSize,
   });
 
   // Create dictionaries for resources, scans, and providers
@@ -227,6 +229,7 @@ const SSRDataTable = async ({
         columns={ColumnFindings}
         data={expandedResponse?.data || []}
         metadata={findingsData?.meta}
+        pageSizeOptions={pageSizeOptions}
       />
     </>
   );

--- a/ui/app/(prowler)/invitations/page.tsx
+++ b/ui/app/(prowler)/invitations/page.tsx
@@ -44,6 +44,7 @@ const SSRDataTable = async ({
 }) => {
   const page = parseInt(searchParams.page?.toString() || "1", 10);
   const sort = searchParams.sort?.toString();
+  const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
 
   // Extract all filter parameters
   const filters = Object.fromEntries(
@@ -54,7 +55,13 @@ const SSRDataTable = async ({
   const query = (filters["filter[search]"] as string) || "";
 
   // Fetch invitations and roles
-  const invitationsData = await getInvitations({ query, page, sort, filters });
+  const invitationsData = await getInvitations({
+    query,
+    page,
+    sort,
+    filters,
+    pageSize,
+  });
   const rolesData = await getRoles({});
 
   // Create a dictionary for roles by invitation ID

--- a/ui/app/(prowler)/manage-groups/page.tsx
+++ b/ui/app/(prowler)/manage-groups/page.tsx
@@ -163,6 +163,7 @@ const SSRDataTable = async ({
 }) => {
   const page = parseInt(searchParams.page?.toString() || "1", 10);
   const sort = searchParams.sort?.toString();
+  const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
 
   // Convert filters to the correct type
   const filters: Record<string, string> = {};
@@ -178,6 +179,7 @@ const SSRDataTable = async ({
     page,
     sort,
     filters,
+    pageSize
   });
   return (
     <DataTable

--- a/ui/app/(prowler)/manage-groups/page.tsx
+++ b/ui/app/(prowler)/manage-groups/page.tsx
@@ -179,7 +179,7 @@ const SSRDataTable = async ({
     page,
     sort,
     filters,
-    pageSize
+    pageSize,
   });
   return (
     <DataTable

--- a/ui/app/(prowler)/providers/page.tsx
+++ b/ui/app/(prowler)/providers/page.tsx
@@ -50,6 +50,7 @@ const SSRDataTable = async ({
 }) => {
   const page = parseInt(searchParams.page?.toString() || "1", 10);
   const sort = searchParams.sort?.toString();
+  const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
 
   // Extract all filter parameters
   const filters = Object.fromEntries(
@@ -59,7 +60,13 @@ const SSRDataTable = async ({
   // Extract query from filters
   const query = (filters["filter[search]"] as string) || "";
 
-  const providersData = await getProviders({ query, page, sort, filters });
+  const providersData = await getProviders({
+    query,
+    page,
+    sort,
+    filters,
+    pageSize,
+  });
 
   const providerGroupDict =
     providersData?.included

--- a/ui/app/(prowler)/roles/page.tsx
+++ b/ui/app/(prowler)/roles/page.tsx
@@ -41,6 +41,7 @@ const SSRDataTable = async ({
 }) => {
   const page = parseInt(searchParams.page?.toString() || "1", 10);
   const sort = searchParams.sort?.toString();
+  const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
 
   // Extract all filter parameters
   const filters = Object.fromEntries(
@@ -50,7 +51,7 @@ const SSRDataTable = async ({
   // Extract query from filters
   const query = (filters["filter[search]"] as string) || "";
 
-  const rolesData = await getRoles({ query, page, sort, filters });
+  const rolesData = await getRoles({ query, page, sort, filters, pageSize });
 
   return (
     <DataTable

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -107,6 +107,7 @@ const SSRDataTableScans = async ({
   searchParams: SearchParamsProps;
 }) => {
   const page = parseInt(searchParams.page?.toString() || "1", 10);
+  const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
   const sort = searchParams.sort?.toString();
 
   // Extract all filter parameters, excluding scanId
@@ -120,7 +121,7 @@ const SSRDataTableScans = async ({
   const query = (filters["filter[search]"] as string) || "";
 
   // Fetch scans data
-  const scansData = await getScans({ query, page, sort, filters });
+  const scansData = await getScans({ query, page, sort, filters, pageSize });
 
   // Handle expanded scans data
   const expandedScansData = await Promise.all(

--- a/ui/app/(prowler)/users/page.tsx
+++ b/ui/app/(prowler)/users/page.tsx
@@ -41,6 +41,7 @@ const SSRDataTable = async ({
 }) => {
   const page = parseInt(searchParams.page?.toString() || "1", 10);
   const sort = searchParams.sort?.toString();
+  const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
 
   // Extract all filter parameters
   const filters = Object.fromEntries(
@@ -50,7 +51,7 @@ const SSRDataTable = async ({
   // Extract query from filters
   const query = (filters["filter[search]"] as string) || "";
 
-  const usersData = await getUsers({ query, page, sort, filters });
+  const usersData = await getUsers({ query, page, sort, filters, pageSize });
   const rolesData = await getRoles({});
 
   // Create a dictionary for roles by user ID

--- a/ui/components/ui/table/data-table-pagination.tsx
+++ b/ui/components/ui/table/data-table-pagination.tsx
@@ -7,19 +7,37 @@ import {
   DoubleArrowRightIcon,
 } from "@radix-ui/react-icons";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 import { getPaginationInfo } from "@/lib";
 import { MetaDataProps } from "@/types";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../select/Select";
 
 interface DataTablePaginationProps {
   pageSizeOptions?: number[];
   metadata?: MetaDataProps;
 }
 
-export function DataTablePagination({ metadata }: DataTablePaginationProps) {
+export function DataTablePagination({
+  metadata,
+  pageSizeOptions,
+}: DataTablePaginationProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const initialPageSize =
+    searchParams.get("pageSize") ?? pageSizeOptions?.[0]?.toString() ?? "10";
+
+  const [selectedPageSize, setSelectedPageSize] = useState(initialPageSize);
 
   if (!metadata) return null;
 
@@ -44,6 +62,38 @@ export function DataTablePagination({ metadata }: DataTablePaginationProps) {
         {totalEntries} entries in Total.
       </div>
       <div className="flex flex-col-reverse items-center gap-4 sm:flex-row sm:gap-6 lg:gap-8">
+        {/* Rows per page selector */}
+        {pageSizeOptions && (
+          <div className="flex items-center space-x-2">
+            <p className="whitespace-nowrap text-sm font-medium">
+              Rows per page
+            </p>
+            <Select
+              value={selectedPageSize}
+              onValueChange={(value) => {
+                setSelectedPageSize(value);
+
+                const params = new URLSearchParams(searchParams);
+                params.set("pageSize", value);
+                params.set("page", "1");
+
+                // This pushes the URL without reloading the page
+                router.push(`${pathname}?${params.toString()}`);
+              }}
+            >
+              <SelectTrigger className="h-8 w-[4.5rem]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent side="top">
+                {pageSizeOptions.map((pageSize) => (
+                  <SelectItem key={pageSize} value={`${pageSize}`}>
+                    {pageSize}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
         <div className="flex items-center justify-center text-sm font-medium">
           Page {currentPage} of {totalPages}
         </div>

--- a/ui/components/ui/table/data-table-pagination.tsx
+++ b/ui/components/ui/table/data-table-pagination.tsx
@@ -22,26 +22,21 @@ import {
 } from "../select/Select";
 
 interface DataTablePaginationProps {
-  pageSizeOptions?: number[];
   metadata?: MetaDataProps;
 }
 
-export function DataTablePagination({
-  metadata,
-  pageSizeOptions,
-}: DataTablePaginationProps) {
+export function DataTablePagination({ metadata }: DataTablePaginationProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
-
-  const initialPageSize =
-    searchParams.get("pageSize") ?? pageSizeOptions?.[0]?.toString() ?? "10";
+  const initialPageSize = searchParams.get("pageSize") ?? "10";
 
   const [selectedPageSize, setSelectedPageSize] = useState(initialPageSize);
 
   if (!metadata) return null;
 
-  const { currentPage, totalPages, totalEntries } = getPaginationInfo(metadata);
+  const { currentPage, totalPages, totalEntries, itemsPerPageOptions } =
+    getPaginationInfo(metadata);
 
   const createPageUrl = (pageNumber: number | string) => {
     const params = new URLSearchParams(searchParams);
@@ -63,37 +58,37 @@ export function DataTablePagination({
       </div>
       <div className="flex flex-col-reverse items-center gap-4 sm:flex-row sm:gap-6 lg:gap-8">
         {/* Rows per page selector */}
-        {pageSizeOptions && (
-          <div className="flex items-center space-x-2">
-            <p className="whitespace-nowrap text-sm font-medium">
-              Rows per page
-            </p>
-            <Select
-              value={selectedPageSize}
-              onValueChange={(value) => {
-                setSelectedPageSize(value);
+        <div className="flex items-center space-x-2">
+          <p className="whitespace-nowrap text-sm font-medium">Rows per page</p>
+          <Select
+            value={selectedPageSize}
+            onValueChange={(value) => {
+              setSelectedPageSize(value);
 
-                const params = new URLSearchParams(searchParams);
-                params.set("pageSize", value);
-                params.set("page", "1");
+              const params = new URLSearchParams(searchParams);
+              params.set("pageSize", value);
+              params.set("page", "1");
 
-                // This pushes the URL without reloading the page
-                router.push(`${pathname}?${params.toString()}`);
-              }}
-            >
-              <SelectTrigger className="h-8 w-[4.5rem]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent side="top">
-                {pageSizeOptions.map((pageSize) => (
-                  <SelectItem key={pageSize} value={`${pageSize}`}>
-                    {pageSize}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
+              // This pushes the URL without reloading the page
+              router.push(`${pathname}?${params.toString()}`);
+            }}
+          >
+            <SelectTrigger className="h-8 w-[4.5rem]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent side="top">
+              {itemsPerPageOptions.map((pageSize) => (
+                <SelectItem
+                  key={pageSize}
+                  value={`${pageSize}`}
+                  className="cursor-pointer"
+                >
+                  {pageSize}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
         <div className="flex items-center justify-center text-sm font-medium">
           Page {currentPage} of {totalPages}
         </div>

--- a/ui/components/ui/table/data-table.tsx
+++ b/ui/components/ui/table/data-table.tsx
@@ -29,14 +29,12 @@ interface DataTableProviderProps<TData, TValue> {
   data: TData[];
   metadata?: MetaDataProps;
   customFilters?: FilterOption[];
-  pageSizeOptions?: number[];
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
   metadata,
-  pageSizeOptions,
 }: DataTableProviderProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -111,10 +109,7 @@ export function DataTable<TData, TValue>({
       </div>
       {metadata && (
         <div className="flex w-full items-center space-x-2 py-4">
-          <DataTablePagination
-            metadata={metadata}
-            pageSizeOptions={pageSizeOptions}
-          />
+          <DataTablePagination metadata={metadata} />
         </div>
       )}
     </>

--- a/ui/components/ui/table/data-table.tsx
+++ b/ui/components/ui/table/data-table.tsx
@@ -29,12 +29,14 @@ interface DataTableProviderProps<TData, TValue> {
   data: TData[];
   metadata?: MetaDataProps;
   customFilters?: FilterOption[];
+  pageSizeOptions?: number[];
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
   metadata,
+  pageSizeOptions,
 }: DataTableProviderProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -48,6 +50,7 @@ export function DataTable<TData, TValue>({
     getSortedRowModel: getSortedRowModel(),
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
+    manualPagination: true,
     state: {
       sorting,
       columnFilters,
@@ -108,7 +111,10 @@ export function DataTable<TData, TValue>({
       </div>
       {metadata && (
         <div className="flex w-full items-center space-x-2 py-4">
-          <DataTablePagination metadata={metadata} />
+          <DataTablePagination
+            metadata={metadata}
+            pageSizeOptions={pageSizeOptions}
+          />
         </div>
       )}
     </>

--- a/ui/lib/helper.ts
+++ b/ui/lib/helper.ts
@@ -161,8 +161,11 @@ export const getPaginationInfo = (metadata: MetaDataProps) => {
   const currentPage = metadata?.pagination.page ?? "1";
   const totalPages = metadata?.pagination.pages;
   const totalEntries = metadata?.pagination.count;
+  const itemsPerPageOptions = metadata?.pagination.itemsPerPage ?? [
+    10, 20, 30, 50, 100,
+  ];
 
-  return { currentPage, totalPages, totalEntries };
+  return { currentPage, totalPages, totalEntries, itemsPerPageOptions };
 };
 
 export function encryptKey(passkey: string) {

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -755,6 +755,7 @@ export interface MetaDataProps {
     page: number;
     pages: number;
     count: number;
+    itemsPerPage: Array<number>;
   };
   version: string;
 }

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -561,12 +561,12 @@ export interface ScanProps {
     name: string;
     trigger: "scheduled" | "manual";
     state:
-      | "available"
-      | "scheduled"
-      | "executing"
-      | "completed"
-      | "failed"
-      | "cancelled";
+    | "available"
+    | "scheduled"
+    | "executing"
+    | "completed"
+    | "failed"
+    | "cancelled";
     unique_resource_count: number;
     progress: number;
     scanner_args: {
@@ -755,7 +755,7 @@ export interface MetaDataProps {
     page: number;
     pages: number;
     count: number;
-    itemsPerPage: Array<number>;
+    itemsPerPage?: Array<number>;
   };
   version: string;
 }

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -561,12 +561,12 @@ export interface ScanProps {
     name: string;
     trigger: "scheduled" | "manual";
     state:
-    | "available"
-    | "scheduled"
-    | "executing"
-    | "completed"
-    | "failed"
-    | "cancelled";
+      | "available"
+      | "scheduled"
+      | "executing"
+      | "completed"
+      | "failed"
+      | "cancelled";
     unique_resource_count: number;
     progress: number;
     scanner_args: {


### PR DESCRIPTION
### Context

This PR introduces the page size handling for datatables to allow more than 10 rows in a table

### Description

- A dropdown menu below DataTable to change the page size

### Checklist

- Are there new checks included in this PR? No
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### Steps

- Checkout feature/add-pagination-for-datatables.
- Run the docker containers 
- Open http://localhost:3000/ in your browser
- Login and goto Findings page, it will now have page size dropdown


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
