### PR TITLE
chore: align Next.js version to 14.2.29 across Prowler and Cloud

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Add `Provider UID` filter to scans page. [(#7820)](https://github.com/prowler-cloud/prowler/pull/7820)
+- Aligned Next.js version to `v14.2.29` across Prowler and Cloud environments for consistency and improved maintainability. [(#7962)](https://github.com/prowler-cloud/prowler/pull/7962)
 
 ---
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -37,7 +37,7 @@
         "jose": "^5.9.3",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.471.0",
-        "next": "^14.2.26",
+        "next": "14.2.29",
         "next-auth": "^5.0.0-beta.25",
         "next-themes": "^0.2.1",
         "radix-ui": "^1.1.3",
@@ -988,9 +988,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.27.tgz",
-      "integrity": "sha512-VLGHu7aBMK0rmSEPjx6qb4njGYfEfN5HpeYV32II1dNZZvPxqa+RfWVgPf4q6hmicavceAGeQneTxofx7Zm/yw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.29.tgz",
+      "integrity": "sha512-UzgLR2eBfhKIQt0aJ7PWH7XRPYw7SXz0Fpzdl5THjUnvxy4kfBk9OU4RNPNiETewEEtaBcExNFNn1QWH8wQTjg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1004,9 +1004,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.27.tgz",
-      "integrity": "sha512-WKJsKqY1f8NkwcfVbUtoTjJ5e8Q2kEFhjM7tVFA3jqesetBR2EegUTed1Ov7lZebQ7XRrphAg665egiCLc9+Iw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.29.tgz",
+      "integrity": "sha512-wWtrAaxCVMejxPHFb1SK/PVV1WDIrXGs9ki0C/kUM8ubKHQm+3hU9MouUywCw8Wbhj3pewfHT2wjunLEr/TaLA==",
       "cpu": [
         "arm64"
       ],
@@ -1020,9 +1020,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.27.tgz",
-      "integrity": "sha512-fsXAM07rt7FQ/dpPFk+YZ8LVQ48xP37KzPFAwdQFmVzNLgizdUyNSg9zwu7l0ziMtHFBofYgBXayg9qAxIhorQ==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.29.tgz",
+      "integrity": "sha512-7Z/jk+6EVBj4pNLw/JQrvZVrAh9Bv8q81zCFSfvTMZ51WySyEHWVpwCEaJY910LyBftv2F37kuDPQm0w9CEXyg==",
       "cpu": [
         "x64"
       ],
@@ -1036,9 +1036,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.27.tgz",
-      "integrity": "sha512-yMIvV5nTOk4p0TDhd9DU6QswEm8YjZnr1o9ZI7A6jh25JHvPsIvjgyTVSlnrGFKlNNtOOJCIv5mwVU7+4VZvsg==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.29.tgz",
+      "integrity": "sha512-o6hrz5xRBwi+G7JFTHc+RUsXo2lVXEfwh4/qsuWBMQq6aut+0w98WEnoNwAwt7hkEqegzvazf81dNiwo7KjITw==",
       "cpu": [
         "arm64"
       ],
@@ -1052,9 +1052,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.27.tgz",
-      "integrity": "sha512-gpOtTwE9GUkp+VNPwTYFn1fN1UINQTulbgO8UJzBgi77g/+T+yQxfBsKUy2H96aKjoMT/AYfn3yyomNXXVoZZg==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.29.tgz",
+      "integrity": "sha512-9i+JEHBOVgqxQ92HHRFlSW1EQXqa/89IVjtHgOqsShCcB/ZBjTtkWGi+SGCJaYyWkr/lzu51NTMCfKuBf7ULNw==",
       "cpu": [
         "arm64"
       ],
@@ -1068,9 +1068,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.27.tgz",
-      "integrity": "sha512-b7bogYfYyutEhyDST5qpBkmVENZz1mVOO2632KerJjwWgr2cdycAPU33VmpTVvTs/fT8+oeoUuZ31aQV6cUhpw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.29.tgz",
+      "integrity": "sha512-B7JtMbkUwHijrGBOhgSQu2ncbCYq9E7PZ7MX58kxheiEOwdkM+jGx0cBb+rN5AeqF96JypEppK6i/bEL9T13lA==",
       "cpu": [
         "x64"
       ],
@@ -1084,9 +1084,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.27.tgz",
-      "integrity": "sha512-yGZX038wBDSRJ7tbZ6OFZtCUvLXZDVpw9rEgNUK/0PL++65hENaiMXhxJtupeCFqzHdMuJwrCnEW29saF4NmEw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.29.tgz",
+      "integrity": "sha512-yCcZo1OrO3aQ38B5zctqKU1Z3klOohIxug6qdiKO3Q3qNye/1n6XIs01YJ+Uf+TdpZQ0fNrOQI2HrTLF3Zprnw==",
       "cpu": [
         "x64"
       ],
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.27.tgz",
-      "integrity": "sha512-yRY9RzPpk+Jex4DthdKja8C3evh6jB+22AeVd6yTbcnGAFGXQWJTs6DfEcEfeFpqIEcIGbWYq7pinz6vRv7tJA==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.29.tgz",
+      "integrity": "sha512-WnrfeOEtTVidI9Z6jDLy+gxrpDcEJtZva54LYC0bSKQqmyuHzl0ego+v0F/v2aXq0am67BRqo/ybmmt45Tzo4A==",
       "cpu": [
         "arm64"
       ],
@@ -1116,9 +1116,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.27.tgz",
-      "integrity": "sha512-VSqDGpoKoUgkE2Ba4/89ZchktDOwPhKy3HgQgTf3gOhK/ZEibujLJN4qzp3rSIadn4cXUID3PmuEEM6uRPA7nQ==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.29.tgz",
+      "integrity": "sha512-vkcriFROT4wsTdSeIzbxaZjTNTFKjSYmLd8q/GVH3Dn8JmYjUKOuKXHK8n+lovW/kdcpIvydO5GtN+It2CvKWA==",
       "cpu": [
         "ia32"
       ],
@@ -1132,9 +1132,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.27.tgz",
-      "integrity": "sha512-bK46G4uS5SVlq88FnxyupRuuaCfHPtB/7heBRAZCiHD9GdVktadjiQPCzlXWTKgv6pJxP8bE7J9GGDwodtn9Mw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.29.tgz",
+      "integrity": "sha512-iPPwUEKnVs7pwR0EBLJlwxLD7TTHWS/AoVZx1l9ZQzfQciqaFEr5AlYzA2uB6Fyby1IF18t4PL0nTpB+k4Tzlw==",
       "cpu": [
         "x64"
       ],
@@ -13169,12 +13169,12 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.27",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.27.tgz",
-      "integrity": "sha512-xmTsnu6rbXVaupRmU2k3BHVpQp7kK+/Ge9XYZlwXQNS2IPP/U9ToDoO6tTSzZIV36fmDBnwKqBUd7KuFXTi0Mw==",
+      "version": "14.2.29",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.29.tgz",
+      "integrity": "sha512-s98mCOMOWLGGpGOfgKSnleXLuegvvH415qtRZXpSp00HeEgdmrxmwL9cgKU+h4XrhB16zEI5d/7BnkS3ATInsA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.27",
+        "@next/env": "14.2.29",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -13189,15 +13189,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.27",
-        "@next/swc-darwin-x64": "14.2.27",
-        "@next/swc-linux-arm64-gnu": "14.2.27",
-        "@next/swc-linux-arm64-musl": "14.2.27",
-        "@next/swc-linux-x64-gnu": "14.2.27",
-        "@next/swc-linux-x64-musl": "14.2.27",
-        "@next/swc-win32-arm64-msvc": "14.2.27",
-        "@next/swc-win32-ia32-msvc": "14.2.27",
-        "@next/swc-win32-x64-msvc": "14.2.27"
+        "@next/swc-darwin-arm64": "14.2.29",
+        "@next/swc-darwin-x64": "14.2.29",
+        "@next/swc-linux-arm64-gnu": "14.2.29",
+        "@next/swc-linux-arm64-musl": "14.2.29",
+        "@next/swc-linux-x64-gnu": "14.2.29",
+        "@next/swc-linux-x64-musl": "14.2.29",
+        "@next/swc-win32-arm64-msvc": "14.2.29",
+        "@next/swc-win32-ia32-msvc": "14.2.29",
+        "@next/swc-win32-x64-msvc": "14.2.29"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "jose": "^5.9.3",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.471.0",
-    "next": "^14.2.26",
+    "next": "14.2.29",
     "next-auth": "^5.0.0-beta.25",
     "next-themes": "^0.2.1",
     "radix-ui": "^1.1.3",


### PR DESCRIPTION

### Description

- This PR upgrades the Next.js version to 14.2.29 in both Prowler and Cloud environments to ensure consistency and avoid potential compatibility issues.
- More details in the jira ticket.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
