### PR TITLE
fix(providers): Fix m365 UID validation

### DIFF
--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -218,7 +218,11 @@ class Provider(RowLevelSecurityProtectedModel):
 
     @staticmethod
     def validate_m365_uid(value):
-        if not re.match(r"^[a-zA-Z0-9-]+\.com$", value):
+        if not re.match(
+            r"""^(?!-)[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.(?!-)[A-Za-z0-9]"""
+            r"""(?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*\.[A-Za-z]{2,}$""",
+            value,
+        ):
             raise ModelValidationError(
                 detail="M365 domain ID must be a valid domain.",
                 code="m365-uid",
@@ -426,6 +430,7 @@ class Scan(RowLevelSecurityProtectedModel):
         PeriodicTask, on_delete=models.CASCADE, null=True, blank=True
     )
     output_location = models.CharField(blank=True, null=True, max_length=200)
+
     # TODO: mutelist foreign key
 
     class Meta(RowLevelSecurityProtectedModel.Meta):

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -918,6 +918,26 @@ class TestProviderViewSet:
                     "uid": "8851db6b-42e5-4533-aa9e-30a32d67e875",
                     "alias": "test",
                 },
+                {
+                    "provider": "m365",
+                    "uid": "TestingPro.onMirosoft.com",
+                    "alias": "test",
+                },
+                {
+                    "provider": "m365",
+                    "uid": "subdomain.domain.es",
+                    "alias": "test",
+                },
+                {
+                    "provider": "m365",
+                    "uid": "microsoft.net",
+                    "alias": "test",
+                },
+                {
+                    "provider": "m365",
+                    "uid": "subdomain1.subdomain2.subdomain3.subdomain4.domain.net",
+                    "alias": "test",
+                },
             ]
         ),
     )
@@ -985,6 +1005,51 @@ class TestProviderViewSet:
                     },
                     "invalid_choice",
                     "provider",
+                ),
+                (
+                    {
+                        "provider": "m365",
+                        "uid": "https://test.com",
+                        "alias": "test",
+                    },
+                    "m365-uid",
+                    "uid",
+                ),
+                (
+                    {
+                        "provider": "m365",
+                        "uid": "thisisnotadomain",
+                        "alias": "test",
+                    },
+                    "m365-uid",
+                    "uid",
+                ),
+                (
+                    {
+                        "provider": "m365",
+                        "uid": "http://test.com",
+                        "alias": "test",
+                    },
+                    "m365-uid",
+                    "uid",
+                ),
+                (
+                    {
+                        "provider": "m365",
+                        "uid": f"{'a' * 64}.domain.com",
+                        "alias": "test",
+                    },
+                    "m365-uid",
+                    "uid",
+                ),
+                (
+                    {
+                        "provider": "m365",
+                        "uid": f"subdomain.{'a' * 64}.com",
+                        "alias": "test",
+                    },
+                    "m365-uid",
+                    "uid",
                 ),
             ]
         ),


### PR DESCRIPTION
### Description

A more accurate regex has been added to validate M365 UIDs in the API, in addition to test cases.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
