### PR TITLE
chore(hadolint): run only when necessary

### DIFF
--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -102,8 +102,15 @@ jobs:
         run: |
           poetry run vulture --exclude "contrib,api,ui" --min-confidence 100 .
 
+      - name: Dockerfile - Check if Dockerfile has changed
+        id: dockerfile-changed-files
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: |
+            Dockerfile
+
       - name: Hadolint
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
+        if: steps.dockerfile-changed-files.outputs.any_changed == 'true'
         run: |
           /tmp/hadolint Dockerfile --ignore=DL3013
 


### PR DESCRIPTION
### Description

Run `hadolint` only when Dockerfile has been changed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
