### PR TITLE
fix(overview): use findings latest to get new

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ## [v1.8.1] (Prowler 5.8.1)
 
 ### 🔄 Changed
-- Latest new failed findings now use `GET /findings/latest` [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
+- Latest new failed findings now use `GET /findings/latest` [(#8219)](https://github.com/prowler-cloud/prowler/pull/8219)
 
 ### Removed
 - Validation of the provider's secret type during updates [(#8197)](https://github.com/prowler-cloud/prowler/pull/8197)

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ## [v1.8.1] (Prowler 5.8.1)
 
+### 🔄 Changed
+- Latest new failed findings now use `GET /findings/latest` [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
+
 ### Removed
 - Validation of the provider's secret type during updates [(#8197)](https://github.com/prowler-cloud/prowler/pull/8197)
 

--- a/ui/app/(prowler)/page.tsx
+++ b/ui/app/(prowler)/page.tsx
@@ -1,8 +1,7 @@
 import { Spacer } from "@nextui-org/react";
-import { format, subDays } from "date-fns";
 import { Suspense } from "react";
 
-import { getFindings } from "@/actions/findings/findings";
+import { getLatestFindings } from "@/actions/findings/findings";
 import {
   getFindingsBySeverity,
   getFindingsByStatus,
@@ -129,15 +128,12 @@ const SSRDataNewFindingsTable = async () => {
   const page = 1;
   const sort = "severity,-inserted_at";
 
-  const twoDaysAgo = format(subDays(new Date(), 2), "yyyy-MM-dd");
-
   const defaultFilters = {
-    "filter[status__in]": "FAIL",
-    "filter[delta__in]": "new",
-    "filter[inserted_at__gte]": twoDaysAgo,
+    "filter[status]": "FAIL",
+    "filter[delta]": "new",
   };
 
-  const findingsData = await getFindings({
+  const findingsData = await getLatestFindings({
     query: undefined,
     page,
     sort,
@@ -178,8 +174,7 @@ const SSRDataNewFindingsTable = async () => {
             Latest new failing findings
           </h3>
           <p className="text-xs text-gray-500">
-            Showing the latest 10 new failing findings by severity from the last
-            2 days.
+            Showing the latest 10 new failing findings by severity.
           </p>
         </div>
         <div className="absolute -top-6 right-0">


### PR DESCRIPTION
### Description

Use `GET /findings/latest` instead of using the old `/findings` endpoint with the 2 days time constraint. This way we can get the real `delta == new` findings.

![Screenshot 2025-07-08 at 15 42 13](https://github.com/user-attachments/assets/44b8b24e-dafb-4b9a-8092-5b63077818be)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
