### PR TITLE
fix(azure/storage): use BaseModel for all Storage models

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - fix(iam): detect wildcarded ARNs in sts:AssumeRole policy resources [(#8164)](https://github.com/prowler-cloud/prowler/pull/8164)
 - fix(ec2): allow empty values for http_endpoint in templates [(#8184)](https://github.com/prowler-cloud/prowler/pull/8184)
+- Convert all Azure Storage models to Pydantic models to avoid serialization issues [(#8222)](https://github.com/prowler-cloud/prowler/pull/8222)
 
 ---
 

--- a/prowler/providers/azure/services/storage/storage_service.py
+++ b/prowler/providers/azure/services/storage/storage_service.py
@@ -32,7 +32,7 @@ class Storage(AzureService):
                         resouce_group_name = None
                     key_expiration_period_in_days = None
                     if storage_account.key_policy:
-                        key_expiration_period_in_days = (
+                        key_expiration_period_in_days = int(
                             storage_account.key_policy.key_expiration_period_in_days
                         )
                     replication_settings = ReplicationSettings(storage_account.sku.name)
@@ -253,6 +253,7 @@ class FileServiceProperties(BaseModel):
 class Account(BaseModel):
     id: str
     name: str
+    location: str
     resouce_group_name: str
     enable_https_traffic_only: bool
     infrastructure_encryption: Optional[bool] = None
@@ -261,8 +262,7 @@ class Account(BaseModel):
     encryption_type: str
     minimum_tls_version: str
     private_endpoint_connections: list[PrivateEndpointConnection]
-    key_expiration_period_in_days: Optional[str] = None
-    location: str
+    key_expiration_period_in_days: Optional[int] = None
     replication_settings: ReplicationSettings = ReplicationSettings.STANDARD_LRS
     allow_cross_tenant_replication: bool = True
     allow_shared_key_access: bool = True

--- a/prowler/providers/azure/services/storage/storage_service.py
+++ b/prowler/providers/azure/services/storage/storage_service.py
@@ -1,6 +1,5 @@
-from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from azure.mgmt.storage import StorageManagementClient
 from pydantic import BaseModel
@@ -203,30 +202,26 @@ class Storage(AzureService):
                     )
 
 
-@dataclass
-class DeleteRetentionPolicy:
+class DeleteRetentionPolicy(BaseModel):
     enabled: bool
     days: int
 
 
-@dataclass
-class BlobProperties:
+class BlobProperties(BaseModel):
     id: str
     name: str
     type: str
-    default_service_version: str
     container_delete_retention_policy: DeleteRetentionPolicy
-    versioning_enabled: bool = False
+    default_service_version: Optional[str] = None
+    versioning_enabled: Optional[bool] = None
 
 
-@dataclass
-class NetworkRuleSet:
+class NetworkRuleSet(BaseModel):
     bypass: str
     default_action: str
 
 
-@dataclass
-class PrivateEndpointConnection:
+class PrivateEndpointConnection(BaseModel):
     id: str
     name: str
     type: str
@@ -255,19 +250,18 @@ class FileServiceProperties(BaseModel):
     smb_protocol_settings: SMBProtocolSettings
 
 
-@dataclass
-class Account:
+class Account(BaseModel):
     id: str
     name: str
     resouce_group_name: str
     enable_https_traffic_only: bool
-    infrastructure_encryption: bool
+    infrastructure_encryption: Optional[bool] = None
     allow_blob_public_access: bool
     network_rule_set: NetworkRuleSet
     encryption_type: str
     minimum_tls_version: str
-    private_endpoint_connections: List[PrivateEndpointConnection]
-    key_expiration_period_in_days: str
+    private_endpoint_connections: list[PrivateEndpointConnection]
+    key_expiration_period_in_days: Optional[str] = None
     location: str
     replication_settings: ReplicationSettings = ReplicationSettings.STANDARD_LRS
     allow_cross_tenant_replication: bool = True

--- a/tests/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists_test.py
+++ b/tests/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists_test.py
@@ -91,6 +91,21 @@ class Test_monitor_diagnostic_settings_exists:
                 )
                 from prowler.providers.azure.services.storage.storage_service import (
                     Account,
+                    BlobProperties,
+                    DeleteRetentionPolicy,
+                    NetworkRuleSet,
+                )
+
+                # Create a valid BlobProperties instance
+                valid_blob_properties = BlobProperties(
+                    id="id",
+                    name="name",
+                    type="type",
+                    default_service_version="default_service_version",
+                    container_delete_retention_policy=DeleteRetentionPolicy(
+                        enabled=False, days=0
+                    ),
+                    versioning_enabled=True,
                 )
 
                 monitor_client.diagnostics_settings = {
@@ -138,42 +153,34 @@ class Test_monitor_diagnostic_settings_exists:
                             name="storageaccountname1",
                             resouce_group_name="rg",
                             enable_https_traffic_only=True,
-                            infrastructure_encryption="Enabled",
+                            infrastructure_encryption=True,
                             allow_blob_public_access=True,
-                            network_rule_set="AllowAll",
+                            network_rule_set=NetworkRuleSet(
+                                bypass="AzureServices", default_action="Allow"
+                            ),
                             encryption_type="Microsoft.CustomerManagedKeyVault",
                             minimum_tls_version="TLS1_2",
                             private_endpoint_connections=[],
-                            key_expiration_period_in_days=365,
+                            key_expiration_period_in_days="365",
                             location="euwest",
-                            blob_properties=mock.MagicMock(
-                                id="id",
-                                name="name",
-                                type="type",
-                                default_service_version="default_service_version",
-                                container_delete_retention_policy="container_delete_retention_policy",
-                            ),
+                            blob_properties=valid_blob_properties,
                         ),
                         Account(
                             id="/subscriptions/1224a5-123a-123a-123a-1234567890ab/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/storageaccountname2",
                             name="storageaccountname2",
                             resouce_group_name="rg",
                             enable_https_traffic_only=False,
-                            infrastructure_encryption="Enabled",
+                            infrastructure_encryption=True,
                             allow_blob_public_access=False,
-                            network_rule_set="AllowAll",
+                            network_rule_set=NetworkRuleSet(
+                                bypass="AzureServices", default_action="Allow"
+                            ),
                             encryption_type="Microsoft.Storage",
                             minimum_tls_version="TLS1_2",
                             private_endpoint_connections=[],
-                            key_expiration_period_in_days=365,
+                            key_expiration_period_in_days="365",
                             location="euwest",
-                            blob_properties=mock.MagicMock(
-                                id="id",
-                                name="name",
-                                type="type",
-                                default_service_version="default_service_version",
-                                container_delete_retention_policy="container_delete_retention_policy",
-                            ),
+                            blob_properties=valid_blob_properties,
                         ),
                     ]
                 }

--- a/tests/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_cmk_encrypted/monitor_storage_account_with_activity_logs_cmk_encrypted_test.py
+++ b/tests/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_cmk_encrypted/monitor_storage_account_with_activity_logs_cmk_encrypted_test.py
@@ -78,6 +78,9 @@ class Test_monitor_storage_account_with_activity_logs_cmk_encrypted:
                 )
                 from prowler.providers.azure.services.storage.storage_service import (
                     Account,
+                    BlobProperties,
+                    DeleteRetentionPolicy,
+                    NetworkRuleSet,
                 )
 
                 monitor_client.diagnostics_settings = {
@@ -125,20 +128,25 @@ class Test_monitor_storage_account_with_activity_logs_cmk_encrypted:
                             name="storageaccountname1",
                             resouce_group_name="rg",
                             enable_https_traffic_only=True,
-                            infrastructure_encryption="Enabled",
+                            infrastructure_encryption=True,  # bool
                             allow_blob_public_access=True,
-                            network_rule_set="AllowAll",
+                            network_rule_set=NetworkRuleSet(
+                                bypass="AzureServices", default_action="Allow"
+                            ),
                             encryption_type="Microsoft.CustomerManagedKeyVault",
                             minimum_tls_version="TLS1_2",
                             private_endpoint_connections=[],
-                            key_expiration_period_in_days=365,
+                            key_expiration_period_in_days="365",  # str
                             location="euwest",
-                            blob_properties=mock.MagicMock(
+                            blob_properties=BlobProperties(
                                 id="id",
                                 name="name",
                                 type="type",
                                 default_service_version="default_service_version",
-                                container_delete_retention_policy="container_delete_retention_policy",
+                                container_delete_retention_policy=DeleteRetentionPolicy(
+                                    enabled=True, days=7
+                                ),
+                                versioning_enabled=True,
                             ),
                         ),
                         Account(
@@ -146,20 +154,25 @@ class Test_monitor_storage_account_with_activity_logs_cmk_encrypted:
                             name="storageaccountname2",
                             resouce_group_name="rg",
                             enable_https_traffic_only=False,
-                            infrastructure_encryption="Enabled",
+                            infrastructure_encryption=True,  # bool
                             allow_blob_public_access=False,
-                            network_rule_set="AllowAll",
+                            network_rule_set=NetworkRuleSet(
+                                bypass="AzureServices", default_action="Allow"
+                            ),
                             encryption_type="Microsoft.Storage",
                             minimum_tls_version="TLS1_2",
                             private_endpoint_connections=[],
-                            key_expiration_period_in_days=365,
+                            key_expiration_period_in_days="365",  # str
                             location="euwest",
-                            blob_properties=mock.MagicMock(
+                            blob_properties=BlobProperties(
                                 id="id",
                                 name="name",
                                 type="type",
                                 default_service_version="default_service_version",
-                                container_delete_retention_policy="container_delete_retention_policy",
+                                container_delete_retention_policy=DeleteRetentionPolicy(
+                                    enabled=True, days=7
+                                ),
+                                versioning_enabled=False,
                             ),
                         ),
                     ]

--- a/tests/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_is_private/monitor_storage_account_with_activity_logs_is_private_test.py
+++ b/tests/providers/azure/services/monitor/monitor_storage_account_with_activity_logs_is_private/monitor_storage_account_with_activity_logs_is_private_test.py
@@ -78,6 +78,9 @@ class Test_monitor_storage_account_with_activity_logs_is_private:
                 )
                 from prowler.providers.azure.services.storage.storage_service import (
                     Account,
+                    BlobProperties,
+                    DeleteRetentionPolicy,
+                    NetworkRuleSet,
                 )
 
                 monitor_client.diagnostics_settings = {
@@ -125,20 +128,25 @@ class Test_monitor_storage_account_with_activity_logs_is_private:
                             name="storageaccountname1",
                             resouce_group_name="rg",
                             enable_https_traffic_only=True,
-                            infrastructure_encryption="Enabled",
+                            infrastructure_encryption=True,
                             allow_blob_public_access=True,
-                            network_rule_set="AllowAll",
+                            network_rule_set=NetworkRuleSet(
+                                bypass="AzureServices", default_action="Allow"
+                            ),
                             encryption_type="Microsoft.Storage",
                             minimum_tls_version="TLS1_2",
                             private_endpoint_connections=[],
                             key_expiration_period_in_days=365,
                             location="euwest",
-                            blob_properties=mock.MagicMock(
+                            blob_properties=BlobProperties(
                                 id="id",
                                 name="name",
                                 type="type",
                                 default_service_version="default_service_version",
-                                container_delete_retention_policy="container_delete_retention_policy",
+                                container_delete_retention_policy=DeleteRetentionPolicy(
+                                    enabled=True, days=7
+                                ),
+                                versioning_enabled=True,
                             ),
                         ),
                         Account(
@@ -146,20 +154,25 @@ class Test_monitor_storage_account_with_activity_logs_is_private:
                             name="storageaccountname2",
                             resouce_group_name="rg",
                             enable_https_traffic_only=False,
-                            infrastructure_encryption="Enabled",
+                            infrastructure_encryption=True,
                             allow_blob_public_access=False,
-                            network_rule_set="AllowAll",
+                            network_rule_set=NetworkRuleSet(
+                                bypass="AzureServices", default_action="Allow"
+                            ),
                             encryption_type="Microsoft.Storage",
                             minimum_tls_version="TLS1_2",
                             private_endpoint_connections=[],
                             key_expiration_period_in_days=365,
                             location="euwest",
-                            blob_properties=mock.MagicMock(
+                            blob_properties=BlobProperties(
                                 id="id",
                                 name="name",
                                 type="type",
                                 default_service_version="default_service_version",
-                                container_delete_retention_policy="container_delete_retention_policy",
+                                container_delete_retention_policy=DeleteRetentionPolicy(
+                                    enabled=True, days=7
+                                ),
+                                versioning_enabled=False,
                             ),
                         ),
                     ]

--- a/tests/providers/azure/services/storage/storage_account_key_access_disabled/storage_account_key_access_disabled_test.py
+++ b/tests/providers/azure/services/storage/storage_account_key_access_disabled/storage_account_key_access_disabled_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_account_key_access_disabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    allow_blob_public_access=True,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     allow_shared_key_access=True,
                 )
             ]
@@ -91,16 +96,18 @@ class Test_storage_account_key_access_disabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     allow_shared_key_access=False,
                 )
             ]

