### PR TITLE
chore: improve info in the download button

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - Error message when launching a scan if user has no permissions [(#8280)](https://github.com/prowler-cloud/prowler/pull/8280)
+- Include compliance in the download button tooltip [(#8307)](https://github.com/prowler-cloud/prowler/pull/8307)
 
 ### Removed
 

--- a/ui/components/scans/table/scans/column-get-scans.tsx
+++ b/ui/components/scans/table/scans/column-get-scans.tsx
@@ -136,7 +136,7 @@ export const ColumnGetScans: ColumnDef<ScanProps>[] = [
         <p className="w-fit text-xs">Download</p>
         <Tooltip
           className="text-xs"
-          content="Download a ZIP file containing the JSON (OCSF), CSV, and HTML reports."
+          content="Download a ZIP file that includes the JSON (OCSF), CSV, and HTML scan reports, along with the compliance report."
         >
           <div className="flex items-center gap-2">
             <InfoIcon className="mb-1 text-primary" size={12} />

--- a/ui/components/ui/entities/info-field.tsx
+++ b/ui/components/ui/entities/info-field.tsx
@@ -13,7 +13,7 @@ interface InfoFieldProps {
 
 <Tooltip
   className="text-xs"
-  content="Download a ZIP file containing the JSON (OCSF), CSV, and HTML reports."
+  content="Download a ZIP file that includes the JSON (OCSF), CSV, and HTML scan reports, along with the compliance report."
 >
   <div className="flex items-center gap-2">
     <InfoIcon className="mb-1 text-primary" size={12} />


### PR DESCRIPTION
### Description

Improve `info` tooltip in the download button including compliance reports.

<img width="683" height="69" alt="Screenshot 2025-07-17 at 13 08 16" src="https://github.com/user-attachments/assets/e7e5e9b0-de1c-4ae3-a85a-236c458bce4e" />


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
