### PR TITLE
fix: bug when updating credentials for m365

### DIFF
--- a/ui/lib/provider-credentials/build-crendentials.ts
+++ b/ui/lib/provider-credentials/build-crendentials.ts
@@ -192,17 +192,8 @@ export const buildUpdateSecretConfig = (
   formData: FormData,
   providerType: ProviderType,
 ) => {
-  // Reuse the same secret building logic as add, but only return the secret
+  // Reuse the same secret building logic as add
   const { secret } = buildSecretConfig(formData, providerType);
-
-  // Handle special case for M365 password field inconsistency
-  if (providerType === "m365") {
-    return {
-      ...secret,
-      password: formData.get(ProviderCredentialFields.PASSWORD),
-    };
-  }
-
   return secret;
 };
 


### PR DESCRIPTION


### Description

- Fix a bug with `password` field when updating credentials for `M365`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
