### PR TITLE
refactor(reports): change API response message when tasks are running

### DIFF
--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -5376,7 +5376,8 @@ paths:
         '403':
           description: There is a problem with credentials
         '404':
-          description: The scan has no reports
+          description: The scan has no reports, or the report generation task has
+            not started yet
   /api/v1/schedules/daily:
     post:
       operationId: schedules_daily_create

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -2304,7 +2304,10 @@ class TestScanViewSet:
         url = reverse("scan-report", kwargs={"pk": scan.id})
         response = authenticated_client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json()["errors"]["detail"] == "The scan has no reports."
+        assert (
+            response.json()["errors"]["detail"]
+            == "The scan has no reports, or the report generation task has not started yet."
+        )
 
     def test_report_s3_no_credentials(
         self, authenticated_client, scans_fixture, monkeypatch
@@ -2372,7 +2375,7 @@ class TestScanViewSet:
     ):
         """
         When output_location is a local path and glob.glob returns an empty list,
-        the view should return HTTP 404 with detail "The scan has no reports."
+        the view should return HTTP 404 with detail "The scan has no reports, or the report generation task has not started yet."
         """
         scan = scans_fixture[0]
         scan.output_location = "/tmp/nonexistent_report_pattern.zip"
@@ -2384,7 +2387,10 @@ class TestScanViewSet:
         response = authenticated_client.get(url)
 
         assert response.status_code == 404
-        assert response.json()["errors"]["detail"] == "The scan has no reports."
+        assert (
+            response.json()["errors"]["detail"]
+            == "The scan has no reports, or the report generation task has not started yet."
+        )
 
     def test_report_local_file(self, authenticated_client, scans_fixture, monkeypatch):
         scan = scans_fixture[0]
@@ -2459,7 +2465,10 @@ class TestScanViewSet:
         url = reverse("scan-compliance", kwargs={"pk": scan.id, "name": framework})
         resp = authenticated_client.get(url)
         assert resp.status_code == status.HTTP_404_NOT_FOUND
-        assert resp.json()["errors"]["detail"] == "The scan has no reports."
+        assert (
+            resp.json()["errors"]["detail"]
+            == "The scan has no reports, or the report generation task has not started yet."
+        )
 
     def test_compliance_s3_no_credentials(
         self, authenticated_client, scans_fixture, monkeypatch
@@ -2681,7 +2690,10 @@ class TestScanViewSet:
         response = authenticated_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json()["errors"]["detail"] == "The scan has no reports."
+        assert (
+            response.json()["errors"]["detail"]
+            == "The scan has no reports, or the report generation task has not started yet."
+        )
 
     @patch("api.v1.views.get_s3_client")
     def test_report_s3_client_error_other(

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1160,7 +1160,9 @@ class ProviderViewSet(BaseRLSViewSet):
             200: OpenApiResponse(description="Report obtained successfully"),
             202: OpenApiResponse(description="The task is in progress"),
             403: OpenApiResponse(description="There is a problem with credentials"),
-            404: OpenApiResponse(description="The scan has no reports"),
+            404: OpenApiResponse(
+                description="The scan has no reports, or the report generation task has not started yet"
+            ),
         },
     ),
     compliance=extend_schema(
@@ -1363,7 +1365,9 @@ class ScanViewSet(BaseRLSViewSet):
                 code = e.response.get("Error", {}).get("Code")
                 if code == "NoSuchKey":
                     return Response(
-                        {"detail": "The scan has no reports."},
+                        {
+                            "detail": "The scan has no reports, or the report generation task has not started yet."
+                        },
                         status=status.HTTP_404_NOT_FOUND,
                     )
                 return Response(
@@ -1376,7 +1380,9 @@ class ScanViewSet(BaseRLSViewSet):
             files = glob.glob(path_pattern)
             if not files:
                 return Response(
-                    {"detail": "The scan has no reports."},
+                    {
+                        "detail": "The scan has no reports, or the report generation task has not started yet."
+                    },
                     status=status.HTTP_404_NOT_FOUND,
                 )
             filepath = files[0]
@@ -1402,7 +1408,10 @@ class ScanViewSet(BaseRLSViewSet):
 
         if not scan.output_location:
             return Response(
-                {"detail": "The scan has no reports."}, status=status.HTTP_404_NOT_FOUND
+                {
+                    "detail": "The scan has no reports, or the report generation task has not started yet."
+                },
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         if scan.output_location.startswith("s3://"):
@@ -1440,7 +1449,10 @@ class ScanViewSet(BaseRLSViewSet):
 
         if not scan.output_location:
             return Response(
-                {"detail": "The scan has no reports."}, status=status.HTTP_404_NOT_FOUND
+                {
+                    "detail": "The scan has no reports, or the report generation task has not started yet."
+                },
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         if scan.output_location.startswith("s3://"):


### PR DESCRIPTION
### Description

In this PR we will change the API response in the following cases:
- The scan-summary task is running when the user try to get the scan report.
- Scans older than the date of insertion of the report functionality.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
