### PR TITLE
fix: retrieve more than 10 providers

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixes
 
 - Added validation to AWS IAM role. [(#7787)](https://github.com/prowler-cloud/prowler/pull/7787)
-  
+- Retrieve more than 10 providers in /scans, /manage-groups and /findings pages. [(#7793)](https://github.com/prowler-cloud/prowler/pull/7793)
+
 ---
 
 ## [v1.7.0] (Prowler v5.7.0)

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -43,7 +43,7 @@ export default async function Findings({
       sort: encodedSort,
       filters,
     }),
-    getProviders({ pageSize: 100 }),
+    getProviders({ pageSize: 50 }),
     getScans({}),
   ]);
 

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -43,7 +43,7 @@ export default async function Findings({
       sort: encodedSort,
       filters,
     }),
-    getProviders({}),
+    getProviders({ pageSize: 100 }),
     getScans({}),
   ]);
 

--- a/ui/app/(prowler)/manage-groups/page.tsx
+++ b/ui/app/(prowler)/manage-groups/page.tsx
@@ -58,7 +58,7 @@ export default function ManageGroupsPage({
 }
 
 const SSRAddGroupForm = async () => {
-  const providersResponse = await getProviders({ pageSize: 100 });
+  const providersResponse = await getProviders({ pageSize: 50 });
   const rolesResponse = await getRoles({});
 
   const providersData =
@@ -95,7 +95,7 @@ const SSRDataEditGroup = async ({
     return <div>Provider group not found</div>;
   }
 
-  const providersResponse = await getProviders({ pageSize: 100 });
+  const providersResponse = await getProviders({ pageSize: 50 });
   const rolesResponse = await getRoles({});
 
   const providersList =

--- a/ui/app/(prowler)/manage-groups/page.tsx
+++ b/ui/app/(prowler)/manage-groups/page.tsx
@@ -58,7 +58,7 @@ export default function ManageGroupsPage({
 }
 
 const SSRAddGroupForm = async () => {
-  const providersResponse = await getProviders({});
+  const providersResponse = await getProviders({ pageSize: 100 });
   const rolesResponse = await getRoles({});
 
   const providersData =
@@ -95,7 +95,7 @@ const SSRDataEditGroup = async ({
     return <div>Provider group not found</div>;
   }
 
-  const providersResponse = await getProviders({});
+  const providersResponse = await getProviders({ pageSize: 100 });
   const rolesResponse = await getRoles({});
 
   const providersList =

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -29,7 +29,7 @@ export default async function Scans({
     filters: {
       "filter[connected]": true,
     },
-    pageSize: 100,
+    pageSize: 50,
   });
 
   const providerInfo =
@@ -43,7 +43,7 @@ export default async function Scans({
 
   const providersCountConnected = await getProviders({
     filters: { "filter[connected]": true },
-    pageSize: 100,
+    pageSize: 50,
   });
   const thereIsNoProviders =
     !providersCountConnected?.data || providersCountConnected.data.length === 0;

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -29,6 +29,7 @@ export default async function Scans({
     filters: {
       "filter[connected]": true,
     },
+    pageSize: 100,
   });
 
   const providerInfo =
@@ -42,6 +43,7 @@ export default async function Scans({
 
   const providersCountConnected = await getProviders({
     filters: { "filter[connected]": true },
+    pageSize: 100,
   });
   const thereIsNoProviders =
     !providersCountConnected?.data || providersCountConnected.data.length === 0;


### PR DESCRIPTION
### Context

Tenants with more than 10 providers cannot retrieve all of them.

### Description

We were asking the API only the first 10 providers in /findings and /scans. We're going to ask for 100 (all of them), ATM only 6 tenants have more than 10 providers, asking for 50 in the actions will return "all".

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
