### PR TITLE
fix(api): make invitation email comparison case-insensitive

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### Fixed
 - Scan with no resources will not trigger legacy code for findings metadata [(#8183)](https://github.com/prowler-cloud/prowler/pull/8183)
+- Make invitation email comparison case-insensitive [(#8206)](https://github.com/prowler-cloud/prowler/pull/8206)
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### Fixed
 - Scan with no resources will not trigger legacy code for findings metadata [(#8183)](https://github.com/prowler-cloud/prowler/pull/8183)
-- Make invitation email comparison case-insensitive [(#8206)](https://github.com/prowler-cloud/prowler/pull/8206)
+- Invitation email comparison case-insensitive [(#8206)](https://github.com/prowler-cloud/prowler/pull/8206)
 
 ---
 

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -943,6 +943,11 @@ class Invitation(RowLevelSecurityProtectedModel):
         null=True,
     )
 
+    def save(self, *args, **kwargs):
+        if self.email:
+            self.email = self.email.strip().lower()
+        super().save(*args, **kwargs)
+
     class Meta(RowLevelSecurityProtectedModel.Meta):
         db_table = "invitations"
 

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -254,7 +254,7 @@ class TestValidateInvitation:
 
             assert result == invitation
             mock_db.get.assert_called_once_with(
-                token="VALID_TOKEN", email="user@example.com"
+                token="VALID_TOKEN", email__iexact="user@example.com"
             )
 
     def test_invitation_not_found_raises_validation_error(self):
@@ -269,7 +269,7 @@ class TestValidateInvitation:
                 "invitation_token": "Invalid invitation code."
             }
             mock_db.get.assert_called_once_with(
-                token="INVALID_TOKEN", email="user@example.com"
+                token="INVALID_TOKEN", email__iexact="user@example.com"
             )
 
     def test_invitation_not_found_raises_not_found(self):
@@ -284,7 +284,7 @@ class TestValidateInvitation:
 
             assert exc_info.value.detail == "Invitation is not valid."
             mock_db.get.assert_called_once_with(
-                token="INVALID_TOKEN", email="user@example.com"
+                token="INVALID_TOKEN", email__iexact="user@example.com"
             )
 
     def test_invitation_expired(self, invitation):
@@ -320,17 +320,24 @@ class TestValidateInvitation:
                 "invitation_token": "This invitation is no longer valid."
             }
 
-    def test_invitation_with_different_email(self):
+    def test_valid_invitation_uppercase_email(self):
+        """Test that validate_invitation works with case-insensitive email lookup."""
+        uppercase_email = "USER@example.com"
+
+        invitation = MagicMock(spec=Invitation)
+        invitation.token = "VALID_TOKEN"
+        invitation.email = uppercase_email
+        invitation.expires_at = datetime.now(timezone.utc) + timedelta(days=1)
+        invitation.state = Invitation.State.PENDING
+        invitation.tenant = MagicMock()
+
         with patch("api.utils.Invitation.objects.using") as mock_using:
             mock_db = mock_using.return_value
-            mock_db.get.side_effect = Invitation.DoesNotExist
+            mock_db.get.return_value = invitation
 
-            with pytest.raises(ValidationError) as exc_info:
-                validate_invitation("VALID_TOKEN", "different@example.com")
+            result = validate_invitation("VALID_TOKEN", "user@example.com")
 
-            assert exc_info.value.detail == {
-                "invitation_token": "Invalid invitation code."
-            }
+            assert result == invitation
             mock_db.get.assert_called_once_with(
-                token="VALID_TOKEN", email="different@example.com"
+                token="VALID_TOKEN", email__iexact="user@example.com"
             )

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -332,7 +332,7 @@ class TestValidateInvitation:
                 "invitation_token": "Invalid invitation code."
             }
             mock_db.get.assert_called_once_with(
-                token="VALID_TOKEN", email="different@example.com"
+                token="VALID_TOKEN", email__iexact="different@example.com"
             )
 
     def test_valid_invitation_uppercase_email(self):

--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -320,6 +320,21 @@ class TestValidateInvitation:
                 "invitation_token": "This invitation is no longer valid."
             }
 
+    def test_invitation_with_different_email(self):
+        with patch("api.utils.Invitation.objects.using") as mock_using:
+            mock_db = mock_using.return_value
+            mock_db.get.side_effect = Invitation.DoesNotExist
+
+            with pytest.raises(ValidationError) as exc_info:
+                validate_invitation("VALID_TOKEN", "different@example.com")
+
+            assert exc_info.value.detail == {
+                "invitation_token": "Invalid invitation code."
+            }
+            mock_db.get.assert_called_once_with(
+                token="VALID_TOKEN", email="different@example.com"
+            )
+
     def test_valid_invitation_uppercase_email(self):
         """Test that validate_invitation works with case-insensitive email lookup."""
         uppercase_email = "USER@example.com"

--- a/api/src/backend/api/utils.py
+++ b/api/src/backend/api/utils.py
@@ -187,7 +187,7 @@ def validate_invitation(
         # Admin DB connector is used to bypass RLS protection since the invitation belongs to a tenant the user
         # is not a member of yet
         invitation = Invitation.objects.using(MainRouter.admin_db).get(
-            token=invitation_token, email=email
+            token=invitation_token, email__iexact=email
         )
     except Invitation.DoesNotExist:
         if raise_not_found:


### PR DESCRIPTION

  ## Description:

  ### Summary

  - Fixed an issue where invitation tokens were invalid when the email case didn't match exactly
  - Changed the email comparison from case-sensitive to case-insensitive using Django's iexact lookup
  - Now users can accept invitations regardless of email capitalization

  ### Problem

  When a user was invited with an email like "mailto:User@prowler.com" but tried to accept the invitation using "mailto:user@prowler.com", the API would return "Token is invalid" error.

  ### Solution

  Modified the query in validate_invitation function (api/src/backend/api/utils.py:190) to use email__iexact instead of email, making the comparison case-insensitive.

  Testing

  - Create invitation for "mailto:User@prowler.com"
  - Accept invitation with "mailto:user@prowler.com" ✅
  - Verify invitation is accepted successfully

Thanks @jfagoagas =D

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
