### PR TITLE
fix(m365): handle tenant_id in mutelist

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `ServiceName` field in Network Firewall checks metadata [(#8280)](https://github.com/prowler-cloud/prowler/pull/8280)
 - Update `entra_users_mfa_capable` check to use the correct resource name and ID [(#8288)](https://github.com/prowler-cloud/prowler/pull/8288)
 - Handle multiple services and severities while listing checks [(#8302)](https://github.com/prowler-cloud/prowler/pull/8302)
+- Handle `tenant_id` for m365 mutelist [(#8306)](https://github.com/prowler-cloud/prowler/pull/8306)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `ServiceName` field in Network Firewall checks metadata [(#8280)](https://github.com/prowler-cloud/prowler/pull/8280)
 - Update `entra_users_mfa_capable` check to use the correct resource name and ID [(#8288)](https://github.com/prowler-cloud/prowler/pull/8288)
 - Handle multiple services and severities while listing checks [(#8302)](https://github.com/prowler-cloud/prowler/pull/8302)
-- Handle `tenant_id` for m365 mutelist [(#8306)](https://github.com/prowler-cloud/prowler/pull/8306)
+- Handle `tenant_id` for M365 Mutelist [(#8306)](https://github.com/prowler-cloud/prowler/pull/8306)
 
 ---
 

--- a/prowler/lib/check/check.py
+++ b/prowler/lib/check/check.py
@@ -635,6 +635,8 @@ def execute(
                 is_finding_muted_args["account_name"] = (
                     global_provider.identity.account_name
                 )
+            elif global_provider.type == "m365":
+                is_finding_muted_args["tenant_id"] = global_provider.identity.tenant_id
             for finding in check_findings:
                 if global_provider.type == "azure":
                     is_finding_muted_args["subscription_id"] = (

--- a/prowler/providers/m365/lib/mutelist/mutelist.py
+++ b/prowler/providers/m365/lib/mutelist/mutelist.py
@@ -7,9 +7,10 @@ class M365Mutelist(Mutelist):
     def is_finding_muted(
         self,
         finding: CheckReportM365,
+        tenant_id: str,
     ) -> bool:
         return self.is_muted(
-            finding.tenant_id,
+            tenant_id,
             finding.check_metadata.CheckID,
             finding.location,
             finding.resource_name,

--- a/tests/providers/m365/lib/mutelist/m365_mutelist_test.py
+++ b/tests/providers/m365/lib/mutelist/m365_mutelist_test.py
@@ -56,7 +56,6 @@ class TestM365Mutelist:
         mutelist = M365Mutelist(mutelist_content=mutelist_content)
 
         finding = MagicMock
-        finding.tenant_id = "subscription_1"
         finding.check_metadata = MagicMock
         finding.check_metadata.CheckID = "check_test"
         finding.status = "FAIL"
@@ -65,7 +64,35 @@ class TestM365Mutelist:
         finding.tenant_domain = "test_domain"
         finding.resource_tags = []
 
-        assert mutelist.is_finding_muted(finding)
+        assert mutelist.is_finding_muted(finding, tenant_id="subscription_1")
+
+    def test_finding_is_not_muted(self):
+        # Mutelist
+        mutelist_content = {
+            "Accounts": {
+                "subscription_1": {
+                    "Checks": {
+                        "check_test": {
+                            "Regions": ["*"],
+                            "Resources": ["test_resource"],
+                        }
+                    }
+                }
+            }
+        }
+
+        mutelist = M365Mutelist(mutelist_content=mutelist_content)
+
+        finding = MagicMock
+        finding.check_metadata = MagicMock
+        finding.check_metadata.CheckID = "check_test"
+        finding.status = "FAIL"
+        finding.location = "global"
+        finding.resource_name = "test_resource"
+        finding.tenant_domain = "test_domain"
+        finding.resource_tags = []
+
+        assert not mutelist.is_finding_muted(finding, tenant_id="subscription_2")
 
     def test_mute_finding(self):
         # Mutelist


### PR DESCRIPTION
### Description

This PR adds the `tenant_id` inside `prowler/providers/m365/lib/mutelist/mutelist.py` in order to handle muting findings from a tenant id.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
