### PR TITLE
chore: add pass PR url

### DIFF
--- a/.github/workflows/pull-request-merged.yml
+++ b/.github/workflows/pull-request-merged.yml
@@ -30,5 +30,6 @@ jobs:
             "PROWLER_COMMIT_SHORT_SHA": "${{ env.SHORT_SHA }}",
             "PROWLER_PR_TITLE": "${{ github.event.pull_request.title }}",
             "PROWLER_PR_LABELS": ${{ toJson(github.event.pull_request.labels.*.name) }},
-            "PROWLER_PR_BODY": ${{ toJson(github.event.pull_request.body) }}
+            "PROWLER_PR_BODY": ${{ toJson(github.event.pull_request.body) }},
+            "PROWLER_PR_URL":${{ toJson(github.event.pull_request.html_url) }}
           }'


### PR DESCRIPTION
### Context

We want to pass PR url for Cloud PR's merged from `prowler`

### Description

Add PR url on payload.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
