### PR TITLE
fix(users): Add user deletion error handling to return expected respo…

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - `/processors` endpoints to post-process findings. Currently, only the Mutelist processor is supported to allow to mute findings.
 - Optimized the underlying queries for resources endpoints [(#8112)](https://github.com/prowler-cloud/prowler/pull/8112)
 - Optimized include parameters for resources view [(#8229)](https://github.com/prowler-cloud/prowler/pull/8229)
+- Improved user deletion error handling with structured JSON response [(#8272)](https://github.com/prowler-cloud/prowler/pull/8272)
 
 ### Fixed
 - Search filter for findings and resources [(#8112)](https://github.com/prowler-cloud/prowler/pull/8112)

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -326,6 +326,19 @@ class TestUserViewSet:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert User.objects.filter(id=another_user.id).exists()
 
+    def test_users_destroy_unexpected_exception(
+        self, authenticated_client, create_test_user
+    ):
+        with patch(
+            "api.v1.views.UserViewSet.perform_destroy",
+            side_effect=Exception("Unexpected"),
+        ):
+            response = authenticated_client.delete(
+                reverse("user-detail", kwargs={"pk": create_test_user.id})
+            )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["errors"][0]["detail"] == "Failed to delete the user"
+
     @pytest.mark.parametrize(
         "attribute_key, attribute_value, error_field",
         [

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -791,7 +791,6 @@ class UserViewSet(BaseUserViewset):
                         "detail": "Failed to delete the user",
                         "status": "400",
                         "code": "delete_failed"
-
                     }
                 ]
             )

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -783,14 +783,14 @@ class UserViewSet(BaseUserViewset):
         try:
             return super().destroy(request, *args, **kwargs)
         except Exception as e:
-            print("Exception caught in destroy():", e) 
+            print("Exception caught in destroy():", e)
 
             raise ValidationError(
                 [
                     {
                         "detail": "Failed to delete the user",
                         "status": "400",
-                        "code": "delete_failed"
+                        "code": "delete_failed",
                     }
                 ]
             )

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -780,7 +780,21 @@ class UserViewSet(BaseUserViewset):
         if kwargs["pk"] != str(self.request.user.id):
             raise ValidationError("Only the current user can be deleted.")
 
-        return super().destroy(request, *args, **kwargs)
+        try:
+            return super().destroy(request, *args, **kwargs)
+        except Exception as e:
+            print("Exception caught in destroy():", e) 
+
+            raise ValidationError(
+                [
+                    {
+                        "detail": "Failed to delete the user",
+                        "status": "400",
+                        "code": "delete_failed"
+
+                    }
+                ]
+            )
 
     @extend_schema(
         parameters=[

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -782,9 +782,7 @@ class UserViewSet(BaseUserViewset):
 
         try:
             return super().destroy(request, *args, **kwargs)
-        except Exception as e:
-            print("Exception caught in destroy():", e)
-
+        except Exception:
             raise ValidationError(
                 [
                     {


### PR DESCRIPTION
### Context

The user deletion API previously returned unstructured error responses, such as plain HTML or raw text, causing issues with frontend error handling and toast notification consistency. This update addresses the issue by returning a structured JSON error response.

### Description

This update improves the user deletion API by:
- Wrapping the deletion logic in a try-except block to handle unexpected errors gracefully.
- Replacing raw or unstructured error responses (e.g., HTML or plain text) with a consistent JSON format.
- Returning structured error fields: `detail`, `status`, and `code`.
- Enabling the frontend to reliably detect failures and display consistent toast notifications to users.



<img width="1901" height="1075" alt="image" src="https://github.com/user-attachments/assets/13c94bf5-0320-42bb-a2d6-b2e364faca41" />

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.