### PR TITLE
fix(threatscore): remove compliance name in tests to remove dummy files

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,7 +25,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Fix `m365_powershell test_credentials` to use sanitized credentials. [(#7761)](https://github.com/prowler-cloud/prowler/pull/7761)
 - Fix `admincenter_users_admins_reduced_license_footprint` check logic to pass when admin user has no license. [(#7779)](https://github.com/prowler-cloud/prowler/pull/7779)
 - Fix `m365_powershell` to close the PowerShell sessions in msgraph services. [(#7816)](https://github.com/prowler-cloud/prowler/pull/7816)
-- Fix tests from prowler threatscore to don't create dummy files [(7859)](https://github.com/prowler-cloud/prowler/pull/7859)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Fix `m365_powershell test_credentials` to use sanitized credentials. [(#7761)](https://github.com/prowler-cloud/prowler/pull/7761)
 - Fix `admincenter_users_admins_reduced_license_footprint` check logic to pass when admin user has no license. [(#7779)](https://github.com/prowler-cloud/prowler/pull/7779)
 - Fix `m365_powershell` to close the PowerShell sessions in msgraph services. [(#7816)](https://github.com/prowler-cloud/prowler/pull/7816)
+- Fix tests from prowler threatscore to don't create dummy files [(7859)](https://github.com/prowler-cloud/prowler/pull/7859)
 
 ---
 

--- a/tests/lib/outputs/compliance/fixtures.py
+++ b/tests/lib/outputs/compliance/fixtures.py
@@ -857,7 +857,6 @@ KISA_ISMSP_AWS = Compliance(
     ],
 )
 
-PROWLER_THREATSCORE_AWS_NAME = "prowler_threatscore_aws"
 PROWLER_THREATSCORE_AWS = Compliance(
     Framework="ProwlerThreatScore",
     Version="1.0",
@@ -901,7 +900,6 @@ PROWLER_THREATSCORE_AWS = Compliance(
     ],
 )
 
-PROWLER_THREATSCORE_AZURE_NAME = "prowler_threatscore_azure"
 PROWLER_THREATSCORE_AZURE = Compliance(
     Framework="ProwlerThreatScore",
     Version="1.0",
@@ -945,7 +943,6 @@ PROWLER_THREATSCORE_AZURE = Compliance(
     ],
 )
 
-PROWLER_THREATSCORE_GCP_NAME = "prowler_threatscore_gcp"
 PROWLER_THREATSCORE_GCP = Compliance(
     Framework="ProwlerThreatScore",
     Version="1.0",
@@ -989,7 +986,6 @@ PROWLER_THREATSCORE_GCP = Compliance(
     ],
 )
 
-PROWLER_THREATSCORE_M365_NAME = "prowler_threatscore_m365"
 PROWLER_THREATSCORE_M365 = Compliance(
     Framework="ProwlerThreatScore",
     Version="1.0",

--- a/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_aws_test.py
+++ b/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_aws_test.py
@@ -10,10 +10,7 @@ from prowler.lib.outputs.compliance.prowler_threatscore.models import (
 from prowler.lib.outputs.compliance.prowler_threatscore.prowler_threatscore_aws import (
     ProwlerThreatScoreAWS,
 )
-from tests.lib.outputs.compliance.fixtures import (
-    PROWLER_THREATSCORE_AWS,
-    PROWLER_THREATSCORE_AWS_NAME,
-)
+from tests.lib.outputs.compliance.fixtures import PROWLER_THREATSCORE_AWS
 from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 from tests.providers.aws.utils import AWS_ACCOUNT_NUMBER, AWS_REGION_EU_WEST_1
 
@@ -24,9 +21,7 @@ class TestProwlerThreatScoreAWS:
             generate_finding_output(compliance={"ProwlerThreatScore-1.0": "1.1.1"})
         ]
 
-        output = ProwlerThreatScoreAWS(
-            findings, PROWLER_THREATSCORE_AWS, PROWLER_THREATSCORE_AWS_NAME
-        )
+        output = ProwlerThreatScoreAWS(findings, PROWLER_THREATSCORE_AWS)
         output_data = output.data[0]
         assert isinstance(output_data, ProwlerThreatScoreAWSModel)
         assert output_data.Provider == "aws"
@@ -134,9 +129,7 @@ class TestProwlerThreatScoreAWS:
         findings = [
             generate_finding_output(compliance={"ProwlerThreatScore-1.0": "1.1.1"})
         ]
-        output = ProwlerThreatScoreAWS(
-            findings, PROWLER_THREATSCORE_AWS, PROWLER_THREATSCORE_AWS_NAME
-        )
+        output = ProwlerThreatScoreAWS(findings, PROWLER_THREATSCORE_AWS)
         output._file_descriptor = mock_file
 
         with patch.object(mock_file, "close", return_value=None):

--- a/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_azure_test.py
+++ b/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_azure_test.py
@@ -10,10 +10,7 @@ from prowler.lib.outputs.compliance.prowler_threatscore.models import (
 from prowler.lib.outputs.compliance.prowler_threatscore.prowler_threatscore_azure import (
     ProwlerThreatScoreAzure,
 )
-from tests.lib.outputs.compliance.fixtures import (
-    PROWLER_THREATSCORE_AZURE,
-    PROWLER_THREATSCORE_AZURE_NAME,
-)
+from tests.lib.outputs.compliance.fixtures import PROWLER_THREATSCORE_AZURE
 from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
@@ -33,9 +30,7 @@ class TestProwlerThreatScoreAzure:
             )
         ]
 
-        output = ProwlerThreatScoreAzure(
-            findings, PROWLER_THREATSCORE_AZURE, PROWLER_THREATSCORE_AZURE_NAME
-        )
+        output = ProwlerThreatScoreAzure(findings, PROWLER_THREATSCORE_AZURE)
         output_data = output.data[0]
         assert isinstance(output_data, ProwlerThreatScoreAzureModel)
         assert output_data.Provider == "azure"
@@ -144,9 +139,7 @@ class TestProwlerThreatScoreAzure:
         findings = [
             generate_finding_output(compliance={"ProwlerThreatScore-1.0": "1.1.1"})
         ]
-        output = ProwlerThreatScoreAzure(
-            findings, PROWLER_THREATSCORE_AZURE, PROWLER_THREATSCORE_AZURE_NAME
-        )
+        output = ProwlerThreatScoreAzure(findings, PROWLER_THREATSCORE_AZURE)
         output._file_descriptor = mock_file
 
         with patch.object(mock_file, "close", return_value=None):

--- a/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_gcp_test.py
+++ b/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_gcp_test.py
@@ -10,10 +10,7 @@ from prowler.lib.outputs.compliance.prowler_threatscore.models import (
 from prowler.lib.outputs.compliance.prowler_threatscore.prowler_threatscore_gcp import (
     ProwlerThreatScoreGCP,
 )
-from tests.lib.outputs.compliance.fixtures import (
-    PROWLER_THREATSCORE_GCP,
-    PROWLER_THREATSCORE_GCP_NAME,
-)
+from tests.lib.outputs.compliance.fixtures import PROWLER_THREATSCORE_GCP
 from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 from tests.providers.gcp.gcp_fixtures import GCP_PROJECT_ID
 
@@ -30,9 +27,7 @@ class TestProwlerThreatScoreGCP:
             )
         ]
 
-        output = ProwlerThreatScoreGCP(
-            findings, PROWLER_THREATSCORE_GCP, PROWLER_THREATSCORE_GCP_NAME
-        )
+        output = ProwlerThreatScoreGCP(findings, PROWLER_THREATSCORE_GCP)
         output_data = output.data[0]
         assert isinstance(output_data, ProwlerThreatScoreGCPModel)
         assert output_data.Provider == "gcp"
@@ -140,9 +135,7 @@ class TestProwlerThreatScoreGCP:
         findings = [
             generate_finding_output(compliance={"ProwlerThreatScore-1.0": "1.1.1"})
         ]
-        output = ProwlerThreatScoreGCP(
-            findings, PROWLER_THREATSCORE_GCP, PROWLER_THREATSCORE_GCP_NAME
-        )
+        output = ProwlerThreatScoreGCP(findings, PROWLER_THREATSCORE_GCP)
         output._file_descriptor = mock_file
 
         with patch.object(mock_file, "close", return_value=None):

--- a/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_m365_test.py
+++ b/tests/lib/outputs/compliance/prowler_threatscore/prowler_threatscore_m365_test.py
@@ -10,10 +10,7 @@ from prowler.lib.outputs.compliance.prowler_threatscore.models import (
 from prowler.lib.outputs.compliance.prowler_threatscore.prowler_threatscore_m365 import (
     ProwlerThreatScoreM365,
 )
-from tests.lib.outputs.compliance.fixtures import (
-    PROWLER_THREATSCORE_M365,
-    PROWLER_THREATSCORE_M365_NAME,
-)
+from tests.lib.outputs.compliance.fixtures import PROWLER_THREATSCORE_M365
 from tests.lib.outputs.fixtures.fixtures import generate_finding_output
 from tests.providers.m365.m365_fixtures import TENANT_ID
 
@@ -30,9 +27,7 @@ class TestProwlerThreatScoreM365:
             )
         ]
 
-        output = ProwlerThreatScoreM365(
-            findings, PROWLER_THREATSCORE_M365, PROWLER_THREATSCORE_M365_NAME
-        )
+        output = ProwlerThreatScoreM365(findings, PROWLER_THREATSCORE_M365)
         output_data = output.data[0]
         assert isinstance(output_data, ProwlerThreatScoreM365Model)
         assert output_data.Provider == "m365"
@@ -142,9 +137,7 @@ class TestProwlerThreatScoreM365:
         findings = [
             generate_finding_output(compliance={"ProwlerThreatScore-1.0": "1.1.1"})
         ]
-        output = ProwlerThreatScoreM365(
-            findings, PROWLER_THREATSCORE_M365, PROWLER_THREATSCORE_M365_NAME
-        )
+        output = ProwlerThreatScoreM365(findings, PROWLER_THREATSCORE_M365)
         output._file_descriptor = mock_file
 
         with patch.object(mock_file, "close", return_value=None):


### PR DESCRIPTION
### Description

This pull request fix the tests behaviour for Prowler ThreatScore. When tests from this compliance where executed, one dummy file for each provider was created.
![image (2)](https://github.com/user-attachments/assets/fe13bab2-45c7-4cc9-b4aa-a09a0d6d3c45)


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
