### PR TITLE
fix(findings): avoid backfill on empty scans

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ---
 
+## [v1.9.1] (Prowler v5.8.1)
+
+### Fixed
+- Scan with no resources will not trigger legacy code for findings metadata [(#8183)](https://github.com/prowler-cloud/prowler/pull/8183)
+
+---
+
 ## [v1.9.0] (Prowler v5.8.0)
 
 ### Added

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -3371,6 +3371,61 @@ class TestFindingViewSet:
             ]
         }
 
+    def test_findings_metadata_backfill(
+        self, authenticated_client, scans_fixture, findings_fixture
+    ):
+        scan = scans_fixture[0]
+        scan.unique_resource_count = 1
+        scan.save()
+
+        with patch(
+            "api.v1.views.backfill_scan_resource_summaries_task.apply_async"
+        ) as mock_backfill_task:
+            response = authenticated_client.get(
+                reverse("finding-metadata"),
+                {"filter[scan]": str(scan.id)},
+            )
+        assert response.status_code == status.HTTP_200_OK
+        mock_backfill_task.assert_called()
+
+    def test_findings_metadata_backfill_no_resources(
+        self, authenticated_client, scans_fixture
+    ):
+        scan_id = str(scans_fixture[0].id)
+        with patch(
+            "api.v1.views.backfill_scan_resource_summaries_task.apply_async"
+        ) as mock_backfill_task:
+            response = authenticated_client.get(
+                reverse("finding-metadata"),
+                {"filter[scan]": scan_id},
+            )
+        assert response.status_code == status.HTTP_200_OK
+        mock_backfill_task.assert_not_called()
+
+    def test_findings_metadata_latest_backfill(
+        self, authenticated_client, scans_fixture, findings_fixture
+    ):
+        scan = scans_fixture[0]
+        scan.unique_resource_count = 1
+        scan.save()
+
+        with patch(
+            "api.v1.views.backfill_scan_resource_summaries_task.apply_async"
+        ) as mock_backfill_task:
+            response = authenticated_client.get(reverse("finding-metadata_latest"))
+        assert response.status_code == status.HTTP_200_OK
+        mock_backfill_task.assert_called()
+
+    def test_findings_metadata_latest_backfill_no_resources(
+        self, authenticated_client, scans_fixture
+    ):
+        with patch(
+            "api.v1.views.backfill_scan_resource_summaries_task.apply_async"
+        ) as mock_backfill_task:
+            response = authenticated_client.get(reverse("finding-metadata_latest"))
+        assert response.status_code == status.HTTP_200_OK
+        mock_backfill_task.assert_not_called()
+
     def test_findings_latest(self, authenticated_client, latest_scan_finding):
         response = authenticated_client.get(
             reverse("finding-latest"),

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -2127,9 +2127,12 @@ class FindingViewSet(PaginateByPkMixin, BaseRLSViewSet):
 
         # ToRemove: Temporary fallback mechanism
         if not queryset.exists():
-            scan_ids = Scan.objects.filter(
+            raw_scans_ids = Scan.objects.filter(
                 tenant_id=tenant_id, **scan_based_filters
-            ).values_list("id", flat=True)
+            ).values_list("id", "unique_resource_count")
+            scan_ids = [
+                scan_id for scan_id, count in raw_scans_ids if count and count > 0
+            ]
             for scan_id in scan_ids:
                 backfill_scan_resource_summaries_task.apply_async(
                     kwargs={"tenant_id": tenant_id, "scan_id": scan_id}
@@ -2215,7 +2218,12 @@ class FindingViewSet(PaginateByPkMixin, BaseRLSViewSet):
             .order_by("provider_id", "-inserted_at")
             .distinct("provider_id")
         )
-        latest_scans_ids = list(latest_scans_queryset.values_list("id", flat=True))
+        raw_latest_scans_ids = list(
+            latest_scans_queryset.values_list("id", "unique_resource_count")
+        )
+        latest_scans_ids = [
+            scan_id for scan_id, count in raw_latest_scans_ids if count and count > 0
+        ]
 
         queryset = ResourceScanSummary.objects.filter(
             tenant_id=tenant_id,


### PR DESCRIPTION
### Context

Scans with 0 resources would trigger the old metadata mechanism, taking longer time and going on an endless loop with the backfill task, trying to trigger it every time.

### Description

Since scans with no resources cannot add anything to the findings metadata, those will be avoided.

![image](https://github.com/user-attachments/assets/a7d1cfe9-84d3-45ab-a512-025d0d8514b8)

A scan with no resources (manually forced through the Prowler SDK) loads as expected, takes no time and does not trigger a backfill task.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