--- a/tests/providers/azure/services/storage/storage_blob_public_access_level_is_disabled/storage_blob_public_access_level_is_disabled_test.py
+++ b/tests/providers/azure/services/storage/storage_blob_public_access_level_is_disabled/storage_blob_public_access_level_is_disabled_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_blob_public_access_level_is_disabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     allow_blob_public_access=True,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                 )
             ]
         }
@@ -90,16 +95,18 @@ class Test_storage_blob_public_access_level_is_disabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     allow_blob_public_access=False,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_blob_versioning_is_enabled/storage_blob_versioning_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_blob_versioning_is_enabled/storage_blob_versioning_is_enabled_test.py
@@ -45,23 +45,28 @@ class Test_storage_blob_versioning_is_enabled:
                 new=storage_client,
             ),
         ):
-            from prowler.providers.azure.services.storage.storage_service import Account
+            from prowler.providers.azure.services.storage.storage_service import (
+                Account,
+                NetworkRuleSet,
+            )
 
             storage_client.storage_accounts = {
                 AZURE_SUBSCRIPTION_ID: [
                     Account(
                         id=storage_account_id,
                         name=storage_account_name,
-                        resouce_group_name=None,
+                        resouce_group_name="rg",
                         enable_https_traffic_only=False,
                         infrastructure_encryption=False,
-                        allow_blob_public_access=None,
-                        network_rule_set=None,
+                        allow_blob_public_access=False,
+                        network_rule_set=NetworkRuleSet(
+                            bypass="AzureServices", default_action="Allow"
+                        ),
                         encryption_type="None",
-                        minimum_tls_version=None,
+                        minimum_tls_version="TLS1_2",
                         key_expiration_period_in_days=None,
                         location="westeurope",
-                        private_endpoint_connections=None,
+                        private_endpoint_connections=[],
                         blob_properties=storage_account_blob_properties,
                     )
                 ]
@@ -92,12 +97,13 @@ class Test_storage_blob_versioning_is_enabled:
                 Account,
                 BlobProperties,
                 DeleteRetentionPolicy,
+                NetworkRuleSet,
             )
 
             storage_account_blob_properties = BlobProperties(
-                id=None,
-                name=None,
-                type=None,
+                id="id",
+                name="name",
+                type="type",
                 default_service_version=None,
                 container_delete_retention_policy=DeleteRetentionPolicy(
                     enabled=False, days=0
@@ -109,16 +115,18 @@ class Test_storage_blob_versioning_is_enabled:
                     Account(
                         id=storage_account_id,
                         name=storage_account_name,
-                        resouce_group_name=None,
+                        resouce_group_name="rg",
                         enable_https_traffic_only=False,
                         infrastructure_encryption=False,
-                        allow_blob_public_access=None,
-                        network_rule_set=None,
+                        allow_blob_public_access=False,
+                        network_rule_set=NetworkRuleSet(
+                            bypass="AzureServices", default_action="Allow"
+                        ),
                         encryption_type="None",
-                        minimum_tls_version=None,
+                        minimum_tls_version="TLS1_2",
                         key_expiration_period_in_days=None,
                         location="westeurope",
-                        private_endpoint_connections=None,
+                        private_endpoint_connections=[],
                         blob_properties=storage_account_blob_properties,
                     )
                 ]
@@ -158,12 +166,13 @@ class Test_storage_blob_versioning_is_enabled:
                 Account,
                 BlobProperties,
                 DeleteRetentionPolicy,
+                NetworkRuleSet,
             )
 
             storage_account_blob_properties = BlobProperties(
-                id=None,
-                name=None,
-                type=None,
+                id="id",
+                name="name",
+                type="type",
                 default_service_version=None,
                 container_delete_retention_policy=DeleteRetentionPolicy(
                     enabled=False, days=0
@@ -175,16 +184,18 @@ class Test_storage_blob_versioning_is_enabled:
                     Account(
                         id=storage_account_id,
                         name=storage_account_name,
-                        resouce_group_name=None,
+                        resouce_group_name="rg",
                         enable_https_traffic_only=False,
                         infrastructure_encryption=False,
-                        allow_blob_public_access=None,
-                        network_rule_set=None,
+                        allow_blob_public_access=False,
+                        network_rule_set=NetworkRuleSet(
+                            bypass="AzureServices", default_action="Allow"
+                        ),
                         encryption_type="None",
-                        minimum_tls_version=None,
+                        minimum_tls_version="TLS1_2",
                         key_expiration_period_in_days=None,
                         location="westeurope",
-                        private_endpoint_connections=None,
+                        private_endpoint_connections=[],
                         blob_properties=storage_account_blob_properties,
                     )
                 ]

--- a/tests/providers/azure/services/storage/storage_cross_tenant_replication_disabled/storage_cross_tenant_replication_disabled_test.py
+++ b/tests/providers/azure/services/storage/storage_cross_tenant_replication_disabled/storage_cross_tenant_replication_disabled_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_cross_tenant_replication_disabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     allow_cross_tenant_replication=True,
                 )
             ]
