### PR TITLE
feat: menu label hidden in side-menu if no items

### DIFF
--- a/ui/components/ui/sidebar/menu.tsx
+++ b/ui/components/ui/sidebar/menu.tsx
@@ -97,7 +97,8 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                 )}
                 key={index}
               >
-                {(isOpen && groupLabel) || isOpen === undefined ? (
+                {(menus.length > 0 && isOpen && groupLabel) ||
+                isOpen === undefined ? (
                   <p className="text-muted-foreground max-w-[248px] truncate px-4 pb-2 text-xs font-normal">
                     {groupLabel}
                   </p>


### PR DESCRIPTION
### Context

Need to hide the menu label when there are no items

### Description

- Conditionally hiding the label in `menu`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
