### PR TITLE
feat(ui): add 32-character limit validation for scan name in create a…

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Navigation link in Scans view to access Compliance Overview [(#8251)](https://github.com/prowler-cloud/prowler/pull/8251)
 - Status column for findings table in the Compliance Detail view [(#8244)](https://github.com/prowler-cloud/prowler/pull/8244)
 - Allow to restrict routes access based on user permissions [(#8287)](https://github.com/prowler-cloud/prowler/pull/8287)
+- Validation for scan name input field in both create and edit scan [(#8319)](https://github.com/prowler-cloud/prowler/pull/8319)
 
 ### Security
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Navigation link in Scans view to access Compliance Overview [(#8251)](https://github.com/prowler-cloud/prowler/pull/8251)
 - Status column for findings table in the Compliance Detail view [(#8244)](https://github.com/prowler-cloud/prowler/pull/8244)
 - Allow to restrict routes access based on user permissions [(#8287)](https://github.com/prowler-cloud/prowler/pull/8287)
-- Validation for scan name input field in both create and edit scan [(#8319)](https://github.com/prowler-cloud/prowler/pull/8319)
+- Max character limit validation for Scan label [(#8319)](https://github.com/prowler-cloud/prowler/pull/8319)
 
 ### Security
 

--- a/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
+++ b/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
@@ -32,8 +32,8 @@ export const LaunchScanWorkflow = ({
       .union([
         z
           .string()
-          .min(3, "Scan name must be at least 3 characters")
-          .max(32, "Scan name must not exceed 32 characters"),
+          .min(3, "Must be at least 3 characters")
+          .max(32, "Must not exceed 32 characters"),
         z.literal(""),
       ])
       .optional(),

--- a/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
+++ b/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
@@ -29,9 +29,13 @@ export const LaunchScanWorkflow = ({
   const formSchema = z.object({
     ...onDemandScanFormSchema().shape,
     scanName: z
-      .string()
-      .min(3, "Must have at least 3 characters")
-      .or(z.literal(""))
+      .union([
+        z
+          .string()
+          .min(3, "Scan name must be at least 3 characters")
+          .max(32, "Scan name must not exceed 32 characters"),
+        z.literal(""),
+      ])
       .optional(),
   });
 

--- a/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
+++ b/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
@@ -105,7 +105,7 @@ export const LaunchScanWorkflow = ({
                   animate={{ opacity: 1, x: 0 }}
                   exit={{ opacity: 0, x: -50 }}
                   transition={{ duration: 0.3 }}
-                  className="min-w-48 self-end"
+                  className="h-[3.4rem] min-w-[15.2rem] self-end"
                 >
                   <CustomInput
                     control={form.control}

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -36,6 +36,9 @@ export const editScanFormSchema = (currentName: string) =>
       .refine((val) => val === "" || val.length >= 3, {
         message: "The alias must be empty or have at least 3 characters.",
       })
+      .refine((val) => val === "" || val.length <= 32, {
+        message: "The alias must not exceed 32 characters.",
+      })
       .refine((val) => val !== currentName, {
         message: "The new name must be different from the current one.",
       })

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -34,10 +34,10 @@ export const editScanFormSchema = (currentName: string) =>
     scanName: z
       .string()
       .refine((val) => val === "" || val.length >= 3, {
-        message: "The alias must be empty or have at least 3 characters.",
+        message: "Must be empty or have at least 3 characters.",
       })
       .refine((val) => val === "" || val.length <= 32, {
-        message: "The alias must not exceed 32 characters.",
+        message: "Must not exceed 32 characters.",
       })
       .refine((val) => val !== currentName, {
         message: "The new name must be different from the current one.",


### PR DESCRIPTION
### Context

This PR addresses consistent validation for the scan name input field during scan creation and scan name editing.

### Description

Added validation for the `scan name` input field in both scan launch and scan name editing.

Enforced the following rules:
- Minimum 3 characters (when not empty)
- Maximum 32 characters
- Allows empty string when scan name is optional

<img width="1539" height="231" alt="image" src="https://github.com/user-attachments/assets/5e53e7d0-4e35-4c0c-bf42-e8370fb2df2a" />

<img width="1547" height="298" alt="image" src="https://github.com/user-attachments/assets/3b819ec4-d3c4-4c02-bbeb-738d42bc8cbd" />

<img width="784" height="371" alt="image" src="https://github.com/user-attachments/assets/8968e9af-c198-49a7-a049-84cfadf636b7" />

<img width="796" height="373" alt="image" src="https://github.com/user-attachments/assets/85971793-490b-4569-a5ac-9f01930a2698" />



### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
