### PR TITLE
fix(dashboard): count rows in the CSV more efficiently

### DIFF
--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -1,5 +1,4 @@
 # Standard library imports
-import csv
 import glob
 import json
 import os
@@ -20,7 +19,6 @@ from dash.dependencies import Input, Output
 # Config import
 from dashboard.config import (
     critical_color,
-    encoding_format,
     fail_color,
     folder_path_overview,
     high_color,
@@ -46,6 +44,7 @@ from dashboard.lib.dropdowns import (
     create_table_row_dropdown,
 )
 from dashboard.lib.layouts import create_layout_overview
+from prowler.lib.logger import logger
 
 # Suppress warnings
 warnings.filterwarnings("ignore")
@@ -55,11 +54,13 @@ warnings.filterwarnings("ignore")
 csv_files = []
 
 for file in glob.glob(os.path.join(folder_path_overview, "*.csv")):
-    with open(file, "r", newline="", encoding=encoding_format) as csvfile:
-        reader = csv.reader(csvfile)
-        num_rows = sum(1 for row in reader)
+    try:
+        df = pd.read_csv(file, sep=";")
+        num_rows = len(df)
         if num_rows > 1:
             csv_files.append(file)
+    except Exception:
+        logger.error(f"Error reading file {file}")
 
 
 # Import logos providers

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -19,6 +19,13 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ---
 
+## [v5.8.2] (Prowler UNRELEASED)
+
+### Fixed
+- Fix error in Dashboard Overview page when reading CSV files [(#8257)](https://github.com/prowler-cloud/prowler/pull/8257)
+
+---
+
 ## [v5.8.1] (Prowler 5.8.1)
 
 ### Fixed


### PR DESCRIPTION
### Context

The dashboard were failing in some CSV files when the output file was quite big. 

Here one example: #8249

And here other local example:

<img width="1916" height="1082" alt="image" src="https://github.com/user-attachments/assets/f33d5d64-5d0b-4cd1-b0cd-8aa97afba449" />

### Description

Fix #8249.

This PR change how the CSV file rows are counted, instead of using the CSV module and iterate with a for loop, pandas lib is used to count in a more efficient way. 

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests. _There is no tests for dashboard_
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
