### PR TITLE
fix(saml): ensure SocialApp and SAMLDomainIndex are deleted with SAMLConfiguration

### DIFF
--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -1522,6 +1522,12 @@ class SAMLConfiguration(RowLevelSecurityProtectedModel):
             email_domain=self.email_domain, defaults={"tenant": self.tenant}
         )
 
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+
+        SocialApp.objects.filter(provider="saml", client_id=self.email_domain).delete()
+        SAMLDomainIndex.objects.filter(email_domain=self.email_domain).delete()
+
     def _parse_metadata(self):
         """
         Parse the raw IdP metadata XML and extract:


### PR DESCRIPTION
### Context

When a SAMLConfiguration is deleted and then recreated for the same email domain, a `django.core.exceptions.MultipleObjectsReturned` error occurs. This is because the associated SocialApp and `SAMLDomainIndex` records are not being removed when the SAMLConfiguration is deleted, leading to duplicate entries upon recreation.

### Description

This PR ensures that when a SAMLConfiguration instance is deleted, all its related objects are also removed to maintain data integrity and prevent errors.

The main changes include:
- Overriding the delete method in the SAMLConfiguration model to atomically delete the associated SocialApp and SAMLDomainIndex records.
- Adding a new test case to `api/src/backend/api/tests/test_models.py` to verify that the deletion logic works correctly and cleans up all related objects.

This change resolves the bug and allows for the seamless deletion and recreation of SAML configurations.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
