### PR TITLE
fix: error about page number persistence when filters change

### DIFF
--- a/ui/components/filters/custom-date-picker.tsx
+++ b/ui/components/filters/custom-date-picker.tsx
@@ -8,12 +8,14 @@ import {
 } from "@internationalized/date";
 import { Button, ButtonGroup, DatePicker } from "@nextui-org/react";
 import { useLocale } from "@react-aria/i18n";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import React, { useCallback, useEffect, useRef } from "react";
 
+import { useUrlFilters } from "@/hooks/use-url-filters";
+
 export const CustomDatePicker = () => {
-  const router = useRouter();
   const searchParams = useSearchParams();
+  const { updateFilter } = useUrlFilters();
 
   const [value, setValue] = React.useState(() => {
     const dateParam = searchParams.get("filter[inserted_at]");
@@ -28,15 +30,13 @@ export const CustomDatePicker = () => {
 
   const applyDateFilter = useCallback(
     (date: any) => {
-      const params = new URLSearchParams(searchParams.toString());
       if (date) {
-        params.set("filter[inserted_at]", date.toString());
+        updateFilter("inserted_at", date.toString());
       } else {
-        params.delete("filter[inserted_at]");
+        updateFilter("inserted_at", null);
       }
-      router.push(`?${params.toString()}`, { scroll: false });
     },
-    [router, searchParams],
+    [updateFilter],
   );
 
   const initialRender = useRef(true);

--- a/ui/components/filters/custom-search-input.tsx
+++ b/ui/components/filters/custom-search-input.tsx
@@ -1,26 +1,25 @@
 import { Input } from "@nextui-org/react";
 import debounce from "lodash.debounce";
 import { SearchIcon, XCircle } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import React, { useCallback, useEffect, useState } from "react";
 
-export const CustomSearchInput: React.FC = () => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+import { useUrlFilters } from "@/hooks/use-url-filters";
 
+export const CustomSearchInput: React.FC = () => {
+  const searchParams = useSearchParams();
+  const { updateFilter } = useUrlFilters();
   const [searchQuery, setSearchQuery] = useState("");
 
   const applySearch = useCallback(
     (query: string) => {
-      const params = new URLSearchParams(searchParams.toString());
       if (query) {
-        params.set("filter[search]", query);
+        updateFilter("search", query);
       } else {
-        params.delete("filter[search]");
+        updateFilter("search", null);
       }
-      router.push(`?${params.toString()}`, { scroll: false });
     },
-    [router, searchParams],
+    [updateFilter],
   );
 
   const debouncedChangeHandler = useCallback(

--- a/ui/components/filters/filter-controls.tsx
+++ b/ui/components/filters/filter-controls.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import React, { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import React, { useEffect, useState } from "react";
 
+import { useUrlFilters } from "@/hooks/use-url-filters";
 import { FilterControlsProps } from "@/types";
 
 import { CrossIcon } from "../icons";
@@ -24,8 +25,8 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
   mutedFindings = false,
   customFilters,
 }) => {
-  const router = useRouter();
   const searchParams = useSearchParams();
+  const { clearAllFilters } = useUrlFilters();
   const [showClearButton, setShowClearButton] = useState(false);
 
   useEffect(() => {
@@ -34,16 +35,6 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
     );
     setShowClearButton(hasFilters);
   }, [searchParams]);
-
-  const clearAllFilters = useCallback(() => {
-    const params = new URLSearchParams(searchParams.toString());
-    Array.from(params.keys()).forEach((key) => {
-      if (key.startsWith("filter[") || key === "sort") {
-        params.delete(key);
-      }
-    });
-    router.push(`?${params.toString()}`, { scroll: false });
-  }, [router, searchParams]);
 
   return (
     <div className="flex flex-col gap-4">

--- a/ui/components/ui/custom/custom-dropdown-filter.tsx
+++ b/ui/components/ui/custom/custom-dropdown-filter.tsx
@@ -11,10 +11,11 @@ import {
   ScrollShadow,
 } from "@nextui-org/react";
 import { XCircle } from "lucide-react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { PlusCircleIcon } from "@/components/icons";
+import { useUrlFilters } from "@/hooks/use-url-filters";
 import { CustomDropdownFilterProps } from "@/types";
 
 const filterSelectedClass =
@@ -24,8 +25,8 @@ export const CustomDropdownFilter: React.FC<CustomDropdownFilterProps> = ({
   filter,
   onFilterChange,
 }) => {
-  const router = useRouter();
   const searchParams = useSearchParams();
+  const { clearFilter } = useUrlFilters();
   const [groupSelected, setGroupSelected] = useState(new Set<string>());
   const [pendingClearFilter, setPendingClearFilter] = useState<string | null>(
     null,
@@ -114,13 +115,11 @@ export const CustomDropdownFilter: React.FC<CustomDropdownFilterProps> = ({
 
   // Execute the update in the router after the render
   useEffect(() => {
-    if (pendingClearFilter) {
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete(`filter[${pendingClearFilter}]`);
-      router.push(`?${params.toString()}`, { scroll: false });
+    if (pendingClearFilter && filter) {
+      clearFilter(pendingClearFilter);
       setPendingClearFilter(null); // Reset the state
     }
-  }, [pendingClearFilter, searchParams, router]);
+  }, [pendingClearFilter, clearFilter, filter]);
 
   return (
     <div className="relative flex w-full flex-col gap-2">

--- a/ui/components/ui/table/data-table-filter-custom.tsx
+++ b/ui/components/ui/table/data-table-filter-custom.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
 import React, { useState } from "react";
 import { useCallback } from "react";
 
 import { CustomFilterIcon } from "@/components/icons";
 import { CustomButton, CustomDropdownFilter } from "@/components/ui/custom";
+import { useUrlFilters } from "@/hooks/use-url-filters";
 import { FilterOption } from "@/types";
 
 export interface DataTableFilterCustomProps {
@@ -17,24 +17,14 @@ export const DataTableFilterCustom = ({
   filters,
   defaultOpen = false,
 }: DataTableFilterCustomProps) => {
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  const { updateFilter } = useUrlFilters();
   const [showFilters, setShowFilters] = useState(defaultOpen);
 
   const pushDropdownFilter = useCallback(
     (key: string, values: string[]) => {
-      const params = new URLSearchParams(searchParams);
-      const filterKey = `filter[${key}]`;
-
-      if (values.length === 0) {
-        params.delete(filterKey);
-      } else {
-        params.set(filterKey, values.join(","));
-      }
-
-      router.push(`?${params.toString()}`);
+      updateFilter(key, values.length > 0 ? values : null);
     },
-    [router, searchParams],
+    [updateFilter],
   );
 
   return (

--- a/ui/hooks/use-url-filters.ts
+++ b/ui/hooks/use-url-filters.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+/**
+ * Custom hook to handle URL filters and automatically reset
+ * pagination when filters change.
+ */
+export const useUrlFilters = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const updateFilter = useCallback(
+    (key: string, value: string | string[] | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      // Always reset page to 1 when a filter is applied
+      params.set("page", "1");
+
+      const filterKey = key.startsWith("filter[") ? key : `filter[${key}]`;
+
+      if (value === null || (Array.isArray(value) && value.length === 0)) {
+        params.delete(filterKey);
+      } else if (Array.isArray(value)) {
+        params.set(filterKey, value.join(","));
+      } else {
+        params.set(filterKey, value);
+      }
+
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams, pathname],
+  );
+
+  const clearFilter = useCallback(
+    (key: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      const filterKey = key.startsWith("filter[") ? key : `filter[${key}]`;
+
+      params.delete(filterKey);
+      params.set("page", "1");
+
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams, pathname],
+  );
+
+  const clearAllFilters = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    Array.from(params.keys()).forEach((key) => {
+      if (key.startsWith("filter[") || key === "sort") {
+        params.delete(key);
+      }
+    });
+
+    params.delete("page");
+
+    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [router, searchParams, pathname]);
+
+  return {
+    updateFilter,
+    clearFilter,
+    clearAllFilters,
+  };
+};


### PR DESCRIPTION
### Context

When you filter in any view, you will get new results. What is happening is that if you are on a page other than the first one, that page could not exist for those new filters.

### Description

We have many ways to handle this scenario, I chose to create a custom hook to handle filter interactions. In this way, we avoid duplicating code and we have a centralized logic to handle all views with filters.
The new custom hook can update and clear filters, always setting the page to the first one when any of these actions are triggered.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
