### PR TITLE
chore(gha): check changelog changes on pull request

### DIFF
--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -18,7 +18,7 @@ jobs:
       MONITORED_FOLDERS: "api ui prowler"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Comment on PR if changelog is missing
         if: steps.check_folders.outputs.missing_changelogs != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Comment on PR if all changelogs are present
         if: steps.check_folders.outputs.missing_changelogs == ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.find_comment.outputs.comment-id }}

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -1,0 +1,87 @@
+name: Check Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'api/**'
+      - 'ui/**'
+      - 'prowler/**'
+
+jobs:
+  check-changelog:
+    if: contains(github.event.pull_request.labels.*.name, 'no-backport') == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      MONITORED_FOLDERS: "api ui prowler"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get list of changed files
+        id: changed_files
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git diff --name-only origin/${{ github.base_ref }}...HEAD > changed_files.txt
+          cat changed_files.txt
+
+      - name: Check for folder changes and changelog presence
+        id: check_folders
+        run: |
+          missing_changelogs=""
+
+          for folder in $MONITORED_FOLDERS; do
+            if grep -q "^${folder}/" changed_files.txt; then
+              echo "Detected changes in ${folder}/"
+              if ! grep -q "^${folder}/CHANGELOG.md$" changed_files.txt; then
+                echo "No changelog update found for ${folder}/"
+                missing_changelogs="${missing_changelogs}- \`${folder}\`\n"
+              fi
+            fi
+          done
+
+          echo "missing_changelogs<<EOF" >> $GITHUB_OUTPUT
+          echo -e "${missing_changelogs}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Find existing changelog comment
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- changelog-check -->'
+
+      - name: Comment on PR if changelog is missing
+        if: steps.check_folders.outputs.missing_changelogs != ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          body: |
+            <!-- changelog-check -->
+            ⚠️ **Changes detected in the following folders without a corresponding update to the `CHANGELOG.md`:**
+
+            ${{ steps.check_folders.outputs.missing_changelogs }}
+
+            Please add an entry to the corresponding `CHANGELOG.md` file to maintain a clear history of changes.
+
+      - name: Comment on PR if all changelogs are present
+        if: steps.check_folders.outputs.missing_changelogs == ''
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          body: |
+            <!-- changelog-check -->
+            ✅ All necessary `CHANGELOG.md` files have been updated. Great job! 🎉
+
+      - name: Fail if changelog is missing
+        if: steps.check_folders.outputs.missing_changelogs != ''
+        run: |
+          echo "ERROR: Missing changelog updates in some folders."
+          exit 1

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Find existing changelog comment
         id: find_comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e #v3.1.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   check-changelog:
-    if: contains(github.event.pull_request.labels.*.name, 'no-backport') == false
+    if: contains(github.event.pull_request.labels.*.name, 'no-changelog') == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
### Context

We want to check if changes are written on their respective `CHANGELOG.md`. This workflow checks if there are changes on `api`, `prowler` and `ui` folders and if their changelog file has been modified. A comment will be shown on the PR if there are missed changes.

https://prowlerpro.atlassian.net/browse/PRWLR-7403

### Description

- Add `check-changelog` workflow

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
