### PR TITLE
fix: Added filter to get connected providers only for banner to show

### DIFF
--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -40,7 +40,9 @@ export default async function Scans({
       connected: provider.attributes.connection.connected,
     })) || [];
 
-  const providersCountConnected = await getProviders({ filters: { "filter[connected]": true } });
+  const providersCountConnected = await getProviders({
+    filters: { "filter[connected]": true },
+  });
   const thereIsNoProviders =
     !providersCountConnected?.data || providersCountConnected.data.length === 0;
 

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -40,7 +40,7 @@ export default async function Scans({
       connected: provider.attributes.connection.connected,
     })) || [];
 
-  const providersCountConnected = await getProviders({});
+  const providersCountConnected = await getProviders({ filters: { "filter[connected]": true } });
   const thereIsNoProviders =
     !providersCountConnected?.data || providersCountConnected.data.length === 0;
 


### PR DESCRIPTION
### Context

This PR solves the issue if we have connected providers but on Scan job page no connected banner shows up

### Description

This issue might exists when we have multiple providers and connected provider will be on second page, so filtering out with connected providers will resolve the above issue.

### Checklist

- Are there new checks included in this PR? No
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
