### PR TITLE
fix: Fix named export for addCredentialsServiceAccountFormSchema

### DIFF
--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { ProviderType } from "./providers";
+
 export const addRoleFormSchema = z.object({
   name: z.string().min(1, "Name is required"),
   manage_users: z.boolean().default(false),
@@ -176,7 +178,9 @@ export const addCredentialsRoleFormSchema = (providerType: string) =>
         providerType: z.string(),
       });
 
-export const addCredentialsServiceAccountFormSchema = (providerType: string) =>
+export const addCredentialsServiceAccountFormSchema = (
+  providerType: ProviderType,
+) =>
   providerType === "gcp"
     ? z.object({
         providerId: z.string(),


### PR DESCRIPTION


### Description

- Fixes import/export of addCredentialsServiceAccountFormSchema to ensure it's correctly used as a named function.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
