### PR TITLE
chore(ocsf): remove version number and point to the latest

### DIFF
--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -116,7 +116,7 @@ The following table shows the mapping between the CSV headers and the the provid
 
 ### JSON-OCSF
 
-The JSON-OCSF output format implements the [Detection Finding](https://schema.ocsf.io/1.1.0/classes/detection_finding) from the [OCSF v1.1.0](https://schema.ocsf.io/1.1.0)
+The JSON-OCSF output format implements the [Detection Finding](https://schema.ocsf.io/classes/detection_finding) from the [OCSF v1.1.0](https://schema.ocsf.io)
 
 ```json
 [{

--- a/docs/tutorials/reporting.md
+++ b/docs/tutorials/reporting.md
@@ -116,7 +116,7 @@ The following table shows the mapping between the CSV headers and the the provid
 
 ### JSON-OCSF
 
-The JSON-OCSF output format implements the [Detection Finding](https://schema.ocsf.io/classes/detection_finding) from the [OCSF v1.1.0](https://schema.ocsf.io)
+The JSON-OCSF output format implements the [Detection Finding](https://schema.ocsf.io/classes/detection_finding) from the [OCSF](https://schema.ocsf.io)
 
 ```json
 [{

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -35,6 +35,9 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `codebuild_project_uses_allowed_github_organizations` check for AWS provider [(#7595)](https://github.com/prowler-cloud/prowler/pull/7595)
 - IaC provider [(#7852)](https://github.com/prowler-cloud/prowler/pull/7852)
 
+### Removed
+- OCSF version number references to point always to the latest [(#8064)](https://github.com/prowler-cloud/prowler/pull/8064)
+
 ---
 
 ## [v5.7.5] (Prowler UNRELEASED)

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -40,7 +40,7 @@ class OCSF(Output):
         - get_finding_status_id(muted: bool) -> StatusID: Returns the StatusID based on the muted value.
 
     References:
-        - OCSF: https://schema.ocsf.io/1.2.0/classes/detection_finding
+        - OCSF: https://schema.ocsf.io/classes/detection_finding
         - PY-OCSF-Model: https://github.com/prowler-cloud/py-ocsf-models
     """
 


### PR DESCRIPTION
### Description

Remove version number references for OCSF.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
