### PR TITLE
chore(saml): redirect to login page on fail

### DIFF
--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -6037,7 +6037,7 @@ class TestTenantFinishACSView:
                 "firstName": ["John"],
                 "lastName": ["Doe"],
                 "organization": ["testing_company"],
-                "userType": ["saml_default_role"],
+                "userType": ["no_permissions"],
             },
         )
 
@@ -6091,7 +6091,7 @@ class TestTenantFinishACSView:
         assert user.name == "John Doe"
         assert user.company_name == "testing_company"
 
-        role = Role.objects.using(MainRouter.admin_db).get(name="saml_default_role")
+        role = Role.objects.using(MainRouter.admin_db).get(name="no_permissions")
         assert role.tenant == tenants_fixture[0]
 
         assert (

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -5978,7 +5978,8 @@ class TestSAMLConfigurationViewSet:
 
 @pytest.mark.django_db
 class TestTenantFinishACSView:
-    def test_dispatch_skips_if_user_not_authenticated(self):
+    def test_dispatch_skips_if_user_not_authenticated(self, monkeypatch):
+        monkeypatch.setenv("AUTH_URL", "http://localhost")
         request = RequestFactory().get(
             reverse("saml_finish_acs", kwargs={"organization_slug": "testtenant"})
         )
@@ -5999,7 +6000,8 @@ class TestTenantFinishACSView:
 
         assert response.status_code in [200, 302]
 
-    def test_dispatch_skips_if_social_app_not_found(self, users_fixture):
+    def test_dispatch_skips_if_social_app_not_found(self, users_fixture, monkeypatch):
+        monkeypatch.setenv("AUTH_URL", "http://localhost")
         request = RequestFactory().get(
             reverse("saml_finish_acs", kwargs={"organization_slug": "testtenant"})
         )


### PR DESCRIPTION
Context

This pull request addresses an improvement in the SAML authentication flow within the application. Previously, when SAML authentication failed or a user was not authenticated, the system did not provide a clear indication or redirection, which could lead to confusion for end users. The motivation behind this change is to enhance the user experience by providing a transparent and user-friendly response in these scenarios. With this update, users will be redirected to the login page with a specific query parameter indicating the SAML failure, making the process more intuitive and informative.

Description

This update modifies the SAML authentication handling logic so that, in the event of a failed authentication or missing user information, users are redirected to the login page with the query parameter ‎`sso_saml_failed=true`. This change ensures that authentication issues are clearly communicated to users and that they are guided to the appropriate next step. Additionally, the default user role assigned when no specific permissions are provided has been changed from ‎`saml_default_role` to ‎`no_permissions` in both the backend logic and the related tests. This adjustment improves security and clarifies the assignment of roles for users who lack explicit SAML permissions.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
