### PR TITLE
fix: handle scans bug when no providers are available

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -4,27 +4,28 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ## [v1.8.0] (Prowler v5.8.0) – Not released
 
-### 🐞 Fixes
-
-- Fix sync between filter buttons and URL when filters change. [(#7928)](https://github.com/prowler-cloud/prowler/pull/7928)
-- Improve heatmap perfomance. [(#7934)](https://github.com/prowler-cloud/prowler/pull/7934)
-
 ### 🚀 Added
 
 - New profile page with details about the user and their roles. [(#7780)](https://github.com/prowler-cloud/prowler/pull/7780)
 - Improved `SnippetChip` component and show resource name in new findings table. [(#7813)](https://github.com/prowler-cloud/prowler/pull/7813)
 - Possibility to edit the organization name. [(#7829)](https://github.com/prowler-cloud/prowler/pull/7829)
 - Add GCP credential method (Account Service Key). [(#7872)](https://github.com/prowler-cloud/prowler/pull/7872)
-- Add compliance detail view: ENS [(#7853)](https://github.com/prowler-cloud/prowler/pull/7853)
-- Add compliance detail view: ISO [(#7897)](https://github.com/prowler-cloud/prowler/pull/7897)
-- Add compliance detail view: CIS [(#7913)](https://github.com/prowler-cloud/prowler/pull/7913)
-- Add compliance detail view: AWS Well-Architected Framework [(#7925)](https://github.com/prowler-cloud/prowler/pull/7925)
+- Add compliance detail view: ENS. [(#7853)](https://github.com/prowler-cloud/prowler/pull/7853)
+- Add compliance detail view: ISO. [(#7897)](https://github.com/prowler-cloud/prowler/pull/7897)
+- Add compliance detail view: CIS. [(#7913)](https://github.com/prowler-cloud/prowler/pull/7913)
+- Add compliance detail view: AWS Well-Architected Framework. [(#7925)](https://github.com/prowler-cloud/prowler/pull/7925)
 - Improve `Scan ID` filter by adding more context and enhancing the UI/UX. [(#7949)](https://github.com/prowler-cloud/prowler/pull/7949)
 
 ### 🔄 Changed
 
 - Add `Provider UID` filter to scans page. [(#7820)](https://github.com/prowler-cloud/prowler/pull/7820)
-- Aligned Next.js version to `v14.2.29` across Prowler and Cloud environments for consistency and improved maintainability. [(#7962)](https://github.com/prowler-cloud/prowler/pull/7962)
+- Update Next.js version to `v14.2.29` across Prowler and Cloud environments for consistency and improved maintainability. [(#7962)](https://github.com/prowler-cloud/prowler/pull/7962)
+  
+### 🐞 Fixes
+
+- Fix sync between filter buttons and URL when filters change. [(#7928)](https://github.com/prowler-cloud/prowler/pull/7928)
+- Improve heatmap perfomance. [(#7934)](https://github.com/prowler-cloud/prowler/pull/7934)
+- Fix handle scans bug when no providers are available. [(#7970)](https://github.com/prowler-cloud/prowler/pull/7970)
 
 ---
 

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -49,8 +49,7 @@ export default async function Scans({
     filters: { "filter[connected]": true },
     pageSize: 50,
   });
-  const thereIsNoProviders =
-    !providersCountConnected?.data || providersCountConnected.data.length === 0;
+  const thereIsNoProviders = !providersCountConnected?.data;
 
   const thereIsNoProvidersConnected = providersCountConnected?.data?.every(
     (provider: ProviderProps) => !provider.attributes.connection.connected,


### PR DESCRIPTION


### Description

Fixes a bug where scans were not visible when **all providers had a "connection failed"** status. This prevented users from accessing old findings if their credentials had expired or were revoked.

---

## Steps to Reproduce

1. Add providers with correct credentials.
2. Launch scans.
3. Let the credentials expire or revoke them.
4. All providers now show “connection failed”.
5. Old scans are no longer visible.

---

## Current (Incorrect) Behaviour

You can’t see old findings if **all providers have “connection failed”**.

---

## Expected Behaviour

Even if all provider credentials are expired or invalid, users should still be able to view previously generated findings.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
