### PR TITLE
chore: ignore some files from AI editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,16 @@ junit-reports/
 
 # Cursor files
 .cursorignore
+.cursor/
+
+# RooCode files
+.roo/
+.rooignore
+.roomodes
+
+# Cline files
+.cline/
+.clineignore
 
 # Terraform
 .terraform*


### PR DESCRIPTION
### Context

Some new AI editors has its own configuration files that are placed at repository level so they are needed to be ignored to ensure that are not added in any commit.

### Description

Added some popular AI editors configuration files to the `.gitignore`.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
