### PR TITLE
fix(scans): capture 403 when no permissions

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🐞 Fixed
 
+- Error message when starting a scan if user has no permissions [(#8280)](https://github.com/prowler-cloud/prowler/pull/8280)
+
 ### Removed
 
 ---

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🐞 Fixed
 
-- Error message when starting a scan if user has no permissions [(#8280)](https://github.com/prowler-cloud/prowler/pull/8280)
+- Error message when launching a scan if user has no permissions [(#8280)](https://github.com/prowler-cloud/prowler/pull/8280)
 
 ### Removed
 

--- a/ui/actions/scans/scans.ts
+++ b/ui/actions/scans/scans.ts
@@ -144,21 +144,18 @@ export const scanOnDemand = async (formData: FormData) => {
     });
 
     if (!response.ok) {
-      try {
-        const errorData = await response.json();
-        throw new Error(errorData?.message || "Failed to start scan");
-      } catch {
-        throw new Error("Failed to start scan");
-      }
+      const errorData = await response.json();
+
+      return { success: false, error: errorData.errors[0].detail };
     }
 
     const data = await response.json();
-
     revalidatePath("/scans");
+
     return parseStringify(data);
   } catch (error) {
-    // eslint-disable-next-line no-console
     console.error("Error starting scan:", error);
+
     return { error: getErrorMessage(error) };
   }
 };

--- a/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
+++ b/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
@@ -63,13 +63,11 @@ export const LaunchScanWorkflow = ({
 
     const data = await scanOnDemand(formData);
 
-    if (data?.errors && data.errors.length > 0) {
-      const error = data.errors[0];
-      const errorMessage = `${error.detail}`;
+    if (data?.error) {
       toast({
         variant: "destructive",
         title: "Oops! Something went wrong",
-        description: errorMessage,
+        description: data.error,
       });
     } else {
       toast({


### PR DESCRIPTION
### Context

We need to capture the 403 if the user has no permissions to launch a scan.
Current incorrect behavior: the UI shows that the scan is launched successfully.

### Description

- Form captures the 403 correctly
<img width="2216" height="1226" alt="Screenshot 2025-07-15 at 12 39 28" src="https://github.com/user-attachments/assets/7b255f26-7548-40af-adf5-dfd6710a9193" />

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
