### PR TITLE
fix: typo `documentdb` service name

### DIFF
--- a/prowler/providers/aws/services/documentdb/documentdb_cluster_backup_enabled/documentdb_cluster_backup_enabled.metadata.json
+++ b/prowler/providers/aws/services/documentdb/documentdb_cluster_backup_enabled/documentdb_cluster_backup_enabled.metadata.json
@@ -3,7 +3,7 @@
   "CheckID": "documentdb_cluster_backup_enabled",
   "CheckTitle": "Check if DocumentDB Clusters have backup enabled.",
   "CheckType": [],
-  "ServiceName": "DocumentDB",
+  "ServiceName": "documentdb",
   "SubServiceName": "",
   "ResourceIdTemplate": "arn:aws:rds:region:account-id:db-cluster",
   "Severity": "medium",


### PR DESCRIPTION
### Context

Fix the ServiceName of the check `documentdb_cluster_backup_enabled` to align it with other checks for `documentdb`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
