### PR TITLE
fix(github): repository `repository_dependency_scanning_enabled` check logic

### DIFF
--- a/prowler/providers/github/github_provider.py
+++ b/prowler/providers/github/github_provider.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from colorama import Fore, Style
 from github import Auth, Github, GithubIntegration
+from github.GithubRetry import GithubRetry
 
 from prowler.config.config import (
     default_config_file_path,
@@ -300,9 +301,10 @@ class GithubProvider(Provider):
         credentials = self.session
 
         try:
+            retry_config = GithubRetry(total=3)
             if credentials.token:
                 auth = Auth.Token(credentials.token)
-                g = Github(auth=auth)
+                g = Github(auth=auth, retry=retry_config)
                 try:
                     identity = GithubIdentityInfo(
                         account_id=g.get_user().id,
@@ -318,7 +320,7 @@ class GithubProvider(Provider):
 
             elif credentials.id != 0 and credentials.key:
                 auth = Auth.AppAuth(credentials.id, credentials.key)
-                gi = GithubIntegration(auth=auth)
+                gi = GithubIntegration(auth=auth, retry=retry_config)
                 try:
                     identity = GithubAppIdentityInfo(app_id=gi.get_app().id)
                     return identity

--- a/prowler/providers/github/lib/service/service.py
+++ b/prowler/providers/github/lib/service/service.py
@@ -1,4 +1,5 @@
 from github import Auth, Github, GithubIntegration
+from github.GithubRetry import GithubRetry
 
 from prowler.lib.logger import logger
 from prowler.providers.github.github_provider import GithubProvider
@@ -20,16 +21,17 @@ class GithubService:
     def __set_clients__(self, session):
         clients = []
         try:
+            retry_config = GithubRetry(total=3)
             if session.token:
                 auth = Auth.Token(session.token)
-                clients = [Github(auth=auth)]
+                clients = [Github(auth=auth, retry=retry_config)]
 
             elif session.key and session.id:
                 auth = Auth.AppAuth(
                     session.id,
                     session.key,
                 )
-                gi = GithubIntegration(auth=auth)
+                gi = GithubIntegration(auth=auth, retry=retry_config)
 
                 for installation in gi.get_installations():
                     clients.append(installation.get_github_for_installation())

--- a/prowler/providers/github/services/repository/repository_service.py
+++ b/prowler/providers/github/services/repository/repository_service.py
@@ -135,7 +135,7 @@ class Repository(GithubService):
                             )
                         try:
                             # Use get_dependabot_alerts to check if Dependabot alerts are enabled
-                            repo.get_dependabot_alerts()[0]
+                            repo.get_dependabot_alerts().totalCount
                             # If the call succeeds, Dependabot is enabled (even if no alerts)
                             dependabot_alerts_enabled = True
                         except Exception as error:


### PR DESCRIPTION
### Context
If the repository has dependabot alert enable but 0 results the check gets an `ERROR: IndexError[138]: list index out of range` and it does not return a finding because we do not handle this properly.

This check was added in https://github.com/prowler-cloud/prowler/pull/7771

### Description
- Use `.totalCount` instead, this will fail with 403 if not enabled and return a number (including 0) if enabled.
- Set the retry count for the Github provider to 3 to speed up scans. (Default was 10)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
