### PR TITLE
fix(entra): `entra_users_mfa_capable` check report

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Ensure `is_service_role` only returns `True` for service roles [(#8274)](https://github.com/prowler-cloud/prowler/pull/8274)
 - Update DynamoDB check metadata to fix broken link [(#8273)](https://github.com/prowler-cloud/prowler/pull/8273)
 - Show correct count of findings in Dashboard Security Posture page [(#8270)](https://github.com/prowler-cloud/prowler/pull/8270)
+- Update `entra_users_mfa_capable` check to use the correct resource name and ID [(#8288)](https://github.com/prowler-cloud/prowler/pull/8288)
 
 ---
 

--- a/prowler/providers/m365/services/entra/entra_users_mfa_capable/entra_users_mfa_capable.py
+++ b/prowler/providers/m365/services/entra/entra_users_mfa_capable/entra_users_mfa_capable.py
@@ -28,9 +28,9 @@ class entra_users_mfa_capable(Check):
         for user in entra_client.users.values():
             report = CheckReportM365(
                 metadata=self.metadata(),
-                resource={},
-                resource_name="Users",
-                resource_id="users",
+                resource=user,
+                resource_name=user.name,
+                resource_id=user.id,
             )
 
             if not user.is_mfa_capable:

--- a/tests/providers/m365/services/entra/entra_users_mfa_capable/entra_users_mfa_capable_test.py
+++ b/tests/providers/m365/services/entra/entra_users_mfa_capable/entra_users_mfa_capable_test.py
@@ -43,9 +43,9 @@ class Test_entra_users_mfa_capable:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "User Test User is not MFA capable."
-            assert result[0].resource == {}
-            assert result[0].resource_name == "Users"
-            assert result[0].resource_id == "users"
+            assert result[0].resource == entra_client.users[user_id]
+            assert result[0].resource_name == "Test User"
+            assert result[0].resource_id == user_id
 
     def test_user_mfa_capable(self):
         """User is MFA capable: expected PASS."""
@@ -84,9 +84,9 @@ class Test_entra_users_mfa_capable:
             assert len(result) == 1
             assert result[0].status == "PASS"
             assert result[0].status_extended == "User Test User is MFA capable."
-            assert result[0].resource == {}
-            assert result[0].resource_name == "Users"
-            assert result[0].resource_id == "users"
+            assert result[0].resource == entra_client.users[user_id]
+            assert result[0].resource_name == "Test User"
+            assert result[0].resource_id == user_id
 
     def test_multiple_users(self):
         """Multiple users with different MFA capabilities: expected mixed results."""
@@ -134,6 +134,12 @@ class Test_entra_users_mfa_capable:
             # First user (MFA capable)
             assert result[0].status == "PASS"
             assert result[0].status_extended == "User Test User 1 is MFA capable."
+            assert result[0].resource == entra_client.users[user1_id]
+            assert result[0].resource_name == "Test User 1"
+            assert result[0].resource_id == user1_id
             # Second user (not MFA capable)
             assert result[1].status == "FAIL"
             assert result[1].status_extended == "User Test User 2 is not MFA capable."
+            assert result[1].resource == entra_client.users[user2_id]
+            assert result[1].resource_name == "Test User 2"
+            assert result[1].resource_id == user2_id


### PR DESCRIPTION
### Context

The previous implementation of the `entra_users_mfa_capable` check had issues with how results were reported. This PR corrects the logic to provide accurate findings avoiding duplicated finding IDs.

### Description

Fixes the reporting logic for the `entra_users_mfa_capable` check in the Entra provider. Updates both the check implementation and its corresponding test to ensure accurate results and proper test coverage.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
