### PR TITLE
chore: fix commit sha when a pr is merged

### DIFF
--- a/.github/workflows/pull-request-merged.yml
+++ b/.github/workflows/pull-request-merged.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set short git commit SHA
         id: vars
         run: |
-          shortSha=$(git rev-parse --short ${{ github.sha }})
+          shortSha=$(git rev-parse --short ${{ github.event.pull_request.merge_commit_sha }})
           echo "SHORT_SHA=${shortSha}" >> $GITHUB_ENV
 
       - name: Trigger pull request
@@ -28,7 +28,7 @@ jobs:
           repository: ${{ secrets.CLOUD_DISPATCH }}
           event-type: prowler-pull-request-merged
           client-payload: '{
-            "PROWLER_COMMIT_SHA": "${{ github.sha }}",
+            "PROWLER_COMMIT_SHA": "${{ github.event.pull_request.merge_commit_sha }}",
             "PROWLER_COMMIT_SHORT_SHA": "${{ env.SHORT_SHA }}",
             "PROWLER_PR_TITLE": "${{ github.event.pull_request.title }}",
             "PROWLER_PR_LABELS": ${{ toJson(github.event.pull_request.labels.*.name) }},


### PR DESCRIPTION
### Context

When a PR is merged, we are finding an issue where `github.sha` value is different from the commit, it gets the previous one. This is a known issue from GitHub support and they've suggested us to use `github.event.pull_request.merge_commit_sha` instead.

### Description

Replace `github.sha` by `github.event.pull_request.merge_commit_sha` on all steps.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
