### PR TITLE
fix(networkfirewall): `ServiceName` in checks metadata

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Ensure `is_service_role` only returns `True` for service roles [(#8274)](https://github.com/prowler-cloud/prowler/pull/8274)
 - Update DynamoDB check metadata to fix broken link [(#8273)](https://github.com/prowler-cloud/prowler/pull/8273)
 - Show correct count of findings in Dashboard Security Posture page [(#8270)](https://github.com/prowler-cloud/prowler/pull/8270)
+- `ServiceName` field in Network Firewall checks metadata [(#8280)](https://github.com/prowler-cloud/prowler/pull/8280)
 
 ---
 

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_deletion_protection/networkfirewall_deletion_protection.metadata.json
@@ -3,7 +3,7 @@
   "CheckID": "networkfirewall_deletion_protection",
   "CheckTitle": "Ensure that Deletion Protection safety feature is enabled for your Amazon VPC network firewalls.",
   "CheckType": [],
-  "ServiceName": "network-firewall",
+  "ServiceName": "networkfirewall",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:network-firewall::account-id:firewall/firewall-name",
   "Severity": "medium",

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc.metadata.json
@@ -3,7 +3,7 @@
   "CheckID": "networkfirewall_in_all_vpc",
   "CheckTitle": "Ensure all VPCs have Network Firewall enabled",
   "CheckType": [],
-  "ServiceName": "network-firewall",
+  "ServiceName": "networkfirewall",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:network-firewall::account-id:firewall/firewall-name",
   "Severity": "medium",

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_logging_enabled/networkfirewall_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_logging_enabled/networkfirewall_logging_enabled.metadata.json
@@ -5,7 +5,7 @@
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53"
   ],
-  "ServiceName": "network-firewall",
+  "ServiceName": "networkfirewall",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:network-firewall::account-id:firewall/firewall-name",
   "Severity": "medium",

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_multi_az/networkfirewall_multi_az.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_multi_az/networkfirewall_multi_az.metadata.json
@@ -5,7 +5,7 @@
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
   ],
-  "ServiceName": "network-firewall",
+  "ServiceName": "networkfirewall",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:network-firewall::account-id:firewall/firewall-name",
   "Severity": "medium",

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_fragmented_packets/networkfirewall_policy_default_action_fragmented_packets.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_fragmented_packets/networkfirewall_policy_default_action_fragmented_packets.metadata.json
@@ -5,7 +5,7 @@
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
   ],
-  "ServiceName": "network-firewall",
+  "ServiceName": "networkfirewall",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:network-firewall::account-id:firewall/firewall-name",
   "Severity": "medium",

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_full_packets/networkfirewall_policy_default_action_full_packets.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_policy_default_action_full_packets/networkfirewall_policy_default_action_full_packets.metadata.json
@@ -5,7 +5,7 @@
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls"
   ],
-  "ServiceName": "network-firewall",
+  "ServiceName": "networkfirewall",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:network-firewall::account-id:firewall/firewall-name",
   "Severity": "medium",

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_policy_rule_group_associated/networkfirewall_policy_rule_group_associated.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_policy_rule_group_associated/networkfirewall_policy_rule_group_associated.metadata.json
@@ -5,7 +5,7 @@
   "CheckType": [
     "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53"
   ],
-  "ServiceName": "network-firewall",
+  "ServiceName": "networkfirewall",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:partition:network-firewall::account-id:firewall-policy/policy-name",
   "Severity": "medium",


### PR DESCRIPTION
### Context

`Prowler Hub` and `--list-checks` flag didn't work as expected since we didn't have the proper `ServiceName` value in metadata.

### Description

This PR fixes the values for the field `ServiceName` in all `NetworkFirewall` service checks to correctly have the expected behavior.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
