### PR TITLE
fix(saml): limit attributes length to satisfy the socialapp restriction

### DIFF
--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -1589,18 +1589,21 @@ class SAMLConfiguration(RowLevelSecurityProtectedModel):
             provider="saml", client_id=previous_email_domain or self.email_domain
         )
 
+        client_id = self.email_domain[:191]
+        name = f"SAML-{self.email_domain}"[:40]
+
         if social_app_qs.exists():
             social_app = social_app_qs.first()
-            social_app.client_id = self.email_domain
-            social_app.name = f"{self.tenant.name} SAML ({self.email_domain})"
+            social_app.client_id = client_id
+            social_app.name = name
             social_app.settings = settings_dict
             social_app.save()
             social_app.sites.set([current_site])
         else:
             social_app = SocialApp.objects.create(
                 provider="saml",
-                client_id=self.email_domain,
-                name=f"{self.tenant.name} SAML ({self.email_domain})",
+                client_id=client_id,
+                name=name,
                 settings=settings_dict,
             )
             social_app.sites.set([current_site])


### PR DESCRIPTION
### Description

In this PR we limit the SAML length name and the client_id to satisfy the socialapp table restrictions.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