@@ -91,16 +96,18 @@ class Test_storage_cross_tenant_replication_disabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     allow_cross_tenant_replication=False,
                 )
             ]

--- a/tests/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied_test.py
+++ b/tests/providers/azure/services/storage/storage_default_network_access_rule_is_denied/storage_default_network_access_rule_is_denied_test.py
@@ -43,18 +43,18 @@ class Test_storage_default_network_access_rule_is_denied:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
+                    allow_blob_public_access=False,
                     network_rule_set=NetworkRuleSet(
-                        default_action="Allow", bypass="AzureServices"
+                        bypass="AzureServices", default_action="Allow"
                     ),
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }
@@ -95,18 +95,18 @@ class Test_storage_default_network_access_rule_is_denied:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
+                    allow_blob_public_access=False,
                     network_rule_set=NetworkRuleSet(
                         default_action="Deny", bypass="AzureServices"
                     ),
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_default_to_entra_authorization_enabled/storage_default_to_entra_authorization_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_default_to_entra_authorization_enabled/storage_default_to_entra_authorization_enabled_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_default_to_entra_authorization_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
                     allow_blob_public_access=False,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     default_to_entra_authorization=True,
                 )
             ]
@@ -91,16 +96,18 @@ class Test_storage_default_to_entra_authorization_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
                     allow_blob_public_access=False,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     default_to_entra_authorization=False,
                 )
             ]

