### PR TITLE
chore(sqs): clean up code

### DIFF
--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -12,6 +12,7 @@ from tests.providers.aws.utils import (
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_provider,
 )
+from botocore.exceptions import ClientError
 
 test_queue = "test-queue"
 test_key = str(uuid4())
@@ -114,3 +115,39 @@ class Test_SQS_Service:
         assert sqs.queues[0].region == AWS_REGION_EU_WEST_1
         assert sqs.queues[0].policy
         assert sqs.queues[0].kms_key_id == test_key
+
+    @mock_aws
+    def test_get_queue_attributes_nonexistent_queue(self):
+        aws_provider = set_mocked_aws_provider([AWS_REGION_EU_WEST_1])
+        sqs_service = SQS(aws_provider)
+
+        queue_url = f"https://sqs.{AWS_REGION_EU_WEST_1}.amazonaws.com/{AWS_ACCOUNT_NUMBER}/{test_queue}"
+        sqs_service.queues = [
+            type("Queue", (), {
+                "id": queue_url,
+                "name": test_queue,
+                "arn": test_queue_arn,
+                "region": AWS_REGION_EU_WEST_1
+            })()
+        ]
+
+        def mock_get_queue_attributes(**kwargs):
+            raise ClientError(
+                {
+                    "Error": {
+                        "Code": "AWS.SimpleQueueService.NonExistentQueue",
+                        "Message": "The specified queue does not exist."
+                    }
+                },
+                "GetQueueAttributes"
+            )
+
+        with patch.object(
+            sqs_service.regional_clients[AWS_REGION_EU_WEST_1],
+            "get_queue_attributes",
+            side_effect=mock_get_queue_attributes,
+        ):
+            sqs_service._get_queue_attributes()
+
+        assert sqs_service.queues == []
+

--- a/tests/providers/aws/services/sqs/sqs_service_test.py
+++ b/tests/providers/aws/services/sqs/sqs_service_test.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import botocore
 from boto3 import client
+from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from prowler.providers.aws.services.sqs.sqs_service import SQS
@@ -12,7 +13,6 @@ from tests.providers.aws.utils import (
     AWS_REGION_EU_WEST_1,
     set_mocked_aws_provider,
 )
-from botocore.exceptions import ClientError
 
 test_queue = "test-queue"
 test_key = str(uuid4())
@@ -123,12 +123,16 @@ class Test_SQS_Service:
 
         queue_url = f"https://sqs.{AWS_REGION_EU_WEST_1}.amazonaws.com/{AWS_ACCOUNT_NUMBER}/{test_queue}"
         sqs_service.queues = [
-            type("Queue", (), {
-                "id": queue_url,
-                "name": test_queue,
-                "arn": test_queue_arn,
-                "region": AWS_REGION_EU_WEST_1
-            })()
+            type(
+                "Queue",
+                (),
+                {
+                    "id": queue_url,
+                    "name": test_queue,
+                    "arn": test_queue_arn,
+                    "region": AWS_REGION_EU_WEST_1,
+                },
+            )()
         ]
 
         def mock_get_queue_attributes(**kwargs):
@@ -136,10 +140,10 @@ class Test_SQS_Service:
                 {
                     "Error": {
                         "Code": "AWS.SimpleQueueService.NonExistentQueue",
-                        "Message": "The specified queue does not exist."
+                        "Message": "The specified queue does not exist.",
                     }
                 },
-                "GetQueueAttributes"
+                "GetQueueAttributes",
             )
 
         with patch.object(
@@ -150,4 +154,3 @@ class Test_SQS_Service:
             sqs_service._get_queue_attributes()
 
         assert sqs_service.queues == []
-


### PR DESCRIPTION
### Context

It seems that the code introduced in https://github.com/prowler-cloud/prowler/pull/8330 was difficult to understand due to an inverted logic. This PR fix this.

### Description

Since we want to exclude queues that got deleted during processing, we add them to `non_existing_queues` in case of an `AWS.SimpleQueueService.NonExistentQueue` error. Afterwards we remove  all `non_existing_queues` from the `queues`.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
