### PR TITLE
chore(API): skip safety vulnerabilities related to asteval

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -169,8 +169,9 @@ jobs:
       - name: Safety
         working-directory: ./api
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
+        # 76352 and 76353 come from SDK, but they cannot upgrade it yet. It does not affect API
         run: |
-          poetry run safety check --ignore 70612,66963,74429
+          poetry run safety check --ignore 70612,66963,74429,76352,76353
 
       - name: Vulture
         working-directory: ./api


### PR DESCRIPTION
### Context

This vulnerability does not affect the API and comes from the SDK. They will upgrade as soon as it is possible.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
