### PR TITLE
feat(exchange): add new check `exchange_organization_mailtips_enabled`

### DIFF
--- a/docs/tutorials/configuration_file.md
+++ b/docs/tutorials/configuration_file.md
@@ -106,6 +106,7 @@ The following list includes all the Microsoft 365 checks with configurable varia
 |---------------------------------------------------------------|--------------------------------------------------|-----------------|
 | `entra_admin_users_sign_in_frequency_enabled`                 | `sign_in_frequency`                              | Integer         |
 | `teams_external_file_sharing_restricted`                      | `allowed_cloud_storage_services`                 | List of Strings |
+| `exchange_organization_mailtips_enabled`                      | `recommended_mailtips_large_audience_threshold`  | Integer         |
 
 
 ## Config YAML File Structure
@@ -520,5 +521,9 @@ m365:
       #"allow_google_drive",
       #"allow_share_file",
     ]
+  # Exchange Organization Settings
+  # m365.exchange_organization_mailtips_enabled
+  recommended_mailtips_large_audience_threshold: 25 # maximum number of recipients
+
 
 ```

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add new check `teams_meeting_presenters_restricted` [(#7613)](https://github.com/prowler-cloud/prowler/pull/7613)
 - Add new check `teams_meeting_chat_anonymous_users_disabled` [(#7579)](https://github.com/prowler-cloud/prowler/pull/7579)
 - Add Prowler Threat Score Compliance Framework [(#7603)](https://github.com/prowler-cloud/prowler/pull/7603)
+- Add new check for MailTips full enabled for Exchange in M365 [(#7637)](https://github.com/prowler-cloud/prowler/pull/7637)
 
 ### Fixed
 

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -132,7 +132,7 @@ def load_and_validate_config_file(provider: str, config_file_path: str) -> dict:
             else:
                 config = config_file if config_file else {}
                 # Not to break Azure, K8s and GCP does not support or use the old config format
-                if provider in ["azure", "gcp", "kubernetes"]:
+                if provider in ["azure", "gcp", "kubernetes", "m365"]:
                     config = {}
 
             return config

--- a/prowler/config/config.yaml
+++ b/prowler/config/config.yaml
@@ -497,3 +497,6 @@ m365:
       #"allow_google_drive",
       #"allow_share_file",
     ]
+  # Exchange Organization Settings
+  # m365.exchange_organization_mailtips_enabled
+  recommended_mailtips_large_audience_threshold: 25 # maximum number of recipients

--- a/prowler/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled.metadata.json
+++ b/prowler/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "m365",
+  "CheckID": "exchange_organization_mailtips_enabled",
+  "CheckTitle": "Ensure MailTips are enabled for end users.",
+  "CheckType": [],
+  "ServiceName": "exchange",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "Exchange Organization Configuration",
+  "Description": "Ensure that MailTips are enabled in Exchange Online to provide users with informative messages while composing emails, helping to avoid issues such as sending to large groups or external recipients unintentionally.",
+  "Risk": "Without MailTips, users may inadvertently send sensitive information externally or generate non-delivery reports, leading to communication errors and potential data exposure.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/mailtips/mailtips",
+  "Remediation": {
+    "Code": {
+      "CLI": "$TipsParams = @{ MailTipsAllTipsEnabled = $true; MailTipsExternalRecipientsTipsEnabled = $true; MailTipsGroupMetricsEnabled = $true; MailTipsLargeAudienceThreshold = '25' }; Set-OrganizationConfig @TipsParams",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable MailTips features in Exchange Online and configure the large audience threshold appropriately to assist users when composing emails.",
+      "Url": "https://learn.microsoft.com/en-us/powershell/module/exchange/set-organizationconfig?view=exchange-ps"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled.py
+++ b/prowler/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.exchange.exchange_client import exchange_client
+
+
+class exchange_organization_mailtips_enabled(Check):
+    """
+    Check if MailTips are enabled for Exchange Online.
+
+    Attributes:
+        metadata: Metadata associated with the check (inherited from Check).
+    """
+
+    def execute(self) -> List[CheckReportM365]:
+        """
+        Execute the check for MailTips in Exchange Online.
+
+        This method checks if MailTips are enabled in the Exchange organization configuration.
+
+        Returns:
+            List[CheckReportM365]: A list of reports containing the result of the check.
+        """
+        findings = []
+        organization_config = exchange_client.organization_config
+        if organization_config:
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=organization_config,
+                resource_name=organization_config.name,
+                resource_id=organization_config.guid,
+            )
+            report.status = "FAIL"
+            report.status_extended = (
+                "MailTips are not fully enabled for Exchange Online."
+            )
+
+            if (
+                organization_config.mailtips_enabled
+                and organization_config.mailtips_external_recipient_enabled
+                and organization_config.mailtips_group_metrics_enabled
+                and organization_config.mailtips_large_audience_threshold
+                <= exchange_client.audit_config.get(
+                    "recommended_mailtips_large_audience_threshold", 25
+                )
+            ):
+                report.status = "PASS"
+                report.status_extended = (
+                    "MailTips are fully enabled for Exchange Online."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/m365/services/exchange/exchange_service.py
+++ b/prowler/providers/m365/services/exchange/exchange_service.py
@@ -35,6 +35,18 @@ class Exchange(M365Service):
                     audit_disabled=organization_configuration.get(
                         "AuditDisabled", False
                     ),
+                    mailtips_enabled=organization_configuration.get(
+                        "MailTipsAllTipsEnabled", True
+                    ),
+                    mailtips_external_recipient_enabled=organization_configuration.get(
+                        "MailTipsExternalRecipientsTipsEnabled", False
+                    ),
+                    mailtips_group_metrics_enabled=organization_configuration.get(
+                        "MailTipsGroupMetricsEnabled", True
+                    ),
+                    mailtips_large_audience_threshold=organization_configuration.get(
+                        "MailTipsLargeAudienceThreshold", 25
+                    ),
                 )
         except Exception as error:
             logger.error(
@@ -117,6 +129,10 @@ class Organization(BaseModel):
     name: str
     guid: str
     audit_disabled: bool
+    mailtips_enabled: bool
+    mailtips_external_recipient_enabled: bool
+    mailtips_group_metrics_enabled: bool
+    mailtips_large_audience_threshold: int
 
 
 class MailboxAuditConfig(BaseModel):

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -346,18 +346,6 @@ config_kubernetes = {
     ],
 }
 
-config_m365 = {
-    "sign_in_frequency": 4,
-    "allowed_cloud_storage_services": [
-        "allow_box",
-        "allow_drop_box",
-        "allow_egnyte",
-        "allow_google_drive",
-        "allow_share_file",
-    ],
-    "recommended_mailtips_large_audience_threshold": 25,
-}
-
 
 class Test_Config:
     @mock.patch(
@@ -456,13 +444,6 @@ class Test_Config:
         provider = "azure"
 
         assert load_and_validate_config_file(provider, config_test_file) == config_azure
-
-    def test_load_and_validate_config_file_m365(self):
-        path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
-        config_test_file = f"{path}/fixtures/config.yaml"
-        provider = "m365"
-
-        assert load_and_validate_config_file(provider, config_test_file) == config_m365
 
     def test_load_and_validate_config_file_old_format(self):
         path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -346,6 +346,12 @@ config_kubernetes = {
     ],
 }
 
+config_m365 = {
+    "sign_in_frequency": 4,
+    "allowed_cloud_storage_services": [],
+    "recommended_mailtips_large_audience_threshold": 25,
+}
+
 
 class Test_Config:
     @mock.patch(
@@ -444,6 +450,13 @@ class Test_Config:
         provider = "azure"
 
         assert load_and_validate_config_file(provider, config_test_file) == config_azure
+
+    def test_load_and_validate_config_file_m365(self):
+        path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
+        config_test_file = f"{path}/fixtures/config.yaml"
+        provider = "m365"
+
+        assert load_and_validate_config_file(provider, config_test_file) == config_m365
 
     def test_load_and_validate_config_file_old_format(self):
         path = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/config/config_test.py
+++ b/tests/config/config_test.py
@@ -348,7 +348,13 @@ config_kubernetes = {
 
 config_m365 = {
     "sign_in_frequency": 4,
-    "allowed_cloud_storage_services": [],
+    "allowed_cloud_storage_services": [
+        "allow_box",
+        "allow_drop_box",
+        "allow_egnyte",
+        "allow_google_drive",
+        "allow_share_file",
+    ],
     "recommended_mailtips_large_audience_threshold": 25,
 }
 

--- a/tests/config/fixtures/config.yaml
+++ b/tests/config/fixtures/config.yaml
@@ -435,3 +435,16 @@ m365:
   # Conditional Access Policy
   # policy.session_controls.sign_in_frequency.frequency in hours
   sign_in_frequency: 4
+  # Teams Settings
+  # m365.teams_external_file_sharing_restricted
+  allowed_cloud_storage_services:
+    [
+      #"allow_box",
+      #"allow_drop_box",
+      #"allow_egnyte",
+      #"allow_google_drive",
+      #"allow_share_file",
+    ]
+  # Exchange Organization Settings
+  # m365.exchange_organization_mailtips_enabled
+  recommended_mailtips_large_audience_threshold: 25 # maximum number of recipients

--- a/tests/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled_test.py
+++ b/tests/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled_test.py
@@ -56,6 +56,10 @@ class Test_exchange_organization_mailtips_enabled:
                 Organization,
             )
 
+            exchange_client.audit_config = {
+                "recommended_mailtips_large_audience_threshold": 25
+            }
+
             exchange_client.organization_config = Organization(
                 name="test-org",
                 guid="org-guid",
@@ -103,6 +107,10 @@ class Test_exchange_organization_mailtips_enabled:
             from prowler.providers.m365.services.exchange.exchange_service import (
                 Organization,
             )
+
+            exchange_client.audit_config = {
+                "recommended_mailtips_large_audience_threshold": 25
+            }
 
             exchange_client.organization_config = Organization(
                 name="test-org",

--- a/tests/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled_test.py
+++ b/tests/providers/m365/services/exchange/exchange_organization_mailtips_enabled/exchange_organization_mailtips_enabled_test.py
@@ -3,7 +3,7 @@ from unittest import mock
 from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
 
 
-class Test_exchange_organization_mailbox_auditing_enabled:
+class Test_exchange_organization_mailtips_enabled:
     def test_no_organization(self):
         exchange_client = mock.MagicMock()
         exchange_client.audited_tenant = "audited_tenant"
@@ -19,19 +19,19 @@ class Test_exchange_organization_mailbox_auditing_enabled:
                 "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
             ),
             mock.patch(
-                "prowler.providers.m365.services.exchange.exchange_organization_mailbox_auditing_enabled.exchange_organization_mailbox_auditing_enabled.exchange_client",
+                "prowler.providers.m365.services.exchange.exchange_organization_mailtips_enabled.exchange_organization_mailtips_enabled.exchange_client",
                 new=exchange_client,
             ),
         ):
-            from prowler.providers.m365.services.exchange.exchange_organization_mailbox_auditing_enabled.exchange_organization_mailbox_auditing_enabled import (
-                exchange_organization_mailbox_auditing_enabled,
+            from prowler.providers.m365.services.exchange.exchange_organization_mailtips_enabled.exchange_organization_mailtips_enabled import (
+                exchange_organization_mailtips_enabled,
             )
 
-            check = exchange_organization_mailbox_auditing_enabled()
+            check = exchange_organization_mailtips_enabled()
             result = check.execute()
-            assert len(result) == 0
+            assert result == []
 
-    def test_audit_log_search_disabled(self):
+    def test_mailtips_not_fully_enabled(self):
         exchange_client = mock.MagicMock()
         exchange_client.audited_tenant = "audited_tenant"
         exchange_client.audited_domain = DOMAIN
@@ -45,41 +45,41 @@ class Test_exchange_organization_mailbox_auditing_enabled:
                 "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
             ),
             mock.patch(
-                "prowler.providers.m365.services.exchange.exchange_organization_mailbox_auditing_enabled.exchange_organization_mailbox_auditing_enabled.exchange_client",
+                "prowler.providers.m365.services.exchange.exchange_organization_mailtips_enabled.exchange_organization_mailtips_enabled.exchange_client",
                 new=exchange_client,
             ),
         ):
-            from prowler.providers.m365.services.exchange.exchange_organization_mailbox_auditing_enabled.exchange_organization_mailbox_auditing_enabled import (
-                exchange_organization_mailbox_auditing_enabled,
+            from prowler.providers.m365.services.exchange.exchange_organization_mailtips_enabled.exchange_organization_mailtips_enabled import (
+                exchange_organization_mailtips_enabled,
             )
             from prowler.providers.m365.services.exchange.exchange_service import (
                 Organization,
             )
 
             exchange_client.organization_config = Organization(
-                audit_disabled=True,
-                name="test",
-                guid="test",
-                mailtips_enabled=True,
-                mailtips_external_recipient_enabled=True,
+                name="test-org",
+                guid="org-guid",
+                audit_disabled=False,
+                mailtips_enabled=False,
+                mailtips_external_recipient_enabled=False,
                 mailtips_group_metrics_enabled=True,
                 mailtips_large_audience_threshold=25,
             )
 
-            check = exchange_organization_mailbox_auditing_enabled()
+            check = exchange_organization_mailtips_enabled()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "Exchange mailbox auditing is not enabled on your organization."
+                == "MailTips are not fully enabled for Exchange Online."
             )
-            assert result[0].resource == exchange_client.organization_config.dict()
-            assert result[0].resource_name == "test"
-            assert result[0].resource_id == "test"
+            assert result[0].resource_name == "test-org"
+            assert result[0].resource_id == "org-guid"
             assert result[0].location == "global"
+            assert result[0].resource == exchange_client.organization_config.dict()
 
-    def test_audit_log_search_enabled(self):
+    def test_mailtips_fully_enabled(self):
         exchange_client = mock.MagicMock()
         exchange_client.audited_tenant = "audited_tenant"
         exchange_client.audited_domain = DOMAIN
@@ -93,36 +93,36 @@ class Test_exchange_organization_mailbox_auditing_enabled:
                 "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
             ),
             mock.patch(
-                "prowler.providers.m365.services.exchange.exchange_organization_mailbox_auditing_enabled.exchange_organization_mailbox_auditing_enabled.exchange_client",
+                "prowler.providers.m365.services.exchange.exchange_organization_mailtips_enabled.exchange_organization_mailtips_enabled.exchange_client",
                 new=exchange_client,
             ),
         ):
-            from prowler.providers.m365.services.exchange.exchange_organization_mailbox_auditing_enabled.exchange_organization_mailbox_auditing_enabled import (
-                exchange_organization_mailbox_auditing_enabled,
+            from prowler.providers.m365.services.exchange.exchange_organization_mailtips_enabled.exchange_organization_mailtips_enabled import (
+                exchange_organization_mailtips_enabled,
             )
             from prowler.providers.m365.services.exchange.exchange_service import (
                 Organization,
             )
 
             exchange_client.organization_config = Organization(
+                name="test-org",
+                guid="org-guid",
                 audit_disabled=False,
-                name="test",
-                guid="test",
                 mailtips_enabled=True,
                 mailtips_external_recipient_enabled=True,
                 mailtips_group_metrics_enabled=True,
                 mailtips_large_audience_threshold=25,
             )
 
-            check = exchange_organization_mailbox_auditing_enabled()
+            check = exchange_organization_mailtips_enabled()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "Exchange mailbox auditing is enabled on your organization."
+                == "MailTips are fully enabled for Exchange Online."
             )
-            assert result[0].resource == exchange_client.organization_config.dict()
-            assert result[0].resource_name == "test"
-            assert result[0].resource_id == "test"
+            assert result[0].resource_name == "test-org"
+            assert result[0].resource_id == "org-guid"
             assert result[0].location == "global"
+            assert result[0].resource == exchange_client.organization_config.dict()

--- a/tests/providers/m365/services/exchange/exchange_service_test.py
+++ b/tests/providers/m365/services/exchange/exchange_service_test.py
@@ -13,7 +13,15 @@ from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
 
 
 def mock_exchange_get_organization_config(_):
-    return Organization(audit_disabled=True, name="test", guid="test")
+    return Organization(
+        audit_disabled=True,
+        name="test",
+        guid="test",
+        mailtips_enabled=True,
+        mailtips_external_recipient_enabled=False,
+        mailtips_group_metrics_enabled=True,
+        mailtips_large_audience_threshold=25,
+    )
 
 
 def mock_exchange_get_mailbox_audit_config(_):
@@ -86,6 +94,10 @@ class Test_Exchange_Service:
             assert organization_config.name == "test"
             assert organization_config.guid == "test"
             assert organization_config.audit_disabled is True
+            assert organization_config.mailtips_enabled is True
+            assert organization_config.mailtips_external_recipient_enabled is False
+            assert organization_config.mailtips_group_metrics_enabled is True
+            assert organization_config.mailtips_large_audience_threshold == 25
 
             exchange_client.powershell.close()
 


### PR DESCRIPTION
### Context

This PR introduces a new check for Exchange in M365. This check verify that MailTips are fully enabled, MailTips are informative messages displayed to users while they're composing a message. While a new message is open and being composed, Exchange analyzes the message (including recipients). If a potential problem is detected, the user is notified with a MailTip prior to sending the message.

Also, I've decided to make this check configurable because the recommended threshold for MailTipsLargeAudience is 25 but this number refer to the maximum number of recipients and that could change depending on the size of your organization.

### Description

Added new check `exchange_organization_mailtips_enabled`, modified the service, modified the needed to make it configurable and added unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
