### PR TITLE
fix: allow raising exceptions from validate_mutelist

### DIFF
--- a/prowler/lib/mutelist/mutelist.py
+++ b/prowler/lib/mutelist/mutelist.py
@@ -439,12 +439,13 @@ class Mutelist(ABC):
             return False
 
     @staticmethod
-    def validate_mutelist(mutelist: dict) -> dict:
+    def validate_mutelist(mutelist: dict, raise_on_exception: bool = False) -> dict:
         """
         Validate the mutelist against the schema.
 
         Args:
             mutelist (dict): The mutelist to be validated.
+            raise_on_exception (bool): Whether to raise an exception if the mutelist is invalid.
 
         Returns:
             dict: The mutelist itself.
@@ -453,7 +454,10 @@ class Mutelist(ABC):
             validate(mutelist, schema=mutelist_schema)
             return mutelist
         except Exception as error:
-            logger.error(
-                f"{error.__class__.__name__} -- Mutelist YAML is malformed - {error}[{error.__traceback__.tb_lineno}]"
-            )
+            if raise_on_exception:
+                raise error
+            else:
+                logger.error(
+                    f"{error.__class__.__name__} -- Mutelist YAML is malformed - {error}[{error.__traceback__.tb_lineno}]"
+                )
             return {}

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -7,6 +7,7 @@ import yaml
 from boto3 import client, resource
 from mock import MagicMock, patch
 from moto import mock_aws
+import pytest
 
 from prowler.config.config import encoding_format_utf_8
 from prowler.providers.aws.lib.mutelist.mutelist import AWSMutelist
@@ -320,6 +321,31 @@ class TestAWSMutelist:
         assert len(mutelist.validate_mutelist(mutelist_fixture)) == 0
         assert mutelist.mutelist == {}
         assert mutelist.mutelist_file_path is None
+
+    def test_validate_mutelist_raise_on_exception(self):
+        """Test that validate_mutelist raises an exception when raise_on_exception=True"""
+        mutelist_path = MUTELIST_FIXTURE_PATH
+        with open(mutelist_path) as f:
+            mutelist_fixture = yaml.safe_load(f)["Mutelist"]
+
+        # Create an invalid mutelist by adding an invalid key
+        invalid_mutelist = mutelist_fixture.copy()
+        invalid_mutelist["Accounts1"] = invalid_mutelist["Accounts"]
+        del invalid_mutelist["Accounts"]
+
+        mutelist = AWSMutelist(mutelist_content=mutelist_fixture)
+
+        # Test that it raises an exception when raise_on_exception=True
+        with pytest.raises(Exception):
+            mutelist.validate_mutelist(invalid_mutelist, raise_on_exception=True)
+
+        # Test that it doesn't raise an exception when raise_on_exception=False (default)
+        result = mutelist.validate_mutelist(invalid_mutelist, raise_on_exception=False)
+        assert result == {}
+
+        # Test that it doesn't raise an exception when raise_on_exception is not specified
+        result = mutelist.validate_mutelist(invalid_mutelist)
+        assert result == {}
 
     def test_mutelist_findings_only_wildcard(self):
         # Mutelist

--- a/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
+++ b/tests/providers/aws/lib/mutelist/aws_mutelist_test.py
@@ -323,7 +323,6 @@ class TestAWSMutelist:
         assert mutelist.mutelist_file_path is None
 
     def test_validate_mutelist_raise_on_exception(self):
-        """Test that validate_mutelist raises an exception when raise_on_exception=True"""
         mutelist_path = MUTELIST_FIXTURE_PATH
         with open(mutelist_path) as f:
             mutelist_fixture = yaml.safe_load(f)["Mutelist"]


### PR DESCRIPTION
### Context

It is helpful for users to see the actual error returned from validating a Mutelist, since it can give clues to what is wrong with the YAML / JSON.

### Description

- Added a `raise_on_exception` arg to the static `validate_mutelist` method (thanks @jfagoagas !).

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
