### PR TITLE
feat: use getFindingsLatest when no scan or date filters are applied

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Added `Accordion` component. [(#7700)](https://github.com/prowler-cloud/prowler/pull/7700)
 - Improve `Provider UID` filter by adding more context and enhancing the UI/UX. [(#7741)](https://github.com/prowler-cloud/prowler/pull/7741)
 - Added an AWS CloudFormation Quick Link to the IAM Role credentials step [(#7735)](https://github.com/prowler-cloud/prowler/pull/7735)
+– Use `getFindingsLatest` on findings page when no scan or date filters are applied. [(#7756)](https://github.com/prowler-cloud/prowler/pull/7756)
 
 ### 🐞 Fixes
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Added `Accordion` component. [(#7700)](https://github.com/prowler-cloud/prowler/pull/7700)
 - Improve `Provider UID` filter by adding more context and enhancing the UI/UX. [(#7741)](https://github.com/prowler-cloud/prowler/pull/7741)
 - Added an AWS CloudFormation Quick Link to the IAM Role credentials step [(#7735)](https://github.com/prowler-cloud/prowler/pull/7735)
-– Use `getFindingsLatest` on findings page when no scan or date filters are applied. [(#7756)](https://github.com/prowler-cloud/prowler/pull/7756)
+– Use `getLatestFindings` on findings page when no scan or date filters are applied. [(#7756)](https://github.com/prowler-cloud/prowler/pull/7756)
 
 ### 🐞 Fixes
 

--- a/ui/actions/findings/findings.ts
+++ b/ui/actions/findings/findings.ts
@@ -44,6 +44,47 @@ export const getFindings = async ({
   }
 };
 
+export const getFindingsLatest = async ({
+  page = 1,
+  pageSize = 10,
+  query = "",
+  sort = "",
+  filters = {},
+}) => {
+  const headers = await getAuthHeaders({ contentType: false });
+
+  if (isNaN(Number(page)) || page < 1)
+    redirect("findings?include=resources,scan.provider");
+
+  const url = new URL(
+    `${apiBaseUrl}/findings/latest?include=resources,scan.provider`,
+  );
+
+  if (page) url.searchParams.append("page[number]", page.toString());
+  if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
+
+  if (query) url.searchParams.append("filter[search]", query);
+  if (sort) url.searchParams.append("sort", sort);
+
+  Object.entries(filters).forEach(([key, value]) => {
+    url.searchParams.append(key, String(value));
+  });
+
+  try {
+    const findings = await fetch(url.toString(), {
+      headers,
+    });
+    const data = await findings.json();
+    const parsedData = parseStringify(data);
+    revalidatePath("/findings");
+    return parsedData;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("Error fetching findings:", error);
+    return undefined;
+  }
+};
+
 export const getMetadataInfo = async ({
   query = "",
   sort = "",
@@ -52,6 +93,48 @@ export const getMetadataInfo = async ({
   const headers = await getAuthHeaders({ contentType: false });
 
   const url = new URL(`${apiBaseUrl}/findings/metadata`);
+
+  if (query) url.searchParams.append("filter[search]", query);
+  if (sort) url.searchParams.append("sort", sort);
+
+  Object.entries(filters).forEach(([key, value]) => {
+    // Define filters to exclude
+    const excludedFilters = ["region__in", "service__in", "resource_type__in"];
+    if (
+      key !== "filter[search]" &&
+      !excludedFilters.some((filter) => key.includes(filter))
+    ) {
+      url.searchParams.append(key, String(value));
+    }
+  });
+
+  try {
+    const response = await fetch(url.toString(), {
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch metadata info: ${response.statusText}`);
+    }
+
+    const parsedData = parseStringify(await response.json());
+
+    return parsedData;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error("Error fetching metadata info:", error);
+    return undefined;
+  }
+};
+
+export const getMetadataInfoLatest = async ({
+  query = "",
+  sort = "",
+  filters = {},
+}) => {
+  const headers = await getAuthHeaders({ contentType: false });
+
+  const url = new URL(`${apiBaseUrl}/findings/metadata/latest`);
 
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);

--- a/ui/actions/findings/findings.ts
+++ b/ui/actions/findings/findings.ts
@@ -44,7 +44,7 @@ export const getFindings = async ({
   }
 };
 
-export const getFindingsLatest = async ({
+export const getLatestFindings = async ({
   page = 1,
   pageSize = 10,
   query = "",
@@ -127,7 +127,7 @@ export const getMetadataInfo = async ({
   }
 };
 
-export const getMetadataInfoLatest = async ({
+export const getLatestMetadataInfo = async ({
   query = "",
   sort = "",
   filters = {},

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -3,9 +3,9 @@ import React, { Suspense } from "react";
 
 import {
   getFindings,
-  getFindingsLatest,
+  getLatestFindings,
   getMetadataInfo,
-  getMetadataInfoLatest,
+  getLatestMetadataInfo,
 } from "@/actions/findings";
 import { getProviders } from "@/actions/providers";
 import { getScans } from "@/actions/scans";
@@ -38,7 +38,7 @@ export default async function Findings({
   const hasDateOrScan = hasDateOrScanFilter(searchParams);
 
   const [metadataInfoData, providersData, scansData] = await Promise.all([
-    (hasDateOrScan ? getMetadataInfo : getMetadataInfoLatest)({
+    (hasDateOrScan ? getMetadataInfo : getLatestMetadataInfo)({
       query,
       sort: encodedSort,
       filters,
@@ -155,7 +155,7 @@ const SSRDataTable = async ({
   // Check if the searchParams contain any date or scan filter
   const hasDateOrScan = hasDateOrScanFilter(searchParams);
 
-  const fetchFindings = hasDateOrScan ? getFindings : getFindingsLatest;
+  const fetchFindings = hasDateOrScan ? getFindings : getLatestFindings;
 
   const findingsData = await fetchFindings({
     query,

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -4,8 +4,8 @@ import React, { Suspense } from "react";
 import {
   getFindings,
   getLatestFindings,
-  getMetadataInfo,
   getLatestMetadataInfo,
+  getMetadataInfo,
 } from "@/actions/findings";
 import { getProviders } from "@/actions/providers";
 import { getScans } from "@/actions/scans";

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -1,8 +1,12 @@
 import { Spacer } from "@nextui-org/react";
-import { format, subDays } from "date-fns";
 import React, { Suspense } from "react";
 
-import { getFindings, getMetadataInfo } from "@/actions/findings";
+import {
+  getFindings,
+  getFindingsLatest,
+  getMetadataInfo,
+  getMetadataInfoLatest,
+} from "@/actions/findings";
 import { getProviders } from "@/actions/providers";
 import { getScans } from "@/actions/scans";
 import { filterFindings } from "@/components/filters/data-filters";
@@ -13,7 +17,12 @@ import {
 } from "@/components/findings/table";
 import { ContentLayout } from "@/components/ui";
 import { DataTable, DataTableFilterCustom } from "@/components/ui/table";
-import { createDict } from "@/lib";
+import {
+  createDict,
+  extractFiltersAndQuery,
+  extractSortAndKey,
+  hasDateOrScanFilter,
+} from "@/lib";
 import { ProviderAccountProps, ProviderProps } from "@/types";
 import { FindingProps, ScanProps, SearchParamsProps } from "@/types/components";
 
@@ -22,41 +31,14 @@ export default async function Findings({
 }: {
   searchParams: SearchParamsProps;
 }) {
-  const searchParamsKey = JSON.stringify(searchParams || {});
-  const sort = searchParams.sort?.toString();
-
-  // Make sure the sort is correctly encoded
-  const encodedSort = sort?.replace(/^\+/, "");
-
-  const twoDaysAgo = format(subDays(new Date(), 2), "yyyy-MM-dd");
+  const { searchParamsKey, encodedSort } = extractSortAndKey(searchParams);
+  const { filters, query } = extractFiltersAndQuery(searchParams);
 
   // Check if the searchParams contain any date or scan filter
-  const hasDateOrScanFilter = Object.keys(searchParams).some(
-    (key) => key.includes("inserted_at") || key.includes("scan__in"),
-  );
-
-  // Default filters for getMetadataInfo
-  const defaultFilters: Record<string, string> = hasDateOrScanFilter
-    ? {} // Do not apply default filters if there are date or scan filters
-    : { "filter[inserted_at__gte]": twoDaysAgo };
-
-  // Extract all filter parameters and combine with default filters
-  const filters: Record<string, string> = {
-    ...defaultFilters,
-    ...Object.fromEntries(
-      Object.entries(searchParams)
-        .filter(([key]) => key.startsWith("filter["))
-        .map(([key, value]) => [
-          key,
-          Array.isArray(value) ? value.join(",") : value?.toString() || "",
-        ]),
-    ),
-  };
-
-  const query = filters["filter[search]"] || "";
+  const hasDateOrScan = hasDateOrScanFilter(searchParams);
 
   const [metadataInfoData, providersData, scansData] = await Promise.all([
-    getMetadataInfo({
+    (hasDateOrScan ? getMetadataInfo : getMetadataInfoLatest)({
       query,
       sort: encodedSort,
       filters,
@@ -163,38 +145,19 @@ const SSRDataTable = async ({
   const page = parseInt(searchParams.page?.toString() || "1", 10);
   const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
   const defaultSort = "severity,status,-inserted_at";
-  const sort = searchParams.sort?.toString() || defaultSort;
 
-  // Make sure the sort is correctly encoded
-  const encodedSort = sort.replace(/^\+/, "");
+  const { encodedSort } = extractSortAndKey({
+    ...searchParams,
+    sort: searchParams.sort ?? defaultSort,
+  });
 
-  const twoDaysAgo = format(subDays(new Date(), 2), "yyyy-MM-dd");
-
+  const { filters, query } = extractFiltersAndQuery(searchParams);
   // Check if the searchParams contain any date or scan filter
-  const hasDateOrScanFilter = Object.keys(searchParams).some(
-    (key) => key.includes("inserted_at") || key.includes("scan__in"),
-  );
+  const hasDateOrScan = hasDateOrScanFilter(searchParams);
 
-  // Default filters for getFindings
-  const defaultFilters: Record<string, string> = hasDateOrScanFilter
-    ? {} // Do not apply default filters if there are date or scan filters
-    : { "filter[inserted_at__gte]": twoDaysAgo };
+  const fetchFindings = hasDateOrScan ? getFindings : getFindingsLatest;
 
-  const filters: Record<string, string> = {
-    ...defaultFilters,
-    ...Object.fromEntries(
-      Object.entries(searchParams)
-        .filter(([key]) => key.startsWith("filter["))
-        .map(([key, value]) => [
-          key,
-          Array.isArray(value) ? value.join(",") : value?.toString() || "",
-        ]),
-    ),
-  };
-
-  const query = filters["filter[search]"] || "";
-
-  const findingsData = await getFindings({
+  const findingsData = await fetchFindings({
     query,
     page,
     sort: encodedSort,

--- a/ui/lib/helper-filters.ts
+++ b/ui/lib/helper-filters.ts
@@ -1,0 +1,46 @@
+/**
+ * Extracts normalized filters and search query from the URL search params.
+ * Used Server Side Rendering (SSR). There is a hook (useUrlFilters) for client side.
+ */
+export const extractFiltersAndQuery = (
+  searchParams: Record<string, unknown>,
+) => {
+  const filters: Record<string, string> = {
+    ...Object.fromEntries(
+      Object.entries(searchParams)
+        .filter(([key]) => key.startsWith("filter["))
+        .map(([key, value]) => [
+          key,
+          Array.isArray(value) ? value.join(",") : value?.toString() || "",
+        ]),
+    ),
+  };
+
+  const query = filters["filter[search]"] || "";
+  return { filters, query };
+};
+
+/**
+ * Returns true if there are any scan or inserted_at filters in the search params.
+ * Used to determine whether to call the full findings endpoint.
+ */
+export const hasDateOrScanFilter = (searchParams: Record<string, unknown>) =>
+  Object.keys(searchParams).some(
+    (key) => key.includes("inserted_at") || key.includes("scan__in"),
+  );
+
+/**
+ * Encodes sort strings by removing leading "+" symbols.
+ */
+export const encodeSort = (sort?: string) => sort?.replace(/^\+/, "") || "";
+
+/**
+ * Extracts the sort string and the stable key to use in Suspense boundaries.
+ */
+export const extractSortAndKey = (searchParams: Record<string, unknown>) => {
+  const searchParamsKey = JSON.stringify(searchParams || {});
+  const rawSort = searchParams.sort?.toString();
+  const encodedSort = encodeSort(rawSort);
+
+  return { searchParamsKey, rawSort, encodedSort };
+};

--- a/ui/lib/index.ts
+++ b/ui/lib/index.ts
@@ -1,4 +1,5 @@
 export * from "./external-urls";
 export * from "./helper";
+export * from "./helper-filters";
 export * from "./menu-list";
 export * from "./utils";


### PR DESCRIPTION


### Description

- Refactor findings page to use `getFindingsLatest` when no scan or date filters are applied. 
- Cleaned up conditional logic in SSRDataTable.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
