### PR TITLE
chore: replace `Directory.Read.All` permission to `Domain.Read.All` for Azure and M365

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -70,7 +70,7 @@ The other three cases does not need additional configuration, `--az-cli-auth` an
 Prowler for Azure needs two types of permission scopes to be set:
 
 - **Microsoft Entra ID permissions**: used to retrieve metadata from the identity assumed by Prowler and specific Entra checks (not mandatory to have access to execute the tool). The permissions required by the tool are the following:
-    - `Directory.Read.All`
+    - `Domain.Read.All`
     - `Policy.Read.All`
     - `UserAuthenticationMethod.Read.All` (used only for the Entra checks related with multifactor authentication)
 - **Subscription scope permissions**: required to launch the checks against your resources, mandatory to launch the tool. It is required to add the following RBAC builtin roles per subscription to the entity that is going to be assumed by the tool:
@@ -199,7 +199,7 @@ Since this is a delegated permission authentication method, necessary permission
 Prowler for M365 requires two types of permission scopes to be set (if you want to run the full provider including PowerShell checks). Both must be configured using Microsoft Entra ID:
 
 - **Service Principal Application Permissions**: These are set at the **application** level and are used to retrieve data from the identity being assessed:
-    - `Directory.Read.All`: Required for all services.
+    - `Domain.Read.All`: Required for all services.
     - `Policy.Read.All`: Required for all services.
     - `User.Read` (IMPORTANT: this must be set as **delegated**): Required for the sign-in.
     - `SharePointTenantSettings.Read.All`: Required for SharePoint service.

--- a/docs/tutorials/azure/create-prowler-service-principal.md
+++ b/docs/tutorials/azure/create-prowler-service-principal.md
@@ -40,7 +40,7 @@ az ad sp create-for-rbac --name "ProwlerApp"
 
 To allow Prowler to retrieve metadata from the identity assumed and run specific Entra checks, it is needed to assign the following permissions:
 
-- `Directory.Read.All`
+- `Domain.Read.All`
 - `Policy.Read.All`
 - `UserAuthenticationMethod.Read.All` (used only for the Entra checks related with multifactor authentication)
 
@@ -58,7 +58,7 @@ To assign the permissions you can make it from the Azure Portal or using the Azu
 5. Then click on "+ Add a permission" and select "Microsoft Graph"
 6. Once in the "Microsoft Graph" view, select "Application permissions"
 7. Finally, search for "Directory", "Policy" and "UserAuthenticationMethod" select the following permissions:
-    - `Directory.Read.All`
+    - `Domain.Read.All`
     - `Policy.Read.All`
     - `UserAuthenticationMethod.Read.All`
 8. Click on "Add permissions" to apply the new permissions.

--- a/docs/tutorials/azure/getting-started-azure.md
+++ b/docs/tutorials/azure/getting-started-azure.md
@@ -90,7 +90,7 @@ A Service Principal is required to grant Prowler the necessary privileges.
 
 Assign the following Microsoft Graph permissions:
 
-    - Directory.Read.All
+    - Domain.Read.All
 
     - Policy.Read.All
 
@@ -107,7 +107,7 @@ Assign the following Microsoft Graph permissions:
 
 3. Search and select:
 
-    - `Directory.Read.All`
+    - `Domain.Read.All`
     - `Policy.Read.All`
     - `UserAuthenticationMethod.Read.All`
 

--- a/docs/tutorials/microsoft365/getting-started-m365.md
+++ b/docs/tutorials/microsoft365/getting-started-m365.md
@@ -96,7 +96,7 @@ With this done you will have all the needed keys, summarized in the following ta
 
 Assign the following Microsoft Graph permissions:
 
-- `Directory.Read.All`: Required for all services.
+- `Domain.Read.All`: Required for all services.
 - `Policy.Read.All`: Required for all services.
 - `SharePointTenantSettings.Read.All`: Required for SharePoint service.
 - `AuditLog.Read.All`: Required for Entra service.
@@ -114,7 +114,7 @@ Follow these steps to assign the permissions:
 
 3. Search and select every permission below and once all are selected click on `Add permissions`:
 
-    - `Directory.Read.All`
+    - `Domain.Read.All`
     - `Policy.Read.All`
     - `SharePointTenantSettings.Read.All`
     - `AuditLog.Read.All`: Required for Entra service.

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Fix `admincenter_users_admins_reduced_license_footprint` check logic to pass when admin user has no license. [(#7779)](https://github.com/prowler-cloud/prowler/pull/7779)
 - Fix `m365_powershell` to close the PowerShell sessions in msgraph services. [(#7816)](https://github.com/prowler-cloud/prowler/pull/7816)
 - Fix `defender_ensure_notify_alerts_severity_is_high`check to accept high or lower severity. [(#7862)](https://github.com/prowler-cloud/prowler/pull/7862)
+- Replace `Directory.Read.All` permission with `Domain.Read.All` which is more restrictive. [(#7888)](https://github.com/prowler-cloud/prowler/pull/7888)
 
 ---
 


### PR DESCRIPTION
### Context

We noticed that `Directory.Read.All` permission is not needed and can be replaced with `Domain.Read.All` which is more restrictive and a better practice.

### Description

This PR reflects this change in documentation.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
