### PR TITLE
chore: ignore Flask Safety alert in API

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -169,9 +169,9 @@ jobs:
       - name: Safety
         working-directory: ./api
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
-        # 76352 and 76353 come from SDK, but they cannot upgrade it yet. It does not affect API
+        # 76352, 76353, 77323 come from SDK, but they cannot upgrade it yet. It does not affect API
         run: |
-          poetry run safety check --ignore 70612,66963,74429,76352,76353
+          poetry run safety check --ignore 70612,66963,74429,76352,76353,77323
 
       - name: Vulture
         working-directory: ./api


### PR DESCRIPTION
### Context

It doesn't affect the Prowler API code and it's blocking PRs.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
