### PR TITLE
revert(views): calling order to initial view method

### DIFF
--- a/api/src/backend/api/base_views.py
+++ b/api/src/backend/api/base_views.py
@@ -47,6 +47,8 @@ class BaseViewSet(ModelViewSet):
 
 class BaseRLSViewSet(BaseViewSet):
     def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+
         # Ideally, this logic would be in the `.setup()` method but DRF view sets don't call it
         # https://docs.djangoproject.com/en/5.1/ref/class-based-views/base/#django.views.generic.base.View.setup
         if request.auth is None:
@@ -60,8 +62,6 @@ class BaseRLSViewSet(BaseViewSet):
 
         self._rls_cm = rls_transaction(tenant_id)
         self._rls_cm.__enter__()
-
-        super().initial(request, *args, **kwargs)
 
     def finalize_response(self, request, response, *args, **kwargs):
         response = super().finalize_response(request, response, *args, **kwargs)
@@ -115,6 +115,8 @@ class BaseTenantViewset(BaseViewSet):
                 pass  # Tenant might not exist, handle gracefully
 
     def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+
         if request.auth is None:
             raise NotAuthenticated
 
@@ -126,8 +128,6 @@ class BaseTenantViewset(BaseViewSet):
 
         self._rls_cm = rls_transaction(value=user_id, parameter=POSTGRES_USER_VAR)
         self._rls_cm.__enter__()
-
-        super().initial(request, *args, **kwargs)
 
     def finalize_response(self, request, response, *args, **kwargs):
         response = super().finalize_response(request, response, *args, **kwargs)
@@ -141,9 +141,11 @@ class BaseTenantViewset(BaseViewSet):
 
 class BaseUserViewset(BaseViewSet):
     def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+
         # TODO refactor after improving RLS on users
         if request.stream is not None and request.stream.method == "POST":
-            return super().initial(request, *args, **kwargs)
+            return
         if request.auth is None:
             raise NotAuthenticated
 
@@ -155,8 +157,6 @@ class BaseUserViewset(BaseViewSet):
 
         self._rls_cm = rls_transaction(tenant_id)
         self._rls_cm.__enter__()
-
-        super().initial(request, *args, **kwargs)
 
     def finalize_response(self, request, response, *args, **kwargs):
         response = super().finalize_response(request, response, *args, **kwargs)


### PR DESCRIPTION
This reverts commit 9ee78fe65f179887a0b134644d5205dc9bee3b8c.

### Description

Initial cannot be called within the RLS transaction or the connection will be closed unexpectedly, leading to `already closed connection` errors in the next requests.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