--- a/tests/providers/azure/services/storage/storage_ensure_azure_services_are_trusted_to_access_is_enabled/storage_ensure_azure_services_are_trusted_to_access_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_azure_services_are_trusted_to_access_is_enabled/storage_ensure_azure_services_are_trusted_to_access_is_enabled_test.py
@@ -43,18 +43,18 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
+                    allow_blob_public_access=False,
                     network_rule_set=NetworkRuleSet(
                         bypass="None", default_action="Deny"
                     ),
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }
@@ -95,18 +95,18 @@ class Test_storage_ensure_azure_services_are_trusted_to_access_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
+                    allow_blob_public_access=False,
                     network_rule_set=NetworkRuleSet(
                         bypass="AzureServices", default_action="Allow"
                     ),
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_ensure_encryption_with_customer_managed_keys/storage_ensure_encryption_with_customer_managed_keys_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_encryption_with_customer_managed_keys/storage_ensure_encryption_with_customer_managed_keys_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     encryption_type="None",
-                    minimum_tls_version=None,
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                 )
             ]
         }
@@ -90,16 +95,18 @@ class Test_storage_ensure_encryption_with_customer_managed_keys:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     encryption_type="Microsoft.Keyvault",
-                    minimum_tls_version=None,
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_file_shares_soft_delete_is_enabled/storage_ensure_file_shares_soft_delete_is_enabled_test.py
@@ -5,6 +5,7 @@ from prowler.providers.azure.services.storage.storage_service import (
     Account,
     DeleteRetentionPolicy,
     FileServiceProperties,
+    NetworkRuleSet,
     SMBProtocolSettings,
 )
 from tests.providers.azure.azure_fixtures import (
@@ -45,16 +46,18 @@ class Test_storage_ensure_file_shares_soft_delete_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     file_service_properties=None,
                 )
             ]
