### PR TITLE
fix(powershell): remove platform-specific execution

### DIFF
--- a/prowler/lib/powershell/powershell.py
+++ b/prowler/lib/powershell/powershell.py
@@ -1,5 +1,4 @@
 import json
-import platform
 import queue
 import re
 import subprocess
@@ -47,12 +46,7 @@ class PowerShellSession:
             This is a base implementation that should be extended by subclasses
             to add specific initialization logic (e.g., credential setup).
         """
-        # Determine the appropriate PowerShell command based on the OS
-        if platform.system() == "Windows":
-            powershell_cmd = "powershell"
-        else:
-            powershell_cmd = "pwsh"
-
+        powershell_cmd = "pwsh"
         self.process = subprocess.Popen(
             [powershell_cmd, "-NoExit", "-Command", "-"],
             stdin=subprocess.PIPE,


### PR DESCRIPTION
### Context

This PR simplifies the logic used to determine which `PowerShell` executable to invoke when initializing a subprocess. Previously, the code dynamically selected between `powershell` and `pwsh` based on the operating system. This conditional check is no longer necessary as we are standardizing on `PowerShell 7.4` and above across all environments.

### Description

The change removes the `platform` module and the conditional logic that differentiated between `powershell` on Windows and `pwsh` on other systems. The subprocess will now always use `pwsh` as the command to invoke `PowerShell`.

This is possible and desirable because we are prioritizing `PowerShell 7.4+` in our toolchain, which consistently uses the `pwsh` command across all supported platforms. This update improves code clarity and reduces platform-specific branching.

No additional dependencies are required.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
