### PR TITLE
fix(azure): consolidate file share properties to the storage account level

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -39,6 +39,9 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add `storage_account_default_to_entra_authorization_enabled` check for Azure provider. [(#7981)](https://github.com/prowler-cloud/prowler/pull/7981)
 - Replace `Domain.Read.All` with `Directory.Read.All` in Azure and M365 docs [(#8075)](https://github.com/prowler-cloud/prowler/pull/8075)
 
+### Fixed
+- Consolidate Azure Storage file service properties to the account level, improving the accuracy of the `storage_ensure_file_shares_soft_delete_is_enabled` check [(#8087)](https://github.com/prowler-cloud/prowler/pull/8087)
+
 ### Removed
 - OCSF version number references to point always to the latest [(#8064)](https://github.com/prowler-cloud/prowler/pull/8064)
 

--- a/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
+++ b/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
@@ -7,23 +7,24 @@ class storage_ensure_file_shares_soft_delete_is_enabled(Check):
         findings = []
         for subscription, storage_accounts in storage_client.storage_accounts.items():
             for storage_account in storage_accounts:
-                report = Check_Report_Azure(
-                    metadata=self.metadata(),
-                    resource=storage_account.file_service_properties,
-                )
-                report.subscription = subscription
-                report.resource_name = storage_account.name
+                if getattr(storage_account, "file_service_properties", None):
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(),
+                        resource=storage_account.file_service_properties,
+                    )
+                    report.subscription = subscription
+                    report.resource_name = storage_account.name
+                    report.location = storage_account.location
 
-                if (
-                    getattr(storage_account, "file_service_properties", None)
-                    and storage_account.file_service_properties.share_delete_retention_policy.enabled
-                ):
-                    report.status = "PASS"
-                    report.status_extended = f"File share soft delete is enabled for storage account {storage_account.name} with a retention period of {storage_account.file_service_properties.share_delete_retention_policy.days} days."
-                else:
-                    report.status = "FAIL"
-                    report.status_extended = f"File share soft delete is not enabled for storage account {storage_account.name}."
+                    if (
+                        storage_account.file_service_properties.share_delete_retention_policy.enabled
+                    ):
+                        report.status = "PASS"
+                        report.status_extended = f"File share soft delete is enabled for storage account {storage_account.name} with a retention period of {storage_account.file_service_properties.share_delete_retention_policy.days} days."
+                    else:
+                        report.status = "FAIL"
+                        report.status_extended = f"File share soft delete is not enabled for storage account {storage_account.name}."
 
-                findings.append(report)
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
+++ b/prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py
@@ -7,29 +7,23 @@ class storage_ensure_file_shares_soft_delete_is_enabled(Check):
         findings = []
         for subscription, storage_accounts in storage_client.storage_accounts.items():
             for storage_account in storage_accounts:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(),
+                    resource=storage_account.file_service_properties,
+                )
+                report.subscription = subscription
+                report.resource_name = storage_account.name
+
                 if (
-                    hasattr(storage_account, "file_shares")
-                    and storage_account.file_shares
+                    getattr(storage_account, "file_service_properties", None)
+                    and storage_account.file_service_properties.share_delete_retention_policy.enabled
                 ):
-                    for file_share in storage_account.file_shares:
-                        report = Check_Report_Azure(
-                            metadata=self.metadata(), resource=storage_account
-                        )
-                        report.subscription = subscription
-                        report.resource_id = file_share.name
-                        if file_share.soft_delete_enabled:
-                            report.status = "PASS"
-                            report.status_extended = (
-                                f"File share {file_share.name} in storage account {storage_account.name} "
-                                f"from subscription {subscription} has soft delete enabled with a retention period of "
-                                f"{file_share.retention_days} days."
-                            )
-                        else:
-                            report.status = "FAIL"
-                            report.status_extended = (
-                                f"File share {file_share.name} in storage account {storage_account.name} "
-                                f"from subscription {subscription} does not have soft delete enabled or has an invalid "
-                                f"retention period."
-                            )
-                        findings.append(report)
+                    report.status = "PASS"
+                    report.status_extended = f"File share soft delete is enabled for storage account {storage_account.name} with a retention period of {storage_account.file_service_properties.share_delete_retention_policy.days} days."
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = f"File share soft delete is not enabled for storage account {storage_account.name}."
+
+                findings.append(report)
+
         return findings


### PR DESCRIPTION
### Context

The previous implementation for Azure Storage file services incorrectly modeled properties, such as soft delete, at the individual file share level. In Azure, these settings are managed at the storage account level for the entire file service. This discrepancy caused inaccurate assessments and findings for the `storage_ensure_file_shares_soft_delete_is_enabled` check.

This change refactors the data model to accurately reflect Azure's architecture, ensuring that file service properties are fetched and evaluated at the storage account level.

### Description

This PR consolidates file service properties from a per-share to a per-account model.

- **`prowler/providers/azure/services/storage/storage_service.py`**:
    - The `FileShare` dataclass has been removed.
    - A new `FileServiceProperties` model has been introduced and added to the `Account` dataclass to store the account-level file service settings, including the `share_delete_retention_policy`.

- **`prowler/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled.py`**:
    - The check logic has been updated to produce one finding per storage account.
    - It now assesses the soft delete policy from the `storage_account.file_service_properties` attribute.
    - The finding's `resource_id` is set to the `file_service_properties.id`, and the `resource_name` is set to the storage account's name, improving clarity.

- **`tests/`**:
    - The tests for `storage_service` and `storage_ensure_file_shares_soft_delete_is_enabled` have been updated to align with the new data structures and check logic.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.