@@ -95,16 +98,18 @@ class Test_storage_ensure_file_shares_soft_delete_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     file_service_properties=file_service_properties,
                 )
             ]
@@ -154,16 +159,18 @@ class Test_storage_ensure_file_shares_soft_delete_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     file_service_properties=file_service_properties,
                 )
             ]

--- a/tests/providers/azure/services/storage/storage_ensure_minimum_tls_version_12/storage_ensure_minimum_tls_version_12_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_minimum_tls_version_12/storage_ensure_minimum_tls_version_12_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_ensure_minimum_tls_version_12:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
                     minimum_tls_version="TLS1_1",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }
@@ -90,16 +95,18 @@ class Test_storage_ensure_minimum_tls_version_12:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
                     minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_ensure_private_endpoints_in_storage_accounts/storage_ensure_private_endpoints_in_storage_accounts_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_private_endpoints_in_storage_accounts/storage_ensure_private_endpoints_in_storage_accounts_test.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import (
     Account,
+    NetworkRuleSet,
     PrivateEndpointConnection,
 )
 from tests.providers.azure.azure_fixtures import (
@@ -45,16 +46,18 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }
@@ -97,22 +100,24 @@ class Test_storage_ensure_private_endpoints_in_storage_accounts:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=PrivateEndpointConnection(
-                        id=str(
-                            uuid4(),
-                        ),
-                        name="Test Private Endpoint Connection",
-                        type="Test Type",
-                    ),
+                    private_endpoint_connections=[
+                        PrivateEndpointConnection(
+                            id="f1ef2e48-978a-4b0e-b34f-e6c34a9e0724",
+                            name="Test Private Endpoint Connection",
+                            type="Test Type",
+                        )
+                    ],
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_ensure_soft_delete_is_enabled/storage_ensure_soft_delete_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_ensure_soft_delete_is_enabled/storage_ensure_soft_delete_is_enabled_test.py
@@ -5,6 +5,7 @@ from prowler.providers.azure.services.storage.storage_service import (
     Account,
     BlobProperties,
     DeleteRetentionPolicy,
+    NetworkRuleSet,
 )
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
@@ -45,16 +46,18 @@ class Test_storage_ensure_soft_delete_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     blob_properties=storage_account_blob_properties,
                 )
             ]
