### PR TITLE
fix(ui): fix hydration warning on compliance and scan pages

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Fix sync between filter buttons and URL when filters change. [(#7928)](https://github.com/prowler-cloud/prowler/pull/7928)
 - Improve heatmap perfomance. [(#7934)](https://github.com/prowler-cloud/prowler/pull/7934)
+- Fixed hydration warning caused by invalid button nesting in `DownloadIconButton` on Compliance and Scan pages. [(#7976)](https://github.com/prowler-cloud/prowler/pull/7976)
 
 ### 🚀 Added
 

--- a/ui/components/ui/custom/custom-button.tsx
+++ b/ui/components/ui/custom/custom-button.tsx
@@ -54,6 +54,7 @@ interface CustomButtonProps {
   isIconOnly?: boolean;
   ref?: React.RefObject<HTMLButtonElement>;
   asLink?: string;
+  as?: React.ElementType;
 }
 
 export const CustomButton = React.forwardRef<
@@ -79,12 +80,13 @@ export const CustomButton = React.forwardRef<
       isLoading = false,
       isIconOnly,
       asLink,
+      as,
       ...props
     },
     ref,
   ) => (
     <Button
-      as={asLink ? Link : undefined}
+      as={asLink ? Link : as || undefined}
       href={asLink}
       target={target}
       type={type}

--- a/ui/components/ui/download-icon-button/download-icon-button.tsx
+++ b/ui/components/ui/download-icon-button/download-icon-button.tsx
@@ -33,6 +33,7 @@ export const DownloadIconButton = ({
           isIconOnly
           ariaLabel={ariaLabel}
           size="sm"
+          as={"div"}
         >
           <DownloadIcon
             className={isDownloading ? "animate-download-icon" : ""}


### PR DESCRIPTION
### Context

fix hydration warning on compliance and scan pages

### Description

Fixes hydration warning caused by invalid button nesting in DownloadIconButton on the Compliance and Scan pages.

![image](https://github.com/user-attachments/assets/3dcf61cf-77df-43c0-8797-95fc8948e8d7)

![image](https://github.com/user-attachments/assets/aa8e4b89-8503-4744-944d-c2bdd7b5d661)


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
