### PR TITLE
fix(ec2): allow empty values for `http_endpoint` in templates

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - fix(iam): detect wildcarded ARNs in sts:AssumeRole policy resources [(#8164)](https://github.com/prowler-cloud/prowler/pull/8164)
+- fix(ec2): allow empty values for http_endpoint in templates [(#8184)](https://github.com/prowler-cloud/prowler/pull/8184)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Changed
 
 ### Fixed
+
+---
+
+## [v5.8.1] (Prowler 5.8.1)
+
+### Fixed
 - fix(iam): detect wildcarded ARNs in sts:AssumeRole policy resources [(#8164)](https://github.com/prowler-cloud/prowler/pull/8164)
 - fix(ec2): allow empty values for http_endpoint in templates [(#8184)](https://github.com/prowler-cloud/prowler/pull/8184)
 

--- a/prowler/providers/aws/services/ec2/ec2_launch_template_imdsv2_required/ec2_launch_template_imdsv2_required.py
+++ b/prowler/providers/aws/services/ec2/ec2_launch_template_imdsv2_required/ec2_launch_template_imdsv2_required.py
@@ -18,7 +18,10 @@ class ec2_launch_template_imdsv2_required(Check):
                     and version.template_data.http_tokens == "required"
                 ):
                     versions_with_imdsv2_required.append(str(version.version_number))
-                elif version.template_data.http_endpoint == "disabled":
+                elif (
+                    version.template_data.http_endpoint == "disabled"
+                    or not version.template_data.http_endpoint
+                ):
                     versions_with_metadata_disabled.append(str(version.version_number))
                 else:
                     versions_with_no_imdsv2.append(str(version.version_number))

--- a/tests/providers/aws/services/ec2/ec2_launch_template_imdsv2_required/ec2_launch_template_imdsv2_required_test.py
+++ b/tests/providers/aws/services/ec2/ec2_launch_template_imdsv2_required/ec2_launch_template_imdsv2_required_test.py
@@ -27,6 +27,24 @@ def mock_make_api_call(self, operation_name, kwarg):
     return make_api_call(self, operation_name, kwarg)
 
 
+def mock_make_api_call_empty(self, operation_name, kwarg):
+    if operation_name == "DescribeLaunchTemplateVersions":
+        return {
+            "LaunchTemplateVersions": [
+                {
+                    "VersionNumber": 1,
+                    "LaunchTemplateData": {
+                        "MetadataOptions": {
+                            "HttpEndpoint": "",
+                            "HttpTokens": "required",
+                        }
+                    },
+                }
+            ]
+        }
+    return make_api_call(self, operation_name, kwarg)
+
+
 def mock_make_api_call_not_required(self, operation_name, kwarg):
     if operation_name == "DescribeLaunchTemplateVersions":
         return {
@@ -125,6 +143,66 @@ class Test_ec2_launch_template_imdsv2_required:
                 assert (
                     result[0].status_extended
                     == f"EC2 Launch Template {launch_template_name} has IMDSv2 enabled and required in the following versions: 1."
+                )
+                assert result[0].resource_id == launch_template_id
+                assert result[0].region == AWS_REGION_US_EAST_1
+                assert (
+                    result[0].resource_arn
+                    == f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:123456789012:launch-template/{launch_template_id}"
+                )
+                assert result[0].resource_tags == []
+
+    @mock_aws
+    def test_launch_template_imdsv2_required_empty(self):
+        with mock.patch(
+            "botocore.client.BaseClient._make_api_call",
+            new=mock_make_api_call_empty,
+        ):
+            ec2_client = client("ec2", region_name=AWS_REGION_US_EAST_1)
+            launch_template_name = "test-imdsv2-required-empty"
+            ec2_client.create_launch_template(
+                LaunchTemplateName=launch_template_name,
+                VersionDescription="Launch Template with IMDSv2 required",
+                LaunchTemplateData={
+                    "InstanceType": "t1.micro",
+                    "MetadataOptions": {
+                        "HttpEndpoint": "",
+                        "HttpTokens": "required",
+                    },
+                },
+            )
+
+            launch_template_id = ec2_client.describe_launch_templates(
+                LaunchTemplateNames=[launch_template_name]
+            )["LaunchTemplates"][0]["LaunchTemplateId"]
+
+            from prowler.providers.aws.services.ec2.ec2_service import EC2
+
+            aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+            with (
+                mock.patch(
+                    "prowler.providers.common.provider.Provider.get_global_provider",
+                    return_value=aws_provider,
+                ),
+                mock.patch(
+                    "prowler.providers.aws.services.ec2.ec2_launch_template_imdsv2_required.ec2_launch_template_imdsv2_required.ec2_client",
+                    new=EC2(aws_provider),
+                ),
+            ):
+                # Test Check
+                from prowler.providers.aws.services.ec2.ec2_launch_template_imdsv2_required.ec2_launch_template_imdsv2_required import (
+                    ec2_launch_template_imdsv2_required,
+                )
+
+                check = ec2_launch_template_imdsv2_required()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"EC2 Launch Template {launch_template_name} has metadata service disabled in the following versions: 1."
                 )
                 assert result[0].resource_id == launch_template_id
                 assert result[0].region == AWS_REGION_US_EAST_1


### PR DESCRIPTION
### Context

Fix #8180

### Description

This PR allows that the value for `http_endpoint` can be empty.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
