### PR TITLE
refactor: use `owner` instead of `repository` in findings attributes

### DIFF
--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -548,7 +548,7 @@ class CheckReportGithub(Check_Report):
 
     resource_name: str
     resource_id: str
-    repository: str
+    owner: str
 
     def __init__(
         self,
@@ -556,7 +556,7 @@ class CheckReportGithub(Check_Report):
         resource: Any,
         resource_name: str = None,
         resource_id: str = None,
-        repository: str = "global",
+        owner: str = None,
     ) -> None:
         """Initialize the GitHub Check's finding information.
 
@@ -565,12 +565,16 @@ class CheckReportGithub(Check_Report):
             resource: Basic information about the resource. Defaults to None.
             resource_name: The name of the resource related with the finding.
             resource_id: The id of the resource related with the finding.
-            repository: The repository of the resource related with the finding.
+            owner: The owner of the resource related with the finding.
         """
         super().__init__(metadata, resource)
         self.resource_name = resource_name or getattr(resource, "name", "")
         self.resource_id = resource_id or getattr(resource, "id", "")
-        self.repository = repository or getattr(resource, "repository", "")
+        self.owner = (
+            owner
+            or getattr(resource, "owner", "")  # For Repositories
+            or getattr(resource, "login", "")  # For Organizations
+        )
 
 
 @dataclass

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -573,7 +573,7 @@ class CheckReportGithub(Check_Report):
         self.owner = (
             owner
             or getattr(resource, "owner", "")  # For Repositories
-            or getattr(resource, "login", "")  # For Organizations
+            or getattr(resource, "name", "")  # For Organizations
         )
 
 

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -251,7 +251,7 @@ class Finding(BaseModel):
                 output_data["resource_uid"] = check_output.resource_id
                 output_data["account_name"] = provider.identity.account_name
                 output_data["account_uid"] = provider.identity.account_id
