### PR TITLE
fix(k8s): UID validation for valid context names

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,14 +10,13 @@ All notable changes to the **Prowler API** are documented in this file.
 ### Changed
 - Renamed field encrypted_password to password for M365 provider [(#7784)](https://github.com/prowler-cloud/prowler/pull/7784)
 
-### Fixed
-- Fixed Kubernetes UID validation to allow valid context names [(#7871)](https://github.com/prowler-cloud/prowler/pull/7871)
 ---
 
 ## [v1.8.2] (Prowler v5.7.2)
 
 ### Fixed
 - Fixed task lookup to use task_kwargs instead of task_args for scan report resolution. [(#7830)](https://github.com/prowler-cloud/prowler/pull/7830)
+- Fixed Kubernetes UID validation to allow valid context names [(#7871)](https://github.com/prowler-cloud/prowler/pull/7871)
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Renamed field encrypted_password to password for M365 provider [(#7784)](https://github.com/prowler-cloud/prowler/pull/7784)
 
 ### Fixed
-- Fixed Kubernetes UID validation to allow valid context names [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
+- Fixed Kubernetes UID validation to allow valid context names [(#7871)](https://github.com/prowler-cloud/prowler/pull/7871)
 ---
 
 ## [v1.8.2] (Prowler v5.7.2)

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the **Prowler API** are documented in this file.
 ### Changed
 - Renamed field encrypted_password to password for M365 provider [(#7784)](https://github.com/prowler-cloud/prowler/pull/7784)
 
+### Fixed
+- Fixed Kubernetes UID validation to allow valid context names [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
 ---
 
 ## [v1.8.2] (Prowler v5.7.2)

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -242,13 +242,14 @@ class Provider(RowLevelSecurityProtectedModel):
     @staticmethod
     def validate_kubernetes_uid(value):
         if not re.match(
-            r"^[a-z0-9][A-Za-z0-9_.:\/-]{1,250}$",
+            r"^[a-z0-9][A-Za-z0-9_.:\/-@]{1,250}$",
             value,
         ):
             raise ModelValidationError(
                 detail="The value must either be a valid Kubernetes UID (up to 63 characters, "
                 "starting and ending with a lowercase letter or number, containing only "
-                "lowercase alphanumeric characters and hyphens) or a valid AWS EKS Cluster ARN, GCP GKE Context Name or Azure AKS Cluster Name.",
+                "lowercase alphanumeric characters and hyphens), a valid email address, "
+                "or a valid AWS EKS Cluster ARN, GCP GKE Context Name or Azure AKS Cluster Name.",
                 code="kubernetes-uid",
                 pointer="/data/attributes/uid",
             )

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -242,14 +242,13 @@ class Provider(RowLevelSecurityProtectedModel):
     @staticmethod
     def validate_kubernetes_uid(value):
         if not re.match(
-            r"^[a-z0-9][A-Za-z0-9_.:\/-@]{1,250}$",
+            r"^[a-zA-Z0-9][a-zA-Z0-9._@:\/-]{1,250}$",
             value,
         ):
             raise ModelValidationError(
                 detail="The value must either be a valid Kubernetes UID (up to 63 characters, "
                 "starting and ending with a lowercase letter or number, containing only "
-                "lowercase alphanumeric characters and hyphens), a valid email address, "
-                "or a valid AWS EKS Cluster ARN, GCP GKE Context Name or Azure AKS Cluster Name.",
+                "lowercase alphanumeric characters and hyphens) or a valid AWS EKS Cluster ARN, GCP GKE Context Name or Azure AKS Cluster Name.",
                 code="kubernetes-uid",
                 pointer="/data/attributes/uid",
             )

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -915,6 +915,16 @@ class TestProviderViewSet:
                     "alias": "GKE",
                 },
                 {
+                    "provider": "kubernetes",
+                    "uid": "gke_project/cluster-name",
+                    "alias": "GKE",
+                },
+                {
+                    "provider": "kubernetes",
+                    "uid": "admin@k8s-demo",
+                    "alias": "test",
+                },
+                {
                     "provider": "azure",
                     "uid": "8851db6b-42e5-4533-aa9e-30a32d67e875",
                     "alias": "test",


### PR DESCRIPTION
### Description

Fix K8s UID validation for valid context names like:
- `admin@domain`
- `project/cluster-name`

<img width="1693" alt="Screenshot 2025-05-28 at 16 54 41" src="https://github.com/user-attachments/assets/ab5d2bd9-0c48-49a3-964a-452a470f39e3" />


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
