### PR TITLE
fix(api): Proper error message when trying to register an already existing email

### DIFF
--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -121,7 +121,7 @@ class User(AbstractBaseUser):
         max_length=254,
         unique=True,
         help_text="Case insensitive",
-        error_messages={"unique": "Please check the email address and try again."},
+        error_messages={"unique": "An account with this email address already exists."},
     )
     company_name = models.CharField(max_length=150, blank=True)
     is_active = models.BooleanField(default=True)


### PR DESCRIPTION
### Context
When the user tries to register an email that already exists the app returns: "Please check the email address and try again." which is confusing.

Now changed to: "An account with this email address already exists."

### Description

Just wording fix to return the user proper error message.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
