### PR TITLE
feat: implement provider UID extraction and mapping in scans pages

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - New profile page with details about the user and their roles. [(#7780)](https://github.com/prowler-cloud/prowler/pull/7780)
 - Improved `SnippetChip` component and show resource name in new findings table. [(#7813)](https://github.com/prowler-cloud/prowler/pull/7813)
+- Add `Provider UID` filter to scans page. [(#7820)](https://github.com/prowler-cloud/prowler/pull/7820)
 
 ---
 

--- a/ui/actions/providers/providers.ts
+++ b/ui/actions/providers/providers.ts
@@ -10,6 +10,7 @@ import {
   parseStringify,
   wait,
 } from "@/lib";
+import { ProvidersApiResponse } from "@/types/providers";
 
 export const getProviders = async ({
   page = 1,
@@ -17,7 +18,7 @@ export const getProviders = async ({
   sort = "",
   filters = {},
   pageSize = 10,
-}) => {
+}): Promise<ProvidersApiResponse | undefined> => {
   const headers = await getAuthHeaders({ contentType: false });
 
   if (isNaN(Number(page)) || page < 1) redirect("/providers");

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -100,21 +100,25 @@ export default async function Findings({
             key: "region__in",
             labelCheckboxGroup: "Regions",
             values: uniqueRegions,
+            index: 5,
           },
           {
             key: "service__in",
             labelCheckboxGroup: "Services",
             values: uniqueServices,
+            index: 6,
           },
           {
             key: "resource_type__in",
             labelCheckboxGroup: "Resource Type",
             values: uniqueResourceTypes,
+            index: 7,
           },
           {
             key: "scan__in",
             labelCheckboxGroup: "Scan ID",
             values: completedScanIds,
+            index: 9,
           },
         ]}
         defaultOpen={true}

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -56,11 +56,11 @@ export default async function Findings({
   const uniqueResourceTypes =
     metadataInfoData?.data?.attributes?.resource_types || [];
 
-  const providerUIDs = extractProviderUIDs(providersData);
-  const providerDetails = createProviderDetailsMapping(
-    providerUIDs,
-    providersData,
-  );
+  // Extract provider UIDs and details using helper functions
+  const providerUIDs = providersData ? extractProviderUIDs(providersData) : [];
+  const providerDetails = providersData
+    ? createProviderDetailsMapping(providerUIDs, providersData)
+    : [];
 
   // Update the Provider UID filter
   const updatedFilters = filterFindings.map((filter) => {

--- a/ui/app/(prowler)/manage-groups/page.tsx
+++ b/ui/app/(prowler)/manage-groups/page.tsx
@@ -115,7 +115,7 @@ const SSRDataEditGroup = async ({
   const associatedProviders = relationships.providers?.data.map(
     (provider: ProviderProps) => {
       const matchingProvider = providersList.find(
-        (p: ProviderProps) => p.id === provider.id,
+        (p: { id: string; name: string }) => p.id === provider.id,
       );
       return {
         id: provider.id,

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -14,6 +14,10 @@ import { SkeletonTableScans } from "@/components/scans/table";
 import { ColumnGetScans } from "@/components/scans/table/scans";
 import { ContentLayout } from "@/components/ui";
 import { DataTable, DataTableFilterCustom } from "@/components/ui/table";
+import {
+  createProviderDetailsMapping,
+  extractProviderUIDs,
+} from "@/lib/provider-helpers";
 import { ProviderProps, ScanProps, SearchParamsProps } from "@/types";
 
 export default async function Scans({
@@ -61,6 +65,24 @@ export default async function Scans({
       scan.attributes.state === "available",
   );
 
+  const providerUIDs = extractProviderUIDs(providersData);
+  const providerDetails = createProviderDetailsMapping(
+    providerUIDs,
+    providersData,
+  );
+
+  // Update the Provider UID filter
+  const updatedFilters = filterScans.map((filter) => {
+    if (filter.key === "provider_uid__in") {
+      return {
+        ...filter,
+        values: providerUIDs,
+        valueLabelMapping: providerDetails,
+      };
+    }
+    return filter;
+  });
+
   return (
     <>
       {thereIsNoProviders && (
@@ -89,7 +111,7 @@ export default async function Scans({
           <div className="grid grid-cols-12 items-start gap-4 px-6 py-4 sm:px-8 xl:px-10">
             <div className="col-span-12">
               <div className="flex flex-row items-center justify-between">
-                <DataTableFilterCustom filters={filterScans || []} />
+                <DataTableFilterCustom filters={updatedFilters || []} />
                 <Spacer x={4} />
                 <FilterControls />
               </div>

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -65,11 +65,11 @@ export default async function Scans({
       scan.attributes.state === "available",
   );
 
-  const providerUIDs = extractProviderUIDs(providersData);
-  const providerDetails = createProviderDetailsMapping(
-    providerUIDs,
-    providersData,
-  );
+  // Extract provider UIDs and create provider details mapping for filtering
+  const providerUIDs = providersData ? extractProviderUIDs(providersData) : [];
+  const providerDetails = providersData
+    ? createProviderDetailsMapping(providerUIDs, providersData)
+    : [];
 
   // Update the Provider UID filter
   const updatedFilters = filterScans.map((filter) => {

--- a/ui/components/filters/data-filters.ts
+++ b/ui/components/filters/data-filters.ts
@@ -43,26 +43,31 @@ export const filterFindings = [
     key: "severity__in",
     labelCheckboxGroup: "Severity",
     values: ["critical", "high", "medium", "low", "informational"],
+    index: 1,
   },
   {
     key: "status__in",
     labelCheckboxGroup: "Status",
     values: ["PASS", "FAIL", "MANUAL"],
-  },
-  {
-    key: "delta__in",
-    labelCheckboxGroup: "Delta",
-    values: ["new", "changed"],
+    index: 2,
   },
   {
     key: "provider_type__in",
     labelCheckboxGroup: "Cloud Provider",
     values: ["aws", "azure", "m365", "gcp", "kubernetes"],
+    index: 4,
   },
   {
     key: "provider_uid__in",
     labelCheckboxGroup: "Provider UID",
     values: [],
+    index: 8,
+  },
+  {
+    key: "delta__in",
+    labelCheckboxGroup: "Delta",
+    values: ["new", "changed"],
+    index: 3,
   },
   // Add more filter categories as needed
 ];

--- a/ui/components/filters/data-filters.ts
+++ b/ui/components/filters/data-filters.ts
@@ -30,6 +30,11 @@ export const filterScans = [
     labelCheckboxGroup: "Trigger",
     values: ["scheduled", "manual"],
   },
+  {
+    key: "provider_uid__in",
+    labelCheckboxGroup: "Provider UID",
+    values: [],
+  },
   // Add more filter categories as needed
 ];
 
@@ -53,6 +58,11 @@ export const filterFindings = [
     key: "provider_type__in",
     labelCheckboxGroup: "Cloud Provider",
     values: ["aws", "azure", "m365", "gcp", "kubernetes"],
+  },
+  {
+    key: "provider_uid__in",
+    labelCheckboxGroup: "Provider UID",
+    values: [],
   },
   // Add more filter categories as needed
 ];

--- a/ui/components/ui/custom/custom-dropdown-filter.tsx
+++ b/ui/components/ui/custom/custom-dropdown-filter.tsx
@@ -213,7 +213,7 @@ export const CustomDropdownFilter: React.FC<CustomDropdownFilterProps> = ({
                       {entity ? (
                         <EntityInfoShort
                           cloudProvider={entity.provider}
-                          entityAlias={entity.alias}
+                          entityAlias={entity.alias ?? undefined}
                           entityId={entity.uid}
                           hideCopyButton
                         />

--- a/ui/components/ui/table/data-table-filter-custom.tsx
+++ b/ui/components/ui/table/data-table-filter-custom.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import { CustomFilterIcon } from "@/components/icons";
 import { CustomButton, CustomDropdownFilter } from "@/components/ui/custom";
@@ -20,6 +20,21 @@ export const DataTableFilterCustom = ({
   const { updateFilter } = useUrlFilters();
   const [showFilters, setShowFilters] = useState(defaultOpen);
 
+  // Sort filters by index property, with fallback to original order for filters without index
+  const sortedFilters = useMemo(() => {
+    return [...filters].sort((a, b) => {
+      // If both have index, sort by index
+      if (a.index !== undefined && b.index !== undefined) {
+        return a.index - b.index;
+      }
+      // If only one has index, prioritize the one with index
+      if (a.index !== undefined) return -1;
+      if (b.index !== undefined) return 1;
+      // If neither has index, maintain original order
+      return 0;
+    });
+  }, [filters]);
+
   const pushDropdownFilter = useCallback(
     (key: string, values: string[]) => {
       updateFilter(key, values.length > 0 ? values : null);
@@ -30,7 +45,7 @@ export const DataTableFilterCustom = ({
   return (
     <div
       className={`flex ${
-        filters.length > 4 ? "flex-col" : "flex-col md:flex-row"
+        sortedFilters.length > 4 ? "flex-col" : "flex-col md:flex-row"
       } gap-4`}
     >
       <CustomButton
@@ -56,12 +71,12 @@ export const DataTableFilterCustom = ({
       >
         <div
           className={`grid gap-4 ${
-            filters.length >= 4
+            sortedFilters.length >= 4
               ? "grid-cols-1 md:grid-cols-4"
               : "grid-cols-1 md:grid-cols-3"
           }`}
         >
-          {filters.map((filter) => (
+          {sortedFilters.map((filter) => (
             <CustomDropdownFilter
               key={filter.key}
               filter={{

--- a/ui/components/ui/table/data-table-filter-custom.tsx
+++ b/ui/components/ui/table/data-table-filter-custom.tsx
@@ -56,7 +56,7 @@ export const DataTableFilterCustom = ({
       >
         <div
           className={`grid gap-4 ${
-            filters.length > 4
+            filters.length >= 4
               ? "grid-cols-1 md:grid-cols-4"
               : "grid-cols-1 md:grid-cols-3"
           }`}

--- a/ui/lib/provider-helpers.ts
+++ b/ui/lib/provider-helpers.ts
@@ -1,0 +1,34 @@
+import { ProviderAccountProps, ProviderProps } from "@/types/providers";
+
+export const extractProviderUIDs = (providersData: any): string[] => {
+  if (!providersData?.data) return [];
+
+  return Array.from(
+    new Set(
+      providersData.data
+        .map((provider: ProviderProps) => provider.attributes?.uid)
+        .filter(Boolean),
+    ),
+  );
+};
+
+export const createProviderDetailsMapping = (
+  providerUIDs: string[],
+  providersData: any,
+): Array<{ [uid: string]: ProviderAccountProps }> => {
+  if (!providersData?.data) return [];
+
+  return providerUIDs.map((uid) => {
+    const provider = providersData.data.find(
+      (p: { attributes: { uid: string } }) => p.attributes?.uid === uid,
+    );
+
+    return {
+      [uid]: {
+        provider: provider?.attributes?.provider || "",
+        uid: uid,
+        alias: provider?.attributes?.alias ?? null,
+      },
+    };
+  });
+};

--- a/ui/lib/provider-helpers.ts
+++ b/ui/lib/provider-helpers.ts
@@ -1,6 +1,12 @@
-import { ProviderAccountProps, ProviderProps } from "@/types/providers";
+import {
+  ProviderAccountProps,
+  ProviderProps,
+  ProvidersApiResponse,
+} from "@/types/providers";
 
-export const extractProviderUIDs = (providersData: any): string[] => {
+export const extractProviderUIDs = (
+  providersData: ProvidersApiResponse,
+): string[] => {
   if (!providersData?.data) return [];
 
   return Array.from(
@@ -14,7 +20,7 @@ export const extractProviderUIDs = (providersData: any): string[] => {
 
 export const createProviderDetailsMapping = (
   providerUIDs: string[],
-  providersData: any,
+  providersData: ProvidersApiResponse,
 ): Array<{ [uid: string]: ProviderAccountProps }> => {
   if (!providersData?.data) return [];
 
@@ -25,7 +31,7 @@ export const createProviderDetailsMapping = (
 
     return {
       [uid]: {
-        provider: provider?.attributes?.provider || "",
+        provider: provider?.attributes?.provider || "aws",
         uid: uid,
         alias: provider?.attributes?.alias ?? null,
       },

--- a/ui/types/filters.ts
+++ b/ui/types/filters.ts
@@ -5,6 +5,7 @@ export interface FilterOption {
   labelCheckboxGroup: string;
   values: string[];
   valueLabelMapping?: Array<{ [uid: string]: ProviderAccountProps }>;
+  index?: number;
 }
 
 export interface CustomDropdownFilterProps {

--- a/ui/types/providers.ts
+++ b/ui/types/providers.ts
@@ -48,7 +48,7 @@ export interface ProviderProps {
 export interface ProviderAccountProps {
   provider: ProviderType;
   uid: string;
-  alias: string;
+  alias: string | null;
 }
 
 export interface ProviderOverviewProps {
@@ -68,6 +68,30 @@ export interface ProviderOverviewProps {
     };
   }[];
   meta: {
+    version: string;
+  };
+}
+
+export interface ProvidersApiResponse {
+  links: {
+    first: string;
+    last: string;
+    next: string | null;
+    prev: string | null;
+  };
+  data: ProviderProps[];
+  included?: Array<{
+    type: string;
+    id: string;
+    attributes: any;
+    relationships?: any;
+  }>;
+  meta: {
+    pagination: {
+      page: number;
+      pages: number;
+      count: number;
+    };
     version: string;
   };
 }


### PR DESCRIPTION
### Context

https://prowlerpro.atlassian.net/browse/PRWLR-7196
In /scan page, we need to add the same filter that we’re using already in /findings page for “Provider UID"

### Description

- Logic extracted, as is the same one for both pages.
- Filter implemented in /scans
- Improve the API's response typing for /providers through the app

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
