### PR TITLE
feat(app): split SDK App service calls

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -81,6 +81,9 @@ Prowler for Azure needs two types of permission scopes to be set:
 
 To assign the permissions, follow the instructions in the [Microsoft Entra ID permissions](../tutorials/azure/create-prowler-service-principal.md#assigning-the-proper-permissions) section and the [Azure subscriptions permissions](../tutorials/azure/subscriptions.md#assign-the-appropriate-permissions-to-the-identity-that-is-going-to-be-assumed-by-prowler) section, respectively.
 
+???+ warning
+    Some permissions in `ProwlerRole` are considered **write** permissions, so if you have a `ReadOnly` lock attached to some resources you may get an error and will not get a finding for that check.
+
 #### Checks that require ProwlerRole
 
 The following checks require the `ProwlerRole` permissions to be executed, if you want to run them, make sure you have assigned the role to the identity that is going to be assumed by Prowler:

--- a/prowler/providers/azure/services/app/app_function_access_keys_configured/app_function_access_keys_configured.py
+++ b/prowler/providers/azure/services/app/app_function_access_keys_configured/app_function_access_keys_configured.py
@@ -11,19 +11,20 @@ class app_function_access_keys_configured(Check):
             functions,
         ) in app_client.functions.items():
             for function in functions.values():
-                report = Check_Report_Azure(metadata=self.metadata(), resource=function)
-                report.subscription = subscription_name
-                report.status = "FAIL"
-                report.status_extended = (
-                    f"Function {function.name} does not have function keys configured."
-                )
-
-                if len(function.function_keys) > 0:
-                    report.status = "PASS"
-                    report.status_extended = (
-                        f"Function {function.name} has function keys configured."
+                if function.function_keys is not None:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=function
                     )
+                    report.subscription = subscription_name
+                    report.status = "FAIL"
+                    report.status_extended = f"Function {function.name} does not have function keys configured."
 
-                findings.append(report)
+                    if len(function.function_keys) > 0:
+                        report.status = "PASS"
+                        report.status_extended = (
+                            f"Function {function.name} has function keys configured."
+                        )
+
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/app/app_function_application_insights_enabled/app_function_application_insights_enabled.py
+++ b/prowler/providers/azure/services/app/app_function_application_insights_enabled/app_function_application_insights_enabled.py
@@ -14,26 +14,29 @@ class app_function_application_insights_enabled(Check):
             functions,
         ) in app_client.functions.items():
             for function in functions.values():
-                report = Check_Report_Azure(metadata=self.metadata(), resource=function)
-                report.subscription = subscription_name
-                report.status = "FAIL"
-                report.status_extended = (
-                    f"Function {function.name} is not using Application Insights."
-                )
-
-                if function.enviroment_variables.get(
-                    "APPINSIGHTS_INSTRUMENTATIONKEY", ""
-                ) in [
-                    component.instrumentation_key
-                    for component in appinsights_client.components[
-                        subscription_name
-                    ].values()
-                ]:
-                    report.status = "PASS"
+                if function.enviroment_variables is not None:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=function
+                    )
+                    report.subscription = subscription_name
+                    report.status = "FAIL"
                     report.status_extended = (
-                        f"Function {function.name} is using Application Insights."
+                        f"Function {function.name} is not using Application Insights."
                     )
 
-                findings.append(report)
+                    if function.enviroment_variables.get(
+                        "APPINSIGHTS_INSTRUMENTATIONKEY", ""
+                    ) in [
+                        component.instrumentation_key
+                        for component in appinsights_client.components[
+                            subscription_name
+                        ].values()
+                    ]:
+                        report.status = "PASS"
+                        report.status_extended = (
+                            f"Function {function.name} is using Application Insights."
+                        )
+
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/app/app_function_latest_runtime_version/app_function_latest_runtime_version.py
+++ b/prowler/providers/azure/services/app/app_function_latest_runtime_version/app_function_latest_runtime_version.py
@@ -11,20 +11,25 @@ class app_function_latest_runtime_version(Check):
             functions,
         ) in app_client.functions.items():
             for function in functions.values():
-                report = Check_Report_Azure(metadata=self.metadata(), resource=function)
-                report.subscription = subscription_name
-                report.status = "PASS"
-                report.status_extended = (
-                    f"Function {function.name} is using the latest runtime."
-                )
+                if function.enviroment_variables is not None:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=function
+                    )
+                    report.subscription = subscription_name
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"Function {function.name} is using the latest runtime."
+                    )
 
-                if (
-                    function.enviroment_variables.get("FUNCTIONS_EXTENSION_VERSION", "")
-                    != "~4"
-                ):
-                    report.status = "FAIL"
-                    report.status_extended = f"Function {function.name} is not using the latest runtime. The current runtime is '{function.enviroment_variables.get('FUNCTIONS_EXTENSION_VERSION', '')}' and should be '~4'."
+                    if (
+                        function.enviroment_variables.get(
+                            "FUNCTIONS_EXTENSION_VERSION", ""
+                        )
+                        != "~4"
+                    ):
+                        report.status = "FAIL"
+                        report.status_extended = f"Function {function.name} is not using the latest runtime. The current runtime is '{function.enviroment_variables.get('FUNCTIONS_EXTENSION_VERSION', '')}' and should be '~4'."
 
-                findings.append(report)
+                    findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

If there was a permissions error when listing the application functions, no finding was generated for that function.

Fix #7651

### Description

- Split the SDK Azure calls in different functions to avoid not generate finding in not affected checks.
- To affected checks ensure first that the configuration to search is not None, in other words, it have been fetched correctly in the service.
- Added a warning in docs about Prowler Role permissions.


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider?
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
