### PR TITLE
fix: muted filter removed from url when value is true

### DIFF
--- a/ui/components/filters/custom-checkbox-muted-findings.tsx
+++ b/ui/components/filters/custom-checkbox-muted-findings.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { useUrlFilters } from "@/hooks/use-url-filters";
 
 export const CustomCheckboxMutedFindings = () => {
-  const { updateFilter } = useUrlFilters();
+  const { updateFilter, clearFilter } = useUrlFilters();
   const searchParams = useSearchParams();
   const [excludeMuted, setExcludeMuted] = useState(
     searchParams.get("filter[muted]") === "false",
@@ -15,7 +15,13 @@ export const CustomCheckboxMutedFindings = () => {
 
   const handleMutedChange = (value: boolean) => {
     setExcludeMuted(value);
-    updateFilter("muted", value ? "false" : "true");
+
+    // Only URL  update if value is false else remove filter
+    if (value) {
+      updateFilter("muted", "false");
+    } else {
+      clearFilter("muted");
+    }
   };
 
   return (

--- a/ui/components/overview/findings-by-status-chart/findings-by-status-chart.tsx
+++ b/ui/components/overview/findings-by-status-chart/findings-by-status-chart.tsx
@@ -121,7 +121,7 @@ export const FindingsByStatusChart: React.FC<FindingsByStatusChartProps> = ({
   return (
     <Card className="h-full dark:bg-prowler-blue-400">
       <CardBody>
-        <div className="flex flex-col items-center gap-6">
+        <div className="flex h-full flex-col items-center justify-between">
           <ChartContainer
             config={chartConfig}
             className="aspect-square w-[250px] min-w-[250px]"
@@ -170,7 +170,7 @@ export const FindingsByStatusChart: React.FC<FindingsByStatusChartProps> = ({
             </PieChart>
           </ChartContainer>
 
-          <div className="flex flex-col gap-6">
+          <div className="flex min-h-[156px] flex-col justify-start gap-4">
             <div className="flex flex-col gap-2">
               <div className="flex items-center space-x-2">
                 <Link
@@ -229,45 +229,47 @@ export const FindingsByStatusChart: React.FC<FindingsByStatusChartProps> = ({
               </div>
             </div>
 
-            {shouldShowMuted && (
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center space-x-2">
-                  <Link
-                    href="/findings?filter[muted]=true"
-                    className="flex items-center space-x-2"
-                  >
-                    <Chip
-                      className="h-5"
-                      variant="flat"
-                      startContent={<MutedIcon size={18} />}
-                      color="warning"
-                      radius="lg"
-                      size="md"
+            <div className="flex min-h-[52px] flex-col gap-2">
+              {shouldShowMuted ? (
+                <>
+                  <div className="flex items-center space-x-2">
+                    <Link
+                      href="/findings?filter[muted]=true"
+                      className="flex items-center space-x-2"
                     >
-                      {chartData.find((item) => item.findings === "Muted")
-                        ?.number || 0}
-                    </Chip>
-                    <span>
-                      {updatedChartData.find(
-                        (item) => item.findings === "Muted",
-                      )?.percent || "0%"}
-                    </span>
-                  </Link>
-                </div>
-                <div className="text-muted-foreground flex items-center gap-1 text-xs font-medium leading-none">
-                  {muted_new > 0 ? (
-                    <>
-                      +{muted_new} muted findings from last day{" "}
-                      <TrendingUp className="h-4 w-4" />
-                    </>
-                  ) : muted_new < 0 ? (
-                    <>{muted_new} muted findings from last day</>
-                  ) : (
-                    "No change from last day"
-                  )}
-                </div>
-              </div>
-            )}
+                      <Chip
+                        className="h-5"
+                        variant="flat"
+                        startContent={<MutedIcon size={18} />}
+                        color="warning"
+                        radius="lg"
+                        size="md"
+                      >
+                        {chartData.find((item) => item.findings === "Muted")
+                          ?.number || 0}
+                      </Chip>
+                      <span>
+                        {updatedChartData.find(
+                          (item) => item.findings === "Muted",
+                        )?.percent || "0%"}
+                      </span>
+                    </Link>
+                  </div>
+                  <div className="text-muted-foreground flex items-center gap-1 text-xs font-medium leading-none">
+                    {muted_new > 0 ? (
+                      <>
+                        +{muted_new} muted findings from last day{" "}
+                        <TrendingUp className="h-4 w-4" />
+                      </>
+                    ) : muted_new < 0 ? (
+                      <>{muted_new} muted findings from last day</>
+                    ) : (
+                      "No change from last day"
+                    )}
+                  </div>
+                </>
+              ) : null}
+            </div>
           </div>
         </div>
       </CardBody>


### PR DESCRIPTION
### Context

The muted filter value should be removed from the URL when it is false.

### Description

- Handle improved, filter cleaned
- Fixed height in status chart

https://github.com/user-attachments/assets/a2944eb7-b1cc-4ba0-ba52-8d0340d0a2f4

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
