### PR TITLE
feat(lighthouse): add openai base url to env file

### DIFF
--- a/.env
+++ b/.env
@@ -150,3 +150,4 @@ LANGSMITH_TRACING=false
 LANGSMITH_ENDPOINT="https://api.smith.langchain.com"
 LANGSMITH_API_KEY=""
 LANGCHAIN_PROJECT=""
+OPENAI_BASE_URL="https://api.openai.com/v1"


### PR DESCRIPTION
### Context

Allows changing OpenAI base URL in Prowler Cloud.

### Description

The default value of `OPENAI_BASE_URL` is `https://api.openai.com/v1`. Modifying it in the environment file enables switching the LLM gateway from OpenAI to other providers. After the change, all calls made by the OpenAI library will be directed to the new URLs.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
