### PR TITLE
fix: AWS I AM role validation when field is empty

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -3,9 +3,13 @@
 All notable changes to the **Prowler UI** are documented in this file.
 
 ## [v1.8.0] (Prowler v5.8.0) – Not released
- - Added validation to AWS IAM role. [(#7787)](https://github.com/prowler-cloud/prowler/pull/7787)
 
+### 🐞 Fixes
+
+- Added validation to AWS IAM role. [(#7787)](https://github.com/prowler-cloud/prowler/pull/7787)
+  
 ---
+
 ## [v1.7.0] (Prowler v5.7.0)
 
 ### 🚀 Added

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the **Prowler UI** are documented in this file.
 
 ## [v1.8.0] (Prowler v5.8.0) – Not released
+ - Added validation to AWS IAM role. [(#7787)](https://github.com/prowler-cloud/prowler/pull/7787)
 
 ---
 ## [v1.7.0] (Prowler v5.7.0)

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -155,7 +155,7 @@ export const addCredentialsRoleFormSchema = (providerType: string) =>
         .object({
           providerId: z.string(),
           providerType: z.string(),
-          role_arn: z.string().optional(),
+          role_arn: z.string().nonempty("AWS Role ARN is required"),
           external_id: z.string().optional(),
           aws_access_key_id: z.string().optional(),
           aws_secret_access_key: z.string().optional(),


### PR DESCRIPTION
### Context

AWS IAM Role Credentials - Validation when all fields are empty

### Description

Added validation to the IAM role as mandatory so that it will error when empty 
![image](https://github.com/user-attachments/assets/eca35d73-ab91-4b04-a088-b393d15ff83d)


### Checklist

- Are there new checks included in this PR? No
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
