### PR TITLE
fix(gcp): handle case sensitivity in `block-project-ssh-keys`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Fix logic in VPC and ELBv2 checks [(#8077)](https://github.com/prowler-cloud/prowler/pull/8077)
 - Retrieve correctly ECS Container insights settings [(#8097)](https://github.com/prowler-cloud/prowler/pull/8097)
 - Fix correct handling for different accounts-dates in prowler dashboard compliance page [(#8108)](https://github.com/prowler-cloud/prowler/pull/8108)
+- Fix handling of `block-project-ssh-keys` in GCP check `compute_instance_block_project_wide_ssh_keys_disabled` [(#8115)](https://github.com/prowler-cloud/prowler/pull/8115)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -57,7 +57,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Fix logic in VPC and ELBv2 checks [(#8077)](https://github.com/prowler-cloud/prowler/pull/8077)
 - Retrieve correctly ECS Container insights settings [(#8097)](https://github.com/prowler-cloud/prowler/pull/8097)
 - Fix correct handling for different accounts-dates in prowler dashboard compliance page [(#8108)](https://github.com/prowler-cloud/prowler/pull/8108)
-- Fix handling of `block-project-ssh-keys` in GCP check `compute_instance_block_project_wide_ssh_keys_disabled` [(#8115)](https://github.com/prowler-cloud/prowler/pull/8115)
+- Handling of `block-project-ssh-keys` in GCP check `compute_instance_block_project_wide_ssh_keys_disabled` [(#8115)](https://github.com/prowler-cloud/prowler/pull/8115)
 
 ---
 

--- a/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
@@ -11,10 +11,10 @@ class compute_instance_block_project_wide_ssh_keys_disabled(Check):
             report.status_extended = f"The VM Instance {instance.name} is making use of common/shared project-wide SSH key(s)."
             if instance.metadata.get("items"):
                 for item in instance.metadata["items"]:
-                    if (
-                        item["key"] == "block-project-ssh-keys"
-                        and item["value"] == "true"
-                    ):
+                    if item["key"] == "block-project-ssh-keys" and item["value"] in [
+                        "true",
+                        "TRUE",
+                    ]:
                         report.status = "PASS"
                         report.status_extended = f"The VM Instance {instance.name} is not making use of common/shared project-wide SSH key(s)."
                         break

--- a/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
@@ -11,9 +11,10 @@ class compute_instance_block_project_wide_ssh_keys_disabled(Check):
             report.status_extended = f"The VM Instance {instance.name} is making use of common/shared project-wide SSH key(s)."
             if instance.metadata.get("items"):
                 for item in instance.metadata["items"]:
-                    item["key"] == "block-project-ssh-keys"
-                    and item["value"].lower() == "true"
-                    ]:
+                    if (
+                        item["key"] == "block-project-ssh-keys"
+                        and item["value"].lower() == "true"
+                    ):
                         report.status = "PASS"
                         report.status_extended = f"The VM Instance {instance.name} is not making use of common/shared project-wide SSH key(s)."
                         break

--- a/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
+++ b/prowler/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled.py
@@ -11,9 +11,8 @@ class compute_instance_block_project_wide_ssh_keys_disabled(Check):
             report.status_extended = f"The VM Instance {instance.name} is making use of common/shared project-wide SSH key(s)."
             if instance.metadata.get("items"):
                 for item in instance.metadata["items"]:
-                    if item["key"] == "block-project-ssh-keys" and item["value"] in [
-                        "true",
-                        "TRUE",
+                    item["key"] == "block-project-ssh-keys"
+                    and item["value"].lower() == "true"
                     ]:
                         report.status = "PASS"
                         report.status_extended = f"The VM Instance {instance.name} is not making use of common/shared project-wide SSH key(s)."

--- a/tests/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled_test.py
+++ b/tests/providers/gcp/services/compute/compute_instance_block_project_wide_ssh_keys_disabled/compute_instance_block_project_wide_ssh_keys_disabled_test.py
@@ -77,6 +77,55 @@ class Test_compute_instance_block_project_wide_ssh_keys_disabled:
             assert result[0].resource_id == instance.id
             assert result[0].location == "us-central1"
 
+    def test_one_compliant_instance_with_block_project_ssh_keys_true_uppercase(self):
+        from prowler.providers.gcp.services.compute.compute_service import Instance
+
+        instance = Instance(
+            name="test",
+            id="1234567890",
+            zone="us-central1-a",
+            region="us-central1",
+            public_ip=True,
+            metadata={"items": [{"key": "block-project-ssh-keys", "value": "TRUE"}]},
+            shielded_enabled_vtpm=True,
+            shielded_enabled_integrity_monitoring=True,
+            confidential_computing=True,
+            service_accounts=[],
+            ip_forward=False,
+            disks_encryption=[("disk1", False), ("disk2", False)],
+            project_id=GCP_PROJECT_ID,
+        )
+
+        compute_client = mock.MagicMock()
+        compute_client.project_ids = [GCP_PROJECT_ID]
+        compute_client.instances = [instance]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_gcp_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.gcp.services.compute.compute_instance_block_project_wide_ssh_keys_disabled.compute_instance_block_project_wide_ssh_keys_disabled.compute_client",
+                new=compute_client,
+            ),
+        ):
+            from prowler.providers.gcp.services.compute.compute_instance_block_project_wide_ssh_keys_disabled.compute_instance_block_project_wide_ssh_keys_disabled import (
+                compute_instance_block_project_wide_ssh_keys_disabled,
+            )
+
+            check = compute_instance_block_project_wide_ssh_keys_disabled()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert search(
+                f"The VM Instance {instance.name} is not making use of common/shared project-wide SSH key",
+                result[0].status_extended,
+            )
+            assert result[0].resource_id == instance.id
+            assert result[0].location == "us-central1"
+
     def test_one_instance_without_metadata(self):
         from prowler.providers.gcp.services.compute.compute_service import Instance
 


### PR DESCRIPTION
### Context

Fix #8110 

### Description

The `compute_instance_block_project_wide_ssh_keys_disabled` check was returning false positives for VM instances with `block-project-ssh-keys=TRUE` (uppercase). The check only looked for lowercase "true".
Updated the check to accept both "true" and "TRUE" values.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
