### PR TITLE
fix(docs): `GitHub` provider `mkdocs` and `-h`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -596,7 +596,7 @@ There are several supported login methods:
 
 ```console
 # Personal Access Token (PAT):
-prowler github --github-personal-access-token pat
+prowler github --personal-access-token pat
 
 # OAuth App Token:
 prowler github --oauth-app-token oauth_token

--- a/docs/index.md
+++ b/docs/index.md
@@ -596,7 +596,7 @@ There are several supported login methods:
 
 ```console
 # Personal Access Token (PAT):
-prowler github --personal-access-token pat
+prowler github --github-personal-access-token pat
 
 # OAuth App Token:
 prowler github --oauth-app-token oauth_token

--- a/docs/tutorials/github/authentication.md
+++ b/docs/tutorials/github/authentication.md
@@ -16,7 +16,7 @@ Here are the available login methods and their respective flags:
 Use this method by providing your personal access token directly.
 
 ```console
-prowler github --personal-access-token pat
+prowler github --github-personal-access-token pat
 ```
 
 ### OAuth App Token

--- a/docs/tutorials/github/authentication.md
+++ b/docs/tutorials/github/authentication.md
@@ -37,7 +37,7 @@ prowler github --github-app-id app_id --github-app-key app_key
 If no login method is explicitly provided, Prowler will automatically attempt to authenticate using environment variables in the following order of precedence:
 
 1. `GITHUB_PERSONAL_ACCESS_TOKEN`
-2. `OAUTH_APP_TOKEN`
+2. `GITHUB_OAUTH_APP_TOKEN`
 3. `GITHUB_APP_ID` and `GITHUB_APP_KEY`
 
 ???+ note

--- a/docs/tutorials/github/authentication.md
+++ b/docs/tutorials/github/authentication.md
@@ -16,7 +16,7 @@ Here are the available login methods and their respective flags:
 Use this method by providing your personal access token directly.
 
 ```console
-prowler github --github-personal-access-token pat
+prowler github --personal-access-token pat
 ```
 
 ### OAuth App Token

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,8 @@ nav:
           - Getting Started: tutorials/microsoft365/getting-started-m365.md
           - Authentication: tutorials/microsoft365/authentication.md
           - Use of PowerShell: tutorials/microsoft365/use-of-powershell.md
+      - GitHub:
+          - Authentication: tutorials/github/authentication.md
       - IaC:
           - Getting Started: tutorials/iac/getting-started-iac.md
   - Developer Guide:

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Changed
 
 ### Fixed
+- Add GitHub provider to lateral panel in documentation and change -h environment variable output [(#8246)](https://github.com/prowler-cloud/prowler/pull/8246)
 
 ---
 

--- a/prowler/providers/github/lib/arguments/arguments.py
+++ b/prowler/providers/github/lib/arguments/arguments.py
@@ -6,7 +6,7 @@ def init_parser(self):
     github_auth_subparser = github_parser.add_argument_group("Authentication Modes")
     # Authentication Modes
     github_auth_subparser.add_argument(
-        "--github-personal-access-token",
+        "--personal-access-token",
         nargs="?",
         help="Personal Access Token to log in against GitHub",
         default=None,

--- a/prowler/providers/github/lib/arguments/arguments.py
+++ b/prowler/providers/github/lib/arguments/arguments.py
@@ -10,6 +10,7 @@ def init_parser(self):
         nargs="?",
         help="Personal Access Token to log in against GitHub",
         default=None,
+        metavar="GITHUB_PERSONAL_ACCESS_TOKEN",
     )
 
     github_auth_subparser.add_argument(
@@ -17,6 +18,7 @@ def init_parser(self):
         nargs="?",
         help="OAuth App Token to log in against GitHub",
         default=None,
+        metavar="GITHUB_OAUTH_APP_TOKEN",
     )
 
     # GitHub App Authentication
@@ -25,10 +27,12 @@ def init_parser(self):
         nargs="?",
         help="GitHub App ID to log in against GitHub",
         default=None,
+        metavar="GITHUB_APP_ID",
     )
     github_auth_subparser.add_argument(
         "--github-app-key",
         nargs="?",
         help="GitHub App Key Path to log in against GitHub",
         default=None,
+        metavar="GITHUB_APP_KEY",
     )

--- a/prowler/providers/github/lib/arguments/arguments.py
+++ b/prowler/providers/github/lib/arguments/arguments.py
@@ -6,7 +6,7 @@ def init_parser(self):
     github_auth_subparser = github_parser.add_argument_group("Authentication Modes")
     # Authentication Modes
     github_auth_subparser.add_argument(
-        "--personal-access-token",
+        "--github-personal-access-token",
         nargs="?",
         help="Personal Access Token to log in against GitHub",
         default=None,


### PR DESCRIPTION
### Context

Currently, the GitHub provider doesn’t appear in the side panel of the documentation and we have several mistakes in prowler -h and docs.

### Description

This PR addresses the problems:

- **Placeholder names:**
  - `PERSONAL_ACCESS_TOKEN` replaced by `GITHUB_PERSONAL_ACCESS_TOKEN`.
  - `OAUTH_APP_TOKEN` replaced by `GITHUB_OAUTH_APP_TOKEN`
 - **Authentication.md:**
   - `OAUTH_APP_TOKEN` replaced by `GITHUB_OAUTH_APP_TOKEN`
   - Added to documentation's lateral panel.



### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
