### PR TITLE
fix(m365): handle none attribute in exchange transport rule

### DIFF
--- a/prowler/providers/m365/services/exchange/exchange_service.py
+++ b/prowler/providers/m365/services/exchange/exchange_service.py
@@ -260,7 +260,7 @@ class ExternalMailConfig(BaseModel):
 class TransportRule(BaseModel):
     name: str
     scl: Optional[int]
-    sender_domain_is: list[str]
+    sender_domain_is: Optional[list[str]]
     redirect_message_to: Optional[list[str]]
 
 


### PR DESCRIPTION
### Description

Handle `None` attribute in Exchange transport rule.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