@@ -85,29 +88,32 @@ class Test_storage_ensure_soft_delete_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_account_blob_properties = BlobProperties(
-            id=None,
-            name=None,
-            type=None,
+            id="id",
+            name="name",
+            type="type",
             default_service_version=None,
             container_delete_retention_policy=DeleteRetentionPolicy(
                 enabled=False, days=7
             ),
+            versioning_enabled=False,
         )
         storage_client.storage_accounts = {
             AZURE_SUBSCRIPTION_ID: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     blob_properties=storage_account_blob_properties,
                 )
             ]
@@ -147,29 +153,32 @@ class Test_storage_ensure_soft_delete_is_enabled:
         storage_account_name = "Test Storage Account"
         storage_client = mock.MagicMock
         storage_account_blob_properties = BlobProperties(
-            id=None,
-            name=None,
-            type=None,
+            id="id",
+            name="name",
+            type="type",
             default_service_version=None,
             container_delete_retention_policy=DeleteRetentionPolicy(
                 enabled=True, days=7
             ),
+            versioning_enabled=True,
         )
         storage_client.storage_accounts = {
             AZURE_SUBSCRIPTION_ID: [
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     blob_properties=storage_account_blob_properties,
                 )
             ]

--- a/tests/providers/azure/services/storage/storage_geo_redundant_enabled/storage_geo_redundant_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_geo_redundant_enabled/storage_geo_redundant_enabled_test.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from prowler.providers.azure.services.storage.storage_service import (
     Account,
+    NetworkRuleSet,
     ReplicationSettings,
 )
 from tests.providers.azure.azure_fixtures import (
@@ -43,16 +44,18 @@ class Test_storage_geo_redundant_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
                     allow_blob_public_access=False,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     replication_settings=ReplicationSettings.STANDARD_GRS,
                 )
             ]
@@ -94,16 +97,18 @@ class Test_storage_geo_redundant_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
                     allow_blob_public_access=False,
-                    network_rule_set=None,
-                    encryption_type=None,
-                    minimum_tls_version=None,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    encryption_type="None",
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
                     replication_settings=ReplicationSettings.STANDARD_LRS,
                 )
             ]

