### PR TITLE
fix(s3): add ContentType in upload_file

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Improve compliance and dashboard [(#7596)](https://github.com/prowler-cloud/prowler/pull/7596)
 - Remove invalid parameter `create_file_descriptor` [(#7600)](https://github.com/prowler-cloud/prowler/pull/7600)
 - Remove first empty line in HTML output [(#7606)](https://github.com/prowler-cloud/prowler/pull/7606)
-- Support ContentType in upload_file [(#7635)](https://github.com/prowler-cloud/prowler/pull/7635)
+- Ensure that ContentType in upload_file matches the uploaded file’s format [(#7635)](https://github.com/prowler-cloud/prowler/pull/7635)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Improve compliance and dashboard [(#7596)](https://github.com/prowler-cloud/prowler/pull/7596)
 - Remove invalid parameter `create_file_descriptor` [(#7600)](https://github.com/prowler-cloud/prowler/pull/7600)
 - Remove first empty line in HTML output [(#7606)](https://github.com/prowler-cloud/prowler/pull/7606)
-- Support ContentType in upload_file [(#7635)](https://github.com/prowler-cloud/prowler/pull/7635)
+- Add support to Content Type while uploading files to Amazon S3 [(#7635)](https://github.com/prowler-cloud/prowler/pull/7635)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Improve compliance and dashboard [(#7596)](https://github.com/prowler-cloud/prowler/pull/7596)
 - Remove invalid parameter `create_file_descriptor` [(#7600)](https://github.com/prowler-cloud/prowler/pull/7600)
 - Remove first empty line in HTML output [(#7606)](https://github.com/prowler-cloud/prowler/pull/7606)
+- Support ContentType in upload_file [(#7635)](https://github.com/prowler-cloud/prowler/pull/7635)
 
 ---
 

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -131,10 +131,6 @@ class S3:
                             f"Sending output file {output.file_descriptor.name} to S3 bucket {self._bucket_name}"
                         )
 
-                        # If the file extension is in the extension_to_content_type dictionary, use the content type of the extension
-                        if file_extension in extension_to_content_type:
-                            content_type = extension_to_content_type[file_extension]
-
                         # TODO: This will need further optimization if some processes are calling this since the files are written
                         # into the local filesystem because S3 upload file is the recommended way.
                         # https://aws.amazon.com/blogs/developer/uploading-files-to-amazon-s3/
@@ -142,7 +138,9 @@ class S3:
                             Filename=output.file_descriptor.name,
                             Bucket=self._bucket_name,
                             Key=object_name,
-                            ExtraArgs={"ContentType": content_type},
+                            ExtraArgs={
+                                "ContentType": extension_to_content_type[file_extension]
+                            },
                         )
 
                         if output.file_extension in uploaded_objects["success"]:

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -131,9 +131,6 @@ class S3:
                             f"Sending output file {output.file_descriptor.name} to S3 bucket {self._bucket_name}"
                         )
 
-                        # By default, the content type is text/html
-                        content_type = "text/html"
-
                         # If the file extension is in the extension_to_content_type dictionary, use the content type of the extension
                         if file_extension in extension_to_content_type:
                             content_type = extension_to_content_type[file_extension]

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -108,7 +108,8 @@ class S3:
             extension_to_content_type = {
                 ".html": "text/html",
                 ".csv": "text/csv",
-                ".json": "application/json",
+                ".ocsf.json": "application/json",
+                ".asff.json": "application/json",
             }
             # Keys are regular and/or compliance
             for key, output_list in outputs.items():
@@ -120,6 +121,7 @@ class S3:
 
                         bucket_directory = self.get_object_path(self._output_directory)
                         basename = path.basename(output.file_descriptor.name)
+                        file_extension = output.file_extension
 
                         if key == "compliance":
                             object_name = f"{bucket_directory}/{key}/{basename}"
@@ -133,12 +135,8 @@ class S3:
                         content_type = "text/html"
 
                         # If the file extension is in the extension_to_content_type dictionary, use the content type of the extension
-                        for (
-                            ext,
-                            content_type_extension,
-                        ) in extension_to_content_type.items():
-                            if basename.endswith(ext):
-                                content_type = content_type_extension
+                        if file_extension in extension_to_content_type:
+                            content_type = extension_to_content_type[file_extension]
 
                         # TODO: This will need further optimization if some processes are calling this since the files are written
                         # into the local filesystem because S3 upload file is the recommended way.

--- a/tests/providers/aws/lib/s3/s3_test.py
+++ b/tests/providers/aws/lib/s3/s3_test.py
@@ -93,7 +93,7 @@ class TestS3:
                 Bucket=S3_BUCKET_NAME,
                 Key=uploaded_object_name,
             )["ContentType"]
-            == "binary/octet-stream"
+            == "text/csv"
         )
 
     @mock_aws
@@ -132,7 +132,7 @@ class TestS3:
                 Bucket=S3_BUCKET_NAME,
                 Key=uploaded_object_name,
             )["ContentType"]
-            == "binary/octet-stream"
+            == "text/csv"
         )
 
         remove(f"{CURRENT_DIRECTORY}/{csv_file}")
@@ -171,7 +171,7 @@ class TestS3:
                 Bucket=S3_BUCKET_NAME,
                 Key=uploaded_object_name,
             )["ContentType"]
-            == "binary/octet-stream"
+            == "application/json"
         )
 
     @mock_aws
@@ -209,7 +209,7 @@ class TestS3:
                 Bucket=S3_BUCKET_NAME,
                 Key=uploaded_object_name,
             )["ContentType"]
-            == "binary/octet-stream"
+            == "text/html"
         )
 
     @mock_aws
@@ -290,7 +290,7 @@ class TestS3:
                 Bucket=S3_BUCKET_NAME,
                 Key=uploaded_object_name,
             )["ContentType"]
-            == "binary/octet-stream"
+            == "text/csv"
         )
 
     def test_get_get_object_path_with_prowler(self):


### PR DESCRIPTION
### Context

Fix #7625

### Description

This PR sets the ContentType when uploading files to s3 buckets.

![Screenshot 2025-04-29 at 14 15 44](https://github.com/user-attachments/assets/af486a57-8cc6-46f2-8d02-74c9d5357d8a)


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
