### PR TITLE
feat(exchange): add new check `exchange_roles_assignment_policy_addins_disabled`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add Prowler Threat Score Compliance Framework [(#7603)](https://github.com/prowler-cloud/prowler/pull/7603)
 - Add new check `sharepoint_onedrive_sync_restricted_unmanaged_devices` [(#7589)](https://github.com/prowler-cloud/prowler/pull/7589)
 - Add new check for Additional Storage restricted for Exchange in M365 [(#7638)](https://github.com/prowler-cloud/prowler/pull/7638)
+- Add new check for Roles Assignment Policy with no AddIns for Exchange in M365 [(#7644)](https://github.com/prowler-cloud/prowler/pull/7644)
 
 ### Fixed
 

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -487,6 +487,27 @@ class M365PowerShell(PowerShellSession):
             "Get-HostedContentFilterPolicy | ConvertTo-Json", json_parse=True
         )
 
+    def get_role_assignment_policies(self) -> dict:
+        """
+        Get Role Assignment Policies.
+
+        Retrieves the current role assignment policies for Exchange Online.
+
+        Returns:
+            dict: Role assignment policies in JSON format.
+
+        Example:
+            >>> get_role_assignment_policies()
+            {
+                "Name": "Default Role Assignment Policy",
+                "Guid": "12345678-1234-1234-1234-123456789012",
+                "AssignedRoles": ["MyRole"]
+            }
+        """
+        return self.execute(
+            "Get-RoleAssignmentPolicy | ConvertTo-Json", json_parse=True
+        )
+
 
 # This function is used to install the required M365 PowerShell modules in Docker containers
 def initialize_m365_powershell_modules():

--- a/prowler/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled.metadata.json
+++ b/prowler/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled.metadata.json
@@ -6,7 +6,7 @@
   "ServiceName": "exchange",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
-  "Severity": "medium",
+  "Severity": "high",
   "ResourceType": "Exchange Role Assignment Policy",
   "Description": "Restricting users from installing Outlook add-ins reduces the risk of data exposure or exploitation through unapproved or vulnerable add-ins.",
   "Risk": "Allowing users to install add-ins may expose sensitive information or introduce malicious behavior through third-party integrations. Disabling this capability mitigates the risk of unauthorized data access.",

--- a/prowler/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled.metadata.json
+++ b/prowler/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "m365",
+  "CheckID": "exchange_roles_assignment_policy_addins_disabled",
+  "CheckTitle": "Ensure there is no policy with Outlook add-ins allowed.",
+  "CheckType": [],
+  "ServiceName": "exchange",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "Exchange Role Assignment Policy",
+  "Description": "Restricting users from installing Outlook add-ins reduces the risk of data exposure or exploitation through unapproved or vulnerable add-ins.",
+  "Risk": "Allowing users to install add-ins may expose sensitive information or introduce malicious behavior through third-party integrations. Disabling this capability mitigates the risk of unauthorized data access.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/add-ins-for-outlook/specify-who-can-install-and-manage-add-ins",
+  "Remediation": {
+    "Code": {
+      "CLI": "$policy = \"Role Assignment Policy - Prevent Add-ins\"; $roles = \"MyTextMessaging\", \"MyDistributionGroups\", \"MyMailSubscriptions\", \"MyBaseOptions\", \"MyVoiceMail\", \"MyProfileInformation\", \"MyContactInformation\", \"MyRetentionPolicies\", \"MyDistributionGroupMembership\"; New-RoleAssignmentPolicy -Name $policy -Roles $roles; Set-RoleAssignmentPolicy -id $policy -IsDefault; Get-EXOMailbox -ResultSize Unlimited | Set-Mailbox -RoleAssignmentPolicy $policy",
+      "NativeIaC": "",
+      "Other": "1. Navigate to Exchange admin center https://admin.exchange.microsoft.com. 2. Click to expand Roles > User roles. 3. Select Default Role Assignment Policy. 4. In the right pane, click Manage permissions. 5. Uncheck My Custom Apps, My Marketplace Apps and My ReadWriteMailboxApps under Other roles. 6. Save changes.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Restrict Outlook add-in installation by updating the Role Assignment Policy to exclude roles that allow app installation.",
+      "Url": "https://learn.microsoft.com/en-us/exchange/permissions-exo/role-assignment-policies"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled.py
+++ b/prowler/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled.py
@@ -1,0 +1,50 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.exchange.exchange_client import exchange_client
+from prowler.providers.m365.services.exchange.exchange_service import AddinRoles
+
+
+class exchange_roles_assignment_policy_addins_disabled(Check):
+    """Check if any Exchange role assignment policy allows Outlook add-ins.
+
+    Attributes:
+        metadata: Metadata associated with the check (inherited from Check).
+    """
+
+    def execute(self) -> List[CheckReportM365]:
+        """Execute the check for role assignment policies that allow Outlook add-ins.
+
+        This method checks all Exchange Online Role Assignment Policies to verify
+        whether any of them allow the installation of add-ins by including risky roles.
+
+        Returns:
+            List[CheckReportM365]: A list of reports containing the result of the check.
+        """
+        findings = []
+
+        addin_roles = [e.value for e in AddinRoles]
+
+        for policy in exchange_client.role_assignment_policies:
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=policy,
+                resource_name=policy.name,
+                resource_id=policy.id,
+            )
+
+            report.status = "PASS"
+            report.status_extended = f"Role assignment policy '{policy.name}' does not allow Outlook add-ins."
+
+            risky_roles_found = []
+            for role in policy.assigned_roles:
+                if role in addin_roles:
+                    risky_roles_found.append(role)
+
+            if risky_roles_found:
+                report.status = "FAIL"
+                report.status_extended = f"Role assignment policy '{policy.name}' allows Outlook add-ins via roles: {', '.join(risky_roles_found)}."
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled_test.py
+++ b/tests/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled_test.py
@@ -119,7 +119,7 @@ class Test_exchange_roles_assignment_policy_addins_disabled:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "Role assignment policy 'Policy2' allows Outlook add-ins via roles: MyCustomApps."
+                == "Role assignment policy 'Policy2' allows Outlook add-ins via roles: My Custom Apps."
             )
             assert result[0].resource_name == "Policy2"
             assert result[0].resource_id == "id-policy2"

--- a/tests/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled_test.py
+++ b/tests/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled_test.py
@@ -62,7 +62,7 @@ class Test_exchange_roles_assignment_policy_addins_disabled:
                 RoleAssignmentPolicy(
                     name="Policy1",
                     id="id-policy1",
-                    assigned_roles=["MyBaseOptions", "MyVoiceMail"],
+                    assigned_roles=["My Base Options", "My Voice Mail"],
                 )
             ]
 
@@ -108,7 +108,7 @@ class Test_exchange_roles_assignment_policy_addins_disabled:
                 RoleAssignmentPolicy(
                     name="Policy2",
                     id="id-policy2",
-                    assigned_roles=["MyCustomApps", "MyVoiceMail"],
+                    assigned_roles=["My Custom Apps", "My Voice Mail"],
                 )
             ]
 

--- a/tests/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled_test.py
+++ b/tests/providers/m365/services/exchange/exchange_roles_assignment_policy_addins_disabled/exchange_roles_assignment_policy_addins_disabled_test.py
@@ -1,0 +1,129 @@
+from unittest import mock
+
+from prowler.providers.m365.services.exchange.exchange_service import (
+    RoleAssignmentPolicy,
+)
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_exchange_roles_assignment_policy_addins_disabled:
+    def test_no_policies(self):
+        exchange_client = mock.MagicMock()
+        exchange_client.audited_tenant = "audited_tenant"
+        exchange_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online",
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.exchange.exchange_roles_assignment_policy_addins_disabled.exchange_roles_assignment_policy_addins_disabled.exchange_client",
+                new=exchange_client,
+            ),
+        ):
+            from prowler.providers.m365.services.exchange.exchange_roles_assignment_policy_addins_disabled.exchange_roles_assignment_policy_addins_disabled import (
+                exchange_roles_assignment_policy_addins_disabled,
+            )
+
+            exchange_client.role_assignment_policies = []
+
+            check = exchange_roles_assignment_policy_addins_disabled()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_policy_with_no_addin_roles(self):
+        exchange_client = mock.MagicMock()
+        exchange_client.audited_tenant = "audited_tenant"
+        exchange_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online",
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.exchange.exchange_roles_assignment_policy_addins_disabled.exchange_roles_assignment_policy_addins_disabled.exchange_client",
+                new=exchange_client,
+            ),
+        ):
+            from prowler.providers.m365.services.exchange.exchange_roles_assignment_policy_addins_disabled.exchange_roles_assignment_policy_addins_disabled import (
+                exchange_roles_assignment_policy_addins_disabled,
+            )
+
+            exchange_client.role_assignment_policies = [
+                RoleAssignmentPolicy(
+                    name="Policy1",
+                    id="id-policy1",
+                    assigned_roles=["MyBaseOptions", "MyVoiceMail"],
+                )
+            ]
+
+            check = exchange_roles_assignment_policy_addins_disabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Role assignment policy 'Policy1' does not allow Outlook add-ins."
+            )
+            assert result[0].resource_name == "Policy1"
+            assert result[0].resource_id == "id-policy1"
+            assert result[0].location == "global"
+            assert (
+                result[0].resource == exchange_client.role_assignment_policies[0].dict()
+            )
+
+    def test_policy_with_addin_roles(self):
+        exchange_client = mock.MagicMock()
+        exchange_client.audited_tenant = "audited_tenant"
+        exchange_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online",
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.exchange.exchange_roles_assignment_policy_addins_disabled.exchange_roles_assignment_policy_addins_disabled.exchange_client",
+                new=exchange_client,
+            ),
+        ):
+            from prowler.providers.m365.services.exchange.exchange_roles_assignment_policy_addins_disabled.exchange_roles_assignment_policy_addins_disabled import (
+                exchange_roles_assignment_policy_addins_disabled,
+            )
+
+            exchange_client.role_assignment_policies = [
+                RoleAssignmentPolicy(
+                    name="Policy2",
+                    id="id-policy2",
+                    assigned_roles=["MyCustomApps", "MyVoiceMail"],
+                )
+            ]
+
+            check = exchange_roles_assignment_policy_addins_disabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Role assignment policy 'Policy2' allows Outlook add-ins via roles: MyCustomApps."
+            )
+            assert result[0].resource_name == "Policy2"
+            assert result[0].resource_id == "id-policy2"
+            assert result[0].location == "global"
+            assert (
+                result[0].resource == exchange_client.role_assignment_policies[0].dict()
+            )


### PR DESCRIPTION
### Context

This PR introduces a new check for Exchange in M365. This check verify that each user roles policy does not allow add-ins, this means that there is no policy with roles `My Custom Apps, My Marketplace Apps, and My ReadWriteMailboxApps`. Attackers exploit vulnerable or custom add-ins to access user data. Disabling userinstalled add-ins in Microsoft Outlook reduces this threat surface.

### Description

Added new check `exchange_roles_assignment_policy_addins_disabled`, modified the service and added unit tests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
