### PR TITLE
feat(exchange): add new check `exchange_mailbox_policy_additional_storage_restricted`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add new check `teams_meeting_presenters_restricted` [(#7613)](https://github.com/prowler-cloud/prowler/pull/7613)
 - Add new check `teams_meeting_chat_anonymous_users_disabled` [(#7579)](https://github.com/prowler-cloud/prowler/pull/7579)
 - Add Prowler Threat Score Compliance Framework [(#7603)](https://github.com/prowler-cloud/prowler/pull/7603)
+- Add new check for Additional Storage restricted for Exchange in M365 [(#7638)](https://github.com/prowler-cloud/prowler/pull/7638)
 
 ### Fixed
 

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -466,3 +466,21 @@ class M365PowerShell(PowerShellSession):
         return self.execute(
             "Get-HostedContentFilterPolicy | ConvertTo-Json", json_parse=True
         )
+
+    def get_mailbox_policy(self) -> dict:
+        """
+        Get Mailbox Policy.
+
+        Retrieves the current mailbox policy settings for Exchange Online.
+
+        Returns:
+            dict: Mailbox policy settings in JSON format.
+
+        Example:
+            >>> get_mailbox_policy()
+            {
+                "Id": "OwaMailboxPolicy-Default",
+                "AdditionalStorageProvidersAvailable": True
+            }
+        """
+        return self.execute("Get-OwaMailboxPolicy | ConvertTo-Json", json_parse=True)

--- a/prowler/providers/m365/services/exchange/exchange_mailbox_policy_additional_storage_restricted/exchange_mailbox_policy_additional_storage_restricted.metadata.json
+++ b/prowler/providers/m365/services/exchange/exchange_mailbox_policy_additional_storage_restricted/exchange_mailbox_policy_additional_storage_restricted.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "m365",
+  "CheckID": "exchange_mailbox_policy_additional_storage_restricted",
+  "CheckTitle": "Ensure additional storage providers are restricted in Outlook on the web.",
+  "CheckType": [],
+  "ServiceName": "exchange",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "Exchange Mailboxes Policy",
+  "Description": "Restrict the availability of additional storage providers (e.g., Box, Dropbox, Google Drive) in Outlook on the web to prevent users from accessing external storage services through the OWA interface.",
+  "Risk": "Allowing users to access third-party storage providers from Outlook on the web increases the risk of data exfiltration and exposure to untrusted content or malware.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/powershell/module/exchange/set-owamailboxpolicy?view=exchange-ps",
+  "Remediation": {
+    "Code": {
+      "CLI": "Set-OwaMailboxPolicy -Identity OwaMailboxPolicy-Default -AdditionalStorageProvidersAvailable $false",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Disable access to additional storage providers in Outlook on the web to reduce the risk of data leakage.",
+      "Url": "https://learn.microsoft.com/en-us/powershell/module/exchange/set-owamailboxpolicy?view=exchange-ps"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/exchange/exchange_mailbox_policy_additional_storage_restricted/exchange_mailbox_policy_additional_storage_restricted.py
+++ b/prowler/providers/m365/services/exchange/exchange_mailbox_policy_additional_storage_restricted/exchange_mailbox_policy_additional_storage_restricted.py
@@ -1,0 +1,44 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.exchange.exchange_client import exchange_client
+
+
+class exchange_mailbox_policy_additional_storage_restricted(Check):
+    """Check if Exchange mailbox policy restricts additional storage providers.
+
+    This check ensures that the mailbox policy does not allow additional storage providers.
+    """
+
+    def execute(self) -> List[CheckReportM365]:
+        """Run the check to validate Exchange mailbox policy restrictions.
+
+        Iterates through the mailbox policy configuration to determine if additional storage
+        providers are restricted and generates a report based on the policy status.
+
+        Returns:
+            List[CheckReportM365]: A list of reports with the restriction status for the mailbox policy.
+        """
+        findings = []
+        mailbox_policy = exchange_client.mailbox_policy
+        if mailbox_policy:
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=mailbox_policy,
+                resource_name="Exchange Mailbox Policy",
+                resource_id=mailbox_policy.id,
+            )
+            report.status = "FAIL"
+            report.status_extended = (
+                "Exchange mailbox policy allows additional storage providers."
+            )
+
+            if not mailbox_policy.additional_storage_enabled:
+                report.status = "PASS"
+                report.status_extended = (
+                    "Exchange mailbox policy restricts additional storage providers."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/m365/services/exchange/exchange_mailbox_policy_additional_storage_restricted/exchange_mailbox_policy_additional_storage_restricted_test.py
+++ b/tests/providers/m365/services/exchange/exchange_mailbox_policy_additional_storage_restricted/exchange_mailbox_policy_additional_storage_restricted_test.py
@@ -1,0 +1,118 @@
+from unittest import mock
+
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_exchange_mailbox_policy_additional_storage_restricted:
+    def test_mailbox_policy_restricts_additional_storage(self):
+        exchange_client = mock.MagicMock()
+        exchange_client.audited_tenant = "audited_tenant"
+        exchange_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.exchange.exchange_mailbox_policy_additional_storage_restricted.exchange_mailbox_policy_additional_storage_restricted.exchange_client",
+                new=exchange_client,
+            ),
+        ):
+            from prowler.providers.m365.services.exchange.exchange_mailbox_policy_additional_storage_restricted.exchange_mailbox_policy_additional_storage_restricted import (
+                exchange_mailbox_policy_additional_storage_restricted,
+            )
+            from prowler.providers.m365.services.exchange.exchange_service import (
+                MailboxPolicy,
+            )
+
+            exchange_client.mailbox_policy = MailboxPolicy(
+                id="OwaMailboxPolicy-Default", additional_storage_enabled=False
+            )
+
+            check = exchange_mailbox_policy_additional_storage_restricted()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Exchange mailbox policy restricts additional storage providers."
+            )
+            assert result[0].resource == exchange_client.mailbox_policy.dict()
+            assert result[0].resource_name == "Exchange Mailbox Policy"
+            assert result[0].resource_id == "OwaMailboxPolicy-Default"
+            assert result[0].location == "global"
+
+    def test_mailbox_policy_allows_additional_storage(self):
+        exchange_client = mock.MagicMock()
+        exchange_client.audited_tenant = "audited_tenant"
+        exchange_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.exchange.exchange_mailbox_policy_additional_storage_restricted.exchange_mailbox_policy_additional_storage_restricted.exchange_client",
+                new=exchange_client,
+            ),
+        ):
+            from prowler.providers.m365.services.exchange.exchange_mailbox_policy_additional_storage_restricted.exchange_mailbox_policy_additional_storage_restricted import (
+                exchange_mailbox_policy_additional_storage_restricted,
+            )
+            from prowler.providers.m365.services.exchange.exchange_service import (
+                MailboxPolicy,
+            )
+
+            exchange_client.mailbox_policy = MailboxPolicy(
+                id="OwaMailboxPolicy-Default", additional_storage_enabled=True
+            )
+
+            check = exchange_mailbox_policy_additional_storage_restricted()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Exchange mailbox policy allows additional storage providers."
+            )
+            assert result[0].resource == exchange_client.mailbox_policy.dict()
+            assert result[0].resource_name == "Exchange Mailbox Policy"
+            assert result[0].resource_id == "OwaMailboxPolicy-Default"
+            assert result[0].location == "global"
+
+    def test_no_mailbox_policy(self):
+        exchange_client = mock.MagicMock()
+        exchange_client.audited_tenant = "audited_tenant"
+        exchange_client.audited_domain = DOMAIN
+        exchange_client.mailbox_policy = None
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.exchange.exchange_mailbox_policy_additional_storage_restricted.exchange_mailbox_policy_additional_storage_restricted.exchange_client",
+                new=exchange_client,
+            ),
+        ):
+            from prowler.providers.m365.services.exchange.exchange_mailbox_policy_additional_storage_restricted.exchange_mailbox_policy_additional_storage_restricted import (
+                exchange_mailbox_policy_additional_storage_restricted,
+            )
+
+            check = exchange_mailbox_policy_additional_storage_restricted()
+            result = check.execute()
+            assert len(result) == 0


### PR DESCRIPTION
### Context

This PR introduces a new check for Exchange in M365. This check verifies that `AdditionalStorageProvidersAvailable` is restricted. This setting allows users to open certain external files while working in Outlook on the web. If allowed, keep in mind that Microsoft doesn't control the use terms or privacy policies of those third-party services.

### Description

Added new check `exchange_mailbox_policy_additional_storage_restricted`, modified the service and added unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
