### PR TITLE
fix(aws): retrieve correctly ECS Container insights settings

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Fix logic in VPC and ELBv2 checks [(#8077)](https://github.com/prowler-cloud/prowler/pull/8077)
+- Retrieve correctly ECS Container insights settings [(#8097)](https://github.com/prowler-cloud/prowler/pull/8097)
 
 ---
 

--- a/prowler/providers/aws/services/ecs/ecs_cluster_container_insights_enabled/ecs_cluster_container_insights_enabled.py
+++ b/prowler/providers/aws/services/ecs/ecs_cluster_container_insights_enabled/ecs_cluster_container_insights_enabled.py
@@ -17,6 +17,6 @@ class ecs_cluster_container_insights_enabled(Check):
                         setting["value"] == "enabled" or setting["value"] == "enhanced"
                     ):
                         report.status = "PASS"
-                        report.status_extended = f"ECS cluster {cluster.name} has container insights {setting["value"]}."
+                        report.status_extended = f"ECS cluster {cluster.name} has container insights {setting['value']}."
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/ecs/ecs_cluster_container_insights_enabled/ecs_cluster_container_insights_enabled.py
+++ b/prowler/providers/aws/services/ecs/ecs_cluster_container_insights_enabled/ecs_cluster_container_insights_enabled.py
@@ -13,11 +13,10 @@ class ecs_cluster_container_insights_enabled(Check):
             )
             if cluster.settings:
                 for setting in cluster.settings:
-                    if (
-                        setting["name"] == "containerInsights"
-                        and setting["value"] == "enabled"
+                    if setting["name"] == "containerInsights" and (
+                        setting["value"] == "enabled" or setting["value"] == "enhanced"
                     ):
                         report.status = "PASS"
-                        report.status_extended = f"ECS cluster {cluster.name} has container insights enabled."
+                        report.status_extended = f"ECS cluster {cluster.name} has container insights {setting["value"]}."
             findings.append(report)
         return findings

--- a/prowler/providers/aws/services/ecs/ecs_service.py
+++ b/prowler/providers/aws/services/ecs/ecs_service.py
@@ -175,6 +175,7 @@ class ECS(AWSService):
                 clusters=[cluster.arn],
                 include=[
                     "TAGS",
+                    "SETTINGS",
                 ],
             )
             cluster.settings = response["clusters"][0].get("settings", [])

--- a/tests/providers/aws/services/ecs/ecs_cluster_container_insights_enabled/ecs_cluster_container_insights_enabled_test.py
+++ b/tests/providers/aws/services/ecs/ecs_cluster_container_insights_enabled/ecs_cluster_container_insights_enabled_test.py
@@ -110,6 +110,45 @@ class Test_ecs_clusters_container_insights_enabled:
             )
 
     @mock_aws
+    def test_cluster_enhanced_container_insights(self):
+        ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
+        cluster_settings = [
+            {"name": "containerInsights", "value": "enhanced"},
+        ]
+        cluster_arn = ecs_client.create_cluster(
+            clusterName=CLUSTER_NAME,
+            settings=cluster_settings,
+        )["cluster"]["clusterArn"]
+
+        from prowler.providers.aws.services.ecs.ecs_service import ECS
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ecs.ecs_cluster_container_insights_enabled.ecs_cluster_container_insights_enabled.ecs_client",
+                new=ECS(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.ecs.ecs_cluster_container_insights_enabled.ecs_cluster_container_insights_enabled import (
+                ecs_cluster_container_insights_enabled,
+            )
+
+            check = ecs_cluster_container_insights_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert result[0].resource_arn == cluster_arn
+            assert (
+                result[0].status_extended
+                == f"ECS cluster {CLUSTER_NAME} has container insights enhanced."
+            )
+
+    @mock_aws
     def test_cluster_disabled_container_insights(self):
         ecs_client = client("ecs", region_name=AWS_REGION_US_EAST_1)
         cluster_settings = [


### PR DESCRIPTION
### Context

ECS Cluster was not retrieving the SETTINGS, so the check was failing. In addition, support the new Enhanced Container Insights as a suitable option for the setting

### Description

When describing the ECS Cluster retrieve the settings.

The Container Insights check now checks for `enhanced` as well as `enabled` values.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
