### PR TITLE
fix(m365): add compliantDevice grant control support

### DIFF
--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -493,6 +493,7 @@ class ConditionalAccessGrantControl(Enum):
     BLOCK = "block"
     DOMAIN_JOINED_DEVICE = "domainJoinedDevice"
     PASSWORD_CHANGE = "passwordChange"
+    COMPLIANT_DEVICE = "compliantDevice"
 
 
 class GrantControlOperator(Enum):

--- a/tests/providers/azure/services/entra/entra_service_test.py
+++ b/tests/providers/azure/services/entra/entra_service_test.py
@@ -93,7 +93,7 @@ async def mock_entra_get_conditional_access_policy(_):
                     "include": ["797f4846-ba00-4fd7-ba43-dac1f8f63013"],
                     "exclude": [],
                 },
-                access_controls={"grant": ["MFA"], "block": []},
+                access_controls={"grant": ["MFA", "compliantDevice"], "block": []},
             )
         }
     }
@@ -216,7 +216,7 @@ class Test_Entra_Service:
         )
         assert entra_client.conditional_access_policy[DOMAIN]["id-1"].access_controls[
             "grant"
-        ] == ["MFA"]
+        ] == ["MFA", "compliantDevice"]
         assert (
             entra_client.conditional_access_policy[DOMAIN]["id-1"].access_controls[
                 "block"

--- a/tests/providers/m365/services/entra/microsoft365_entra_service_test.py
+++ b/tests/providers/m365/services/entra/microsoft365_entra_service_test.py
@@ -68,7 +68,10 @@ async def mock_entra_get_conditional_access_policies(_):
                 ),
             ),
             grant_controls=GrantControls(
-                built_in_controls=[ConditionalAccessGrantControl.BLOCK],
+                built_in_controls=[
+                    ConditionalAccessGrantControl.BLOCK,
+                    ConditionalAccessGrantControl.COMPLIANT_DEVICE,
+                ],
                 operator=GrantControlOperator.OR,
                 authentication_strength=AuthenticationStrength.PHISHING_RESISTANT_MFA,
             ),
@@ -211,7 +214,10 @@ class Test_Entra_Service:
                     ),
                 ),
                 grant_controls=GrantControls(
-                    built_in_controls=[ConditionalAccessGrantControl.BLOCK],
+                    built_in_controls=[
+                        ConditionalAccessGrantControl.BLOCK,
+                        ConditionalAccessGrantControl.COMPLIANT_DEVICE,
+                    ],
                     operator=GrantControlOperator.OR,
                     authentication_strength=AuthenticationStrength.PHISHING_RESISTANT_MFA,
                 ),


### PR DESCRIPTION
### Context

`2025-05-26 22:18:34,981 [File: entra_service.py:292]    [Module: entra_service]  ERROR: ValueError[217]: 'compliantDevice' is not a valid ConditionalAccessGrantControl`

### Description

This change fixes the ValueError when processing conditional access policies that use the compliantDevice grant control.

- Add COMPLIANT_DEVICE to ConditionalAccessGrantControl enum
- Update test cases in both M365 and Azure test files to include compliantDevice
- Ensure consistent handling of multiple grant controls across providers

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
