### PR TITLE
fix(k8s): remove typo for PCI 4.0 compliance framework

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Automatically encrypt password in Microsoft365 provider. [(#7784)](https://github.com/prowler-cloud/prowler/pull/7784)
 - Remove last encrypted password appearances. [(#7825)](https://github.com/prowler-cloud/prowler/pull/7825)
+- Fix typo in PCI 4.0 for K8S provider. [(#7971)](https://github.com/prowler-cloud/prowler/pull/7971) 
 
 ---
 

--- a/prowler/compliance/kubernetes/pci_4.0_kubernetes.json
+++ b/prowler/compliance/kubernetes/pci_4.0_kubernetes.json
@@ -1,7 +1,7 @@
 {
   "Framework": "PCI",
   "Version": "4.0",
-  "Provider": "Core",
+  "Provider": "Kubernetes",
   "Description": "The Payment Card Industry Data Security Standard (PCI DSS) is a proprietary information security standard. It's administered by the PCI Security Standards Council, which was founded by American Express, Discover Financial Services, JCB International, MasterCard Worldwide, and Visa Inc. PCI DSS applies to entities that store, process, or transmit cardholder data (CHD) or sensitive authentication data (SAD). This includes, but isn't limited to, merchants, processors, acquirers, issuers, and service providers. The PCI DSS is mandated by the card brands and administered by the Payment Card Industry Security Standards Council.",
   "Requirements": [
     {


### PR DESCRIPTION
### Description

This PR includes a fix for the PCI 4.0 compliance framework in the K8S provider.
There was a typo in the compliance `"Provider"` field.
 
![Screenshot 2025-06-09 at 09 42 46](https://github.com/user-attachments/assets/42be0b31-6209-4bc5-af7e-8b65d1ea808a)


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
