### PR TITLE
refactor(finding-detail): remove "Next Scan" field

### DIFF
--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -290,16 +290,12 @@ export const FindingDetail = ({
           <InfoField label="Launched At">
             <DateWithTime inline dateTime={scan.inserted_at || "-"} />
           </InfoField>
-          <InfoField label="Next Scan">
-            <DateWithTime inline dateTime={scan.next_scan_at || "-"} />
-          </InfoField>
+          {scan.scheduled_at && (
+            <InfoField label="Scheduled At">
+              <DateWithTime inline dateTime={scan.scheduled_at} />
+            </InfoField>
+          )}
         </div>
-
-        {scan.scheduled_at && (
-          <InfoField label="Scheduled At">
-            <DateWithTime inline dateTime={scan.scheduled_at} />
-          </InfoField>
-        )}
       </Section>
 
       {/* Provider Details section */}


### PR DESCRIPTION
### Context

We need to remove the Next Scan field from the findings detail.

### Description

Next Scan field removed from finding details view.
<img width="728" alt="Screenshot 2025-05-07 at 10 53 31" src="https://github.com/user-attachments/assets/06acaecc-0468-41d3-996c-bf3e6e4403ee" />

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
