### PR TITLE
fix(dashboard): security posture showing incomplete data

### DIFF
--- a/dashboard/pages/overview.py
+++ b/dashboard/pages/overview.py
@@ -191,7 +191,13 @@ else:
         data.rename(columns={"RESOURCE_ID": "RESOURCE_UID"}, inplace=True)
 
     # Remove dupplicates on the finding_uid colummn but keep the last one taking into account the timestamp
-    data = data.sort_values("TIMESTAMP").drop_duplicates("FINDING_UID", keep="last")
+    data["DATE"] = data["TIMESTAMP"].dt.date
+    data = (
+        data.sort_values("TIMESTAMP")
+        .groupby(["DATE", "FINDING_UID"], as_index=False)
+        .last()
+    )
+    data["TIMESTAMP"] = pd.to_datetime(data["TIMESTAMP"])
 
     data["ASSESSMENT_TIME"] = data["TIMESTAMP"].dt.strftime("%Y-%m-%d")
     data_valid = pd.DataFrame()

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Add GitHub provider to lateral panel in documentation and change -h environment variable output [(#8246)](https://github.com/prowler-cloud/prowler/pull/8246)
+- Show correct count of findings in Dashboard Security Posture page [(#8270)](https://github.com/prowler-cloud/prowler/pull/8270)
 
 ---
 


### PR DESCRIPTION
### Context

The dashboard security posture was showing incomplete data for the same account with scans of two different days. It should show all the findings for that day, removing dupes only between scans with the same date not between scans with different dates.

Fix #7989

### Description

Modified the line that removes dupes.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
