### PR TITLE
fix: add new get method to avoid race conditions when creating async tasks

### DIFF
--- a/.env
+++ b/.env
@@ -24,6 +24,10 @@ POSTGRES_USER=prowler
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=prowler_db
 
+# Celery-Prowler task settings
+TASK_GET_RETRY_DELAY_SECONDS=0.1
+TASK_GET_MAX_RETRIES=5
+
 # Valkey settings
 # If running Valkey and celery on host, use localhost, else use 'valkey'
 VALKEY_HOST=valkey

--- a/.env
+++ b/.env
@@ -25,8 +25,8 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=prowler_db
 
 # Celery-Prowler task settings
-TASK_GET_RETRY_DELAY_SECONDS=0.1
-TASK_GET_MAX_RETRIES=5
+TASK_RETRY_DELAY_SECONDS=0.1
+TASK_RETRY_ATTEMPTS=5
 
 # Valkey settings
 # If running Valkey and celery on host, use localhost, else use 'valkey'

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### Fixed
 - Fixed task lookup to use task_kwargs instead of task_args for scan report resolution. [(#7830)](https://github.com/prowler-cloud/prowler/pull/7830)
 - Fixed Kubernetes UID validation to allow valid context names [(#7871)](https://github.com/prowler-cloud/prowler/pull/7871)
+- Fixed a race condition when creating async tasks [(#7876)](https://github.com/prowler-cloud/prowler/pull/7876).
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### Fixed
 - Fixed task lookup to use task_kwargs instead of task_args for scan report resolution. [(#7830)](https://github.com/prowler-cloud/prowler/pull/7830)
 - Fixed Kubernetes UID validation to allow valid context names [(#7871)](https://github.com/prowler-cloud/prowler/pull/7871)
-- Fixed a race condition when creating async tasks [(#7876)](https://github.com/prowler-cloud/prowler/pull/7876).
+- Fixed a race condition when creating background tasks [(#7876)](https://github.com/prowler-cloud/prowler/pull/7876).
 
 ---
 

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -3,6 +3,7 @@ import re
 import time
 from uuid import UUID, uuid4
 
+from config.env import env
 from cryptography.fernet import Fernet
 from django.conf import settings
 from django.contrib.auth.models import AbstractBaseUser
@@ -354,7 +355,7 @@ class ProviderGroupMembership(RowLevelSecurityProtectedModel):
 
 
 class TaskManager(models.Manager):
-    def get_with_retry(self, id, max_retries=5, delay_seconds=0.1):
+    def get_with_retry(self, id, max_retries: int = 0, delay_seconds: int = 0):
         """
         Retry fetching a Task by ID in case it hasn't been created yet.
 
@@ -369,6 +370,9 @@ class TaskManager(models.Manager):
         Raises:
             Task.DoesNotExist: If the task is not found after all retries.
         """
+        max_retries = max_retries or env("TASK_RETRY_ATTEMPTS", default=5)
+        delay_seconds = delay_seconds or env("TASK_RETRY_DELAY_SECONDS", default=0.1)
+
         for _attempt in range(max_retries):
             try:
                 return self.get(id=id)

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -354,7 +354,7 @@ class ProviderGroupMembership(RowLevelSecurityProtectedModel):
 
 
 class TaskManager(models.Manager):
-    def get_with_retry(self, id, max_retries=5, delay_seconds=0.5):
+    def get_with_retry(self, id, max_retries=5, delay_seconds=0.1):
         """
         Retry fetching a Task by ID in case it hasn't been created yet.
 

--- a/api/src/backend/api/tests/test_models.py
+++ b/api/src/backend/api/tests/test_models.py
@@ -1,6 +1,9 @@
+import uuid
+from unittest import mock
+
 import pytest
 
-from api.models import Resource, ResourceTag
+from api.models import Resource, ResourceTag, Task
 
 
 @pytest.mark.django_db
@@ -120,3 +123,35 @@ class TestResourceModel:
 #             compliance={},
 #         )
 #         assert Finding.objects.filter(uid=long_uid).exists()
+
+
+@pytest.mark.django_db
+class TestTaskManager:
+    def test_get_with_retry_success(self):
+        task_id = uuid.uuid4()
+        call_counter = {"count": 0}
+
+        def side_effect(*args, **kwargs):
+            if call_counter["count"] < 2:
+                call_counter["count"] += 1
+                raise Task.DoesNotExist()
+            return Task(id=task_id)
+
+        with mock.patch.object(Task.objects, "get", side_effect=side_effect):
+            task = Task.objects.get_with_retry(
+                task_id, max_retries=5, delay_seconds=0.01
+            )
+
+        assert task.id == task_id
+        assert call_counter["count"] == 2
+
+    def test_get_with_retry_fail(self):
+        non_existent_id = uuid.uuid4()
+
+        with mock.patch.object(Task.objects, "get", side_effect=Task.DoesNotExist):
+            with pytest.raises(Task.DoesNotExist) as excinfo:
+                Task.objects.get_with_retry(
+                    non_existent_id, max_retries=3, delay_seconds=0.01
+                )
+
+        assert str(non_existent_id) in str(excinfo.value)

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -1086,7 +1086,7 @@ class ProviderViewSet(BaseRLSViewSet):
             task = check_provider_connection_task.delay(
                 provider_id=pk, tenant_id=self.request.tenant_id
             )
-        prowler_task = Task.objects.get(id=task.id)
+        prowler_task = Task.objects.get_with_retry(id=task.id)
         serializer = TaskSerializer(prowler_task)
         return Response(
             data=serializer.data,
@@ -1109,7 +1109,7 @@ class ProviderViewSet(BaseRLSViewSet):
             task = delete_provider_task.delay(
                 provider_id=pk, tenant_id=self.request.tenant_id
             )
-        prowler_task = Task.objects.get(id=task.id)
+        prowler_task = Task.objects.get_with_retry(id=task.id)
         serializer = TaskSerializer(prowler_task)
         return Response(
             data=serializer.data,
@@ -1489,10 +1489,10 @@ class ScanViewSet(BaseRLSViewSet):
                 },
             )
 
+        prowler_task = Task.objects.get_with_retry(id=task.id)
         scan.task_id = task.id
         scan.save(update_fields=["task_id"])
 
-        prowler_task = Task.objects.get(id=task.id)
         self.response_serializer_class = TaskSerializer
         output_serializer = self.get_serializer(prowler_task)
 
@@ -2823,7 +2823,7 @@ class ScheduleViewSet(BaseRLSViewSet):
         with transaction.atomic():
             task = schedule_provider_scan(provider_instance)
 
-        prowler_task = Task.objects.get(id=task.id)
+        prowler_task = Task.objects.get_with_retry(id=task.id)
         self.response_serializer_class = TaskSerializer
         output_serializer = self.get_serializer(prowler_task)
 


### PR DESCRIPTION
## Description

In this PR we added a new method to avoid a race condition when we create Celery tasks

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
