### PR TITLE
feat: add DeltaIndicator in new findings

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -10,16 +10,15 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Support for the `M365` Cloud Provider. [(#7590)](https://github.com/prowler-cloud/prowler/pull/7590)
 - Added option to customize the number of items displayed per table page. [(#7634)](https://github.com/prowler-cloud/prowler/pull/7634)
-- Add delta attribute in findings detail view.[(#7654)](https://github.com/prowler-cloud/prowler/pull/7654)
+- Add delta attribute in findings detail view. [(#7654)](https://github.com/prowler-cloud/prowler/pull/7654)
+- Add delta indicator in new findings table. [(#7676)](https://github.com/prowler-cloud/prowler/pull/7676)
 - Add a button to download the CSV report in compliance card. [(#7665)](https://github.com/prowler-cloud/prowler/pull/7665)
 - Show loading state while checking provider connection. [(#7669)](https://github.com/prowler-cloud/prowler/pull/7669)
-
 
 ### 🔄 Changed
 
 - Finding URLs now include the ID, allowing them to be shared within the organization. [(#7654)](https://github.com/prowler-cloud/prowler/pull/7654)
 - Show Add/Update credentials depending on whether a secret is already set or not. [(#7669)](https://github.com/prowler-cloud/prowler/pull/7669)
-
 
 ### 🐞 Fixes
 

--- a/ui/components/overview/new-findings-table/table/column-new-findings-to-date.tsx
+++ b/ui/components/overview/new-findings-table/table/column-new-findings-to-date.tsx
@@ -4,6 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { useSearchParams } from "next/navigation";
 
 import { DataTableRowDetails } from "@/components/findings/table";
+import { DeltaIndicator } from "@/components/findings/table/delta-indicator";
 import { InfoIcon } from "@/components/icons";
 import { DateWithTime, EntityInfoShort } from "@/components/ui/entities";
 import { TriggerSheet } from "@/components/ui/sheet";
@@ -76,11 +77,17 @@ export const ColumnNewFindingsToDate: ColumnDef<FindingProps>[] = [
       const {
         attributes: { muted },
       } = getFindingsData(row);
+      const { delta } = row.original.attributes;
       return (
         <div className="relative flex max-w-[410px] flex-row items-center gap-2 3xl:max-w-[660px]">
-          <p className="mr-7 whitespace-normal break-words text-sm">
-            {checktitle}
-          </p>
+          <div className="flex flex-row items-center gap-4">
+            {(delta === "new" || delta === "changed") && (
+              <DeltaIndicator delta={delta} />
+            )}
+            <p className="mr-7 whitespace-normal break-words text-sm">
+              {checktitle}
+            </p>
+          </div>
           <span className="absolute -right-2 top-1/2 -translate-y-1/2">
             <Muted isMuted={muted} />
           </span>


### PR DESCRIPTION
### Context

As we added the delta indicator to the findings table, we also need to show it on the new findings table.

### Description

In the new findings table in /overview page:
<img width="1340" alt="Screenshot 2025-05-07 at 12 35 04" src="https://github.com/user-attachments/assets/489c065b-d452-4324-bcb4-20ad2dbbfa49" />

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
