### PR TITLE
feat(database): handle already closed connections

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ## [v1.8.3] (Prowler v5.7.3)
 
+### Added
+- Database backend to handle already closed connections [(#7935)](https://github.com/prowler-cloud/prowler/pull/7935).
+
 ### Fixed
 - Fixed transaction persistence with RLS operations [(#7916)](https://github.com/prowler-cloud/prowler/pull/7916).
 

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -128,6 +128,7 @@ DJANGO_GUID = {
 }
 
 DATABASE_ROUTERS = ["api.db_router.MainRouter"]
+POSTGRES_EXTRA_DB_BACKEND_BASE = "database_backend"
 
 
 # Password validation

--- a/api/src/backend/database_backend/base.py
+++ b/api/src/backend/database_backend/base.py
@@ -1,0 +1,15 @@
+import django.db
+from django.db.backends.postgresql.base import (
+    DatabaseWrapper as BuiltinPostgresDatabaseWrapper,
+)
+from psycopg2 import InterfaceError
+
+
+class DatabaseWrapper(BuiltinPostgresDatabaseWrapper):
+    def create_cursor(self, name=None):
+        try:
+            return super().create_cursor(name=name)
+        except InterfaceError:
+            django.db.close_old_connections()
+            django.db.connection.connect()
+            return super().create_cursor(name=name)


### PR DESCRIPTION
### Context

Sometimes, already closed connections would force a 500 in some requests.

### Description

We are using a custom backend now to force a new connection if the latter failed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
