### PR TITLE
feat: make user and password fields optional but mutually required fo…

### DIFF
--- a/ui/components/providers/workflow/forms/via-credentials/m365-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/via-credentials/m365-credentials-form.tsx
@@ -59,7 +59,7 @@ export const M365CredentialsForm = ({
         labelPlacement="inside"
         placeholder="Enter the User"
         variant="bordered"
-        isRequired
+        isRequired={false}
         isInvalid={!!control._formState.errors.user}
       />
       <CustomInput
@@ -70,7 +70,7 @@ export const M365CredentialsForm = ({
         labelPlacement="inside"
         placeholder="Enter the Password"
         variant="bordered"
-        isRequired
+        isRequired={false}
         isInvalid={!!control._formState.errors.password}
       />
     </>

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -211,16 +211,16 @@ export type M365Credentials = {
   [ProviderCredentialFields.CLIENT_ID]: string;
   [ProviderCredentialFields.CLIENT_SECRET]: string;
   [ProviderCredentialFields.TENANT_ID]: string;
-  [ProviderCredentialFields.USER]: string;
-  [ProviderCredentialFields.PASSWORD]: string;
-  providerId: string;
+  [ProviderCredentialFields.USER]?: string;
+  [ProviderCredentialFields.PASSWORD]?: string;
+  [ProviderCredentialFields.PROVIDER_ID]: string;
 };
 
 export type GCPDefaultCredentials = {
   client_id: string;
   client_secret: string;
   refresh_token: string;
-  providerId: string;
+  [ProviderCredentialFields.PROVIDER_ID]: string;
 };
 
 export type GCPServiceAccountKey = {

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -88,7 +88,6 @@ export const addProviderFormSchema = z
         providerType: z.literal("m365"),
         [ProviderCredentialFields.PROVIDER_ALIAS]: z.string(),
         providerUid: z.string(),
-        awsCredentialsType: z.string().optional(),
       }),
       z.object({
         providerType: z.literal("gcp"),
@@ -106,32 +105,21 @@ export const addProviderFormSchema = z
   );
 
 export const addCredentialsFormSchema = (providerType: string) =>
-  z.object({
-    [ProviderCredentialFields.PROVIDER_ID]: z.string(),
-    [ProviderCredentialFields.PROVIDER_TYPE]: z.string(),
-    ...(providerType === "aws"
-      ? {
-          [ProviderCredentialFields.AWS_ACCESS_KEY_ID]: z
-            .string()
-            .nonempty("AWS Access Key ID is required"),
-          [ProviderCredentialFields.AWS_SECRET_ACCESS_KEY]: z
-            .string()
-            .nonempty("AWS Secret Access Key is required"),
-          [ProviderCredentialFields.AWS_SESSION_TOKEN]: z.string().optional(),
-        }
-      : providerType === "azure"
+  z
+    .object({
+      [ProviderCredentialFields.PROVIDER_ID]: z.string(),
+      [ProviderCredentialFields.PROVIDER_TYPE]: z.string(),
+      ...(providerType === "aws"
         ? {
-            [ProviderCredentialFields.CLIENT_ID]: z
+            [ProviderCredentialFields.AWS_ACCESS_KEY_ID]: z
               .string()
-              .nonempty("Client ID is required"),
-            [ProviderCredentialFields.CLIENT_SECRET]: z
+              .nonempty("AWS Access Key ID is required"),
+            [ProviderCredentialFields.AWS_SECRET_ACCESS_KEY]: z
               .string()
-              .nonempty("Client Secret is required"),
-            [ProviderCredentialFields.TENANT_ID]: z
-              .string()
-              .nonempty("Tenant ID is required"),
+              .nonempty("AWS Secret Access Key is required"),
+            [ProviderCredentialFields.AWS_SESSION_TOKEN]: z.string().optional(),
           }
-        : providerType === "gcp"
+        : providerType === "azure"
           ? {
               [ProviderCredentialFields.CLIENT_ID]: z
                 .string()
@@ -139,36 +127,66 @@ export const addCredentialsFormSchema = (providerType: string) =>
               [ProviderCredentialFields.CLIENT_SECRET]: z
                 .string()
                 .nonempty("Client Secret is required"),
-              [ProviderCredentialFields.REFRESH_TOKEN]: z
+              [ProviderCredentialFields.TENANT_ID]: z
                 .string()
-                .nonempty("Refresh Token is required"),
+                .nonempty("Tenant ID is required"),
             }
-          : providerType === "kubernetes"
+          : providerType === "gcp"
             ? {
-                [ProviderCredentialFields.KUBECONFIG_CONTENT]: z
+                [ProviderCredentialFields.CLIENT_ID]: z
                   .string()
-                  .nonempty("Kubeconfig Content is required"),
+                  .nonempty("Client ID is required"),
+                [ProviderCredentialFields.CLIENT_SECRET]: z
+                  .string()
+                  .nonempty("Client Secret is required"),
+                [ProviderCredentialFields.REFRESH_TOKEN]: z
+                  .string()
+                  .nonempty("Refresh Token is required"),
               }
-            : providerType === "m365"
+            : providerType === "kubernetes"
               ? {
-                  [ProviderCredentialFields.CLIENT_ID]: z
+                  [ProviderCredentialFields.KUBECONFIG_CONTENT]: z
                     .string()
-                    .nonempty("Client ID is required"),
-                  [ProviderCredentialFields.CLIENT_SECRET]: z
-                    .string()
-                    .nonempty("Client Secret is required"),
-                  [ProviderCredentialFields.TENANT_ID]: z
-                    .string()
-                    .nonempty("Tenant ID is required"),
-                  [ProviderCredentialFields.USER]: z
-                    .string()
-                    .nonempty("User is required"),
-                  [ProviderCredentialFields.PASSWORD]: z
-                    .string()
-                    .nonempty("Password is required"),
+                    .nonempty("Kubeconfig Content is required"),
                 }
-              : {}),
-  });
+              : providerType === "m365"
+                ? {
+                    [ProviderCredentialFields.CLIENT_ID]: z
+                      .string()
+                      .nonempty("Client ID is required"),
+                    [ProviderCredentialFields.CLIENT_SECRET]: z
+                      .string()
+                      .nonempty("Client Secret is required"),
+                    [ProviderCredentialFields.TENANT_ID]: z
+                      .string()
+                      .nonempty("Tenant ID is required"),
+                    [ProviderCredentialFields.USER]: z.string().optional(),
+                    [ProviderCredentialFields.PASSWORD]: z.string().optional(),
+                  }
+                : {}),
+    })
+    .superRefine((data: Record<string, any>, ctx) => {
+      if (providerType === "m365") {
+        const hasUser = !!data[ProviderCredentialFields.USER];
+        const hasPassword = !!data[ProviderCredentialFields.PASSWORD];
+
+        if (hasUser && !hasPassword) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "If you provide a user, you must also provide a password",
+            path: [ProviderCredentialFields.PASSWORD],
+          });
+        }
+
+        if (hasPassword && !hasUser) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "If you provide a password, you must also provide a user",
+            path: [ProviderCredentialFields.USER],
+          });
+        }
+      }
+    });
 
 export const addCredentialsRoleFormSchema = (providerType: string) =>
   providerType === "aws"


### PR DESCRIPTION


### Description


- Remove validation from provider form schema to fix discriminated union type error
- Add interdependent user/password validation to credentials form schema
- Make user and password fields optional but mutually required

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
