### PR TITLE
feat(storage): add new check `storage_ensure_file_shares_soft_delete_is_enabled`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add NIS 2 compliance framework for AWS. [(7839)](https://github.com/prowler-cloud/prowler/pull/7839)
 - Add NIS 2 compliance framework for Azure. [(7857)](https://github.com/prowler-cloud/prowler/pull/7857)
 - Add search bar in Dashboard Overview page. [(#7804)](https://github.com/prowler-cloud/prowler/pull/7804)
+- Add `storage_ensure_file_shares_soft_delete_is_enabled` check for Azure provider. [(#7966)](https://github.com/prowler-cloud/prowler/pull/7966)
 
 ---
 

--- a/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.metadata.json
+++ b/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "azure",
+  "CheckID": "storage_ensure_file_shares_soft_delete_is_enabled",
+  "CheckTitle": "Ensure soft delete for Azure File Shares is enabled",
+  "CheckType": [],
+  "ServiceName": "storage",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "",
+  "Description": "Ensure that soft delete is enabled for Azure File Shares to protect against accidental or malicious deletion of important data. This feature allows deleted file shares to be retained for a specified period, during which they can be recovered before permanent deletion occurs.",
+  "Risk": "Without soft delete enabled, accidental or malicious deletions of file shares result in permanent data loss, making recovery impossible unless a separate backup mechanism is in place.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/azure/storage/files/storage-files-prevent-file-share-deletion?tabs=azure-portal",
+  "Remediation": {
+    "Code": {
+      "CLI": "az storage account file-service-properties update --account-name <storage-account-name> --enable-delete-retention true --delete-retention-days <number-of-days>",
+      "NativeIaC": "",
+      "Other": "https://www.trendmicro.com/cloudoneconformity-staging/knowledge-base/azure/StorageAccounts/enable-soft-delete-for-file-shares.html",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable soft delete for file shares on your Azure Storage Account to allow recovery of deleted shares within a configured retention period.",
+      "Url": "https://learn.microsoft.com/en-us/azure/storage/files/storage-files-prevent-file-share-deletion?tabs=azure-portal"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
+++ b/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
@@ -1,0 +1,38 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.storage.storage_client import storage_client
+
+
+class storage_ensure_file_shares_soft_delete_is_enabled(Check):
+    def execute(self) -> list:
+        findings = []
+        for subscription, storage_accounts in storage_client.storage_accounts.items():
+            for storage_account in storage_accounts:
+                if (
+                    hasattr(storage_account, "file_shares")
+                    and storage_account.file_shares
+                ):
+                    for file_share in storage_account.file_shares:
+                        report = Check_Report_Azure(
+                            metadata=self.metadata(), resource=storage_account
+                        )
+                        report.subscription = subscription
+                        report.resource_id = file_share.name
+                        if (
+                            file_share.soft_delete_enabled
+                            and file_share.retention_days > 0
+                        ):
+                            report.status = "PASS"
+                            report.status_extended = (
+                                f"File share {file_share.name} in storage account {storage_account.name} "
+                                f"from subscription {subscription} has soft delete enabled with a retention period of "
+                                f"{file_share.retention_days} days."
+                            )
+                        else:
+                            report.status = "FAIL"
+                            report.status_extended = (
+                                f"File share {file_share.name} in storage account {storage_account.name} "
+                                f"from subscription {subscription} does not have soft delete enabled or has an invalid "
+                                f"retention period."
+                            )
+                        findings.append(report)
+        return findings

--- a/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
+++ b/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
@@ -17,10 +17,7 @@ class storage_ensure_file_shares_soft_delete_is_enabled(Check):
                         )
                         report.subscription = subscription
                         report.resource_id = file_share.name
-                        if (
-                            file_share.soft_delete_enabled
-                            and file_share.retention_days > 0
-                        ):
+                        if file_share.soft_delete_enabled:
                             report.status = "PASS"
                             report.status_extended = (
                                 f"File share {file_share.name} in storage account {storage_account.name} "

--- a/prowler/providers/azure/services/storage/storage_service.py
+++ b/prowler/providers/azure/services/storage/storage_service.py
@@ -13,6 +13,7 @@ class Storage(AzureService):
         super().__init__(StorageManagementClient, provider)
         self.storage_accounts = self._get_storage_accounts()
         self._get_blob_properties()
+        self._get_file_share_properties()
 
     def _get_storage_accounts(self):
         logger.info("Storage - Getting storage accounts...")
@@ -122,6 +123,54 @@ class Storage(AzureService):
                 f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
 
+    def _get_file_share_properties(self):
+        logger.info("Storage - Getting file share properties...")
+        for subscription, accounts in self.storage_accounts.items():
+            client = self.clients[subscription]
+            for account in accounts:
+                try:
+                    service_properties = client.file_services.get_service_properties(
+                        account.resouce_group_name, account.name
+                    )
+                    soft_delete_enabled = False
+                    retention_days = 0
+                    if (
+                        hasattr(service_properties, "share_delete_retention_policy")
+                        and service_properties.share_delete_retention_policy
+                    ):
+                        soft_delete_enabled = getattr(
+                            service_properties.share_delete_retention_policy,
+                            "enabled",
+                            False,
+                        )
+                        retention_days = (
+                            getattr(
+                                service_properties.share_delete_retention_policy,
+                                "days",
+                                0,
+                            )
+                            if soft_delete_enabled
+                            else 0
+                        )
+
+                    file_shares = client.file_shares.list(
+                        account.resouce_group_name, account.name
+                    )
+                    account.file_shares = []
+                    for file_share in file_shares:
+                        account.file_shares.append(
+                            FileShare(
+                                id=file_share.id,
+                                name=file_share.name,
+                                soft_delete_enabled=soft_delete_enabled,
+                                retention_days=retention_days,
+                            )
+                        )
+                except Exception as error:
+                    logger.error(
+                        f"Subscription name: {subscription} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                    )
+
 
 @dataclass
 class DeleteRetentionPolicy:
@@ -166,3 +215,12 @@ class Account:
     key_expiration_period_in_days: str
     location: str
     blob_properties: Optional[BlobProperties] = None
+    file_shares: list = None
+
+
+@dataclass
+class FileShare:
+    id: str
+    name: str
+    soft_delete_enabled: bool
+    retention_days: int

--- a/tests/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled_test.py
@@ -1,0 +1,188 @@
+from unittest import mock
+from uuid import uuid4
+
+from prowler.providers.azure.services.storage.storage_service import Account, FileShare
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_ID,
+    set_mocked_azure_provider,
+)
+
+
+class Test_storage_ensure_file_shares_soft_delete_is_enabled:
+    def test_no_storage_accounts(self):
+        storage_client = mock.MagicMock
+        storage_client.storage_accounts = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled.storage_client",
+                new=storage_client,
+            ),
+        ):
+            from prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled import (
+                storage_ensure_file_shares_soft_delete_is_enabled,
+            )
+
+            check = storage_ensure_file_shares_soft_delete_is_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_no_file_shares(self):
+        storage_account_id = str(uuid4())
+        storage_account_name = "Test Storage Account"
+        storage_client = mock.MagicMock
+        storage_client.storage_accounts = {
+            AZURE_SUBSCRIPTION_ID: [
+                Account(
+                    id=storage_account_id,
+                    name=storage_account_name,
+                    resouce_group_name=None,
+                    enable_https_traffic_only=False,
+                    infrastructure_encryption=False,
+                    allow_blob_public_access=None,
+                    network_rule_set=None,
+                    encryption_type="None",
+                    minimum_tls_version=None,
+                    key_expiration_period_in_days=None,
+                    location="westeurope",
+                    private_endpoint_connections=None,
+                    file_shares=[],
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled.storage_client",
+                new=storage_client,
+            ),
+        ):
+            from prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled import (
+                storage_ensure_file_shares_soft_delete_is_enabled,
+            )
+
+            check = storage_ensure_file_shares_soft_delete_is_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_file_share_soft_delete_disabled(self):
+        storage_account_id = str(uuid4())
+        storage_account_name = "Test Storage Account"
+        file_share = FileShare(
+            id="fs1",
+            name="share1",
+            soft_delete_enabled=False,
+            retention_days=0,
+        )
+        storage_client = mock.MagicMock
+        storage_client.storage_accounts = {
+            AZURE_SUBSCRIPTION_ID: [
+                Account(
+                    id=storage_account_id,
+                    name=storage_account_name,
+                    resouce_group_name=None,
+                    enable_https_traffic_only=False,
+                    infrastructure_encryption=False,
+                    allow_blob_public_access=None,
+                    network_rule_set=None,
+                    encryption_type="None",
+                    minimum_tls_version=None,
+                    key_expiration_period_in_days=None,
+                    location="westeurope",
+                    private_endpoint_connections=None,
+                    file_shares=[file_share],
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled.storage_client",
+                new=storage_client,
+            ),
+        ):
+            from prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled import (
+                storage_ensure_file_shares_soft_delete_is_enabled,
+            )
+
+            check = storage_ensure_file_shares_soft_delete_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"File share {file_share.name} in storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION_ID} does not have soft delete enabled or has an invalid retention period."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == file_share.name
+            assert result[0].location == "westeurope"
+            assert result[0].resource_name == storage_account_name
+
+    def test_file_share_soft_delete_enabled(self):
+        storage_account_id = str(uuid4())
+        storage_account_name = "Test Storage Account"
+        file_share = FileShare(
+            id="fs2",
+            name="share2",
+            soft_delete_enabled=True,
+            retention_days=7,
+        )
+        storage_client = mock.MagicMock
+        storage_client.storage_accounts = {
+            AZURE_SUBSCRIPTION_ID: [
+                Account(
+                    id=storage_account_id,
+                    name=storage_account_name,
+                    resouce_group_name=None,
+                    enable_https_traffic_only=False,
+                    infrastructure_encryption=False,
+                    allow_blob_public_access=None,
+                    network_rule_set=None,
+                    encryption_type="None",
+                    minimum_tls_version=None,
+                    key_expiration_period_in_days=None,
+                    location="westeurope",
+                    private_endpoint_connections=None,
+                    file_shares=[file_share],
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled.storage_client",
+                new=storage_client,
+            ),
+        ):
+            from prowler.providers.azure.services.storage.storage_ensure_file_shares_soft_delete_is_enabled.storage_ensure_file_shares_soft_delete_is_enabled import (
+                storage_ensure_file_shares_soft_delete_is_enabled,
+            )
+
+            check = storage_ensure_file_shares_soft_delete_is_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"File share {file_share.name} in storage account {storage_account_name} from subscription {AZURE_SUBSCRIPTION_ID} has soft delete enabled with a retention period of {file_share.retention_days} days."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == file_share.name
+            assert result[0].location == "westeurope"
+            assert result[0].resource_name == storage_account_name

--- a/tests/providers/azure/services/storage/storage_service_test.py
+++ b/tests/providers/azure/services/storage/storage_service_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from prowler.providers.azure.services.storage.storage_service import (
     Account,
     BlobProperties,
+    FileShare,
     Storage,
 )
 from tests.providers.azure.azure_fixtures import (
@@ -19,6 +20,10 @@ def mock_storage_get_storage_accounts(_):
         default_service_version=None,
         container_delete_retention_policy=None,
     )
+    file_shares = [
+        FileShare(id="fs1", name="share1", soft_delete_enabled=True, retention_days=7),
+        FileShare(id="fs2", name="share2", soft_delete_enabled=False, retention_days=0),
+    ]
     return {
         AZURE_SUBSCRIPTION_ID: [
             Account(
@@ -35,6 +40,7 @@ def mock_storage_get_storage_accounts(_):
                 private_endpoint_connections=None,
                 location="westeurope",
                 blob_properties=blob_properties,
+                file_shares=file_shares,
             )
         ]
     }
@@ -143,3 +149,15 @@ class Test_Storage_Service:
             ].blob_properties.container_delete_retention_policy
             is None
         )
+
+    def test_get_file_shares_properties(self):
+        storage = Storage(set_mocked_azure_provider())
+        account = storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0]
+        assert hasattr(account, "file_shares")
+        assert len(account.file_shares) == 2
+        assert account.file_shares[0].name == "share1"
+        assert account.file_shares[0].soft_delete_enabled is True
+        assert account.file_shares[0].retention_days == 7
+        assert account.file_shares[1].name == "share2"
+        assert account.file_shares[1].soft_delete_enabled is False
+        assert account.file_shares[1].retention_days == 0


### PR DESCRIPTION
### Context

Soft delete must be enabled for Azure File Shares to protect against accidental or malicious deletion of important data. When enabled, deleted file shares are retained for a specified period, during which they can be recovered before permanent deletion occurs.

### Description

This PR adds the check `storage_ensure_file_shares_soft_delete_is_enabled` that verifies if File Shares have soft delete enabled.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
