### PR TITLE
feat: add delta attribute in findings detail view with and finding id to the url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ junit-reports/
 # VSCode files
 .vscode/
 
+# Cursor files
+.cursorignore
+
 # Terraform
 .terraform*
 *.tfstate

--- a/ui/components/findings/table/column-findings.tsx
+++ b/ui/components/findings/table/column-findings.tsx
@@ -59,6 +59,18 @@ const FindingDetailsCell = ({ row }: { row: any }) => {
   const findingId = searchParams.get("id");
   const isOpen = findingId === row.original.id;
 
+  const handleOpenChange = (open: boolean) => {
+    const params = new URLSearchParams(searchParams);
+
+    if (open) {
+      params.set("id", row.original.id);
+    } else {
+      params.delete("id");
+    }
+
+    window.history.pushState({}, "", `?${params.toString()}`);
+  };
+
   return (
     <div className="flex justify-center">
       <TriggerSheet
@@ -66,6 +78,7 @@ const FindingDetailsCell = ({ row }: { row: any }) => {
         title="Finding Details"
         description="View the finding details"
         defaultOpen={isOpen}
+        onOpenChange={handleOpenChange}
       >
         <DataTableRowDetails
           entityId={row.original.id}

--- a/ui/components/findings/table/column-findings.tsx
+++ b/ui/components/findings/table/column-findings.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Tooltip } from "@nextui-org/react";
 import { ColumnDef } from "@tanstack/react-table";
 import { useSearchParams } from "next/navigation";
 
@@ -12,6 +13,7 @@ import {
   SeverityBadge,
   StatusFindingBadge,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 import { FindingProps } from "@/types";
 
 import { Muted } from "../muted";
@@ -43,16 +45,6 @@ const getProviderData = (
     `No ${field} found in provider`
   );
 };
-
-// const getScanData = (
-//   row: { original: FindingProps },
-//   field: keyof FindingProps["relationships"]["scan"]["attributes"],
-// ) => {
-//   return (
-//     row.original.relationships?.scan?.attributes?.[field] ||
-//     `No ${field} found in scan`
-//   );
-// };
 
 const FindingDetailsCell = ({ row }: { row: any }) => {
   const searchParams = useSearchParams();
@@ -109,11 +101,47 @@ export const ColumnFindings: ColumnDef<FindingProps>[] = [
       const {
         attributes: { muted },
       } = getFindingsData(row);
+      const { delta } = row.original.attributes;
+
       return (
         <div className="relative flex max-w-[410px] flex-row items-center gap-2 3xl:max-w-[660px]">
-          <p className="mr-7 whitespace-normal break-words text-sm">
-            {checktitle}
-          </p>
+          <div className="flex flex-row items-center gap-4">
+            {(delta === "new" || delta === "changed") && (
+              <Tooltip
+                content={
+                  <div className="flex gap-1 text-xs">
+                    <span>
+                      {delta === "new"
+                        ? "New finding."
+                        : "Status changed since the previous scan."}
+                    </span>
+                    <a
+                      href="https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/#step-8-analyze-the-findings"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary"
+                    >
+                      Learn more
+                    </a>
+                  </div>
+                }
+              >
+                <div
+                  className={cn(
+                    "h-2 min-w-2 cursor-pointer rounded-full",
+                    delta === "new"
+                      ? "bg-system-severity-high"
+                      : delta === "changed"
+                        ? "bg-system-severity-medium"
+                        : "bg-gray-500",
+                  )}
+                />
+              </Tooltip>
+            )}
+            <p className="mr-7 whitespace-normal break-words text-sm">
+              {checktitle}
+            </p>
+          </div>
           <span className="absolute -right-2 top-1/2 -translate-y-1/2">
             <Muted isMuted={muted} />
           </span>

--- a/ui/components/findings/table/column-findings.tsx
+++ b/ui/components/findings/table/column-findings.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Tooltip } from "@nextui-org/react";
 import { ColumnDef } from "@tanstack/react-table";
 import { useSearchParams } from "next/navigation";
 
@@ -13,10 +12,10 @@ import {
   SeverityBadge,
   StatusFindingBadge,
 } from "@/components/ui/table";
-import { cn } from "@/lib/utils";
 import { FindingProps } from "@/types";
 
 import { Muted } from "../muted";
+import { DeltaTooltip } from "./delta-tooltip";
 
 const getFindingsData = (row: { original: FindingProps }) => {
   return row.original;
@@ -107,36 +106,7 @@ export const ColumnFindings: ColumnDef<FindingProps>[] = [
         <div className="relative flex max-w-[410px] flex-row items-center gap-2 3xl:max-w-[660px]">
           <div className="flex flex-row items-center gap-4">
             {(delta === "new" || delta === "changed") && (
-              <Tooltip
-                content={
-                  <div className="flex gap-1 text-xs">
-                    <span>
-                      {delta === "new"
-                        ? "New finding."
-                        : "Status changed since the previous scan."}
-                    </span>
-                    <a
-                      href="https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/#step-8-analyze-the-findings"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary"
-                    >
-                      Learn more
-                    </a>
-                  </div>
-                }
-              >
-                <div
-                  className={cn(
-                    "h-2 min-w-2 cursor-pointer rounded-full",
-                    delta === "new"
-                      ? "bg-system-severity-high"
-                      : delta === "changed"
-                        ? "bg-system-severity-medium"
-                        : "bg-gray-500",
-                  )}
-                />
-              </Tooltip>
+              <DeltaTooltip delta={delta} className="min-w-2" />
             )}
             <p className="mr-7 whitespace-normal break-words text-sm">
               {checktitle}

--- a/ui/components/findings/table/column-findings.tsx
+++ b/ui/components/findings/table/column-findings.tsx
@@ -15,7 +15,7 @@ import {
 import { FindingProps } from "@/types";
 
 import { Muted } from "../muted";
-import { DeltaTooltip } from "./delta-tooltip";
+import { DeltaIndicator } from "./delta-indicator";
 
 const getFindingsData = (row: { original: FindingProps }) => {
   return row.original;
@@ -106,7 +106,7 @@ export const ColumnFindings: ColumnDef<FindingProps>[] = [
         <div className="relative flex max-w-[410px] flex-row items-center gap-2 3xl:max-w-[660px]">
           <div className="flex flex-row items-center gap-4">
             {(delta === "new" || delta === "changed") && (
-              <DeltaTooltip delta={delta} className="min-w-2" />
+              <DeltaIndicator delta={delta} />
             )}
             <p className="mr-7 whitespace-normal break-words text-sm">
               {checktitle}

--- a/ui/components/findings/table/data-table-row-details.tsx
+++ b/ui/components/findings/table/data-table-row-details.tsx
@@ -1,40 +1,14 @@
 "use client";
 
-// import { usePathname, useRouter, useSearchParams } from "next/navigation";
-// import { useEffect } from "react";
-
 import { FindingProps } from "@/types/components";
 
 import { FindingDetail } from "./finding-detail";
 
 export const DataTableRowDetails = ({
-  // entityId,
   findingDetails,
 }: {
   entityId: string;
   findingDetails: FindingProps;
 }) => {
-  // const router = useRouter();
-  // const pathname = usePathname();
-  // const searchParams = useSearchParams();
-
-  // useEffect(() => {
-  //   if (entityId) {
-  //     const params = new URLSearchParams(searchParams.toString());
-  //     params.set("id", entityId);
-  //     router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  //   }
-
-  //   return () => {
-  //     if (entityId) {
-  //       const cleanupParams = new URLSearchParams(searchParams.toString());
-  //       cleanupParams.delete("id");
-  //       router.push(`${pathname}?${cleanupParams.toString()}`, {
-  //         scroll: false,
-  //       });
-  //     }
-  //   };
-  // }, [entityId, pathname, router, searchParams]);
-
   return <FindingDetail findingDetails={findingDetails} />;
 };

--- a/ui/components/findings/table/delta-indicator.tsx
+++ b/ui/components/findings/table/delta-indicator.tsx
@@ -10,6 +10,7 @@ interface DeltaIndicatorProps {
 export const DeltaIndicator = ({ delta }: DeltaIndicatorProps) => {
   return (
     <Tooltip
+      className="pointer-events-auto"
       content={
         <div className="flex gap-1 text-xs">
           <span>

--- a/ui/components/findings/table/delta-indicator.tsx
+++ b/ui/components/findings/table/delta-indicator.tsx
@@ -1,13 +1,13 @@
 import { Tooltip } from "@nextui-org/react";
 
+import { CustomButton } from "@/components/ui/custom/custom-button";
 import { cn } from "@/lib/utils";
 
-interface DeltaTooltipProps {
+interface DeltaIndicatorProps {
   delta: string;
-  className?: string;
 }
 
-export const DeltaTooltip = ({ delta, className }: DeltaTooltipProps) => {
+export const DeltaIndicator = ({ delta }: DeltaIndicatorProps) => {
   return (
     <Tooltip
       content={
@@ -17,26 +17,27 @@ export const DeltaTooltip = ({ delta, className }: DeltaTooltipProps) => {
               ? "New finding."
               : "Status changed since the previous scan."}
           </span>
-          <a
-            href="https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/#step-8-analyze-the-findings"
+          <CustomButton
+            ariaLabel="Learn more about findings"
+            color="transparent"
+            size="sm"
+            className="h-auto min-w-0 p-0 text-primary"
+            asLink="https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/#step-8-analyze-the-findings"
             target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary"
           >
             Learn more
-          </a>
+          </CustomButton>
         </div>
       }
     >
       <div
         className={cn(
-          "h-2 w-2 cursor-pointer rounded-full",
+          "h-2 w-2 min-w-2 cursor-pointer rounded-full",
           delta === "new"
             ? "bg-system-severity-high"
             : delta === "changed"
               ? "bg-system-severity-medium"
               : "bg-gray-500",
-          className,
         )}
       />
     </Tooltip>

--- a/ui/components/findings/table/delta-tooltip.tsx
+++ b/ui/components/findings/table/delta-tooltip.tsx
@@ -1,0 +1,44 @@
+import { Tooltip } from "@nextui-org/react";
+
+import { cn } from "@/lib/utils";
+
+interface DeltaTooltipProps {
+  delta: string;
+  className?: string;
+}
+
+export const DeltaTooltip = ({ delta, className }: DeltaTooltipProps) => {
+  return (
+    <Tooltip
+      content={
+        <div className="flex gap-1 text-xs">
+          <span>
+            {delta === "new"
+              ? "New finding."
+              : "Status changed since the previous scan."}
+          </span>
+          <a
+            href="https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/#step-8-analyze-the-findings"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary"
+          >
+            Learn more
+          </a>
+        </div>
+      }
+    >
+      <div
+        className={cn(
+          "h-2 w-2 cursor-pointer rounded-full",
+          delta === "new"
+            ? "bg-system-severity-high"
+            : delta === "changed"
+              ? "bg-system-severity-medium"
+              : "bg-gray-500",
+          className,
+        )}
+      />
+    </Tooltip>
+  );
+};

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Snippet, Tooltip } from "@nextui-org/react";
+import { Snippet } from "@nextui-org/react";
 import Link from "next/link";
 
 import { InfoField } from "@/components/ui/entities";
@@ -13,7 +13,6 @@ import { SeverityBadge } from "@/components/ui/table/severity-badge";
 import { FindingProps } from "@/types";
 
 import { Muted } from "../muted";
-import { InfoIcon } from "lucide-react";
 
 const renderValue = (value: string | null | undefined) => {
   return value && value.trim() !== "" ? value : "-";

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Snippet } from "@nextui-org/react";
+import { Snippet, Tooltip } from "@nextui-org/react";
 import Link from "next/link";
 
 import { InfoField } from "@/components/ui/entities";
@@ -13,6 +13,7 @@ import { SeverityBadge } from "@/components/ui/table/severity-badge";
 import { FindingProps } from "@/types";
 
 import { Muted } from "../muted";
+import { InfoIcon } from "lucide-react";
 
 const renderValue = (value: string | null | undefined) => {
   return value && value.trim() !== "" ? value : "-";
@@ -87,33 +88,40 @@ export const FindingDetail = ({
 
       {/* Check Metadata */}
       <Section title="Finding Details">
-        <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-4">
-          <InfoField label="Provider" variant="simple">
-            <div className="flex items-center gap-2">
-              {getProviderLogo(
-                attributes.check_metadata.provider as ProviderType,
-              )}
-            </div>
+        <div className="flex flex-wrap gap-4">
+          <InfoField label="Provider" variant="simple" className="flex-grow">
+            {getProviderLogo(
+              attributes.check_metadata.provider as ProviderType,
+            )}
           </InfoField>
-          <InfoField label="Service">
+          <InfoField label="Service" className="flex-grow">
             {attributes.check_metadata.servicename}
           </InfoField>
-          <InfoField label="Region">{resource.region}</InfoField>
-          <InfoField label="First Seen">
+          <InfoField label="Region" className="flex-grow">
+            {resource.region}
+          </InfoField>
+          <InfoField label="First Seen" className="flex-grow">
             <DateWithTime inline dateTime={attributes.first_seen_at || "-"} />
+          </InfoField>
+          <InfoField
+            label="Delta"
+            tooltipContent="Indicates whether the finding is new (NEW), has changed status (CHANGED), or remains unchanged (NONE) compared to previous scans."
+            className="flex-grow capitalize"
+          >
+            {attributes.delta}
           </InfoField>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="flex flex-wrap gap-4">
           <InfoField label="Check ID" variant="simple">
             <Snippet
-              className="max-w-full bg-gray-50 py-1 text-xs dark:bg-slate-800"
+              className="bg-gray-50 py-1 text-xs dark:bg-slate-800"
               hideSymbol
             >
               {attributes.check_id}
             </Snippet>
           </InfoField>
-          <InfoField label="Severity" variant="simple">
+          <InfoField label="Severity" variant="simple" className="flex-grow">
             <SeverityBadge severity={attributes.severity || "-"} />
           </InfoField>
         </div>

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -14,6 +14,7 @@ import { SeverityBadge } from "@/components/ui/table/severity-badge";
 import { FindingProps } from "@/types";
 
 import { Muted } from "../muted";
+import { DeltaTooltip } from "./delta-tooltip";
 
 const renderValue = (value: string | null | undefined) => {
   return value && value.trim() !== "" ? value : "-";
@@ -101,13 +102,18 @@ export const FindingDetail = ({
           <InfoField label="First Seen">
             <DateWithTime inline dateTime={attributes.first_seen_at || "-"} />
           </InfoField>
-          <InfoField
-            label="Delta"
-            tooltipContent="Indicates whether the finding is new (NEW), has changed status (CHANGED), or remains unchanged (NONE) compared to previous scans."
-            className="capitalize"
-          >
-            {attributes.delta}
-          </InfoField>
+          {attributes.delta && (
+            <InfoField
+              label="Delta"
+              tooltipContent="Indicates whether the finding is new (NEW), has changed status (CHANGED), or remains unchanged (NONE) compared to previous scans."
+              className="capitalize"
+            >
+              <div className="flex items-center gap-2">
+                <DeltaTooltip delta={attributes.delta} />
+                {attributes.delta}
+              </div>
+            </InfoField>
+          )}
           <InfoField label="Severity" variant="simple">
             <SeverityBadge severity={attributes.severity || "-"} />
           </InfoField>

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -14,7 +14,7 @@ import { SeverityBadge } from "@/components/ui/table/severity-badge";
 import { FindingProps } from "@/types";
 
 import { Muted } from "../muted";
-import { DeltaTooltip } from "./delta-tooltip";
+import { DeltaIndicator } from "./delta-indicator";
 
 const renderValue = (value: string | null | undefined) => {
   return value && value.trim() !== "" ? value : "-";
@@ -109,7 +109,7 @@ export const FindingDetail = ({
               className="capitalize"
             >
               <div className="flex items-center gap-2">
-                <DeltaTooltip delta={attributes.delta} />
+                <DeltaIndicator delta={attributes.delta} />
                 {attributes.delta}
               </div>
             </InfoField>

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -3,6 +3,7 @@
 import { Snippet } from "@nextui-org/react";
 import Link from "next/link";
 
+import { CodeSnippet } from "@/components/ui/code-snippet/code-snippet";
 import { InfoField } from "@/components/ui/entities";
 import { DateWithTime } from "@/components/ui/entities/date-with-time";
 import {
@@ -88,42 +89,38 @@ export const FindingDetail = ({
       {/* Check Metadata */}
       <Section title="Finding Details">
         <div className="flex flex-wrap gap-4">
-          <InfoField label="Provider" variant="simple" className="flex-grow">
+          <InfoField label="Provider" variant="simple">
             {getProviderLogo(
               attributes.check_metadata.provider as ProviderType,
             )}
           </InfoField>
-          <InfoField label="Service" className="flex-grow">
+          <InfoField label="Service">
             {attributes.check_metadata.servicename}
           </InfoField>
-          <InfoField label="Region" className="flex-grow">
-            {resource.region}
-          </InfoField>
-          <InfoField label="First Seen" className="flex-grow">
+          <InfoField label="Region">{resource.region}</InfoField>
+          <InfoField label="First Seen">
             <DateWithTime inline dateTime={attributes.first_seen_at || "-"} />
           </InfoField>
           <InfoField
             label="Delta"
             tooltipContent="Indicates whether the finding is new (NEW), has changed status (CHANGED), or remains unchanged (NONE) compared to previous scans."
-            className="flex-grow capitalize"
+            className="capitalize"
           >
             {attributes.delta}
           </InfoField>
-        </div>
-
-        <div className="flex flex-wrap gap-4">
-          <InfoField label="Check ID" variant="simple">
-            <Snippet
-              className="bg-gray-50 py-1 text-xs dark:bg-slate-800"
-              hideSymbol
-            >
-              {attributes.check_id}
-            </Snippet>
-          </InfoField>
-          <InfoField label="Severity" variant="simple" className="flex-grow">
+          <InfoField label="Severity" variant="simple">
             <SeverityBadge severity={attributes.severity || "-"} />
           </InfoField>
         </div>
+        <InfoField label="ID" variant="simple">
+          <CodeSnippet value={findingDetails.id} />
+        </InfoField>
+        <InfoField label="Check ID" variant="simple">
+          <CodeSnippet value={attributes.check_id} />
+        </InfoField>
+        <InfoField label="UID" variant="simple">
+          <CodeSnippet value={attributes.uid} />
+        </InfoField>
 
         {attributes.status === "FAIL" && (
           <InfoField label="Risk" variant="simple">

--- a/ui/components/ui/code-snippet/code-snippet.tsx
+++ b/ui/components/ui/code-snippet/code-snippet.tsx
@@ -1,0 +1,13 @@
+import { Snippet } from "@nextui-org/react";
+
+export const CodeSnippet = ({ value }: { value: string }) => (
+  <Snippet
+    className="w-full bg-gray-50 py-1 text-xs dark:bg-slate-800"
+    hideSymbol
+    classNames={{
+      pre: "w-full truncate",
+    }}
+  >
+    {value}
+  </Snippet>
+);

--- a/ui/components/ui/entities/info-field.tsx
+++ b/ui/components/ui/entities/info-field.tsx
@@ -1,5 +1,5 @@
-import clsx from "clsx";
 import { Tooltip } from "@nextui-org/react";
+import clsx from "clsx";
 import { InfoIcon } from "lucide-react";
 
 interface InfoFieldProps {

--- a/ui/components/ui/entities/info-field.tsx
+++ b/ui/components/ui/entities/info-field.tsx
@@ -1,39 +1,55 @@
 import clsx from "clsx";
+import { Tooltip } from "@nextui-org/react";
+import { InfoIcon } from "lucide-react";
 
 interface InfoFieldProps {
   label: string;
   children: React.ReactNode;
   variant?: "default" | "simple";
   className?: string;
+  tooltipContent?: string;
 }
+
+<Tooltip
+  className="text-xs"
+  content="Download a ZIP file containing the JSON (OCSF), CSV, and HTML reports."
+>
+  <div className="flex items-center gap-2">
+    <InfoIcon className="mb-1 text-primary" size={12} />
+  </div>
+</Tooltip>;
 
 export const InfoField = ({
   label,
   children,
   variant = "default",
+  tooltipContent,
   className,
 }: InfoFieldProps) => {
-  if (variant === "simple") {
-    return (
-      <div className="flex flex-col gap-1">
-        <span className="text-xs font-bold text-gray-500 dark:text-prowler-theme-pale/70">
-          {label}
-        </span>
-        <div className="text-small text-gray-900 dark:text-prowler-theme-pale">
-          {children}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className={clsx("flex flex-col gap-1", className)}>
       <span className="text-xs font-bold text-gray-500 dark:text-prowler-theme-pale/70">
-        {label}
+        <span className="flex items-center gap-1">
+          {label}
+          {tooltipContent && (
+            <Tooltip className="text-xs" content={tooltipContent}>
+              <div className="flex cursor-pointer items-center gap-2">
+                <InfoIcon className="mb-1 text-primary" size={12} />
+              </div>
+            </Tooltip>
+          )}
+        </span>
       </span>
-      <div className="rounded-lg bg-gray-50 px-3 py-2 text-small text-gray-900 dark:bg-slate-800 dark:text-prowler-theme-pale">
-        {children}
-      </div>
+
+      {variant === "simple" ? (
+        <div className="text-small text-gray-900 dark:text-prowler-theme-pale">
+          {children}
+        </div>
+      ) : (
+        <div className="rounded-lg bg-gray-50 px-3 py-2 text-small text-gray-900 dark:bg-slate-800 dark:text-prowler-theme-pale">
+          {children}
+        </div>
+      )}
     </div>
   );
 };

--- a/ui/components/ui/sheet/trigger-sheet.tsx
+++ b/ui/components/ui/sheet/trigger-sheet.tsx
@@ -13,6 +13,7 @@ interface TriggerSheetProps {
   description: string;
   children: React.ReactNode;
   defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function TriggerSheet({
@@ -21,9 +22,10 @@ export function TriggerSheet({
   description,
   children,
   defaultOpen = false,
+  onOpenChange,
 }: TriggerSheetProps) {
   return (
-    <Sheet defaultOpen={defaultOpen}>
+    <Sheet defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
       <SheetTrigger className="flex items-center gap-2">
         {triggerComponent}
       </SheetTrigger>


### PR DESCRIPTION
### Context

We have to show in the findings details view some fields being retrieved from the API, which are the _finding id_ and the _delta_, and at the moment, they were not being shown.

### Description

For _delta_: new info field is added to the view, with a tooltip explaining what is _delta_.
![819shots_so](https://github.com/user-attachments/assets/ce6adab6-3815-48e3-ae93-4e64d5953b4b)

For _finding id_, _finding uid_ and _delta_ : it's shown in the URL when a user opens the finding detail view.
![752shots_so](https://github.com/user-attachments/assets/56df0ea4-577b-465b-ad40-4614d21a26f9)


I've also fixed some layout wrapping errors and modified the snippet component to be able to ellipsize the content.


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [X] Verify if API specs need to be regenerated.
- [X] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
