### PR TITLE
fix: set user_id for tenant operations

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Fixed task lookup to use task_kwargs instead of task_args for scan report resolution. [(#7830)](https://github.com/prowler-cloud/prowler/pull/7830)
 - Fixed Kubernetes UID validation to allow valid context names [(#7871)](https://github.com/prowler-cloud/prowler/pull/7871)
 - Fixed a race condition when creating background tasks [(#7876)](https://github.com/prowler-cloud/prowler/pull/7876).
+- Fixed an error when modifying or retrieving tenants due to missing user UUID in transaction context [(#7890)](https://github.com/prowler-cloud/prowler/pull/7890).
 
 ---
 

--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -109,25 +109,11 @@ class BaseTenantViewset(BaseViewSet):
                 pass  # Tenant might not exist, handle gracefully
 
     def initial(self, request, *args, **kwargs):
-        if (
-            request.resolver_match.url_name != "tenant-detail"
-            and request.method != "DELETE"
-        ):
-            user_id = str(request.user.id)
-
-            with rls_transaction(value=user_id, parameter=POSTGRES_USER_VAR):
-                return super().initial(request, *args, **kwargs)
-
-        # TODO: DRY this when we have time
         if request.auth is None:
             raise NotAuthenticated
 
-        tenant_id = request.auth.get("tenant_id")
-        if tenant_id is None:
-            raise NotAuthenticated("Tenant ID is not present in token")
-
-        with rls_transaction(tenant_id):
-            self.request.tenant_id = tenant_id
+        user_id = str(request.user.id)
+        with rls_transaction(value=user_id, parameter=POSTGRES_USER_VAR):
             return super().initial(request, *args, **kwargs)
 
 

--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -112,6 +112,10 @@ class BaseTenantViewset(BaseViewSet):
         if request.auth is None:
             raise NotAuthenticated
 
+        tenant_id = request.auth.get("tenant_id")
+        if tenant_id is None:
+            raise NotAuthenticated("Tenant ID is not present in token")
+
         user_id = str(request.user.id)
         with rls_transaction(value=user_id, parameter=POSTGRES_USER_VAR):
             return super().initial(request, *args, **kwargs)


### PR DESCRIPTION
### Description

In this PR, we fixed an issue related to modifying and retrieving tenants in the system. Sometimes the API would return a 500 error indicating that the UUID hadn’t been set, in this case, the user’s UUID for the transaction

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
