### PR TITLE
fix: add fallback for apiBaseUrl

### DIFF
--- a/ui/lib/helper.ts
+++ b/ui/lib/helper.ts
@@ -5,7 +5,9 @@ import { useToast } from "@/components/ui";
 import { AuthSocialProvider, MetaDataProps, PermissionInfo } from "@/types";
 
 export const baseUrl = process.env.AUTH_URL || "http://localhost:3000";
-export const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+export const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 
+                         process.env.API_BASE_URL || 
+                         'http://localhost:8000/api/v1';
 
 /**
  * Extracts a form value from a FormData object


### PR DESCRIPTION
This PR solves Issue: #8211
Add fallback support for `process.env.API_BASE_URL` while maintaining backward compatibility with `NEXT_PUBLIC_API_BASE_URL`.