### PR TITLE
fix(organizations): `Key Error: Statement` in check `organizations_scp_deny_regions`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Removed
 - OCSF version number references to point always to the latest [(#8064)](https://github.com/prowler-cloud/prowler/pull/8064)
 
+### Fixed
+- `organizations_scp_check_deny_regions` check to pass when SCP policies have no statements [(#8091)](https://github.com/prowler-cloud/prowler/pull/8091)
+
 ---
 
 ## [v5.7.5] (Prowler UNRELEASED)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -47,14 +47,12 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Removed
 - OCSF version number references to point always to the latest [(#8064)](https://github.com/prowler-cloud/prowler/pull/8064)
 
-### Fixed
-- `organizations_scp_check_deny_regions` check to pass when SCP policies have no statements [(#8091)](https://github.com/prowler-cloud/prowler/pull/8091)
-
 ---
 
 ## [v5.7.6] (Prowler UNRELEASED)
 
 ### Fixed
+- `organizations_scp_check_deny_regions` check to pass when SCP policies have no statements [(#8091)](https://github.com/prowler-cloud/prowler/pull/8091)
 - Fix logic in VPC and ELBv2 checks [(#8077)](https://github.com/prowler-cloud/prowler/pull/8077)
 
 ---

--- a/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
+++ b/prowler/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions.py
@@ -29,69 +29,76 @@ class organizations_scp_check_deny_regions(Check):
                     report.status_extended = f"AWS Organizations {organizations_client.organization.id} does not have SCP policies."
                     # We use this flag if we find a statement that is restricting regions but not all the configured ones:
                     is_region_restricted_statement = False
+                    has_statements = False
 
                     for policy in organizations_client.organization.policies.get(
                         "SERVICE_CONTROL_POLICY", []
                     ):
                         # Statements are not always list
                         statements = policy.content.get("Statement")
-                        if type(policy.content["Statement"]) is not list:
-                            statements = [policy.content.get("Statement")]
+                        if statements:
+                            has_statements = True
+                            if type(policy.content["Statement"]) is not list:
+                                statements = [policy.content.get("Statement")]
 
-                        for statement in statements:
-                            # Deny if Condition = {"StringNotEquals": {"aws:RequestedRegion": [region1, region2]}}
-                            if (
-                                statement.get("Effect") == "Deny"
-                                and "Condition" in statement
-                                and "StringNotEquals" in statement["Condition"]
-                                and "aws:RequestedRegion"
-                                in statement["Condition"]["StringNotEquals"]
-                            ):
-                                if all(
-                                    region
-                                    in statement["Condition"]["StringNotEquals"][
-                                        "aws:RequestedRegion"
-                                    ]
-                                    for region in organizations_enabled_regions
+                            for statement in statements:
+                                # Deny if Condition = {"StringNotEquals": {"aws:RequestedRegion": [region1, region2]}}
+                                if (
+                                    statement.get("Effect") == "Deny"
+                                    and "Condition" in statement
+                                    and "StringNotEquals" in statement["Condition"]
+                                    and "aws:RequestedRegion"
+                                    in statement["Condition"]["StringNotEquals"]
                                 ):
-                                    # All defined regions are restricted, we exit here, no need to continue.
-                                    report.status = "PASS"
-                                    report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policy {policy.id} restricting all configured regions found."
-                                    findings.append(report)
-                                    return findings
-                                else:
-                                    # Regions are restricted, but not the ones defined, we keep this finding, but we continue analyzing:
-                                    is_region_restricted_statement = True
-                                    report.status = "FAIL"
-                                    report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policies {policy.id} restricting some AWS Regions, but not all the configured ones, please check config."
+                                    if all(
+                                        region
+                                        in statement["Condition"]["StringNotEquals"][
+                                            "aws:RequestedRegion"
+                                        ]
+                                        for region in organizations_enabled_regions
+                                    ):
+                                        # All defined regions are restricted, we exit here, no need to continue.
+                                        report.status = "PASS"
+                                        report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policy {policy.id} restricting all configured regions found."
+                                        findings.append(report)
+                                        return findings
+                                    else:
+                                        # Regions are restricted, but not the ones defined, we keep this finding, but we continue analyzing:
+                                        is_region_restricted_statement = True
+                                        report.status = "FAIL"
+                                        report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policies {policy.id} restricting some AWS Regions, but not all the configured ones, please check config."
 
-                            # Allow if Condition = {"StringEquals": {"aws:RequestedRegion": [region1, region2]}}
-                            if (
-                                policy.content.get("Statement") == "Allow"
-                                and "Condition" in statement
-                                and "StringEquals" in statement["Condition"]
-                                and "aws:RequestedRegion"
-                                in statement["Condition"]["StringEquals"]
-                            ):
-                                if all(
-                                    region
-                                    in statement["Condition"]["StringEquals"][
-                                        "aws:RequestedRegion"
-                                    ]
-                                    for region in organizations_enabled_regions
+                                # Allow if Condition = {"StringEquals": {"aws:RequestedRegion": [region1, region2]}}
+                                if (
+                                    policy.content.get("Statement") == "Allow"
+                                    and "Condition" in statement
+                                    and "StringEquals" in statement["Condition"]
+                                    and "aws:RequestedRegion"
+                                    in statement["Condition"]["StringEquals"]
                                 ):
-                                    # All defined regions are restricted, we exit here, no need to continue.
-                                    report.status = "PASS"
-                                    report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policy {policy.id} restricting all configured regions found."
-                                    findings.append(report)
-                                    return findings
-                                else:
-                                    # Regions are restricted, but not the ones defined, we keep this finding, but we continue analyzing:
-                                    is_region_restricted_statement = True
-                                    report.status = "FAIL"
-                                    report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policies {policy.id} restricting some AWS Regions, but not all the configured ones, please check config."
+                                    if all(
+                                        region
+                                        in statement["Condition"]["StringEquals"][
+                                            "aws:RequestedRegion"
+                                        ]
+                                        for region in organizations_enabled_regions
+                                    ):
+                                        # All defined regions are restricted, we exit here, no need to continue.
+                                        report.status = "PASS"
+                                        report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policy {policy.id} restricting all configured regions found."
+                                        findings.append(report)
+                                        return findings
+                                    else:
+                                        # Regions are restricted, but not the ones defined, we keep this finding, but we continue analyzing:
+                                        is_region_restricted_statement = True
+                                        report.status = "FAIL"
+                                        report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policies {policy.id} restricting some AWS Regions, but not all the configured ones, please check config."
 
-                    if not is_region_restricted_statement:
+                        else:
+                            report.status = "FAIL"
+                            report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policies {policy.id} but don't have any statement configured."
+
+                    if not is_region_restricted_statement and has_statements:
                         report.status = "FAIL"
                         report.status_extended = f"AWS Organization {organizations_client.organization.id} has SCP policies but don't restrict AWS Regions."
 

--- a/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
+++ b/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
@@ -17,6 +17,10 @@ def scp_restrict_regions_with_deny():
     return '{"Version":"2012-10-17","Statement":{"Effect":"Deny","NotAction":"s3:*","Resource":"*","Condition":{"StringNotEquals":{"aws:RequestedRegion":["eu-central-1","eu-west-1"]}}}}'
 
 
+def scp_restrict_regions_without_statement():
+    return '{"Version":"2012-10-17"}'
+
+
 class Test_organizations_scp_check_deny_regions:
     @mock_aws
     def test_no_organization(self):
@@ -277,3 +281,74 @@ class Test_organizations_scp_check_deny_regions:
                 result = check.execute()
 
                 assert len(result) == 0
+
+    @mock_aws
+    def test_organizations_scp_check_deny_regions_without_statement(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+
+        # Create Organization
+        conn = client("organizations", region_name=AWS_REGION_EU_WEST_1)
+        response = conn.describe_organization()
+        # Delete the default FullAWSAccess policy created by Moto
+        policies = conn.list_policies(Filter="SERVICE_CONTROL_POLICY")["Policies"]
+        for policy in policies:
+            if policy["Name"] == "FullAWSAccess":
+                policy_id = policy["Id"]
+                # Detach from all roots
+                roots = conn.list_roots()["Roots"]
+                for root in roots:
+                    conn.detach_policy(PolicyId=policy_id, TargetId=root["Id"])
+                # Detach from all OUs
+                ous = conn.list_organizational_units_for_parent(
+                    ParentId=roots[0]["Id"]
+                )["OrganizationalUnits"]
+                for ou in ous:
+                    conn.detach_policy(PolicyId=policy_id, TargetId=ou["Id"])
+                # Detach from all accounts
+                accounts = conn.list_accounts()["Accounts"]
+                for account in accounts:
+                    conn.detach_policy(PolicyId=policy_id, TargetId=account["Id"])
+                # Now delete
+                conn.delete_policy(PolicyId=policy_id)
+                break
+        # Create Policy
+        response_policy = conn.create_policy(
+            Content=scp_restrict_regions_without_statement(),
+            Description="Test",
+            Name="Test",
+            Type="SERVICE_CONTROL_POLICY",
+        )
+        org_id = response["Organization"]["Id"]
+        policy_id = response_policy["Policy"]["PolicySummary"]["Id"]
+
+        # Set config variable
+        aws_provider._audit_config = {"organizations_enabled_regions": ["us-east-1"]}
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.organizations.organizations_scp_check_deny_regions.organizations_scp_check_deny_regions.organizations_client",
+                new=Organizations(aws_provider),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.organizations.organizations_scp_check_deny_regions.organizations_scp_check_deny_regions import (
+                    organizations_scp_check_deny_regions,
+                )
+
+                check = organizations_scp_check_deny_regions()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert result[0].resource_id == response["Organization"]["Id"]
+                assert (
+                    "arn:aws:organizations::123456789012:organization/o-"
+                    in result[0].resource_arn
+                )
+                assert (
+                    result[0].status_extended
+                    == f"AWS Organization {org_id} has SCP policies {policy_id} but don't have any statement configured."
+                )
+                assert result[0].region == AWS_REGION_EU_WEST_1

--- a/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
+++ b/tests/providers/aws/services/organizations/organizations_scp_check_deny_regions/organizations_scp_check_deny_regions_test.py
@@ -349,6 +349,6 @@ class Test_organizations_scp_check_deny_regions:
                 )
                 assert (
                     result[0].status_extended
-                    == f"AWS Organization {org_id} has SCP policies {policy_id} but don't have any statement configured."
+                    == f"AWS Organization {org_id} has SCP policies but don't restrict AWS Regions."
                 )
                 assert result[0].region == AWS_REGION_EU_WEST_1


### PR DESCRIPTION
### Context

This PR introduces a fix for the check `organizations_scp_deny_regions`, we noticed that we were having the following error `organizations_scp_check_deny_regions -- KeyError[38]: 'Statement'`

The problem was that when an organization has a policy without statement, the policy.content.get("Statement") return a None and that makes the rest of the code to fail.

For the unit tests I needed to delete the default policy that Moto creates in order to make the test more realistic.

### Description

Modified the check and added an unit test to cover the case.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
