### PR TITLE
fix(findings): exclude blank resource types from metadata endpoints

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### Fixed
 - Normalize provider UID to ensure safe and unique export directory paths [(#8007)](https://github.com/prowler-cloud/prowler/pull/8007).
+- Blank resource types in `/metadata` endpoints [(#8027)](https://github.com/prowler-cloud/prowler/pull/8027)
 
 ---
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -2090,6 +2090,8 @@ class FindingViewSet(PaginateByPkMixin, BaseRLSViewSet):
         )
         resource_types = list(
             queryset.values_list("resource_type", flat=True)
+            .exclude(resource_type__isnull=True)
+            .exclude(resource_type__exact="")
             .distinct()
             .order_by("resource_type")
         )
@@ -2191,6 +2193,8 @@ class FindingViewSet(PaginateByPkMixin, BaseRLSViewSet):
         )
         resource_types = list(
             queryset.values_list("resource_type", flat=True)
+            .exclude(resource_type__isnull=True)
+            .exclude(resource_type__exact="")
             .distinct()
             .order_by("resource_type")
         )


### PR DESCRIPTION
### Context

Due to a bug in the SDK, blank resource types could be stored in the database.

### Description

Blank resource types are excluded in the SQL query to avoid this bug in the API.

> Pointing to the same environment, same credentials, where the error was raised

![image](https://github.com/user-attachments/assets/962975f1-4a2f-4cf1-b461-801e1be84578)


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