-                output_data["region"] = check_output.repository
+                output_data["region"] = check_output.owner
 
             elif provider.type == "m365":
                 output_data["auth_method"] = (

--- a/prowler/lib/outputs/outputs.py
+++ b/prowler/lib/outputs/outputs.py
@@ -17,7 +17,7 @@ def stdout_report(finding, color, verbose, status, fix):
     if finding.check_metadata.Provider == "kubernetes":
         details = finding.namespace.lower()
     if finding.check_metadata.Provider == "github":
-        details = finding.repository
+        details = finding.owner
     if finding.check_metadata.Provider == "m365":
         details = finding.location
     if finding.check_metadata.Provider == "nhn":

--- a/prowler/providers/github/services/repository/repository_branch_delete_on_merge_enabled/repository_branch_delete_on_merge_enabled.py
+++ b/prowler/providers/github/services/repository/repository_branch_delete_on_merge_enabled/repository_branch_delete_on_merge_enabled.py
@@ -22,9 +22,7 @@ class repository_branch_delete_on_merge_enabled(Check):
         """
         findings = []
         for repo in repository_client.repositories.values():
-            report = CheckReportGithub(
-                metadata=self.metadata(), resource=repo, repository=repo.name
-            )
+            report = CheckReportGithub(metadata=self.metadata(), resource=repo)
             report.status = "FAIL"
             report.status_extended = (
                 f"Repository {repo.name} does not delete branches on merge."

--- a/prowler/providers/github/services/repository/repository_default_branch_deletion_disabled/repository_default_branch_deletion_disabled.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_deletion_disabled/repository_default_branch_deletion_disabled.py
@@ -23,9 +23,7 @@ class repository_default_branch_deletion_disabled(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.default_branch_deletion is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = (
                     f"Repository {repo.name} does allow default branch deletion."

--- a/prowler/providers/github/services/repository/repository_default_branch_disallows_force_push/repository_default_branch_disallows_force_push.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_disallows_force_push/repository_default_branch_disallows_force_push.py
@@ -23,9 +23,7 @@ class repository_default_branch_disallows_force_push(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.allow_force_pushes is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = (
                     f"Repository {repo.name} does allow force push."

--- a/prowler/providers/github/services/repository/repository_default_branch_protection_applies_to_admins/repository_default_branch_protection_applies_to_admins.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_protection_applies_to_admins/repository_default_branch_protection_applies_to_admins.py
@@ -23,9 +23,7 @@ class repository_default_branch_protection_applies_to_admins(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.enforce_admins is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = f"Repository {repo.name} does not enforce administrators to be subject to the same branch protection rules as other users."
 

--- a/prowler/providers/github/services/repository/repository_default_branch_protection_enabled/repository_default_branch_protection_enabled.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_protection_enabled/repository_default_branch_protection_enabled.py
@@ -23,9 +23,7 @@ class repository_default_branch_protection_enabled(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.default_branch_protection is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = f"Repository {repo.name} does not enforce branch protection on default branch ({repo.default_branch})."
 

--- a/prowler/providers/github/services/repository/repository_default_branch_requires_codeowners_review/repository_default_branch_requires_codeowners_review.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_requires_codeowners_review/repository_default_branch_requires_codeowners_review.py
@@ -23,9 +23,7 @@ class repository_default_branch_requires_codeowners_review(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.require_code_owner_reviews is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 if repo.require_code_owner_reviews:
                     report.status = "PASS"
                     report.status_extended = f"Repository {repo.name} requires code owner approval for changes to owned code."

--- a/prowler/providers/github/services/repository/repository_default_branch_requires_conversation_resolution/repository_default_branch_requires_conversation_resolution.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_requires_conversation_resolution/repository_default_branch_requires_conversation_resolution.py
@@ -23,9 +23,7 @@ class repository_default_branch_requires_conversation_resolution(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.conversation_resolution is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = (
                     f"Repository {repo.name} does not require conversation resolution."

--- a/prowler/providers/github/services/repository/repository_default_branch_requires_linear_history/repository_default_branch_requires_linear_history.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_requires_linear_history/repository_default_branch_requires_linear_history.py
@@ -23,9 +23,7 @@ class repository_default_branch_requires_linear_history(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.required_linear_history is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = f"Repository {repo.name} does not require linear history on default branch ({repo.default_branch})."
 

--- a/prowler/providers/github/services/repository/repository_default_branch_requires_multiple_approvals/repository_default_branch_requires_multiple_approvals.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_requires_multiple_approvals/repository_default_branch_requires_multiple_approvals.py
@@ -23,9 +23,7 @@ class repository_default_branch_requires_multiple_approvals(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.approval_count is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = f"Repository {repo.name} does not enforce at least 2 approvals for code changes."
 

--- a/prowler/providers/github/services/repository/repository_default_branch_requires_signed_commits/repository_default_branch_requires_signed_commits.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_requires_signed_commits/repository_default_branch_requires_signed_commits.py
@@ -23,9 +23,7 @@ class repository_default_branch_requires_signed_commits(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.require_signed_commits is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "FAIL"
                 report.status_extended = f"Repository {repo.name} does not require signed commits on default branch ({repo.default_branch})."
 

--- a/prowler/providers/github/services/repository/repository_default_branch_status_checks_required/repository_default_branch_status_checks_required.py
+++ b/prowler/providers/github/services/repository/repository_default_branch_status_checks_required/repository_default_branch_status_checks_required.py
@@ -24,7 +24,7 @@ class repository_default_branch_status_checks_required(Check):
         for repo in repository_client.repositories.values():
             if repo.status_checks is not None:
                 report = CheckReportGithub(
-                    self.metadata(), resource=repo, repository=repo.name
+                    self.metadata(), resource=repo, owner=repo.name
                 )
                 report.status = "FAIL"
                 report.status_extended = (

--- a/prowler/providers/github/services/repository/repository_dependency_scanning_enabled/repository_dependency_scanning_enabled.py
+++ b/prowler/providers/github/services/repository/repository_dependency_scanning_enabled/repository_dependency_scanning_enabled.py
@@ -23,9 +23,7 @@ class repository_dependency_scanning_enabled(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.dependabot_alerts_enabled is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 if repo.dependabot_alerts_enabled:
                     report.status = "PASS"
                     report.status_extended = f"Repository {repo.name} has package vulnerability scanning (Dependabot alerts) enabled."

--- a/prowler/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file.py
+++ b/prowler/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file.py
@@ -23,9 +23,7 @@ class repository_has_codeowners_file(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.codeowners_exists is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 if repo.codeowners_exists:
                     report.status = "PASS"
                     report.status_extended = (

--- a/prowler/providers/github/services/repository/repository_public_has_securitymd_file/repository_public_has_securitymd_file.py
+++ b/prowler/providers/github/services/repository/repository_public_has_securitymd_file/repository_public_has_securitymd_file.py
@@ -23,9 +23,7 @@ class repository_public_has_securitymd_file(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if not repo.private and repo.securitymd is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 report.status = "PASS"
                 report.status_extended = (
                     f"Repository {repo.name} does have a SECURITY.md file."

--- a/prowler/providers/github/services/repository/repository_secret_scanning_enabled/repository_secret_scanning_enabled.py
+++ b/prowler/providers/github/services/repository/repository_secret_scanning_enabled/repository_secret_scanning_enabled.py
@@ -23,9 +23,7 @@ class repository_secret_scanning_enabled(Check):
         findings = []
         for repo in repository_client.repositories.values():
             if repo.secret_scanning_enabled is not None:
-                report = CheckReportGithub(
-                    metadata=self.metadata(), resource=repo, repository=repo.name
-                )
+                report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 if getattr(repo, "secret_scanning_enabled", None):
                     report.status = "PASS"
                     report.status_extended = f"Repository {repo.name} has secret scanning enabled to detect sensitive data."

--- a/prowler/providers/github/services/repository/repository_service.py
+++ b/prowler/providers/github/services/repository/repository_service.py
@@ -160,6 +160,7 @@ class Repository(GithubService):
                     repos[repo.id] = Repo(
                         id=repo.id,
                         name=repo.name,
+                        owner=repo.owner.login,
                         full_name=repo.full_name,
                         default_branch=repo.default_branch,
                         private=repo.private,
@@ -193,6 +194,7 @@ class Repo(BaseModel):
 
     id: int
     name: str
+    owner: str
     full_name: str
     default_branch_protection: Optional[bool]
     default_branch: str

--- a/tests/providers/github/services/repository/repository_branch_delete_on_merge_enabled/repository_branch_delete_on_merge_enabled_test.py
+++ b/tests/providers/github/services/repository/repository_branch_delete_on_merge_enabled/repository_branch_delete_on_merge_enabled_test.py
@@ -34,6 +34,7 @@ class Test_repository_branch_delete_on_merge_enabled_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,
@@ -74,6 +75,7 @@ class Test_repository_branch_delete_on_merge_enabled_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,

--- a/tests/providers/github/services/repository/repository_default_branch_deletion_disabled/repository_default_branch_deletion_disabled_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_deletion_disabled/repository_default_branch_deletion_disabled_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_deletion_disabled_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch=default_branch,
                 default_branch_deletion=True,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_deletion_disabled_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_default_branch_disallows_force_push/repository_default_branch_disallows_force_push_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_disallows_force_push/repository_default_branch_disallows_force_push_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_disallows_force_push_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch=default_branch,
                 allow_force_pushes=True,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_disallows_force_push_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_default_branch_protection_applies_to_admins/repository_default_branch_protection_applies_to_admins_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_protection_applies_to_admins/repository_default_branch_protection_applies_to_admins_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_protection_applies_to_admins_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch=default_branch,
                 private=False,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_protection_applies_to_admins_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_default_branch_protection_enabled/repository_default_branch_protection_enabled_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_protection_enabled/repository_default_branch_protection_enabled_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_protection_enabled_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch=default_branch,
                 private=False,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_protection_enabled_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_default_branch_requires_codeowners_review/repository_default_branch_requires_codeowners_review_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_requires_codeowners_review/repository_default_branch_requires_codeowners_review_test.py
@@ -34,6 +34,7 @@ class Test_repository_default_branch_requires_codeowners_review:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_requires_codeowners_review:
             2: Repo(
                 id=2,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo2",
                 default_branch="main",
                 private=False,

--- a/tests/providers/github/services/repository/repository_default_branch_requires_conversation_resolution/repository_default_branch_requires_conversation_resolution_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_requires_conversation_resolution/repository_default_branch_requires_conversation_resolution_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_requires_conversation_resolution_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch=default_branch,
                 conversation_resolution=False,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_requires_conversation_resolution_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_default_branch_requires_linear_history/repository_default_branch_requires_linear_history_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_requires_linear_history/repository_default_branch_requires_linear_history_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_requires_linear_history_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch=default_branch,
                 required_linear_history=False,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_requires_linear_history_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_default_branch_requires_multiple_approvals/repository_default_branch_requires_multiple_approvals_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_requires_multiple_approvals/repository_default_branch_requires_multiple_approvals_test.py
@@ -34,6 +34,7 @@ class Test_repository_default_branch_requires_multiple_approvals:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch_protection=False,
                 default_branch="main",
@@ -76,6 +77,7 @@ class Test_repository_default_branch_requires_multiple_approvals:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch_protection=False,
                 default_branch="master",
@@ -118,6 +120,7 @@ class Test_repository_default_branch_requires_multiple_approvals:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch_protection=True,
                 default_branch="master",

--- a/tests/providers/github/services/repository/repository_default_branch_requires_signed_commits/repository_default_branch_requires_signed_commits_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_requires_signed_commits/repository_default_branch_requires_signed_commits_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_requires_signed_commits:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_requires_signed_commits:
             2: Repo(
                 id=2,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo2",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_default_branch_status_checks_required/repository_default_branch_status_checks_required_test.py
+++ b/tests/providers/github/services/repository/repository_default_branch_status_checks_required/repository_default_branch_status_checks_required_test.py
@@ -35,6 +35,7 @@ class Test_repository_default_branch_status_checks_required_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch=default_branch,
                 status_checks=False,
@@ -76,6 +77,7 @@ class Test_repository_default_branch_status_checks_required_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 private=False,
                 default_branch=default_branch,

--- a/tests/providers/github/services/repository/repository_dependency_scanning_enabled/repository_dependency_scanning_enabled_test.py
+++ b/tests/providers/github/services/repository/repository_dependency_scanning_enabled/repository_dependency_scanning_enabled_test.py
@@ -34,6 +34,7 @@ class Test_repository_dependency_scanning_enabled:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,
@@ -77,6 +78,7 @@ class Test_repository_dependency_scanning_enabled:
             2: Repo(
                 id=2,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo2",
                 default_branch="main",
                 private=False,

--- a/tests/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file_test.py
+++ b/tests/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file_test.py
@@ -34,6 +34,7 @@ class Test_repository_has_codeowners_file:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,
@@ -76,6 +77,7 @@ class Test_repository_has_codeowners_file:
             2: Repo(
                 id=2,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo2",
                 default_branch="main",
                 private=False,

--- a/tests/providers/github/services/repository/repository_public_has_securitymd_file/repository_public_has_securitymd_file_test.py
+++ b/tests/providers/github/services/repository/repository_public_has_securitymd_file/repository_public_has_securitymd_file_test.py
@@ -34,6 +34,7 @@ class Test_repository_public_has_securitymd_file_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,
@@ -75,6 +76,7 @@ class Test_repository_public_has_securitymd_file_test:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,

--- a/tests/providers/github/services/repository/repository_secret_scanning_enabled/repository_secret_scanning_enabled_test.py
+++ b/tests/providers/github/services/repository/repository_secret_scanning_enabled/repository_secret_scanning_enabled_test.py
@@ -34,6 +34,7 @@ class Test_repository_secret_scanning_enabled:
             1: Repo(
                 id=1,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo1",
                 default_branch="main",
                 private=False,
@@ -76,6 +77,7 @@ class Test_repository_secret_scanning_enabled:
             2: Repo(
                 id=2,
                 name=repo_name,
+                owner="account-name",
                 full_name="account-name/repo2",
                 default_branch="main",
                 private=False,

--- a/tests/providers/github/services/repository/repository_service_test.py
+++ b/tests/providers/github/services/repository/repository_service_test.py
@@ -12,6 +12,7 @@ def mock_list_repositories(_):
         1: Repo(
             id=1,
             name="repo1",
+            owner="account-name",
             full_name="account-name/repo1",
             default_branch_protection=True,
             default_branch="main",


### PR DESCRIPTION
### Context
Findings results where the use has the same repo from different owners (forks) can be confusing.

### Description
- Refactor model to use `owner` instead of `repository` in findings attributes.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