--- a/tests/providers/azure/services/storage/storage_infrastructure_encryption_is_enabled/storage_infrastructure_encryption_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_infrastructure_encryption_is_enabled/storage_infrastructure_encryption_is_enabled_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_infrastructure_encryption_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
                     minimum_tls_version="TLS1_1",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }
@@ -90,16 +95,18 @@ class Test_storage_infrastructure_encryption_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=True,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version="TLS1_1",
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_key_rotation_90_days/storage_key_rotation_90_days_test.py
+++ b/tests/providers/azure/services/storage/storage_key_rotation_90_days/storage_key_rotation_90_days_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -41,16 +44,18 @@ class Test_storage_key_rotation_90_dayss:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    key_expiration_period_in_days="91",
                     encryption_type="None",
-                    minimum_tls_version="TLS1_1",
-                    key_expiration_period_in_days=expiration_days,
+                    minimum_tls_version="TLS1_2",
+                    private_endpoint_connections=[],
                     location="westeurope",
-                    private_endpoint_connections=None,
                 )
             ]
         }
@@ -92,16 +97,18 @@ class Test_storage_key_rotation_90_dayss:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    key_expiration_period_in_days=90,
                     encryption_type="None",
                     minimum_tls_version="TLS1_2",
-                    key_expiration_period_in_days=expiration_days,
+                    private_endpoint_connections=[],
                     location="westeurope",
-                    private_endpoint_connections=None,
                 )
             ]
         }
@@ -142,16 +149,18 @@ class Test_storage_key_rotation_90_dayss:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
+                    key_expiration_period_in_days=None,
                     encryption_type="None",
                     minimum_tls_version="TLS1_2",
-                    key_expiration_period_in_days=None,
+                    private_endpoint_connections=[],
                     location="westeurope",
-                    private_endpoint_connections=None,
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_secure_transfer_required_is_enabled/storage_secure_transfer_required_is_enabled_test.py
+++ b/tests/providers/azure/services/storage/storage_secure_transfer_required_is_enabled/storage_secure_transfer_required_is_enabled_test.py
@@ -1,7 +1,10 @@
 from unittest import mock
 from uuid import uuid4
 
-from prowler.providers.azure.services.storage.storage_service import Account
+from prowler.providers.azure.services.storage.storage_service import (
+    Account,
+    NetworkRuleSet,
+)
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
@@ -40,16 +43,18 @@ class Test_storage_secure_transfer_required_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version="TLS1_1",
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }
@@ -90,16 +95,18 @@ class Test_storage_secure_transfer_required_is_enabled:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=True,
                     infrastructure_encryption=True,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version="TLS1_1",
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                 )
             ]
         }

--- a/tests/providers/azure/services/storage/storage_service_test.py
+++ b/tests/providers/azure/services/storage/storage_service_test.py
@@ -5,6 +5,7 @@ from prowler.providers.azure.services.storage.storage_service import (
     BlobProperties,
     DeleteRetentionPolicy,
     FileServiceProperties,
+    NetworkRuleSet,
     ReplicationSettings,
     SMBProtocolSettings,
     Storage,
@@ -21,7 +22,7 @@ def mock_storage_get_storage_accounts(_):
         name="name",
         type="type",
         default_service_version=None,
-        container_delete_retention_policy=None,
+        container_delete_retention_policy=DeleteRetentionPolicy(enabled=True, days=7),
     )
     retention_policy = DeleteRetentionPolicy(enabled=True, days=7)
     file_service_properties = FileServiceProperties(
@@ -36,15 +37,17 @@ def mock_storage_get_storage_accounts(_):
             Account(
                 id="id",
                 name="name",
-                resouce_group_name=None,
+                resouce_group_name="rg",
                 enable_https_traffic_only=False,
                 infrastructure_encryption=False,
-                allow_blob_public_access=None,
-                network_rule_set=None,
+                allow_blob_public_access=False,
+                network_rule_set=NetworkRuleSet(
+                    bypass="AzureServices", default_action="Allow"
+                ),
                 encryption_type="None",
-                minimum_tls_version=None,
+                minimum_tls_version="TLS1_2",
                 key_expiration_period_in_days=None,
-                private_endpoint_connections=None,
+                private_endpoint_connections=[],
                 location="westeurope",
                 blob_properties=blob_properties,
                 default_to_entra_authorization=True,
@@ -79,7 +82,7 @@ class Test_Storage_Service:
         assert storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].name == "name"
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].resouce_group_name
-            is None
+            == "rg"
         )
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].enable_https_traffic_only
@@ -91,10 +94,21 @@ class Test_Storage_Service:
         )
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].allow_blob_public_access
-            is None
+            is False
         )
         assert (
-            storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].network_rule_set is None
+            storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].network_rule_set
+            is not None
+        )
+        assert (
+            storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].network_rule_set.bypass
+            == "AzureServices"
+        )
+        assert (
+            storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
+                0
+            ].network_rule_set.default_action
+            == "Allow"
         )
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].encryption_type == "None"
@@ -104,7 +118,7 @@ class Test_Storage_Service:
         )
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][0].minimum_tls_version
-            is None
+            == "TLS1_2"
         )
         assert (
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
@@ -116,7 +130,7 @@ class Test_Storage_Service:
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
                 0
             ].private_endpoint_connections
