### PR TITLE
chore(ec2): improve severity logic in SG all ports open check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Update CIS 4.0 for M365 provider. [(#7699)](https://github.com/prowler-cloud/prowler/pull/7699)
 - Cover policies with conditions with SNS endpoint in `sns_topics_not_publicly_accessible`. [(#7750)](https://github.com/prowler-cloud/prowler/pull/7750)
+- Change severity logic for `ec2_securitygroup_allow_ingress_from_internet_to_all_ports` check. [(#7764)](https://github.com/prowler-cloud/prowler/pull/7764)
 
 ---
 

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports.metadata.json
@@ -8,7 +8,7 @@
   "ServiceName": "ec2",
   "SubServiceName": "securitygroup",
   "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
-  "Severity": "high",
+  "Severity": "critical",
   "ResourceType": "AwsEc2SecurityGroup",
   "Description": "Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to all ports.",
   "Risk": "If Security groups are not properly configured the attack surface is increased. An attacker could exploit this misconfiguration to gain unauthorized access to resources.",

--- a/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports_test.py
+++ b/tests/providers/aws/services/ec2/ec2_securitygroup_allow_ingress_from_internet_to_all_ports/ec2_securitygroup_allow_ingress_from_internet_to_all_ports_test.py
@@ -269,6 +269,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_all_ports:
                         == f"arn:{aws_provider.identity.partition}:ec2:{AWS_REGION_US_EAST_1}:{aws_provider.identity.account}:security-group/{default_sg_id}"
                     )
                     assert sg.resource_details == default_sg_name
+                    assert sg.check_metadata.Severity == "high"
                     assert sg.resource_tags == []
 
     @mock_aws
@@ -361,6 +362,7 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_all_ports:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].check_metadata.Severity == "critical"
 
     @mock_aws
     def test_set_failed_check_called_correctly(self):
@@ -409,7 +411,6 @@ class Test_ec2_securitygroup_allow_ingress_from_internet_to_all_ports:
                 "prowler.providers.aws.lib.service.service.AWSService.set_failed_check"
             ) as mock_set_failed_check,
         ):
-
             from prowler.providers.aws.services.ec2.ec2_securitygroup_allow_ingress_from_internet_to_all_ports.ec2_securitygroup_allow_ingress_from_internet_to_all_ports import (
                 ec2_securitygroup_allow_ingress_from_internet_to_all_ports,
             )


### PR DESCRIPTION
### Description

Improve severity logic in `ec2_securitygroup_allow_ingress_from_internet_to_all_ports` and set a `critical` severity when the SG is attached.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
