### PR TITLE
fix(defender): avoid duplicated findings in check `defender_domain_dkim_enabled`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
+## [v5.9.2] (Prowler v5.9.2) UNRELEASED
+
+### Fixed
+- Use the correct resource name in `defender_domain_dkim_enabled` check [(#8334)](https://github.com/prowler-cloud/prowler/pull/8334)
+
+---
+
 ## [v5.9.0] (Prowler v5.9.0)
 
 ### Added

--- a/prowler/providers/m365/services/defender/defender_domain_dkim_enabled/defender_domain_dkim_enabled.py
+++ b/prowler/providers/m365/services/defender/defender_domain_dkim_enabled/defender_domain_dkim_enabled.py
@@ -26,7 +26,7 @@ class defender_domain_dkim_enabled(Check):
             report = CheckReportM365(
                 metadata=self.metadata(),
                 resource=config,
-                resource_name="DKIM Configuration",
+                resource_name=config.id,
                 resource_id=config.id,
             )
             report.status = "FAIL"

--- a/tests/providers/m365/services/defender/defender_domain_dkim_enabled/defender_domain_dkim_enabled_test.py
+++ b/tests/providers/m365/services/defender/defender_domain_dkim_enabled/defender_domain_dkim_enabled_test.py
@@ -43,7 +43,7 @@ class Test_defender_domain_dkim_enabled:
                 == "DKIM is enabled for domain with ID domain1."
             )
             assert result[0].resource == defender_client.dkim_configurations[0].dict()
-            assert result[0].resource_name == "DKIM Configuration"
+            assert result[0].resource_name == "domain1"
             assert result[0].resource_id == "domain1"
             assert result[0].location == "global"
 
@@ -86,7 +86,7 @@ class Test_defender_domain_dkim_enabled:
                 == "DKIM is not enabled for domain with ID domain2."
             )
             assert result[0].resource == defender_client.dkim_configurations[0].dict()
-            assert result[0].resource_name == "DKIM Configuration"
+            assert result[0].resource_name == "domain2"
             assert result[0].resource_id == "domain2"
             assert result[0].location == "global"
 


### PR DESCRIPTION
### Context

The finding UID generation in Prowler uses the resource_name field as part of the UID construction. When a check evaluates multiple resources (like multiple domains) but uses a generic resource_name, it can result in duplicate UIDs for different findings.
This issue was identified during a comprehensive review of all M365 checks that use generic `resource_name` values. While 37 checks initially appeared suspicious, only `defender_domain_dkim_enabled` actually generates multiple findings with the same UID due to its loop structure.
The fix ensures that each domain evaluation generates a unique finding UID, improving the accuracy of finding tracking and deduplication.

### Description

Update `resource_name` assignment in `defender_domain_dkim_enabled` replacing generic `DKIM Configuration` with the actual domain name.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
