### PR TITLE
fix(m365): remove last encrypted password appearances

### DIFF
--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -9242,7 +9242,7 @@ components:
                         description: User microsoft email address.
                       password:
                         type: string
-                        description: User encrypted password.
+                        description: User password.
                     required:
                     - client_id
                     - client_secret
@@ -10487,7 +10487,7 @@ components:
                     description: User microsoft email address.
                   password:
                     type: string
-                    description: User encrypted password.
+                    description: User password.
                 required:
                 - client_id
                 - client_secret
@@ -10696,7 +10696,7 @@ components:
                         description: User microsoft email address.
                       password:
                         type: string
-                        description: User encrypted password.
+                        description: User password.
                     required:
                     - client_id
                     - client_secret
@@ -10921,7 +10921,7 @@ components:
                     description: User microsoft email address.
                   password:
                     type: string
-                    description: User encrypted password.
+                    description: User password.
                 required:
                 - client_id
                 - client_secret

--- a/api/src/backend/api/v1/serializer_utils/providers.py
+++ b/api/src/backend/api/v1/serializer_utils/providers.py
@@ -121,7 +121,7 @@ from rest_framework_json_api import serializers
                     },
                     "password": {
                         "type": "string",
-                        "description": "User encrypted password.",
+                        "description": "User password.",
                     },
                 },
                 "required": [

--- a/prowler/providers/m365/exceptions/exceptions.py
+++ b/prowler/providers/m365/exceptions/exceptions.py
@@ -106,9 +106,9 @@ class M365BaseException(ProwlerException):
             "message": "The provided User is not valid.",
             "remediation": "Check the User and ensure it is a valid user.",
         },
-        (6025, "M365NotValidEncryptedPasswordError"): {
-            "message": "The provided Encrypted Password is not valid.",
-            "remediation": "Check the Encrypted Password and ensure it is a valid password.",
+        (6025, "M365NotValidPasswordError"): {
+            "message": "The provided Password is not valid.",
+            "remediation": "Check the Password and ensure it is a valid password.",
         },
         (6026, "M365UserNotBelongingToTenantError"): {
             "message": "The provided User does not belong to the specified tenant.",
@@ -312,7 +312,7 @@ class M365NotValidUserError(M365CredentialsError):
         )
 
 
-class M365NotValidEncryptedPasswordError(M365CredentialsError):
+class M365NotValidPasswordError(M365CredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             6025, file=file, original_exception=original_exception, message=message

--- a/prowler/providers/m365/m365_provider.py
+++ b/prowler/providers/m365/m365_provider.py
@@ -43,7 +43,7 @@ from prowler.providers.m365.exceptions.exceptions import (
     M365NotTenantIdButClientIdAndClientSecretError,
     M365NotValidClientIdError,
     M365NotValidClientSecretError,
-    M365NotValidEncryptedPasswordError,
+    M365NotValidPasswordError,
     M365NotValidTenantIdError,
     M365NotValidUserError,
     M365SetUpRegionConfigError,
@@ -296,7 +296,7 @@ class M365Provider(Provider):
             client_id (str): The M365 Client ID.
             client_secret (str): The M365 Client Secret.
             user (str): The M365 User Account.
-            encrpted_password (str): The M365 Encrypted Password.
+            password (str): The M365 User Password.
 
         Raises:
             M365BrowserAuthNoTenantIDError: If browser authentication is enabled but the tenant ID is not found.
@@ -494,7 +494,7 @@ class M365Provider(Provider):
                 - client_id: The M365 client ID.
                 - client_secret: The M365 client secret
                 - user: The M365 user email
-                - password: The M365 encrypted password
+                - password: The M365 user password
                 - provider_id: The M365 provider ID (in this case the Tenant ID).
             region_config (M365RegionConfig): The region configuration object.
 
@@ -985,7 +985,7 @@ class M365Provider(Provider):
             client_id (str): The M365 client ID.
             client_secret (str): The M365 client secret.
             user (str): The M365 user email.
-            password (str): The M365 encrypted password.
+            password (str): The M365 user password.
 
         Raises:
             M365NotValidTenantIdError: If the provided M365 Tenant ID is not valid.
@@ -1030,11 +1030,11 @@ class M365Provider(Provider):
                 message="The provided User is not valid.",
             )
 
-        # Validate the Encrypted Password
+        # Validate the Password
         if not password:
-            raise M365NotValidEncryptedPasswordError(
+            raise M365NotValidPasswordError(
                 file=os.path.basename(__file__),
-                message="The provided Encrypted Password is not valid.",
+                message="The provided Password is not valid.",
             )
 
         try:

--- a/tests/providers/m365/m365_provider_test.py
+++ b/tests/providers/m365/m365_provider_test.py
@@ -24,7 +24,7 @@ from prowler.providers.m365.exceptions.exceptions import (
     M365NoAuthenticationMethodError,
     M365NotValidClientIdError,
     M365NotValidClientSecretError,
-    M365NotValidEncryptedPasswordError,
+    M365NotValidPasswordError,
     M365NotValidTenantIdError,
     M365NotValidUserError,
     M365UserNotBelongingToTenantError,
@@ -396,14 +396,12 @@ class TestM365Provider:
         with patch(
             "prowler.providers.m365.m365_provider.M365Provider.validate_static_credentials"
         ) as mock_validate_static_credentials:
-            mock_validate_static_credentials.side_effect = (
-                M365NotValidEncryptedPasswordError(
-                    file=os.path.basename(__file__),
-                    message="The provided M365 Encrypted Password is not valid.",
-                )
+            mock_validate_static_credentials.side_effect = M365NotValidPasswordError(
+                file=os.path.basename(__file__),
+                message="The provided M365 Password is not valid.",
             )
 
-            with pytest.raises(M365NotValidEncryptedPasswordError) as exception:
+            with pytest.raises(M365NotValidPasswordError) as exception:
                 M365Provider.test_connection(
                     tenant_id=str(uuid4()),
                     region="M365Global",
@@ -414,10 +412,8 @@ class TestM365Provider:
                     password=None,
                 )
 
-            assert exception.type == M365NotValidEncryptedPasswordError
-            assert "The provided M365 Encrypted Password is not valid." in str(
-                exception.value
-            )
+            assert exception.type == M365NotValidPasswordError
+            assert "The provided M365 Password is not valid." in str(exception.value)
 
     def test_test_connection_with_httpresponseerror(self):
         with patch(
@@ -588,7 +584,7 @@ class TestM365Provider:
         assert "The provided User is not valid." in str(exception.value)
 
     def test_validate_static_credentials_missing_password(self):
-        with pytest.raises(M365NotValidEncryptedPasswordError) as exception:
+        with pytest.raises(M365NotValidPasswordError) as exception:
             M365Provider.validate_static_credentials(
                 tenant_id="12345678-1234-5678-1234-567812345678",
                 client_id="12345678-1234-5678-1234-567812345678",
@@ -596,7 +592,7 @@ class TestM365Provider:
                 user="test@example.com",
                 password="",
             )
-        assert "The provided Encrypted Password is not valid." in str(exception.value)
+        assert "The provided Password is not valid." in str(exception.value)
 
     def test_validate_arguments_missing_env_credentials(self):
         with pytest.raises(M365MissingEnvironmentCredentialsError) as exception:


### PR DESCRIPTION
### Context

I found mistakes in https://github.com/prowler-cloud/prowler/pull/7784 while in reviewing https://github.com/prowler-cloud/prowler-cloud/pull/661.

### Description

Last encryption password references have been updated to normal password.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
