### PR TITLE
fix(ui): increase limit to retrieve more than 10 scan list

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Download report behaviour updated to show feedback based on API response. [(#7758)](https://github.com/prowler-cloud/prowler/pull/7758)
 - Missing KISA and ProwlerThreat icons added to the compliance page. [(#7860)(https://github.com/prowler-cloud/prowler/pull/7860)]
 
+### 🐞 Fixes
+- Retrieve more than 10 scans in /compliance page. [(#7865)](https://github.com/prowler-cloud/prowler/pull/7865)
+
 ---
 
 ## [v1.7.1] (Prowler v5.7.1)

--- a/ui/app/(prowler)/compliance/page.tsx
+++ b/ui/app/(prowler)/compliance/page.tsx
@@ -33,6 +33,7 @@ export default async function Compliance({
     filters: {
       "filter[state]": "completed",
     },
+    pageSize: 50,
   });
 
   if (!scansData?.data) {


### PR DESCRIPTION
### Context

Support retrieving more than 10 scan records.

### Description

This PR updates the scan list to fetch more than 10 records. 

### Checklist

- Are there new checks included in this PR? No
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
