### PR TITLE
feat(kubernetes): support `HTTPS_PROXY` and `K8S_SKIP_TLS_VERIFY`

### DIFF
--- a/docs/tutorials/kubernetes/misc.md
+++ b/docs/tutorials/kubernetes/misc.md
@@ -21,3 +21,23 @@ To specify the namespace(s) to be scanned, use the `--namespace` flag followed b
 ```console
 prowler --namespace namespace1 namespace2
 ```
+
+## Proxy and TLS Verification
+
+If your Kubernetes cluster is only accessible via an internal proxy, Prowler will respect the `HTTPS_PROXY` or `https_proxy` environment variable:
+
+```console
+export HTTPS_PROXY=http://my.internal.proxy:8888
+prowler kubernetes ...
+```
+
+If you need to skip TLS verification for internal proxies, you can set the `K8S_SKIP_TLS_VERIFY` environment variable:
+
+```console
+export K8S_SKIP_TLS_VERIFY=true
+prowler kubernetes ...
+```
+
+This will allow Prowler to connect to the cluster even if the proxy uses a self-signed certificate.
+
+These environment variables are supported both when using an external `kubeconfig` and in in-cluster mode.


### PR DESCRIPTION
### Context

Fix #7342 

### Description

This PR adds support for environments where Kubernetes clusters are only accessible through an internal proxy. It does so by:

- Respecting the `HTTPS_PROXY` or `https_proxy` environment variable for API communication.

- Allowing TLS verification to be disabled using the `K8S_SKIP_TLS_VERIFY=true` environment variable (opt-in only).

- Applying both proxy and TLS settings in both kubeconfig-based and in-cluster setups.

Tests are included to validate that the proxy and TLS settings are applied correctly.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
