### PR TITLE
chore(gha): check changelog when label is added or deleted

### DIFF
--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -2,7 +2,7 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - 'api/**'
       - 'ui/**'

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -2,7 +2,7 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
     paths:
       - 'api/**'
       - 'ui/**'

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -3,10 +3,6 @@ name: Check Changelog
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    paths:
-      - 'api/**'
-      - 'ui/**'
-      - 'prowler/**'
 
 jobs:
   check-changelog:

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -3,6 +3,12 @@ name: Check Changelog
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'api/**'
+      - 'ui/**'
+      - 'prowler/**'
+  pull_request_target:
+    types: [labeled, unlabeled]
 
 jobs:
   check-changelog:

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -2,13 +2,7 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-    paths:
-      - 'api/**'
-      - 'ui/**'
-      - 'prowler/**'
-  pull_request_target:
-    types: [labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   check-changelog:


### PR DESCRIPTION
### Context

When a PR is labeled with `no-changelog` after it's created this pipeline is not detecting the changes. This will make it run again when it's labeled and will detect the change, same if the label is deleted.

### Description

- Add `labeled` and `unlabeled` states for the PR to run the workflow

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
