### PR TITLE
feat(findings): Add new index for finding UID lookup

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ## [v1.8.1] (Prowler v5.7.1)
 
 ### Fixed
-- Added database index to improve performance on finding lookup. [()]()
+- Added database index to improve performance on finding lookup. [(#7800)](https://github.com/prowler-cloud/prowler/pull/7800)
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [v1.8.1] (Prowler v5.7.1)
+
+### Fixed
+- Added database index to improve performance on finding lookup. [()]()
+
+---
+
 ## [v1.8.0] (Prowler v5.7.0)
 
 ### Added

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -35,7 +35,7 @@ name = "prowler-api"
 package-mode = false
 # Needed for the SDK compatibility
 requires-python = ">=3.11,<3.13"
-version = "1.8.0"
+version = "1.8.1"
 
 [project.scripts]
 celery = "src.backend.config.settings.celery"

--- a/api/src/backend/api/migrations/0024_findings_uid_index_partitions.py
+++ b/api/src/backend/api/migrations/0024_findings_uid_index_partitions.py
@@ -1,0 +1,29 @@
+from functools import partial
+
+from django.db import migrations
+
+from api.db_utils import create_index_on_partitions, drop_index_on_partitions
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("api", "0023_resources_lookup_optimization"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            partial(
+                create_index_on_partitions,
+                parent_table="findings",
+                index_name="find_tenant_uid_inserted_idx",
+                columns="tenant_id, uid, inserted_at DESC",
+            ),
+            reverse_code=partial(
+                drop_index_on_partitions,
+                parent_table="findings",
+                index_name="find_tenant_uid_inserted_idx",
+            ),
+        )
+    ]

--- a/api/src/backend/api/migrations/0025_findings_uid_index_parent.py
+++ b/api/src/backend/api/migrations/0025_findings_uid_index_parent.py
@@ -10,7 +10,8 @@ class Migration(migrations.Migration):
         migrations.AddIndex(
             model_name="finding",
             index=models.Index(
-                fields=["tenant_id", "uid", "-inserted_at"], name="find_tenant_uid_inserted_idx"
+                fields=["tenant_id", "uid", "-inserted_at"],
+                name="find_tenant_uid_inserted_idx",
             ),
         ),
     ]

--- a/api/src/backend/api/migrations/0025_findings_uid_index_parent.py
+++ b/api/src/backend/api/migrations/0025_findings_uid_index_parent.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0024_findings_uid_index_partitions"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="finding",
+            index=models.Index(
+                fields=["tenant_id", "uid", "-inserted_at"], name="find_tenant_uid_inserted_idx"
+            ),
+        ),
+    ]

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -755,6 +755,10 @@ class Finding(PostgresPartitionedModel, RowLevelSecurityProtectedModel):
                 condition=Q(delta="new"),
                 name="find_delta_new_idx",
             ),
+            models.Index(
+                fields=["tenant_id", "uid", "-inserted_at"],
+                name="find_tenant_uid_inserted_idx",
+            ),
             GinIndex(fields=["resource_services"], name="gin_find_service_idx"),
             GinIndex(fields=["resource_regions"], name="gin_find_region_idx"),
             GinIndex(fields=["resource_types"], name="gin_find_rtype_idx"),

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Prowler API
-  version: 1.8.0
+  version: 1.8.1
   description: |-
     Prowler API specification.
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -260,7 +260,7 @@ class SchemaView(SpectacularAPIView):
 
     def get(self, request, *args, **kwargs):
         spectacular_settings.TITLE = "Prowler API"
-        spectacular_settings.VERSION = "1.8.0"
+        spectacular_settings.VERSION = "1.8.1"
         spectacular_settings.DESCRIPTION = (
             "Prowler API specification.\n\nThis file is auto-generated."
         )


### PR DESCRIPTION
### Context

During the latest release, we removed an important database index used during scans to identify findings by UID.

### Description

An improved index has been added to improve performance during scans and relieve database load.

![image](https://github.com/user-attachments/assets/060c2406-4287-4d2c-aebe-1bbc66b245cc)

<details>

<summary>Affected query</summary>

```
SELECT "findings"."status", "findings"."first_seen_at" FROM "findings" WHERE ("findings"."tenant_id" = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid AND "findings"."uid" = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown') ORDER BY "findings"."inserted_at" DESC LIMIT 1
```

```
                QUERY PLAN                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.38..9.14 rows=1 width=20) (actual time=0.462..0.498 rows=0 loops=1)
   ->  Merge Append  (cost=1.38..63.45 rows=8 width=20) (actual time=0.369..0.378 rows=0 loops=1)
         Sort Key: findings.inserted_at DESC
         ->  Index Scan using findings_2025_may_tenant_id_uid_inserted_at_idx on findings_2025_may findings_1  (cost=0.28..6.05 rows=1 width=20) (actual time=0.127..0.128 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
         ->  Index Scan using findings_2025_jun_tenant_id_uid_inserted_at_idx on findings_2025_jun findings_2  (cost=0.14..8.16 rows=1 width=20) (actual time=0.015..0.015 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
         ->  Index Scan using findings_2025_jul_tenant_id_uid_inserted_at_idx on findings_2025_jul findings_3  (cost=0.14..8.16 rows=1 width=20) (actual time=0.005..0.005 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
         ->  Index Scan using findings_2025_aug_tenant_id_uid_inserted_at_idx on findings_2025_aug findings_4  (cost=0.14..8.16 rows=1 width=20) (actual time=0.005..0.005 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
         ->  Index Scan using findings_2025_sep_tenant_id_uid_inserted_at_idx on findings_2025_sep findings_5  (cost=0.14..8.16 rows=1 width=20) (actual time=0.005..0.005 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
         ->  Index Scan using findings_2025_oct_tenant_id_uid_inserted_at_idx on findings_2025_oct findings_6  (cost=0.14..8.16 rows=1 width=20) (actual time=0.004..0.004 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
         ->  Index Scan using findings_2025_nov_tenant_id_uid_inserted_at_idx on findings_2025_nov findings_7  (cost=0.14..8.16 rows=1 width=20) (actual time=0.011..0.011 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
         ->  Index Scan using findings_default_find_tenant_uid_inserted_idx on findings_default findings_8  (cost=0.14..8.16 rows=1 width=20) (actual time=0.159..0.159 rows=0 loops=1)
               Index Cond: ((tenant_id = '4edc8512-e99d-4f51-b0ca-53b1d50e89e6'::uuid) AND ((uid)::text = 'prowler-aws-accessanalyzer_enabled-805101104197-eu-west-1-analyzer/unknown'::text))
 Planning Time: 30.323 ms
 Execution Time: 1.987 ms
(21 rows)
```

</details>

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
