### PR TITLE
fix(saml): avoid IndexError when some attributes are not specified

### DIFF
--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -43,10 +43,20 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
 
             if provider == "saml":
                 # Handle SAML-specific logic
-                user.first_name = extra.get("firstName", [""])[0]
-                user.last_name = extra.get("lastName", [""])[0]
-                user.company_name = extra.get("organization", [""])[0]
+                user.first_name = (
+                    extra.get("firstName", [""])[0] if extra.get("firstName") else ""
+                )
+                user.last_name = (
+                    extra.get("lastName", [""])[0] if extra.get("lastName") else ""
+                )
+                user.company_name = (
+                    extra.get("organization", [""])[0]
+                    if extra.get("organization")
+                    else ""
+                )
                 user.name = f"{user.first_name} {user.last_name}".strip()
+                if user.name == "":
+                    user.name = "NoName"
                 user.save(using=MainRouter.admin_db)
 
                 email_domain = user.email.split("@")[-1]

--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -67,7 +67,11 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
                 )
 
                 with rls_transaction(str(tenant.id)):
-                    role_name = extra.get("userType", ["saml_default_role"])[0].strip()
+                    role_name = (
+                        extra.get("userType", ["saml_default_role"])[0].strip()
+                        if extra.get("userType")
+                        else "saml_default_role"
+                    )
 
                     try:
                         role = Role.objects.using(MainRouter.admin_db).get(

--- a/api/src/backend/api/adapters.py
+++ b/api/src/backend/api/adapters.py
@@ -56,7 +56,7 @@ class ProwlerSocialAccountAdapter(DefaultSocialAccountAdapter):
                 )
                 user.name = f"{user.first_name} {user.last_name}".strip()
                 if user.name == "":
-                    user.name = "NoName"
+                    user.name = "N/A"
                 user.save(using=MainRouter.admin_db)
 
                 email_domain = user.email.split("@")[-1]

--- a/api/src/backend/api/tests/test_adapters.py
+++ b/api/src/backend/api/tests/test_adapters.py
@@ -80,7 +80,7 @@ class TestProwlerSocialAccountAdapter:
 
         user = adapter.save_user(request, saml_sociallogin)
 
-        assert user.name == "NoName"
+        assert user.name == "N/A"
         assert user.company_name == ""
         assert user.email == saml_setup["email"]
         assert (

--- a/api/src/backend/api/tests/test_adapters.py
+++ b/api/src/backend/api/tests/test_adapters.py
@@ -63,6 +63,12 @@ class TestProwlerSocialAccountAdapter:
         adapter = ProwlerSocialAccountAdapter()
         request = rf.get("/")
         saml_sociallogin.user.email = saml_setup["email"]
+        saml_sociallogin.account.extra_data = {
+            "firstName": [],
+            "lastName": [],
+            "organization": [],
+            "userType": [],
+        }
 
         tenant = Tenant.objects.using(MainRouter.admin_db).get(
             id=saml_setup["tenant_id"]
@@ -74,6 +80,8 @@ class TestProwlerSocialAccountAdapter:
 
         user = adapter.save_user(request, saml_sociallogin)
 
+        assert user.name == "NoName"
+        assert user.company_name == ""
         assert user.email == saml_setup["email"]
         assert (
             Membership.objects.using(MainRouter.admin_db)

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -518,7 +518,7 @@ class TenantFinishACSView(FinishACSView):
         )
         user.name = f"{user.first_name} {user.last_name}".strip()
         if user.name == "":
-            user.name = "NoName"
+            user.name = "N/A"
         user.save()
 
         email_domain = user.email.split("@")[-1]

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -527,7 +527,11 @@ class TenantFinishACSView(FinishACSView):
             .get(email_domain=email_domain)
             .tenant
         )
-        role_name = extra.get("userType", ["saml_default_role"])[0].strip()
+        role_name = (
+            extra.get("userType", ["saml_default_role"])[0].strip()
+            if extra.get("userType")
+            else "saml_default_role"
+        )
         try:
             role = Role.objects.using(MainRouter.admin_db).get(
                 name=role_name, tenant=tenant

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -509,10 +509,16 @@ class TenantFinishACSView(FinishACSView):
             return response
 
         extra = social_account.extra_data
-        user.first_name = extra.get("firstName", [""])[0]
-        user.last_name = extra.get("lastName", [""])[0]
-        user.company_name = extra.get("organization", [""])[0]
+        user.first_name = (
+            extra.get("firstName", [""])[0] if extra.get("firstName") else ""
+        )
+        user.last_name = extra.get("lastName", [""])[0] if extra.get("lastName") else ""
+        user.company_name = (
+            extra.get("organization", [""])[0] if extra.get("organization") else ""
+        )
         user.name = f"{user.first_name} {user.last_name}".strip()
+        if user.name == "":
+            user.name = "NoName"
         user.save()
 
         email_domain = user.email.split("@")[-1]


### PR DESCRIPTION
### Description

We recently discovered that if an attribute is not defined in the IdP, the API raises a 500 error due to an IndexError. In this PR, we’ve fixed that issue. To test this change, configure SAML and set an IdP attribute like "organization" to None.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
