### PR TITLE
fix(admincenter): service and group visibility

### DIFF
--- a/prowler/providers/m365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility.py
+++ b/prowler/providers/m365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility.py
@@ -36,7 +36,7 @@ class admincenter_groups_not_public_visibility(Check):
             report.status = "FAIL"
             report.status_extended = f"Group {group.name} has {group.visibility} visibility and should be Private."
 
-            if group.visibility != "Public":
+            if group.visibility and group.visibility != "Public":
                 report.status = "PASS"
                 report.status_extended = (
                     f"Group {group.name} has {group.visibility} visibility."

--- a/prowler/providers/m365/services/admincenter/admincenter_service.py
+++ b/prowler/providers/m365/services/admincenter/admincenter_service.py
@@ -201,7 +201,7 @@ class DirectoryRole(BaseModel):
 class Group(BaseModel):
     id: str
     name: str
-    visibility: str
+    visibility: Optional[str]
 
 
 class Domain(BaseModel):

--- a/prowler/providers/m365/services/admincenter/admincenter_service.py
+++ b/prowler/providers/m365/services/admincenter/admincenter_service.py
@@ -11,8 +11,6 @@ from prowler.providers.m365.m365_provider import M365Provider
 class AdminCenter(M365Service):
     def __init__(self, provider: M365Provider):
         super().__init__(provider)
-        if self.powershell:
-            self.powershell.close()
 
         self.organization_config = None
         self.sharing_policy = None

--- a/tests/providers/m365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
+++ b/tests/providers/m365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py
@@ -114,3 +114,91 @@ class Test_admincenter_groups_not_public_visibility:
             assert result[0].resource_name == "Group1"
             assert result[0].resource_id == id_group1
             assert result[0].location == "global"
+
+    def test_admincenter_group_public_visibility(self):
+        admincenter_client = mock.MagicMock
+        admincenter_client.audited_tenant = "audited_tenant"
+        admincenter_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.admincenter.admincenter_groups_not_public_visibility.admincenter_groups_not_public_visibility.admincenter_client",
+                new=admincenter_client,
+            ),
+        ):
+            from prowler.providers.m365.services.admincenter.admincenter_groups_not_public_visibility.admincenter_groups_not_public_visibility import (
+                admincenter_groups_not_public_visibility,
+            )
+            from prowler.providers.m365.services.admincenter.admincenter_service import (
+                Group,
+            )
+
+            id_group1 = str(uuid4())
+
+            admincenter_client.groups = {
+                id_group1: Group(id=id_group1, name="Group1", visibility="Public"),
+            }
+
+            check = admincenter_groups_not_public_visibility()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Group Group1 has Public visibility and should be Private."
+            )
+            assert result[0].resource == admincenter_client.groups[id_group1].dict()
+            assert result[0].resource_name == "Group1"
+            assert result[0].resource_id == id_group1
+            assert result[0].location == "global"
+
+    def test_admincenter_group_none_visibility(self):
+        admincenter_client = mock.MagicMock
+        admincenter_client.audited_tenant = "audited_tenant"
+        admincenter_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.lib.powershell.m365_powershell.M365PowerShell.connect_exchange_online"
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.admincenter.admincenter_groups_not_public_visibility.admincenter_groups_not_public_visibility.admincenter_client",
+                new=admincenter_client,
+            ),
+        ):
+            from prowler.providers.m365.services.admincenter.admincenter_groups_not_public_visibility.admincenter_groups_not_public_visibility import (
+                admincenter_groups_not_public_visibility,
+            )
+            from prowler.providers.m365.services.admincenter.admincenter_service import (
+                Group,
+            )
+
+            id_group1 = str(uuid4())
+
+            admincenter_client.groups = {
+                id_group1: Group(id=id_group1, name="Group1", visibility=None),
+            }
+
+            check = admincenter_groups_not_public_visibility()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "Group Group1 has None visibility and should be Private."
+            )
+            assert result[0].resource == admincenter_client.groups[id_group1].dict()
+            assert result[0].resource_name == "Group1"
+            assert result[0].resource_id == id_group1
+            assert result[0].location == "global"


### PR DESCRIPTION
### Context

I found an error caused by bad merging, resulting in duplicated code in two different parts of the codebase, and a service error while constructing `Admincenter Group` objects.

### Description

Both errors have been fixed. Also need them in `v5.7`.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
