### PR TITLE
feat: SAML toast error

### DIFF
--- a/ui/components/auth/oss/auth-form.tsx
+++ b/ui/components/auth/oss/auth-form.tsx
@@ -55,7 +55,7 @@ export const AuthForm = ({
           variant: "destructive",
           title: "SAML Authentication Error",
           description:
-            "An error occurred while attempting to login via your third-party account.",
+            "An error occurred while attempting to login via your Identity Provider (IdP). Please check your IdP configuration.",
         });
       }, 100);
     }

--- a/ui/components/auth/oss/auth-form.tsx
+++ b/ui/components/auth/oss/auth-form.tsx
@@ -3,7 +3,8 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Icon } from "@iconify/react";
 import { Button, Checkbox, Divider, Link, Tooltip } from "@nextui-org/react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -41,6 +42,24 @@ export const AuthForm = ({
 }) => {
   const formSchema = authFormSchema(type);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const samlError = searchParams.get("sso_saml_failed");
+
+    if (samlError) {
+      // Add a delay to the toast to ensure it is rendered
+      setTimeout(() => {
+        toast({
+          variant: "destructive",
+          title: "SAML Authentication Error",
+          description:
+            "An error occurred while attempting to login via your third-party account.",
+        });
+      }, 100);
+    }
+  }, [searchParams, toast]);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -58,7 +77,6 @@ export const AuthForm = ({
   });
 
   const isLoading = form.formState.isSubmitting;
-  const { toast } = useToast();
   const isSamlMode = form.watch("isSamlMode");
 
   const onSubmit = async (data: z.infer<typeof formSchema>) => {


### PR DESCRIPTION
### Context

We need a Toast error for SAML login specific case.

### Description

- We will catch the sso_saml_failed param and show the toast
- 
<img width="1886" height="1222" alt="Screenshot 2025-07-14 at 15 58 39" src="https://github.com/user-attachments/assets/353301b3-1473-4d29-bfd0-ddaf3f5858fa" />


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
