### PR TITLE
chore(release): Bump version to v5.6.1

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -12,7 +12,7 @@ from prowler.lib.logger import logger
 
 timestamp = datetime.today()
 timestamp_utc = datetime.now(timezone.utc).replace(tzinfo=timezone.utc)
-prowler_version = "5.6.0"
+prowler_version = "5.6.1"
 html_logo_url = "https://github.com/prowler-cloud/prowler/"
 square_logo_img = "https://prowler.com/wp-content/uploads/logo-html.png"
 aws_logo = "https://user-images.githubusercontent.com/38561120/235953920-3e3fba08-0795-41dc-b480-9bea57db9f2e.png"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ maintainers = [{name = "Prowler Engineering", email = "engineering@prowler.com"}
 name = "prowler"
 readme = "README.md"
 requires-python = ">3.9.1,<3.13"
-version = "5.6.0"
+version = "5.6.1"
 
 [project.scripts]
 prowler = "prowler.__main__:prowler"


### PR DESCRIPTION
### Description

Bump Prowler version to v5.6.1 in `v5.6` branch

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.