### PR TITLE
feat(aws): new check `bedrock_api_key_no_administrative_privileges`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
-## [v5.9.1] (Prowler UNRELEASED)
+## [v5.10.0] (Prowler UNRELEASED)
 
 ### Added
 - Add `bedrock_api_key_no_administrative_privileges` check for AWS provider [(#8321)](https://github.com/prowler-cloud/prowler/pull/8321)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
+## [v5.9.1] (Prowler UNRELEASED)
+
+### Added
+- Add `bedrock_api_key_no_administrative_privileges` check for AWS provider [(#8321)](https://github.com/prowler-cloud/prowler/pull/8321)
+
+---
+
 ## [v5.9.0] (Prowler v5.9.0)
 
 ### Added
@@ -32,12 +39,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update `entra_users_mfa_capable` check to use the correct resource name and ID [(#8288)](https://github.com/prowler-cloud/prowler/pull/8288)
 - Handle multiple services and severities while listing checks [(#8302)](https://github.com/prowler-cloud/prowler/pull/8302)
 - Handle `tenant_id` for M365 Mutelist [(#8306)](https://github.com/prowler-cloud/prowler/pull/8306)
-
----
-
-## [v5.8.2] (Prowler 5.8.2)
-
-### Fixed
 - Fix error in Dashboard Overview page when reading CSV files [(#8257)](https://github.com/prowler-cloud/prowler/pull/8257)
 
 ---

--- a/prowler/providers/aws/services/bedrock/bedrock_api_key_no_administrative_privileges/bedrock_api_key_no_administrative_privileges.metadata.json
+++ b/prowler/providers/aws/services/bedrock/bedrock_api_key_no_administrative_privileges/bedrock_api_key_no_administrative_privileges.metadata.json
@@ -1,0 +1,36 @@
+{
+  "Provider": "aws",
+  "CheckID": "bedrock_api_key_no_administrative_privileges",
+  "CheckTitle": "Ensure Amazon Bedrock API keys do not have administrative privileges or privilege escalation",
+  "CheckType": [
+    "Software and Configuration Checks",
+    "Industry and Regulatory Standards"
+  ],
+  "ServiceName": "bedrock",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "arn:partition:iam:region:account-id:user/{user-name}/credential/{api-key-id}",
+  "Severity": "high",
+  "ResourceType": "AwsIamServiceSpecificCredential",
+  "Description": "Ensure that Amazon Bedrock API keys do not have administrative privileges or privilege escalation capabilities. API keys with administrative privileges can perform any action on any resource in your AWS environment, while privilege escalation allows users to grant themselves additional permissions, both posing significant security risks.",
+  "Risk": "Amazon Bedrock API keys with administrative privileges can perform any action on any resource in your AWS environment. Privilege escalation capabilities allow users to grant themselves additional permissions beyond their intended scope. Both violations of the principle of least privilege can lead to security vulnerabilities, data leaks, data loss, or unexpected charges if the API key is compromised or misused.",
+  "RelatedUrl": "https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html",
+  "Remediation": {
+    "Code": {
+      "CLI": "aws iam delete-service-specific-credential --user-name <username> --service-specific-credential-id <credential-id>",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Apply the principle of least privilege to Amazon Bedrock API keys. Instead of granting administrative privileges or privilege escalation capabilities, assign only the permissions necessary for specific tasks. Create custom IAM policies with minimal permissions based on the principle of least privilege. Regularly review and audit API key permissions to ensure they cannot be used for privilege escalation.",
+      "Url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege"
+    }
+  },
+  "Categories": [
+    "gen-ai",
+    "trustboundaries"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "This check verifies that Amazon Bedrock API keys do not have administrative privileges or privilege escalation capabilities through attached IAM policies or inline policies. It follows the principle of least privilege to ensure API keys only have the minimum necessary permissions and cannot be used to escalate privileges."
+}

--- a/prowler/providers/aws/services/bedrock/bedrock_api_key_no_administrative_privileges/bedrock_api_key_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/bedrock/bedrock_api_key_no_administrative_privileges/bedrock_api_key_no_administrative_privileges.py
@@ -1,0 +1,57 @@
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.providers.aws.services.iam.iam_client import iam_client
+from prowler.providers.aws.services.iam.lib.policy import (
+    check_admin_access,
+    check_full_service_access,
+)
+from prowler.providers.aws.services.iam.lib.privilege_escalation import (
+    check_privilege_escalation,
+)
+
+
+class bedrock_api_key_no_administrative_privileges(Check):
+    def execute(self):
+        findings = []
+        for api_key in iam_client.service_specific_credentials:
+            if api_key.service_name != "bedrock.amazonaws.com":
+                continue
+            report = Check_Report_AWS(metadata=self.metadata(), resource=api_key)
+            report.status = "PASS"
+            report.status_extended = f"API key {api_key.id} in user {api_key.user.name} has no administrative privileges."
+            for policy in api_key.user.attached_policies:
+                policy_arn = policy["PolicyArn"]
+                if policy_arn in iam_client.policies:
+                    policy_document = iam_client.policies[policy_arn].document
+                    if policy_document:
+                        if check_admin_access(policy_document):
+                            report.status = "FAIL"
+                            report.status_extended = f"API key {api_key.id} in user {api_key.user.name} has administrative privileges through attached policy {policy['PolicyName']}."
+                            break
+                        elif check_privilege_escalation(policy_document):
+                            report.status = "FAIL"
+                            report.status_extended = f"API key {api_key.id} in user {api_key.user.name} has privilege escalation through attached policy {policy['PolicyName']}."
+                            break
+                        elif check_full_service_access("bedrock", policy_document):
+                            report.status = "FAIL"
+                            report.status_extended = f"API key {api_key.id} in user {api_key.user.name} has full service access through attached policy {policy['PolicyName']}."
+                            break
+            for inline_policy_name in api_key.user.inline_policies:
+                inline_policy_arn = f"{api_key.user.arn}:policy/{inline_policy_name}"
+                if inline_policy_arn in iam_client.policies:
+                    policy_document = iam_client.policies[inline_policy_arn].document
+                    if policy_document:
+                        if check_admin_access(policy_document):
+                            report.status = "FAIL"
+                            report.status_extended = f"API key {api_key.id} in user {api_key.user.name} has administrative privileges through inline policy {inline_policy_name}."
+                            break
+                        elif check_privilege_escalation(policy_document):
+                            report.status = "FAIL"
+                            report.status_extended = f"API key {api_key.id} in user {api_key.user.name} has privilege escalation through inline policy {inline_policy_name}."
+                            break
+                        elif check_full_service_access("bedrock", policy_document):
+                            report.status = "FAIL"
+                            report.status_extended = f"API key {api_key.id} in user {api_key.user.name} has full service access through inline policy {inline_policy_name}."
+                            break
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_aws_attached_policy_no_administrative_privileges/iam_aws_attached_policy_no_administrative_privileges.py
@@ -6,7 +6,7 @@ from prowler.providers.aws.services.iam.lib.policy import check_admin_access
 class iam_aws_attached_policy_no_administrative_privileges(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             # Check only for attached AWS policies
             if policy.attached and policy.type == "AWS":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)

--- a/prowler/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_customer_attached_policy_no_administrative_privileges/iam_customer_attached_policy_no_administrative_privileges.py
@@ -6,7 +6,7 @@ from prowler.providers.aws.services.iam.lib.policy import check_admin_access
 class iam_customer_attached_policy_no_administrative_privileges(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             # Check only for attached custom policies
             if policy.attached and policy.type == "Custom":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)

--- a/prowler/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_customer_unattached_policy_no_administrative_privileges/iam_customer_unattached_policy_no_administrative_privileges.py
@@ -6,7 +6,7 @@ from prowler.providers.aws.services.iam.lib.policy import check_admin_access
 class iam_customer_unattached_policy_no_administrative_privileges(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             # Check only for cutomer unattached policies
             if not policy.attached and policy.type == "Custom":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)

--- a/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation.py
@@ -9,7 +9,7 @@ class iam_inline_policy_allows_privilege_escalation(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
 
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             if policy.type == "Inline":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)
                 report.resource_id = f"{policy.entity}/{policy.name}"

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_administrative_privileges/iam_inline_policy_no_administrative_privileges.py
@@ -6,7 +6,7 @@ from prowler.providers.aws.services.iam.lib.policy import check_admin_access
 class iam_inline_policy_no_administrative_privileges(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             if policy.type == "Inline":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)
                 report.region = iam_client.region

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_cloudtrail/iam_inline_policy_no_full_access_to_cloudtrail.py
@@ -9,7 +9,7 @@ class iam_inline_policy_no_full_access_to_cloudtrail(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
 
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             # Check only inline policies
             if policy.type == "Inline":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)

--- a/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
+++ b/prowler/providers/aws/services/iam/iam_inline_policy_no_full_access_to_kms/iam_inline_policy_no_full_access_to_kms.py
@@ -9,7 +9,7 @@ class iam_inline_policy_no_full_access_to_kms(Check):
     def execute(self):
         findings = []
 
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             if policy.type == "Inline":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)
                 report.region = iam_client.region

--- a/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
+++ b/prowler/providers/aws/services/iam/iam_no_custom_policy_permissive_role_assumption/iam_no_custom_policy_permissive_role_assumption.py
@@ -13,7 +13,7 @@ class iam_no_custom_policy_permissive_role_assumption(Check):
                 return any("*" in r for r in resource)
             return False
 
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             # Check only custom policies
             if policy.type == "Custom":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)

--- a/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.py
@@ -9,7 +9,7 @@ class iam_policy_allows_privilege_escalation(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
 
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             if policy.type == "Custom":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)
                 report.region = iam_client.region

--- a/prowler/providers/aws/services/iam/iam_policy_no_full_access_to_cloudtrail/iam_policy_no_full_access_to_cloudtrail.py
+++ b/prowler/providers/aws/services/iam/iam_policy_no_full_access_to_cloudtrail/iam_policy_no_full_access_to_cloudtrail.py
@@ -8,7 +8,7 @@ critical_service = "cloudtrail"
 class iam_policy_no_full_access_to_cloudtrail(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             # Check only custom policies
             if policy.type == "Custom":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)

--- a/prowler/providers/aws/services/iam/iam_policy_no_full_access_to_kms/iam_policy_no_full_access_to_kms.py
+++ b/prowler/providers/aws/services/iam/iam_policy_no_full_access_to_kms/iam_policy_no_full_access_to_kms.py
@@ -8,7 +8,7 @@ critical_service = "kms"
 class iam_policy_no_full_access_to_kms(Check):
     def execute(self) -> Check_Report_AWS:
         findings = []
-        for policy in iam_client.policies:
+        for policy in iam_client.policies.values():
             # Check only custom policies
             if policy.type == "Custom":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=policy)

--- a/tests/providers/aws/services/bedrock/bedrock_api_key_no_administrative_privileges/bedrock_api_key_no_administrative_privileges_test.py
+++ b/tests/providers/aws/services/bedrock/bedrock_api_key_no_administrative_privileges/bedrock_api_key_no_administrative_privileges_test.py
@@ -1,0 +1,618 @@
+from datetime import timezone
+from json import dumps
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+# Test policy documents
+ADMIN_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [{"Effect": "Allow", "Action": ["*"], "Resource": "*"}],
+}
+
+NON_ADMIN_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [{"Effect": "Allow", "Action": ["bedrock:*"], "Resource": "*"}],
+}
+
+PRIVILEGE_ESCALATION_POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateAccessKey",
+                "iam:CreateUser",
+                "iam:AttachUserPolicy",
+            ],
+            "Resource": "*",
+        }
+    ],
+}
+
+
+class Test_bedrock_api_key_no_administrative_privileges:
+    @mock_aws
+    def test_no_bedrock_api_keys(self):
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    @mock_aws
+    def test_bedrock_api_key_with_admin_attached_policy(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create user
+        user_name = "test_user"
+        user_arn = iam_client.create_user(UserName=user_name)["User"]["Arn"]
+
+        # Create admin policy
+        admin_policy_arn = iam_client.create_policy(
+            PolicyName="AdminPolicy",
+            PolicyDocument=dumps(ADMIN_POLICY),
+            Path="/",
+        )["Policy"]["Arn"]
+
+        # Attach admin policy to user
+        iam_client.attach_user_policy(UserName=user_name, PolicyArn=admin_policy_arn)
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        # Mock service-specific credentials
+        from datetime import datetime
+
+        from prowler.providers.aws.services.iam.iam_service import (
+            ServiceSpecificCredential,
+            User,
+        )
+
+        # Create a mock user with the attached policy
+        mock_user = User(
+            name=user_name,
+            arn=user_arn,
+            attached_policies=[
+                {"PolicyArn": admin_policy_arn, "PolicyName": "AdminPolicy"}
+            ],
+            inline_policies=[],
+        )
+
+        # Create a mock service-specific credential
+        mock_credential = ServiceSpecificCredential(
+            arn=f"arn:aws:iam:{AWS_REGION_US_EAST_1}:123456789012:user/{user_name}/credential/test-credential-id",
+            user=mock_user,
+            status="Active",
+            create_date=datetime.now(timezone.utc),
+            service_user_name=None,
+            service_credential_alias=None,
+            expiration_date=None,
+            id="test-credential-id",
+            service_name="bedrock.amazonaws.com",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        iam.service_specific_credentials = [mock_credential]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=iam,
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "API key test-credential-id in user test_user has administrative privileges through attached policy AdminPolicy."
+            )
+            assert result[0].resource_id == "test-credential-id"
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bedrock_api_key_with_admin_inline_policy(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create user
+        user_name = "test_user"
+        user_arn = iam_client.create_user(UserName=user_name)["User"]["Arn"]
+
+        # Create inline admin policy
+        iam_client.put_user_policy(
+            UserName=user_name,
+            PolicyName="AdminInlinePolicy",
+            PolicyDocument=dumps(ADMIN_POLICY),
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        # Mock service-specific credentials
+        from datetime import datetime
+
+        from prowler.providers.aws.services.iam.iam_service import (
+            ServiceSpecificCredential,
+            User,
+        )
+
+        # Create a mock user with the inline policy
+        mock_user = User(
+            name=user_name,
+            arn=user_arn,
+            attached_policies=[],
+            inline_policies=["AdminInlinePolicy"],
+        )
+
+        # Create a mock service-specific credential
+        mock_credential = ServiceSpecificCredential(
+            arn=f"arn:aws:iam:{AWS_REGION_US_EAST_1}:123456789012:user/{user_name}/credential/test-credential-id",
+            user=mock_user,
+            status="Active",
+            create_date=datetime.now(timezone.utc),
+            service_user_name=None,
+            service_credential_alias=None,
+            expiration_date=None,
+            id="test-credential-id",
+            service_name="bedrock.amazonaws.com",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        iam.service_specific_credentials = [mock_credential]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=iam,
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "API key test-credential-id in user test_user has administrative privileges through inline policy AdminInlinePolicy."
+            )
+            assert result[0].resource_id == "test-credential-id"
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bedrock_api_key_with_privilege_escalation_attached_policy(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create user
+        user_name = "test_user"
+        user_arn = iam_client.create_user(UserName=user_name)["User"]["Arn"]
+
+        # Create privilege escalation policy
+        escalation_policy_arn = iam_client.create_policy(
+            PolicyName="EscalationPolicy",
+            PolicyDocument=dumps(PRIVILEGE_ESCALATION_POLICY),
+            Path="/",
+        )["Policy"]["Arn"]
+
+        # Attach privilege escalation policy to user
+        iam_client.attach_user_policy(
+            UserName=user_name, PolicyArn=escalation_policy_arn
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        # Mock service-specific credentials
+        from datetime import datetime
+
+        from prowler.providers.aws.services.iam.iam_service import (
+            ServiceSpecificCredential,
+            User,
+        )
+
+        # Create a mock user with the attached policy
+        mock_user = User(
+            name=user_name,
+            arn=user_arn,
+            attached_policies=[
+                {"PolicyArn": escalation_policy_arn, "PolicyName": "EscalationPolicy"}
+            ],
+            inline_policies=[],
+        )
+
+        # Create a mock service-specific credential
+        mock_credential = ServiceSpecificCredential(
+            arn=f"arn:aws:iam:{AWS_REGION_US_EAST_1}:123456789012:user/{user_name}/credential/test-credential-id",
+            user=mock_user,
+            status="Active",
+            create_date=datetime.now(timezone.utc),
+            service_user_name=None,
+            service_credential_alias=None,
+            expiration_date=None,
+            id="test-credential-id",
+            service_name="bedrock.amazonaws.com",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        iam.service_specific_credentials = [mock_credential]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=iam,
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "API key test-credential-id in user test_user has privilege escalation through attached policy EscalationPolicy."
+            )
+            assert result[0].resource_id == "test-credential-id"
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bedrock_api_key_with_privilege_escalation_inline_policy(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create user
+        user_name = "test_user"
+        user_arn = iam_client.create_user(UserName=user_name)["User"]["Arn"]
+
+        # Create inline privilege escalation policy
+        iam_client.put_user_policy(
+            UserName=user_name,
+            PolicyName="EscalationInlinePolicy",
+            PolicyDocument=dumps(PRIVILEGE_ESCALATION_POLICY),
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        # Mock service-specific credentials
+        from datetime import datetime
+
+        from prowler.providers.aws.services.iam.iam_service import (
+            ServiceSpecificCredential,
+            User,
+        )
+
+        # Create a mock user with the inline policy
+        mock_user = User(
+            name=user_name,
+            arn=user_arn,
+            attached_policies=[],
+            inline_policies=["EscalationInlinePolicy"],
+        )
+
+        # Create a mock service-specific credential
+        mock_credential = ServiceSpecificCredential(
+            arn=f"arn:aws:iam:{AWS_REGION_US_EAST_1}:123456789012:user/{user_name}/credential/test-credential-id",
+            user=mock_user,
+            status="Active",
+            create_date=datetime.now(timezone.utc),
+            service_user_name=None,
+            service_credential_alias=None,
+            expiration_date=None,
+            id="test-credential-id",
+            service_name="bedrock.amazonaws.com",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        iam.service_specific_credentials = [mock_credential]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=iam,
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "API key test-credential-id in user test_user has privilege escalation through inline policy EscalationInlinePolicy."
+            )
+            assert result[0].resource_id == "test-credential-id"
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bedrock_api_key_with_non_admin_policy(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create user
+        user_name = "test_user"
+        user_arn = iam_client.create_user(UserName=user_name)["User"]["Arn"]
+
+        # Create non-admin policy
+        non_admin_policy_arn = iam_client.create_policy(
+            PolicyName="NonAdminPolicy",
+            PolicyDocument=dumps(NON_ADMIN_POLICY),
+            Path="/",
+        )["Policy"]["Arn"]
+
+        # Attach non-admin policy to user
+        iam_client.attach_user_policy(
+            UserName=user_name, PolicyArn=non_admin_policy_arn
+        )
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        # Mock service-specific credentials
+        from datetime import datetime
+
+        from prowler.providers.aws.services.iam.iam_service import (
+            ServiceSpecificCredential,
+            User,
+        )
+
+        # Create a mock user with the attached policy
+        mock_user = User(
+            name=user_name,
+            arn=user_arn,
+            attached_policies=[
+                {"PolicyArn": non_admin_policy_arn, "PolicyName": "NonAdminPolicy"}
+            ],
+            inline_policies=[],
+        )
+
+        # Create a mock service-specific credential
+        mock_credential = ServiceSpecificCredential(
+            arn=f"arn:aws:iam:{AWS_REGION_US_EAST_1}:123456789012:user/{user_name}/credential/test-credential-id",
+            user=mock_user,
+            status="Active",
+            create_date=datetime.now(timezone.utc),
+            service_user_name=None,
+            service_credential_alias=None,
+            expiration_date=None,
+            id="test-credential-id",
+            service_name="bedrock.amazonaws.com",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        iam.service_specific_credentials = [mock_credential]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=iam,
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "API key test-credential-id in user test_user has full service access through attached policy NonAdminPolicy."
+            )
+            assert result[0].resource_id == "test-credential-id"
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_bedrock_api_key_with_no_policies(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create user
+        user_name = "test_user"
+        user_arn = iam_client.create_user(UserName=user_name)["User"]["Arn"]
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        # Mock service-specific credentials
+        from datetime import datetime
+
+        from prowler.providers.aws.services.iam.iam_service import (
+            ServiceSpecificCredential,
+            User,
+        )
+
+        # Create a mock user with no policies
+        mock_user = User(
+            name=user_name,
+            arn=user_arn,
+            attached_policies=[],
+            inline_policies=[],
+        )
+
+        # Create a mock service-specific credential
+        mock_credential = ServiceSpecificCredential(
+            arn=f"arn:aws:iam:{AWS_REGION_US_EAST_1}:123456789012:user/{user_name}/credential/test-credential-id",
+            user=mock_user,
+            status="Active",
+            create_date=datetime.now(timezone.utc),
+            service_user_name=None,
+            service_credential_alias=None,
+            expiration_date=None,
+            id="test-credential-id",
+            service_name="bedrock.amazonaws.com",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        iam.service_specific_credentials = [mock_credential]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=iam,
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "API key test-credential-id in user test_user has no administrative privileges."
+            )
+            assert result[0].resource_id == "test-credential-id"
+            assert result[0].region == AWS_REGION_US_EAST_1
+
+    @mock_aws
+    def test_non_bedrock_api_key_ignored(self):
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+
+        # Create user
+        user_name = "test_user"
+        user_arn = iam_client.create_user(UserName=user_name)["User"]["Arn"]
+
+        # Create admin policy
+        admin_policy_arn = iam_client.create_policy(
+            PolicyName="AdminPolicy",
+            PolicyDocument=dumps(ADMIN_POLICY),
+            Path="/",
+        )["Policy"]["Arn"]
+
+        # Attach admin policy to user
+        iam_client.attach_user_policy(UserName=user_name, PolicyArn=admin_policy_arn)
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam = IAM(aws_provider)
+
+        # Mock service-specific credentials
+        from datetime import datetime
+
+        from prowler.providers.aws.services.iam.iam_service import (
+            ServiceSpecificCredential,
+            User,
+        )
+
+        # Create a mock user with the attached policy
+        mock_user = User(
+            name=user_name,
+            arn=user_arn,
+            attached_policies=[
+                {"PolicyArn": admin_policy_arn, "PolicyName": "AdminPolicy"}
+            ],
+            inline_policies=[],
+        )
+
+        # Create a mock service-specific credential for a different service (not Bedrock)
+        mock_credential = ServiceSpecificCredential(
+            arn=f"arn:aws:iam:{AWS_REGION_US_EAST_1}:123456789012:user/{user_name}/credential/test-credential-id",
+            user=mock_user,
+            status="Active",
+            create_date=datetime.now(timezone.utc),
+            service_user_name=None,
+            service_credential_alias=None,
+            expiration_date=None,
+            id="test-credential-id",
+            service_name="codecommit.amazonaws.com",
+            region=AWS_REGION_US_EAST_1,
+        )
+
+        iam.service_specific_credentials = [mock_credential]
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges.iam_client",
+                new=iam,
+            ),
+        ):
+            from prowler.providers.aws.services.bedrock.bedrock_api_key_no_administrative_privileges.bedrock_api_key_no_administrative_privileges import (
+                bedrock_api_key_no_administrative_privileges,
+            )
+
+            check = bedrock_api_key_no_administrative_privileges()
+            result = check.execute()
+
+            # Should return 0 results since the API key is not for Bedrock
+            assert len(result) == 0

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -760,7 +760,7 @@ class Test_IAM_Service:
         aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
         iam = IAM(aws_provider)
         custom_policies = 0
-        for policy in iam.policies:
+        for policy in iam.policies.values():
             if policy.type == "Custom":
                 custom_policies += 1
                 assert policy.name == "policy1"
@@ -786,7 +786,7 @@ class Test_IAM_Service:
         iam = IAM(aws_provider)
 
         custom_policies = 0
-        for policy in iam.policies:
+        for policy in iam.policies.values():
             if policy.type == "Custom":
                 custom_policies += 1
                 assert policy.name == "policy2"
@@ -872,7 +872,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert iam.users[0].tags == []
 
         # TODO: Workaround until this gets fixed https://github.com/getmoto/moto/issues/6712
-        for policy in iam.policies:
+        for policy in iam.policies.values():
             if policy.name == policy_name:
                 assert policy == Policy(
                     name=policy_name,
@@ -914,7 +914,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert iam.groups[0].users == []
 
         # TODO: Workaround until this gets fixed https://github.com/getmoto/moto/issues/6712
-        for policy in iam.policies:
+        for policy in iam.policies.values():
             if policy.name == policy_name:
                 assert policy == Policy(
                     name=policy_name,
@@ -960,7 +960,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert iam.roles[0].tags == []
 
         # TODO: Workaround until this gets fixed https://github.com/getmoto/moto/issues/6712
-        for policy in iam.policies:
+        for policy in iam.policies.values():
             if policy.name == policy_name:
                 assert policy == Policy(
                     name=policy_name,


### PR DESCRIPTION
### Context

Amazon Bedrock's new API keys create dedicated IAM users (https://aws.amazon.com/blogs/machine-learning/accelerate-ai-development-with-amazon-bedrock-api-keys/). If these users are misconfigured with excessive permissions (e.g., `bedrock:*`), the key's bearer token can be abused for destructive actions within the service.

### Description

This check identifies Bedrock API keys and verifies their underlying IAM user does not have administrative, privilege escalation, or bedrock:* permissions, mitigating this risk.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
