### PR TITLE
fix: correct parenthesis around the render condition

### DIFF
--- a/ui/components/compliance/compliance-header/compliance-header.tsx
+++ b/ui/components/compliance/compliance-header/compliance-header.tsx
@@ -56,14 +56,15 @@ export const ComplianceHeader = ({
 
   return (
     <>
-      {showProviders ||
-        (showSearch && (
+      {(showProviders || showSearch) && (
+        <>
           <div className="flex items-center justify-start gap-4">
             {showProviders && <DataCompliance scans={scans} />}
             {showSearch && <FilterControls search />}
-            <Spacer x={8} />
           </div>
-        ))}
+          <Spacer y={8} />
+        </>
+      )}
       {allFilters.length > 0 && (
         <DataTableFilterCustom filters={allFilters} defaultOpen={true} />
       )}


### PR DESCRIPTION
### Context

`Fix #8022`

### Description

- Add the correct enclosure around the rendering condition in the compliance-header.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
