### PR TITLE
fix(inspector2): handle error when getting active findings

### DIFF
--- a/prowler/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist.py
@@ -8,7 +8,7 @@ class inspector2_active_findings_exist(Check):
     def execute(self):
         findings = []
         for inspector in inspector2_client.inspectors:
-            if inspector.status == "ENABLED":
+            if inspector.status == "ENABLED" and inspector.active_findings is not None:
                 report = Check_Report_AWS(metadata=self.metadata(), resource=inspector)
                 report.status = "PASS"
                 report.status_extended = (

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -45,7 +45,7 @@ class Inspector2(AWSService):
             regional_client = self.regional_clients[inspector.region]
             active_findings = regional_client.list_findings(
                 filterCriteria={
-                    "awsAccountId": [
+                    "awsAccountI": [
                         {"comparison": "EQUALS", "value": self.audited_account},
                     ],
                     "findingStatus": [{"comparison": "EQUALS", "value": "ACTIVE"}],
@@ -69,4 +69,4 @@ class Inspector(BaseModel):
     ecr_status: str
     lambda_status: str
     lambda_code_status: str
-    active_findings: bool = False
+    active_findings: bool = None

--- a/prowler/providers/aws/services/inspector2/inspector2_service.py
+++ b/prowler/providers/aws/services/inspector2/inspector2_service.py
@@ -45,7 +45,7 @@ class Inspector2(AWSService):
             regional_client = self.regional_clients[inspector.region]
             active_findings = regional_client.list_findings(
                 filterCriteria={
-                    "awsAccountI": [
+                    "awsAccountId": [
                         {"comparison": "EQUALS", "value": self.audited_account},
                     ],
                     "findingStatus": [{"comparison": "EQUALS", "value": "ACTIVE"}],

--- a/tests/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist_test.py
+++ b/tests/providers/aws/services/inspector2/inspector2_active_findings_exist/inspector2_active_findings_exist_test.py
@@ -46,7 +46,6 @@ class Test_inspector2_active_findings_exist:
                 "prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist.inspector2_client",
                 new=inspector2_client,
             ):
-
                 # Test Check
                 from prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist import (
                     inspector2_active_findings_exist,
@@ -101,7 +100,6 @@ class Test_inspector2_active_findings_exist:
                 "prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist.inspector2_client",
                 new=inspector2_client,
             ):
-
                 # Test Check
                 from prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist import (
                     inspector2_active_findings_exist,
@@ -156,7 +154,6 @@ class Test_inspector2_active_findings_exist:
                 "prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist.inspector2_client",
                 new=inspector2_client,
             ):
-
                 # Test Check
                 from prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist import (
                     inspector2_active_findings_exist,
@@ -176,6 +173,49 @@ class Test_inspector2_active_findings_exist:
                     == f"arn:aws:inspector2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:inspector2"
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1
+
+    def test_enabled_with_none_finding(self):
+        # Mock the inspector2 client
+        inspector2_client = mock.MagicMock
+
+        inspector2_client.provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        inspector2_client.audited_account = AWS_ACCOUNT_NUMBER
+        inspector2_client.audited_account_arn = (
+            f"arn:aws:iam::{AWS_ACCOUNT_NUMBER}:root"
+        )
+        inspector2_client.region = AWS_REGION_EU_WEST_1
+        inspector2_client.inspectors = [
+            Inspector(
+                id=AWS_ACCOUNT_NUMBER,
+                arn=f"arn:aws:inspector2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:inspector2",
+                region=AWS_REGION_EU_WEST_1,
+                status="ENABLED",
+                ec2_status="ENABLED",
+                ecr_status="DISABLED",
+                lambda_status="DISABLED",
+                lambda_code_status="ENABLED",
+                active_findings=None,
+            )
+        ]
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist.inspector2_client",
+                new=inspector2_client,
+            ):
+                # Test Check
+                from prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist import (
+                    inspector2_active_findings_exist,
+                )
+
+                check = inspector2_active_findings_exist()
+                result = check.execute()
+
+                assert len(result) == 0
 
     def test_inspector2_disabled_ignoring(self):
         # Mock the inspector2 client
@@ -221,7 +261,6 @@ class Test_inspector2_active_findings_exist:
                 "prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist.inspector2_client",
                 new=inspector2_client,
             ):
-
                 # Test Check
                 from prowler.providers.aws.services.inspector2.inspector2_active_findings_exist.inspector2_active_findings_exist import (
                     inspector2_active_findings_exist,


### PR DESCRIPTION
### Context

Fix #7597 

### Description

Handle error when getting active findings in Inspector2 and do not make false positives findings.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
