### PR TITLE
chore(api): Set tab name for API reference

### DIFF
--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -111,6 +111,7 @@ SPECTACULAR_SETTINGS = {
     "PREPROCESSING_HOOKS": [
         "drf_spectacular_jsonapi.hooks.fix_nested_path_parameters",
     ],
+    "TITLE": "API Reference - Prowler",
 }
 
 WSGI_APPLICATION = "config.wsgi.application"


### PR DESCRIPTION
### Description

Set Prowler API docs at http://localhost:8000/api/v1/docs to `API Reference - Prowler` instead of just `Redoc`
- Previous
![Screenshot 2025-05-12 at 12 12 58](https://github.com/user-attachments/assets/06af82de-159f-479e-8fe2-7c3f813accce)
- New
![Screenshot 2025-05-12 at 12 17 22](https://github.com/user-attachments/assets/067144c1-9f56-4b02-a5f6-b7acec2a70c0)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
