### PR TITLE
feat: enhance getScans API to support fields and include parameters; …

### DIFF
--- a/ui/actions/scans/scans.ts
+++ b/ui/actions/scans/scans.ts
@@ -16,6 +16,8 @@ export const getScans = async ({
   sort = "",
   filters = {},
   pageSize = 10,
+  fields = {},
+  include = "",
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -27,6 +29,12 @@ export const getScans = async ({
   if (pageSize) url.searchParams.append("page[size]", pageSize.toString());
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
+  if (include) url.searchParams.append("include", include);
+
+  // Handle fields parameters
+  Object.entries(fields).forEach(([key, value]) => {
+    url.searchParams.append(`fields[${key}]`, String(value));
+  });
 
   // Handle multiple filters
   Object.entries(filters).forEach(([key, value]) => {

--- a/ui/app/(prowler)/compliance/[compliancetitle]/page.tsx
+++ b/ui/app/(prowler)/compliance/[compliancetitle]/page.tsx
@@ -115,7 +115,9 @@ export default async function ComplianceDetail({
     >
       {selectedScanId && selectedScan && (
         <div className="flex max-w-[328px] flex-col items-start">
-          <ComplianceScanInfo scan={selectedScan} />
+          <div className="rounded-lg bg-gray-50 p-2 dark:bg-gray-800">
+            <ComplianceScanInfo scan={selectedScan} />
+          </div>
           <Spacer y={8} />
         </div>
       )}

--- a/ui/app/(prowler)/compliance/page.tsx
+++ b/ui/app/(prowler)/compliance/page.tsx
@@ -146,7 +146,7 @@ const SSRComplianceGrid = async ({
     query,
   });
 
-  const type = compliancesData?.data?.[0]?.type;
+  const type = compliancesData?.data?.type;
 
   // Check if the response contains no data
   if (

--- a/ui/app/(prowler)/compliance/page.tsx
+++ b/ui/app/(prowler)/compliance/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from "react";
 
 import { getCompliancesOverview } from "@/actions/compliances";
 import { getComplianceOverviewMetadataInfo } from "@/actions/compliances";
-import { getProvider } from "@/actions/providers";
 import { getScans } from "@/actions/scans";
 import {
   ComplianceCard,
@@ -36,34 +35,41 @@ export default async function Compliance({
       "filter[state]": "completed",
     },
     pageSize: 50,
+    fields: {
+      scans: "name,completed_at,provider",
+    },
+    include: "provider",
   });
 
   if (!scansData?.data) {
     return <NoScansAvailable />;
   }
 
-  // Expand scans with provider information - only include scans with valid provider
-  const expandedScansData: ExpandedScanData[] = await Promise.all(
-    scansData.data
-      .filter((scan: ScanProps) => scan.relationships?.provider?.data?.id)
-      .map(async (scan: ScanProps) => {
-        const providerId = scan.relationships!.provider!.data!.id;
+  // Process scans with provider information from included data
+  const expandedScansData: ExpandedScanData[] = scansData.data
+    .filter((scan: ScanProps) => scan.relationships?.provider?.data?.id)
+    .map((scan: ScanProps) => {
+      const providerId = scan.relationships!.provider!.data!.id;
 
-        const formData = new FormData();
-        formData.append("id", providerId);
+      // Find the provider data in the included array
+      const providerData = scansData.included?.find(
+        (item: any) => item.type === "providers" && item.id === providerId,
+      );
 
-        const providerData = await getProvider(formData);
+      if (!providerData) {
+        return null;
+      }
 
-        return {
-          ...scan,
-          providerInfo: {
-            provider: providerData.data.attributes.provider,
-            uid: providerData.data.attributes.uid,
-            alias: providerData.data.attributes.alias,
-          },
-        };
-      }),
-  );
+      return {
+        ...scan,
+        providerInfo: {
+          provider: providerData.attributes.provider,
+          uid: providerData.attributes.uid,
+          alias: providerData.attributes.alias,
+        },
+      };
+    })
+    .filter(Boolean) as ExpandedScanData[];
 
   const selectedScanId =
     searchParams.scanId || expandedScansData[0]?.id || null;

--- a/ui/types/scans.ts
+++ b/ui/types/scans.ts
@@ -67,3 +67,27 @@ export interface ExpandedScanData extends ScanProps {
     alias: string;
   };
 }
+
+export interface ScansApiResponse {
+  links: {
+    first: string;
+    last: string;
+    next: string | null;
+    prev: string | null;
+  };
+  data: ScanProps[];
+  included?: Array<{
+    type: string;
+    id: string;
+    attributes: any;
+    relationships?: any;
+  }>;
+  meta: {
+    pagination: {
+      page: number;
+      pages: number;
+      count: number;
+    };
+    version: string;
+  };
+}


### PR DESCRIPTION
### Context

For the new scan filter being released in 5.8, we can optimize performance by using an include and avoiding duplicate requests:
{{baseUrl}}/api/v1/scans?fields[scans]=name,completed_at,provider&include=provider

### Description

- Properly API call
- Background color re-applied

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