-            is None
+            == []
         )
         assert storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
             0
@@ -125,7 +139,9 @@ class Test_Storage_Service:
             name="name",
             type="type",
             default_service_version=None,
-            container_delete_retention_policy=None,
+            container_delete_retention_policy=DeleteRetentionPolicy(
+                enabled=True, days=7
+            ),
         )
         assert storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
             0
@@ -175,7 +191,19 @@ class Test_Storage_Service:
             storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
                 0
             ].blob_properties.container_delete_retention_policy
-            is None
+            is not None
+        )
+        assert (
+            storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
+                0
+            ].blob_properties.container_delete_retention_policy.enabled
+            is True
+        )
+        assert (
+            storage.storage_accounts[AZURE_SUBSCRIPTION_ID][
+                0
+            ].blob_properties.container_delete_retention_policy.days
+            == 7
         )
 
     def test_get_file_service_properties(self):

--- a/tests/providers/azure/services/storage/storage_smb_channel_encryption_with_secure_algorithm/storage_smb_channel_encryption_with_secure_algorithm_test.py
+++ b/tests/providers/azure/services/storage/storage_smb_channel_encryption_with_secure_algorithm/storage_smb_channel_encryption_with_secure_algorithm_test.py
@@ -5,6 +5,7 @@ from prowler.providers.azure.services.storage.storage_service import (
     Account,
     DeleteRetentionPolicy,
     FileServiceProperties,
+    NetworkRuleSet,
     SMBProtocolSettings,
 )
 from tests.providers.azure.azure_fixtures import (
@@ -44,16 +45,18 @@ class Test_storage_smb_channel_encryption_with_secure_algorithm:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     file_service_properties=None,
                 )
             ]
@@ -92,16 +95,18 @@ class Test_storage_smb_channel_encryption_with_secure_algorithm:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     file_service_properties=file_service_properties,
                 )
             ]
@@ -146,16 +151,18 @@ class Test_storage_smb_channel_encryption_with_secure_algorithm:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     file_service_properties=file_service_properties,
                 )
             ]
@@ -200,16 +207,18 @@ class Test_storage_smb_channel_encryption_with_secure_algorithm:
                 Account(
                     id=storage_account_id,
                     name=storage_account_name,
-                    resouce_group_name=None,
+                    resouce_group_name="rg",
                     enable_https_traffic_only=False,
                     infrastructure_encryption=False,
-                    allow_blob_public_access=None,
-                    network_rule_set=None,
+                    allow_blob_public_access=False,
+                    network_rule_set=NetworkRuleSet(
+                        bypass="AzureServices", default_action="Allow"
+                    ),
                     encryption_type="None",
-                    minimum_tls_version=None,
+                    minimum_tls_version="TLS1_2",
                     key_expiration_period_in_days=None,
                     location="westeurope",
-                    private_endpoint_connections=None,
+                    private_endpoint_connections=[],
                     file_service_properties=file_service_properties,
                 )
             ]


### PR DESCRIPTION
### Context

The Account Model were causing some issues when serializing it due the mix of dataclass and BaseModels attributes, using just BaseModels avoid this serialization error.

![image](https://github.com/user-attachments/assets/bb2e7d72-683b-402f-9a47-4afaf373eb2e)


### Description

This PR changes all the models of Storage service to be Pydantic BaseModels instead dataclass and fix the mocked values in test to be the exact types that are defined in models

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
