### PR TITLE
fix(migrations): Manage concurrent index migrations properly

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Support GCP Service Account key [(#7824)](https://github.com/prowler-cloud/prowler/pull/7824)
 - `GET /compliance-overviews` endpoints to retrieve compliance metadata and specific requirements statuses [(#7877)](https://github.com/prowler-cloud/prowler/pull/7877)
 - Lighthouse configuration support [(#7848)](https://github.com/prowler-cloud/prowler/pull/7848)
+- Database concurrent index migration helpers [(#8045)](https://github.com/prowler-cloud/prowler/pull/8045)
 
 ### Changed
 - Reworked `GET /compliance-overviews` to return proper requirement metrics [(#7877)](https://github.com/prowler-cloud/prowler/pull/7877)

--- a/api/src/backend/api/db_utils.py
+++ b/api/src/backend/api/db_utils.py
@@ -250,6 +250,7 @@ def register_enum(apps, schema_editor, enum_class):  # noqa: F841
         register_adapter(enum_class, enum_adapter)
 
 
+# DEPRECATED
 def _should_create_index_on_partition(
     partition_name: str, all_partitions: bool = False
 ) -> bool:
@@ -316,6 +317,7 @@ def _should_create_index_on_partition(
         return True
 
 
+# DEPRECATED
 def create_index_on_partitions(
     apps,  # noqa: F841
     schema_editor,
@@ -381,6 +383,7 @@ def create_index_on_partitions(
             schema_editor.execute(sql)
 
 
+# DEPRECATED
 def drop_index_on_partitions(
     apps,  # noqa: F841
     schema_editor,

--- a/api/src/backend/api/migrations/0028_findings_check_index_partitions.py
+++ b/api/src/backend/api/migrations/0028_findings_check_index_partitions.py
@@ -1,8 +1,6 @@
-from functools import partial
-
 from django.db import migrations
 
-from api.db_utils import create_index_on_partitions, drop_index_on_partitions
+from api.operations import CreatePartitionedIndex
 
 
 class Migration(migrations.Migration):
@@ -13,17 +11,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(
-            partial(
-                create_index_on_partitions,
-                parent_table="findings",
-                index_name="find_tenant_scan_check_idx",
-                columns="tenant_id, scan_id, check_id",
-            ),
-            reverse_code=partial(
-                drop_index_on_partitions,
-                parent_table="findings",
-                index_name="find_tenant_scan_check_idx",
-            ),
+        CreatePartitionedIndex(
+            parent_table="findings",
+            index_name="find_tenant_scan_check_idx",
+            columns="tenant_id, scan_id, check_id",
+            method="BTREE",
+            all_partitions=False,
+            create_parent_index=True,
         )
     ]

--- a/api/src/backend/api/migrations/0029_findings_check_index_parent.py
+++ b/api/src/backend/api/migrations/0029_findings_check_index_parent.py
@@ -1,4 +1,4 @@
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):
@@ -7,11 +7,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddIndex(
-            model_name="finding",
-            index=models.Index(
-                fields=["tenant_id", "scan_id", "check_id"],
-                name="find_tenant_scan_check_idx",
-            ),
-        ),
+        # No-op: Index managed manually via CratePartitionedIndex in the previous migrations
+        # Deprecated
     ]

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -772,10 +772,11 @@ class Finding(PostgresPartitionedModel, RowLevelSecurityProtectedModel):
             GinIndex(fields=["resource_services"], name="gin_find_service_idx"),
             GinIndex(fields=["resource_regions"], name="gin_find_region_idx"),
             GinIndex(fields=["resource_types"], name="gin_find_rtype_idx"),
-            models.Index(
-                fields=["tenant_id", "scan_id", "check_id"],
-                name="find_tenant_scan_check_idx",
-            ),
+            # Indexes added through custom operation
+            # models.Index(
+            #     fields=["tenant_id", "scan_id", "check_id"],
+            #     name="find_tenant_scan_check_idx",
+            # ),
         ]
 
     class JSONAPIMeta:

--- a/api/src/backend/api/operations.py
+++ b/api/src/backend/api/operations.py
@@ -1,0 +1,140 @@
+import re
+from datetime import datetime, timezone
+
+from django.db import connection
+from django.db.migrations.operations.base import Operation
+
+
+class CreatePartitionedIndex(Operation):
+    reversible = True
+
+    def __init__(
+        self,
+        parent_table: str,
+        index_name: str,
+        columns: str,
+        method: str = "BTREE",
+        where: str = "",
+        all_partitions: bool = False,
+        create_parent_index: bool = True,
+    ):
+        self.parent_table = parent_table
+        self.index_name = index_name
+        self.columns = columns
+        self.method = method
+        self.where = where
+        self.all_partitions = all_partitions
+        self.create_parent_index = create_parent_index
+
+    def state_forwards(self, app_label, state):
+        pass  # No state change
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        parent_index_name = f"{self.index_name}"
+        where_sql = f" WHERE {self.where}" if self.where else ""
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT inhrelid::regclass::text
+                FROM pg_inherits
+                WHERE inhparent = %s::regclass
+                """,
+                [self.parent_table],
+            )
+            partitions = [row[0] for row in cursor.fetchall()]
+
+        if self.create_parent_index:
+            sql = (
+                f"CREATE INDEX IF NOT EXISTS {parent_index_name} "
+                f"ON ONLY {self.parent_table} USING {self.method} ({self.columns})"
+                f"{where_sql};"
+            )
+            schema_editor.execute(sql)
+
+        for partition in partitions:
+            if self._should_create_index_on_partition(partition, self.all_partitions):
+                child_index_name = f"{partition.replace('.', '_')}_{self.index_name}"
+                create_sql = (
+                    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {child_index_name} "
+                    f"ON {partition} USING {self.method} ({self.columns})"
+                    f"{where_sql};"
+                )
+                schema_editor.execute(create_sql)
+
+                if self.create_parent_index:
+                    attach_sql = (
+                        f"ALTER INDEX {parent_index_name} "
+                        f"ATTACH PARTITION {child_index_name};"
+                    )
+                    try:
+                        schema_editor.execute(attach_sql)
+                    except Exception as e:
+                        print(
+                            f"Warning: Could not attach index {child_index_name}: {e}"
+                        )
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        if self.create_parent_index:
+            parent_index_name = self.index_name
+            drop_parent_sql = f"DROP INDEX IF EXISTS {parent_index_name};"
+            schema_editor.execute(drop_parent_sql)
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT inhrelid::regclass::text
+                FROM pg_inherits
+                WHERE inhparent = %s::regclass
+                """,
+                [self.parent_table],
+            )
+            partitions = [row[0] for row in cursor.fetchall()]
+
+        for partition in partitions:
+            idx_name = f"{partition.replace('.', '_')}_{self.index_name}"
+            drop_sql = f"DROP INDEX CONCURRENTLY IF EXISTS {idx_name};"
+            schema_editor.execute(drop_sql)
+
+    def describe(self):
+        return f"Create partitioned index {self.index_name} on {self.parent_table}"
+
+    def _should_create_index_on_partition(
+        self, partition_name: str, all_partitions: bool
+    ) -> bool:
+        if all_partitions:
+            return True
+
+        date_pattern = r"(\d{4})_([a-z]{3})$"
+        match = re.search(date_pattern, partition_name)
+        if not match:
+            return True
+
+        try:
+            year_str, month_abbr = match.groups()
+            year = int(year_str)
+            month_map = {
+                "jan": 1,
+                "feb": 2,
+                "mar": 3,
+                "apr": 4,
+                "may": 5,
+                "jun": 6,
+                "jul": 7,
+                "aug": 8,
+                "sep": 9,
+                "oct": 10,
+                "nov": 11,
+                "dec": 12,
+            }
+            month = month_map.get(month_abbr.lower())
+            if month is None:
+                return True
+
+            partition_date = datetime(year, month, 1, tzinfo=timezone.utc)
+            current_month_start = datetime.now(timezone.utc).replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0
+            )
+            return partition_date >= current_month_start
+        except Exception:
+            return True

--- a/api/src/backend/api/operations.py
+++ b/api/src/backend/api/operations.py
@@ -26,10 +26,10 @@ class CreatePartitionedIndex(Operation):
         self.all_partitions = all_partitions
         self.create_parent_index = create_parent_index
 
-    def state_forwards(self, app_label, state):
+    def state_forwards(self, app_label, state):  # noqa: F841
         pass  # No state change
 
-    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):  # noqa: F841
         parent_index_name = f"{self.index_name}"
         where_sql = f" WHERE {self.where}" if self.where else ""
 
@@ -74,7 +74,7 @@ class CreatePartitionedIndex(Operation):
                             f"Warning: Could not attach index {child_index_name}: {e}"
                         )
 
-    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):  # noqa: F841
         if self.create_parent_index:
             parent_index_name = self.index_name
             drop_parent_sql = f"DROP INDEX IF EXISTS {parent_index_name};"

--- a/api/src/backend/api/rls.py
+++ b/api/src/backend/api/rls.py
@@ -132,9 +132,7 @@ class RowLevelSecurityConstraint(models.BaseConstraint):
         path, _, kwargs = super().deconstruct()
         return (path, (self.target_field,), kwargs)
 
-    def validate(
-        self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS
-    ):  # noqa: F841
+    def validate(self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS):  # noqa: F841
         if not hasattr(instance, "tenant_id"):
             raise ValidationError(f"{model.__name__} does not have a tenant_id field.")
 

--- a/api/src/backend/api/rls.py
+++ b/api/src/backend/api/rls.py
@@ -132,7 +132,9 @@ class RowLevelSecurityConstraint(models.BaseConstraint):
         path, _, kwargs = super().deconstruct()
         return (path, (self.target_field,), kwargs)
 
-    def validate(self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS):  # noqa: F841
+    def validate(
+        self, model, instance, exclude=None, using=DEFAULT_DB_ALIAS
+    ):  # noqa: F841
         if not hasattr(instance, "tenant_id"):
             raise ValidationError(f"{model.__name__} does not have a tenant_id field.")
 
@@ -145,7 +147,7 @@ class BaseSecurityConstraint(models.BaseConstraint):
     """
 
     drop_sql_query = """
-        REVOKE ALL ON TABLE %(table_name) TO %(db_user)s;
+        REVOKE ALL ON TABLE %(table_name)s FROM %(db_user)s;
     """
 
     def __init__(self, name: str, statements: list | None = None) -> None:


### PR DESCRIPTION
### Description

Through a Django custom Operation, we can manage migrations to add new indexes concurrently efficiently. This Operation allows:

- Applying the index only to future partitions.
- Excluding the parent table if needed.
- Reversing the migration efficiently.

#### Migrations are reversible

```shellsession
prowler@prowler-api:~/backend$ poetry run python manage.py migrate api 0027 --database admin
Operations to perform:
  Target specific migration: 0027_compliance_requirement_overviews, from api
Running migrations:
  Rendering model states... DONE
  Unapplying api.0031_lighthouseconfiguration... OK
  Unapplying api.0030_samlconfigurations... OK
  Unapplying api.0029_findings_check_index_parent... OK
  Unapplying api.0028_findings_check_index_partitions... OK
prowler@prowler-api:~/backend$ 
prowler@prowler-api:~/backend$ 
prowler@prowler-api:~/backend$ 
prowler@prowler-api:~/backend$ 
prowler@prowler-api:~/backend$ poetry run python manage.py migrate --database admin
Operations to perform:
  Apply all migrations: account, admin, api, auth, authtoken, contenttypes, django_celery_beat, django_celery_results, sessions, sites, socialaccount, token_blacklist
Running migrations:
  Applying api.0028_findings_check_index_partitions... OK
  Applying api.0029_findings_check_index_parent... OK
  Applying api.0030_samlconfigurations... OK
  Applying api.0031_lighthouseconfiguration... OK
prowler@prowler-api:~/backend$ 
```

-----

#### Old partitions are not updated if `all_partitions=False`

 Updating this code block in `partitions.py`, we can force recreating old partitions for fresh local testing

```python
manager = PostgresPartitioningManager(
    [
        PostgresPartitioningConfig(
            model=Finding,
            strategy=PostgresUUIDv7PartitioningStrategy(
                # start_date=datetime.now(timezone.utc),
                start_date=datetime(2025, 1, 1),
```

<details>

<summary>Findings January Partition (no index)</summary>

```
prowler_db=# \d findings_2025_jan
                                                                                                                                                                                                                                                 Table "public.findings_2025_jan"
      Column       |           Type           | Collation | Nullable |                                                                                                                                                                                                                           Default                                                                                                                                                                                                                           
-------------------+--------------------------+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 id                | uuid                     |           | not null | 
 inserted_at       | timestamp with time zone |           | not null | 
 updated_at        | timestamp with time zone |           | not null | 
 uid               | character varying(300)   |           | not null | 
 delta             | finding_delta            |           |          | 
 status            | status                   |           | not null | 
 status_extended   | text                     |           |          | 
 severity          | severity                 |           | not null | 
 impact            | severity                 |           | not null | 
 impact_extended   | text                     |           |          | 
 raw_result        | jsonb                    |           | not null | 
 check_id          | character varying(100)   |           | not null | 
 check_metadata    | jsonb                    |           | not null | 
 tags              | jsonb                    |           |          | 
 scan_id           | uuid                     |           | not null | 
 tenant_id         | uuid                     |           | not null | 
 text_search       | tsvector                 |           |          | generated always as (((setweight(to_tsvector('english'::regconfig, COALESCE(impact_extended, ''::text)), 'A'::"char") || setweight(to_tsvector('english'::regconfig, COALESCE(status_extended, ''::text)), 'B'::"char")) || setweight(jsonb_to_tsvector('simple'::regconfig, check_metadata, '["string", "numeric"]'::jsonb), 'D'::"char")) || setweight(jsonb_to_tsvector('simple'::regconfig, tags, '["string", "numeric"]'::jsonb), 'D'::"char")) stored
 first_seen_at     | timestamp with time zone |           |          | 
 muted             | boolean                  |           | not null | 
 compliance        | jsonb                    |           |          | 
 resource_regions  | character varying(100)[] |           |          | 
 resource_services | character varying(100)[] |           |          | 
 resource_types    | character varying(100)[] |           |          | 
Partition of: findings FOR VALUES FROM ('01941f29-7c00-74b2-8e2c-804c72810a9d') TO ('0194bece-9fff-7329-8cf3-32bfa324f3a6')
Indexes: 
    "findings_2025_jan_pkey" PRIMARY KEY, btree (id)
    "findings_2025_jan_resource_regions_idx" gin (resource_regions)
    "findings_2025_jan_resource_services_idx" gin (resource_services)
    "findings_2025_jan_resource_types_idx" gin (resource_types)
    "findings_2025_jan_scan_id_idx" btree (scan_id)
    "findings_2025_jan_tenant_id_id_idx" btree (tenant_id, id)
    "findings_2025_jan_tenant_id_id_idx1" btree (tenant_id, id) WHERE delta = 'new'::finding_delta
    "findings_2025_jan_tenant_id_idx" btree (tenant_id)
    "findings_2025_jan_tenant_id_scan_id_id_idx" btree (tenant_id, scan_id, id)
    "findings_2025_jan_tenant_id_scan_id_idx" btree (tenant_id, scan_id)
    "findings_2025_jan_tenant_id_uid_inserted_at_idx" btree (tenant_id, uid, inserted_at DESC)
    "findings_2025_jan_text_search_idx" gin (text_search)
Foreign-key constraints:
    TABLE "findings" CONSTRAINT "findings_scan_id_4df6a7a0_fk_scans_id" FOREIGN KEY (scan_id) REFERENCES scans(id) DEFERRABLE INITIALLY DEFERRED
    TABLE "findings" CONSTRAINT "findings_tenant_id_924c8b16_fk_tenants_id" FOREIGN KEY (tenant_id) REFERENCES tenants(id) DEFERRABLE INITIALLY DEFERRED
Referenced by:
    TABLE "resource_finding_mappings" CONSTRAINT "resource_finding_mappings_finding_id_d5a5c48e_fk_findings_id" FOREIGN KEY (finding_id) REFERENCES findings(id) DEFERRABLE INITIALLY DEFERRED
Policies (forced row security enabled):
    POLICY "prowler_findings_2025_jan_delete" FOR DELETE
      TO prowler
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_findings_2025_jan_insert" FOR INSERT
      TO prowler
      WITH CHECK (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_findings_2025_jan_select" FOR SELECT
      TO prowler
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_findings_2025_jan_update" FOR UPDATE
      TO prowler
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
```

</details>

<details>

<summary>Findings June Partition (index is created)</summary>

```
prowler_db=# \d findings_2025_jun
                                                                                                                                                                                                                                                 Table "public.findings_2025_jun"
      Column       |           Type           | Collation | Nullable |                                                                                                                                                                                                                           Default                                                                                                                                                                                                                           
-------------------+--------------------------+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 id                | uuid                     |           | not null | 
 inserted_at       | timestamp with time zone |           | not null | 
 updated_at        | timestamp with time zone |           | not null | 
 uid               | character varying(300)   |           | not null | 
 delta             | finding_delta            |           |          | 
 status            | status                   |           | not null | 
 status_extended   | text                     |           |          | 
 severity          | severity                 |           | not null | 
 impact            | severity                 |           | not null | 
 impact_extended   | text                     |           |          | 
 raw_result        | jsonb                    |           | not null | 
 check_id          | character varying(100)   |           | not null | 
 check_metadata    | jsonb                    |           | not null | 
 tags              | jsonb                    |           |          | 
 scan_id           | uuid                     |           | not null | 
 tenant_id         | uuid                     |           | not null | 
 text_search       | tsvector                 |           |          | generated always as (((setweight(to_tsvector('english'::regconfig, COALESCE(impact_extended, ''::text)), 'A'::"char") || setweight(to_tsvector('english'::regconfig, COALESCE(status_extended, ''::text)), 'B'::"char")) || setweight(jsonb_to_tsvector('simple'::regconfig, check_metadata, '["string", "numeric"]'::jsonb), 'D'::"char")) || setweight(jsonb_to_tsvector('simple'::regconfig, tags, '["string", "numeric"]'::jsonb), 'D'::"char")) stored
 first_seen_at     | timestamp with time zone |           |          | 
 muted             | boolean                  |           | not null | 
 compliance        | jsonb                    |           |          | 
 resource_regions  | character varying(100)[] |           |          | 
 resource_services | character varying(100)[] |           |          | 
 resource_types    | character varying(100)[] |           |          | 
Partition of: findings FOR VALUES FROM ('019728c9-c000-72e0-a55d-05220b816a80') TO ('0197c348-87ff-740b-a2ad-8431b315cde1')
Indexes: 
    "findings_2025_jun_pkey" PRIMARY KEY, btree (id)
    "findings_2025_jun_find_tenant_scan_check_idx" btree (tenant_id, scan_id, check_id)
    "findings_2025_jun_resource_regions_idx" gin (resource_regions)
    "findings_2025_jun_resource_services_idx" gin (resource_services)
    "findings_2025_jun_resource_types_idx" gin (resource_types)
    "findings_2025_jun_scan_id_idx" btree (scan_id)
    "findings_2025_jun_tenant_id_id_idx" btree (tenant_id, id)
    "findings_2025_jun_tenant_id_id_idx1" btree (tenant_id, id) WHERE delta = 'new'::finding_delta
    "findings_2025_jun_tenant_id_idx" btree (tenant_id)
    "findings_2025_jun_tenant_id_scan_id_id_idx" btree (tenant_id, scan_id, id)
    "findings_2025_jun_tenant_id_scan_id_idx" btree (tenant_id, scan_id)
    "findings_2025_jun_tenant_id_uid_inserted_at_idx" btree (tenant_id, uid, inserted_at DESC)
    "findings_2025_jun_text_search_idx" gin (text_search)
Foreign-key constraints:
    TABLE "findings" CONSTRAINT "findings_scan_id_4df6a7a0_fk_scans_id" FOREIGN KEY (scan_id) REFERENCES scans(id) DEFERRABLE INITIALLY DEFERRED
    TABLE "findings" CONSTRAINT "findings_tenant_id_924c8b16_fk_tenants_id" FOREIGN KEY (tenant_id) REFERENCES tenants(id) DEFERRABLE INITIALLY DEFERRED
Referenced by:
    TABLE "resource_finding_mappings" CONSTRAINT "resource_finding_mappings_finding_id_d5a5c48e_fk_findings_id" FOREIGN KEY (finding_id) REFERENCES findings(id) DEFERRABLE INITIALLY DEFERRED
Policies (forced row security enabled):
    POLICY "prowler_findings_2025_jun_delete" FOR DELETE
      TO prowler
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_findings_2025_jun_insert" FOR INSERT
      TO prowler
      WITH CHECK (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_findings_2025_jun_select" FOR SELECT
      TO prowler
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
    POLICY "prowler_findings_2025_jun_update" FOR UPDATE
      TO prowler
      USING (
CASE
    WHEN (current_setting('api.tenant_id'::text, true) IS NULL) THEN false
    ELSE (tenant_id = (current_setting('api.tenant_id'::text))::uuid)
END)
```

</details>


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
