### PR TITLE
fix: clear filters sync

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ## [v1.8.0] (Prowler v5.8.0) – Not released
 
+### 🐞 Fixes
+
+- Fix sync between filter buttons and URL when filters change. [(#7928)](https://github.com/prowler-cloud/prowler/pull/7928)
+
 ### 🚀 Added
 
 - New profile page with details about the user and their roles. [(#7780)](https://github.com/prowler-cloud/prowler/pull/7780)

--- a/ui/components/ui/custom/custom-dropdown-filter.tsx
+++ b/ui/components/ui/custom/custom-dropdown-filter.tsx
@@ -45,55 +45,76 @@ export const CustomDropdownFilter = ({
     return filterParam ? filterParam.split(",") : [];
   }, [searchParams, filter?.key]);
 
-  // Sync URL state with component state
-  useEffect(() => {
-    if (activeFilterValue.length > 0) {
-      const newSelection = new Set(activeFilterValue);
+  // Helper function to handle URL filter values sync
+  const syncWithActiveFilters = useCallback(() => {
+    const newSelection = new Set(activeFilterValue);
+    if (
+      newSelection.size === filterValues.length &&
+      filter?.showSelectAll !== false
+    ) {
+      newSelection.add("all");
+    }
+    setGroupSelected(newSelection);
+  }, [activeFilterValue, filterValues, filter?.showSelectAll]);
+
+  // Helper function to reset component state when filters are cleared
+  const resetComponentState = useCallback(() => {
+    setGroupSelected(new Set());
+    hasUserInteracted.current = false;
+  }, []);
+
+  // Helper function to apply default values when component loads
+  const applyDefaultValues = useCallback(() => {
+    if (filter?.defaultToSelectAll && filterValues.length > 0) {
+      const newSelection = new Set(filterValues);
+      if (filter?.showSelectAll !== false) {
+        newSelection.add("all");
+      }
+      setGroupSelected(newSelection);
+    } else if (filter?.defaultValues && filter.defaultValues.length > 0) {
+      const validDefaultValues = filter.defaultValues.filter((value) =>
+        filterValues.includes(value),
+      );
+      const newSelection = new Set(validDefaultValues);
+
+      // Add "all" if all items are selected and showSelectAll is not false
       if (
-        newSelection.size === filterValues.length &&
+        validDefaultValues.length === filterValues.length &&
         filter?.showSelectAll !== false
       ) {
         newSelection.add("all");
       }
       setGroupSelected(newSelection);
-    } else if (!hasUserInteracted.current) {
-      // Handle default behavior when no URL params exist
-      // Only apply defaults if user hasn't interacted yet
-      // Only set visual state, don't trigger URL changes automatically
-      if (filter?.defaultToSelectAll && filterValues.length > 0) {
-        const newSelection = new Set(filterValues);
-        if (filter?.showSelectAll !== false) {
-          newSelection.add("all");
-        }
-        setGroupSelected(newSelection);
-        // DON'T notify parent automatically - wait for user interaction
-      } else if (filter?.defaultValues && filter.defaultValues.length > 0) {
-        // Handle specific default values
-        const validDefaultValues = filter.defaultValues.filter((value) =>
-          filterValues.includes(value),
-        );
-        const newSelection = new Set(validDefaultValues);
-
-        // Add "all" if all items are selected and showSelectAll is not false
-        if (
-          validDefaultValues.length === filterValues.length &&
-          filter?.showSelectAll !== false
-        ) {
-          newSelection.add("all");
-        }
-
-        setGroupSelected(newSelection);
-        // DON'T notify parent automatically - wait for user interaction
-      } else {
-        setGroupSelected(new Set());
-      }
+    } else {
+      setGroupSelected(new Set());
     }
   }, [
-    activeFilterValue,
     filterValues,
     filter?.defaultToSelectAll,
     filter?.defaultValues,
     filter?.showSelectAll,
+  ]);
+
+  // Sync URL state with component state
+  useEffect(() => {
+    const hasActiveFilters = activeFilterValue.length > 0;
+    const userHasInteracted = hasUserInteracted.current;
+
+    if (hasActiveFilters) {
+      // URL has filter values - sync component state with URL
+      syncWithActiveFilters();
+    } else if (userHasInteracted) {
+      // URL has no filters but user had interacted - reset component state
+      resetComponentState();
+    } else {
+      // URL has no filters and user hasn't interacted - apply defaults
+      applyDefaultValues();
+    }
+  }, [
+    activeFilterValue,
+    syncWithActiveFilters,
+    resetComponentState,
+    applyDefaultValues,
   ]);
 
   const updateSelection = useCallback(

--- a/ui/components/ui/custom/custom-dropdown-filter.tsx
+++ b/ui/components/ui/custom/custom-dropdown-filter.tsx
@@ -20,9 +20,8 @@ import React, {
   useState,
 } from "react";
 
+import { EntityInfoShort } from "@/components/ui/entities";
 import { CustomDropdownFilterProps } from "@/types";
-
-import { EntityInfoShort } from "../entities";
 
 export const CustomDropdownFilter = ({
   filter,
@@ -57,13 +56,11 @@ export const CustomDropdownFilter = ({
     setGroupSelected(newSelection);
   }, [activeFilterValue, filterValues, filter?.showSelectAll]);
 
-  // Helper function to reset component state when filters are cleared
   const resetComponentState = useCallback(() => {
     setGroupSelected(new Set());
     hasUserInteracted.current = false;
   }, []);
 
-  // Helper function to apply default values when component loads
   const applyDefaultValues = useCallback(() => {
     if (filter?.defaultToSelectAll && filterValues.length > 0) {
       const newSelection = new Set(filterValues);
@@ -95,7 +92,6 @@ export const CustomDropdownFilter = ({
     filter?.showSelectAll,
   ]);
 
-  // Sync URL state with component state
   useEffect(() => {
     const hasActiveFilters = activeFilterValue.length > 0;
     const userHasInteracted = hasUserInteracted.current;

--- a/ui/hooks/use-url-filters.ts
+++ b/ui/hooks/use-url-filters.ts
@@ -16,8 +16,10 @@ export const useUrlFilters = () => {
     (key: string, value: string | string[] | null) => {
       const params = new URLSearchParams(searchParams.toString());
 
-      // Always reset page to 1 when a filter is applied
-      params.set("page", "1");
+      // Only reset page to 1 if page parameter already exists
+      if (params.has("page")) {
+        params.set("page", "1");
+      }
 
       const filterKey = key.startsWith("filter[") ? key : `filter[${key}]`;
 
@@ -40,7 +42,11 @@ export const useUrlFilters = () => {
       const filterKey = key.startsWith("filter[") ? key : `filter[${key}]`;
 
       params.delete(filterKey);
-      params.set("page", "1");
+
+      // Only reset page to 1 if page parameter already exists
+      if (params.has("page")) {
+        params.set("page", "1");
+      }
 
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     },


### PR DESCRIPTION
### Context

Clear all filters button doesn't work as expected.

### Description

- Now url is sync with all filter buttons.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
