### PR TITLE
fix(docs): add mfa warning for users

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -171,6 +171,9 @@ These two new environment variables are **required** to execute the PowerShell m
 - `M365_USER` should be your Microsoft account email using the **assigned domain in the tenant**. This means it must look like `example@YourCompany.onmicrosoft.com` or `example@YourCompany.com`, but it must be the exact domain assigned to that user in the tenant.
 
     ???+ warning
+        The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically to PowerShell modules.
+
+    ???+ warning
         Using a tenant domain other than the one assigned — even if it belongs to the same tenant — will cause Prowler to fail, as Microsoft authentication will not succeed.
 
     Ensure you are using the right domain for the user you are trying to authenticate with.

--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -171,7 +171,7 @@ These two new environment variables are **required** to execute the PowerShell m
 - `M365_USER` should be your Microsoft account email using the **assigned domain in the tenant**. This means it must look like `example@YourCompany.onmicrosoft.com` or `example@YourCompany.com`, but it must be the exact domain assigned to that user in the tenant.
 
     ???+ warning
-        The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically to PowerShell modules.
+        The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically. See [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-acquire-token-username-password?tabs=dotnet) for more information.
 
     ???+ warning
         Using a tenant domain other than the one assigned — even if it belongs to the same tenant — will cause Prowler to fail, as Microsoft authentication will not succeed.

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ---
 
+### [v5.7.3] Fixed
+- Add MFA warning for users. [(#7924)](https://github.com/prowler-cloud/prowler/pull/7924)
+
+---
+
 ### [v5.7.2] Fixed
 - Fix `m365_powershell test_credentials` to use sanitized credentials. [(#7761)](https://github.com/prowler-cloud/prowler/pull/7761)
 - Fix `admincenter_users_admins_reduced_license_footprint` check logic to pass when admin user has no license. [(#7779)](https://github.com/prowler-cloud/prowler/pull/7779)


### PR DESCRIPTION
### Context

Microsoft users must not be `MFA capable` to successfully run `M365` provider as Microsoft does not allow it.

### Description

Added warning in `M365` auth documentation that **user can not be MFA capable** in order to successfully run `M365` provider.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
