### PR TITLE
fix(k8s): return a session if using kubeconfig_content

### DIFF
--- a/tests/providers/kubernetes/kubernetes_provider_test.py
+++ b/tests/providers/kubernetes/kubernetes_provider_test.py
@@ -409,3 +409,183 @@ class TestKubernetesProvider:
             KubernetesProvider.setup_session()
 
         assert captured["verify_ssl"] is False
+
+    @patch(
+        "prowler.providers.kubernetes.kubernetes_provider.client.CoreV1Api.list_namespace"
+    )
+    @patch("kubernetes.config.list_kube_config_contexts")
+    @patch("kubernetes.config.load_kube_config_from_dict")
+    def test_kubernetes_provider_kubeconfig_content(
+        self,
+        mock_load_kube_config_from_dict,
+        mock_list_kube_config_contexts,
+        mock_list_namespace,
+    ):
+        mock_load_kube_config_from_dict.return_value = None
+        mock_list_kube_config_contexts.return_value = (
+            [
+                {
+                    "name": "example-context",
+                    "context": {
+                        "cluster": "example-cluster",
+                        "user": "example-user",
+                    },
+                }
+            ],
+            None,
+        )
+        mock_list_namespace.return_value.items = [
+            client.V1Namespace(metadata=client.V1ObjectMeta(name="namespace-1")),
+        ]
+
+        kubeconfig_content = '{"apiVersion": "v1", "clusters": [{"cluster": {"server": "https://kubernetes.example.com"}, "name": "example-cluster"}], "contexts": [{"context": {"cluster": "example-cluster", "user": "example-user"}, "name": "example-context"}], "current-context": "example-context", "kind": "Config", "preferences": {}, "users": [{"name": "example-user", "user": {"token": "EXAMPLE_TOKEN"}}]}'
+
+        session = KubernetesProvider.setup_session(
+            kubeconfig_file=None,
+            kubeconfig_content=kubeconfig_content,
+            provider_id="example-context",
+            raise_on_exception=False,
+        )
+
+        assert isinstance(session, KubernetesSession)
+        assert isinstance(session.api_client, client.ApiClient)
+
+        assert session.context == {
+            "name": "example-context",
+            "context": {
+                "cluster": "example-cluster",
+                "user": "example-user",
+            },
+        }
+
+    def test_set_proxy_settings_no_proxy_no_tls_skip(self):
+        """Test set_proxy_settings with no environment variables set."""
+        with patch.dict("os.environ", {}, clear=True):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert hasattr(config, "proxy")
+            assert config.proxy is None
+            assert hasattr(config, "verify_ssl")
+            assert config.verify_ssl is True
+
+    def test_set_proxy_settings_with_https_proxy_uppercase(self):
+        """Test set_proxy_settings with HTTPS_PROXY environment variable."""
+        proxy_url = "http://proxy.example.com:8080"
+        with patch.dict("os.environ", {"HTTPS_PROXY": proxy_url}, clear=True):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy == proxy_url
+            assert config.verify_ssl is True
+
+    def test_set_proxy_settings_with_https_proxy_lowercase(self):
+        """Test set_proxy_settings with https_proxy environment variable."""
+        proxy_url = "http://proxy.example.com:3128"
+        with patch.dict("os.environ", {"https_proxy": proxy_url}, clear=True):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy == proxy_url
+            assert config.verify_ssl is True
+
+    def test_set_proxy_settings_uppercase_proxy_takes_precedence(self):
+        """Test that HTTPS_PROXY takes precedence over https_proxy."""
+        uppercase_proxy = "http://uppercase.proxy.com:8080"
+        lowercase_proxy = "http://lowercase.proxy.com:3128"
+        with patch.dict(
+            "os.environ",
+            {"HTTPS_PROXY": uppercase_proxy, "https_proxy": lowercase_proxy},
+            clear=True,
+        ):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy == uppercase_proxy
+            assert config.verify_ssl is True
+
+    def test_set_proxy_settings_with_tls_skip_true(self):
+        """Test set_proxy_settings with K8S_SKIP_TLS_VERIFY set to true."""
+        with patch.dict("os.environ", {"K8S_SKIP_TLS_VERIFY": "true"}, clear=True):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy is None
+            assert config.verify_ssl is False
+
+    def test_set_proxy_settings_with_tls_skip_true_uppercase(self):
+        """Test set_proxy_settings with K8S_SKIP_TLS_VERIFY set to TRUE."""
+        with patch.dict("os.environ", {"K8S_SKIP_TLS_VERIFY": "TRUE"}, clear=True):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy is None
+            assert config.verify_ssl is False
+
+    def test_set_proxy_settings_with_tls_skip_false(self):
+        """Test set_proxy_settings with K8S_SKIP_TLS_VERIFY set to false."""
+        with patch.dict("os.environ", {"K8S_SKIP_TLS_VERIFY": "false"}, clear=True):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy is None
+            assert config.verify_ssl is True
+
+    def test_set_proxy_settings_with_tls_skip_invalid_value(self):
+        """Test set_proxy_settings with K8S_SKIP_TLS_VERIFY set to invalid value."""
+        with patch.dict("os.environ", {"K8S_SKIP_TLS_VERIFY": "invalid"}, clear=True):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy is None
+            assert config.verify_ssl is True
+
+    def test_set_proxy_settings_with_both_proxy_and_tls_skip(self):
+        """Test set_proxy_settings with both proxy and TLS skip settings."""
+        proxy_url = "http://secure.proxy.com:8080"
+        with patch.dict(
+            "os.environ",
+            {"HTTPS_PROXY": proxy_url, "K8S_SKIP_TLS_VERIFY": "true"},
+            clear=True,
+        ):
+            config = KubernetesProvider.set_proxy_settings()
+
+            # Verify it's a Configuration instance from kubernetes.client
+            from kubernetes.client import Configuration
+
+            assert isinstance(config, Configuration)
+
+            assert config.proxy == proxy_url
+            assert config.verify_ssl is False


### PR DESCRIPTION
### Context

Fixes an issue introduced in https://github.com/prowler-cloud/prowler/pull/7720

### Description

🥪 

Return a `KubernetesSession` when using `kubeconfig_content`.

### Tests

1. Add a K8s provider
2. Set `kubeconfig` credentials

![Screenshot 2025-06-06 at 08 53 32](https://github.com/user-attachments/assets/51f35a87-b81b-4564-85ee-287cfddabecc)



### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. -> **NO BACKPORT SINCE THIS FIXES A NOT RELEASED FEATURE**
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
