### PR TITLE
chore(gha): avoid comment on PRs for check-changelog workflow

### DIFF
--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -55,7 +55,7 @@ jobs:
           body-includes: '<!-- changelog-check -->'
 
       - name: Comment on PR if changelog is missing
-        if: steps.check_folders.outputs.missing_changelogs != ''
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.check_folders.outputs.missing_changelogs != ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -69,7 +69,7 @@ jobs:
             Please add an entry to the corresponding `CHANGELOG.md` file to maintain a clear history of changes.
 
       - name: Comment on PR if all changelogs are present
-        if: steps.check_folders.outputs.missing_changelogs == ''
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.check_folders.outputs.missing_changelogs == ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### Context

Comments from forks need other permissions to manage the messages. We will avoid them and check it manually.

### Description

Update `if` condition for comments

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
