### PR TITLE
chore(backport): create label on minor release

### DIFF
--- a/.github/workflows/create-backport-label.yml
+++ b/.github/workflows/create-backport-label.yml
@@ -1,0 +1,67 @@
+name: Create Backport Label
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  create_label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Create backport label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          OWNER_REPO: ${{ github.repository }}
+        run: |
+          VERSION_ONLY=${RELEASE_TAG#v} # Remove 'v' prefix if present (e.g., v3.2.0 -> 3.2.0)
+
+          # Check if it's a minor version (X.Y.0)
+          if [[ "$VERSION_ONLY" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "Release ${RELEASE_TAG} (version ${VERSION_ONLY}) is a minor version. Proceeding to create backport label."
+
+            FINAL_LABEL_NAME="backport-to-v${VERSION_ONLY}"
+            FINAL_DESCRIPTION="Backport PR to the v${VERSION_ONLY} branch"
+
+            echo "Effective label name will be: ${FINAL_LABEL_NAME}"
+            echo "Effective description will be: ${FINAL_DESCRIPTION}"
+
+            # Check if the label already exists
+            STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${OWNER_REPO}/labels/${FINAL_LABEL_NAME}")
+
+            if [ "${STATUS_CODE}" -eq 200 ]; then
+              echo "Label '${FINAL_LABEL_NAME}' already exists."
+            elif [ "${STATUS_CODE}" -eq 404 ]; then
+              echo "Label '${FINAL_LABEL_NAME}' does not exist. Creating it..."
+              # Prepare JSON data payload
+              JSON_DATA=$(printf '{"name":"%s","description":"%s","color":"B60205"}' "${FINAL_LABEL_NAME}" "${FINAL_DESCRIPTION}")
+
+              CREATE_STATUS_CODE=$(curl -s -o /tmp/curl_create_response.json -w "%{http_code}" -X POST \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              --data "${JSON_DATA}" \
+              "https://api.github.com/repos/${OWNER_REPO}/labels")
+
+              CREATE_RESPONSE_BODY=$(cat /tmp/curl_create_response.json)
+              rm -f /tmp/curl_create_response.json # Clean up temporary file
+
+              if [ "$CREATE_STATUS_CODE" -eq 201 ]; then
+                echo "Label '${FINAL_LABEL_NAME}' created successfully."
+              else
+                echo "Error creating label '${FINAL_LABEL_NAME}'. Status: $CREATE_STATUS_CODE"
+                echo "Response: $CREATE_RESPONSE_BODY"
+                exit 1
+              fi
+            else
+              echo "Error checking for label '${FINAL_LABEL_NAME}'. HTTP Status: ${STATUS_CODE}"
+              # If you want to see the response for other errors, you can add a curl call here, e.g.:
+              # curl -s -i -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${OWNER_REPO}/labels/${FINAL_LABEL_NAME}"
+              exit 1
+            fi
+          else
+            echo "Release ${RELEASE_TAG} (version ${VERSION_ONLY}) is not a minor version. Skipping backport label creation."
+            exit 0 # Exit successfully as this is not an error for the workflow
+          fi

--- a/.github/workflows/create-backport-label.yml
+++ b/.github/workflows/create-backport-label.yml
@@ -23,8 +23,10 @@ jobs:
           if [[ "$VERSION_ONLY" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
             echo "Release ${RELEASE_TAG} (version ${VERSION_ONLY}) is a minor version. Proceeding to create backport label."
 
-            FINAL_LABEL_NAME="backport-to-v${VERSION_ONLY}"
-            FINAL_DESCRIPTION="Backport PR to the v${VERSION_ONLY} branch"
+            TWO_DIGIT_VERSION=${VERSION_ONLY%.0} # Extract X.Y from X.Y.0 (e.g., 5.6 from 5.6.0)
+
+            FINAL_LABEL_NAME="backport-to-v${TWO_DIGIT_VERSION}"
+            FINAL_DESCRIPTION="Backport PR to the v${TWO_DIGIT_VERSION} branch"
 
             echo "Effective label name will be: ${FINAL_LABEL_NAME}"
             echo "Effective description will be: ${FINAL_DESCRIPTION}"
@@ -46,7 +48,7 @@ jobs:
               "https://api.github.com/repos/${OWNER_REPO}/labels")
 
               CREATE_RESPONSE_BODY=$(cat /tmp/curl_create_response.json)
-              rm -f /tmp/curl_create_response.json # Clean up temporary file
+              rm -f /tmp/curl_create_response.json
 
               if [ "$CREATE_STATUS_CODE" -eq 201 ]; then
                 echo "Label '${FINAL_LABEL_NAME}' created successfully."
@@ -57,11 +59,9 @@ jobs:
               fi
             else
               echo "Error checking for label '${FINAL_LABEL_NAME}'. HTTP Status: ${STATUS_CODE}"
-              # If you want to see the response for other errors, you can add a curl call here, e.g.:
-              # curl -s -i -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/${OWNER_REPO}/labels/${FINAL_LABEL_NAME}"
               exit 1
             fi
           else
             echo "Release ${RELEASE_TAG} (version ${VERSION_ONLY}) is not a minor version. Skipping backport label creation."
-            exit 0 # Exit successfully as this is not an error for the workflow
+            exit 0
           fi


### PR DESCRIPTION
### Description

Create `backport-to-vX.Y` label automatically on release.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
