### PR TITLE
feat: diff between providers actions depending on their secrets

### DIFF
--- a/ui/components/providers/provider-info.tsx
+++ b/ui/components/providers/provider-info.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from "@nextui-org/react";
 import React from "react";
 
 import { ConnectionFalse, ConnectionPending, ConnectionTrue } from "../icons";
@@ -20,21 +21,27 @@ export const ProviderInfo: React.FC<ProviderInfoProps> = ({
     switch (connected) {
       case true:
         return (
-          <div className="flex items-center justify-center rounded-medium border-2 border-system-success bg-system-success-lighter p-1">
-            <ConnectionTrue className="text-system-success" size={24} />
-          </div>
+          <Tooltip content="Provider connected" className="text-xs">
+            <div className="flex items-center justify-center rounded-medium border-2 border-system-success bg-system-success-lighter p-1">
+              <ConnectionTrue className="text-system-success" size={24} />
+            </div>
+          </Tooltip>
         );
       case false:
         return (
-          <div className="flex items-center justify-center rounded-medium border-2 border-danger bg-system-error-lighter p-1">
-            <ConnectionFalse className="text-danger" size={24} />
-          </div>
+          <Tooltip content="Provider connection failed" className="text-xs">
+            <div className="flex items-center justify-center rounded-medium border-2 border-danger bg-system-error-lighter p-1">
+              <ConnectionFalse className="text-danger" size={24} />
+            </div>
+          </Tooltip>
         );
       case null:
         return (
-          <div className="bg-info-lighter border-info-lighter flex items-center justify-center rounded-medium border p-1">
-            <ConnectionPending className="text-info" size={24} />
-          </div>
+          <Tooltip content="Provider not connected" className="text-xs">
+            <div className="bg-info-lighter border-info-lighter flex items-center justify-center rounded-medium border p-1">
+              <ConnectionPending className="text-info" size={24} />
+            </div>
+          </Tooltip>
         );
       default:
         return <ConnectionPending size={24} />;

--- a/ui/components/providers/table/data-table-row-actions.tsx
+++ b/ui/components/providers/table/data-table-row-actions.tsx
@@ -49,6 +49,8 @@ export function DataTableRowActions<ProviderProps>({
     await checkConnectionProvider(formData);
   };
 
+  const hasSecret = (row.original as any).relationships?.secret?.data;
+
   return (
     <>
       <CustomAlertModal
@@ -89,24 +91,33 @@ export function DataTableRowActions<ProviderProps>({
           >
             <DropdownSection title="Actions">
               <DropdownItem
-                key="update"
-                description="Update the provider credentials"
-                textValue="Update Credentials"
+                key={hasSecret ? "update" : "add"}
+                description={
+                  hasSecret
+                    ? "Update the provider credentials"
+                    : "Add the provider credentials"
+                }
+                textValue={hasSecret ? "Update Credentials" : "Add Credentials"}
                 startContent={<EditDocumentBulkIcon className={iconClasses} />}
                 onPress={() =>
                   router.push(
-                    `/providers/update-credentials?type=${providerType}&id=${providerId}${providerSecretId ? `&secretId=${providerSecretId}` : ""}`,
+                    `/providers/${hasSecret ? "update" : "add"}-credentials?type=${providerType}&id=${providerId}${providerSecretId ? `&secretId=${providerSecretId}` : ""}`,
                   )
                 }
               >
-                Update Credentials
+                {hasSecret ? "Update Credentials" : "Add Credentials"}
               </DropdownItem>
               <DropdownItem
                 key="new"
-                description="Check the connection to the provider"
+                description={
+                  hasSecret
+                    ? "Check the connection to the provider"
+                    : "Add credentials to test the connection"
+                }
                 textValue="Check Connection"
                 startContent={<AddNoteBulkIcon className={iconClasses} />}
                 onPress={handleTestConnection}
+                isDisabled={!hasSecret}
               >
                 Test Connection
               </DropdownItem>

--- a/ui/components/providers/table/data-table-row-actions.tsx
+++ b/ui/components/providers/table/data-table-row-actions.tsx
@@ -37,6 +37,7 @@ export function DataTableRowActions<ProviderProps>({
   const router = useRouter();
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
   const providerId = (row.original as { id: string }).id;
   const providerType = (row.original as any).attributes?.provider;
   const providerAlias = (row.original as any).attributes?.alias;
@@ -44,9 +45,11 @@ export function DataTableRowActions<ProviderProps>({
     (row.original as any).relationships?.secret?.data?.id || null;
 
   const handleTestConnection = async () => {
+    setLoading(true);
     const formData = new FormData();
     formData.append("providerId", providerId);
     await checkConnectionProvider(formData);
+    setLoading(false);
   };
 
   const hasSecret = (row.original as any).relationships?.secret?.data;
@@ -83,12 +86,7 @@ export function DataTableRowActions<ProviderProps>({
               <VerticalDotsIcon className="text-default-400" />
             </Button>
           </DropdownTrigger>
-          <DropdownMenu
-            closeOnSelect
-            aria-label="Actions"
-            color="default"
-            variant="flat"
-          >
+          <DropdownMenu aria-label="Actions" color="default" variant="flat">
             <DropdownSection title="Actions">
               <DropdownItem
                 key={hasSecret ? "update" : "add"}
@@ -104,22 +102,26 @@ export function DataTableRowActions<ProviderProps>({
                     `/providers/${hasSecret ? "update" : "add"}-credentials?type=${providerType}&id=${providerId}${providerSecretId ? `&secretId=${providerSecretId}` : ""}`,
                   )
                 }
+                closeOnSelect={true}
               >
                 {hasSecret ? "Update Credentials" : "Add Credentials"}
               </DropdownItem>
               <DropdownItem
                 key="new"
                 description={
-                  hasSecret
-                    ? "Check the connection to the provider"
-                    : "Add credentials to test the connection"
+                  hasSecret && !loading
+                    ? "Check the provider connection"
+                    : loading
+                      ? "Checking provider connection"
+                      : "Add credentials to test the connection"
                 }
                 textValue="Check Connection"
                 startContent={<AddNoteBulkIcon className={iconClasses} />}
                 onPress={handleTestConnection}
-                isDisabled={!hasSecret}
+                isDisabled={!hasSecret || loading}
+                closeOnSelect={false}
               >
-                Test Connection
+                {loading ? "Testing..." : "Test Connection"}
               </DropdownItem>
               <DropdownItem
                 key="edit"
@@ -127,6 +129,7 @@ export function DataTableRowActions<ProviderProps>({
                 textValue="Edit Provider"
                 startContent={<EditDocumentBulkIcon className={iconClasses} />}
                 onPress={() => setIsEditOpen(true)}
+                closeOnSelect={true}
               >
                 Edit Provider Alias
               </DropdownItem>
@@ -144,6 +147,7 @@ export function DataTableRowActions<ProviderProps>({
                   />
                 }
                 onPress={() => setIsDeleteOpen(true)}
+                closeOnSelect={true}
               >
                 Delete Provider
               </DropdownItem>


### PR DESCRIPTION
### Context

This PR contains 2 tasks:
- https://prowlerpro.atlassian.net/browse/PRWLR-6496
- https://prowlerpro.atlassian.net/browse/PRWLR-6497

Both are connected and have the same components involved.
We need to give more context about what actions the user should perform.

### Description

- Loading state when testing
- Tooltip in the connection icon
- correct path (add/update) depending on secrets
- correct button text content

<img width="985" alt="Screenshot 2025-05-06 at 17 16 47" src="https://github.com/user-attachments/assets/35c9a6b7-f59f-4676-8c2e-9ff12be93fd2" />
<img width="987" alt="Screenshot 2025-05-06 at 17 16 42" src="https://github.com/user-attachments/assets/9f4716ec-81c0-47cd-8f94-c883671e0d08" />
<img width="986" alt="Screenshot 2025-05-06 at 17 16 37" src="https://github.com/user-attachments/assets/c0b061a3-d80f-4d47-947e-aa583b7ef3a9" />


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
