### PR TITLE
fix(mutelist): properly handle wildcards and regex

### DIFF
--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -433,8 +433,8 @@ class Mutelist(ABC):
                 if tag:
                     is_item_matched = True
                 for item in matched_items:
-                    if item.startswith("*"):
-                        item = ".*" + item[1:]
+                    if "*" in item:
+                        item = item.replace("*", ".*")
                     if tag:
                         if not re.search(item, finding_items):
                             is_item_matched = False


### PR DESCRIPTION
### Context

Fix #7544 


### Description

Properly converts wildcard `*` to regex `.*` in `is_item_matched()` to ensure correct matching of check IDs, resources, and tags. Fixes overmatching and undermatching issues in the Mutelist logic.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
