### PR TITLE
chore(docs): update m365 docs for app auth in cloud

### DIFF
--- a/docs/getting-started/requirements.md
+++ b/docs/getting-started/requirements.md
@@ -175,6 +175,7 @@ export M365_PASSWORD="examplepassword"
 These two new environment variables are **required** to execute the PowerShell modules needed to retrieve information from M365 services. Prowler uses Service Principal authentication to access Microsoft Graph and user credentials to authenticate to Microsoft PowerShell modules.
 
 - `M365_USER` should be your Microsoft account email using the **assigned domain in the tenant**. This means it must look like `example@YourCompany.onmicrosoft.com` or `example@YourCompany.com`, but it must be the exact domain assigned to that user in the tenant.
+
     ???+ warning
         If the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
 

--- a/docs/tutorials/microsoft365/getting-started-m365.md
+++ b/docs/tutorials/microsoft365/getting-started-m365.md
@@ -30,7 +30,7 @@ Go to the Entra ID portal, then you can search for `Domain` or go to Identity > 
 
 ![Custom Domain Names](./img/custom-domain-names.png)
 
-Once you are there just select the domain you want to use.
+Once you are there just select the domain you want to use as unique identifier for your M365 account in Prowler Cloud/App.
 
 ---
 
@@ -139,10 +139,7 @@ The permissions you need to grant depends on whether you are using user credenti
     Make sure you add the correct set of permissions for the authentication method you are using.
 
 
-#### If using application(service principal) authentication
-
-???+ warning "Warning"
-    Currently Prowler Cloud only supports user authentication.
+#### If using application(service principal) authentication (Recommended)
 
 To grant the permissions for the PowerShell modules via application authentication, you need to add the necessary APIs to your app registration.
 
@@ -191,12 +188,15 @@ To grant the permissions for the PowerShell modules via application authenticati
 
     ![Final Permission Assignment](./img/final-permissions.png)
 
+---
+
+#### If using user authentication
+
+This method is not recommended because it requires a user with MFA enabled and Microsoft will not allow MFA capable users to authenticate programmatically after 1st September 2025. See [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-mandatory-multifactor-authentication?tabs=dotnet) for more information.
+
 ???+ warning
     Remember that if the user is newly created, you need to sign in with that account first, as Microsoft will prompt you to change the password. If you don’t complete this step, user authentication will fail because Microsoft marks the initial password as expired.
 
----
-
-#### If using user authentication (Currently Prowler Cloud only supports this method)
 
 1. Search and select:
 

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -170,7 +170,7 @@ By default, the `kubeconfig` file is located at `~/.kube/config`.
 ---
 
 ### **Step 4.5: M365 Credentials**
-For M365, Prowler App uses a service principal application with user and password to authenticate, for more information about the requirements needed for this provider check this [section](../getting-started/requirements.md#microsoft-365). Also, the detailed steps of how to add this provider to Prowler Cloud and start using it are [here](./microsoft365/getting-started-m365.md).
+For M365, Prowler App uses a service principal application (before we already asked for user and password but now those parameters are optional, they will continue working only if you don't have MFA enabled) to authenticate, for more information about the requirements needed for this provider check this [section](../getting-started/requirements.md#microsoft-365). Also, the detailed steps of how to add this provider to Prowler Cloud and start using it are [here](./microsoft365/getting-started-m365.md).
 
 <img src="../../img/m365-credentials.png" alt="Prowler Cloud M365 Credentials" width="700"/>
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
-## [5.8.1] (Prowler 5.8.1 UNRELEASED)
-
-### Added
-
-- Update M365 docs with new authentication method on cloud [(#8147)](https://github.com/prowler-cloud/prowler/pull/8147)
-
 ## [v5.8.0] (Prowler UNRELEASED)
 
 ### Added

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
+## [5.8.1] (Prowler 5.8.1 UNRELEASED)
+
+### Added
+
+- Update M365 docs with new authentication method on cloud [(#8147)](https://github.com/prowler-cloud/prowler/pull/8147)
+
 ## [v5.8.0] (Prowler UNRELEASED)
 
 ### Added


### PR DESCRIPTION
### Context

Once the new auth method is available in cloud we need to remove the warnings and update the docs

### Description

Modified needed docs files.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
