### PR TITLE
fix(ec2): add check that protocol is matched in security group checks

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - False positives in SQS encryption check for ephemeral queues [(#8330)](https://github.com/prowler-cloud/prowler/pull/8330)
+- Add protocol validation check in security group checks to ensure proper protocol matching [(#8374)](https://github.com/prowler-cloud/prowler/pull/8374)
 
 ---
 

--- a/prowler/providers/aws/services/ec2/lib/security_groups.py
+++ b/prowler/providers/aws/services/ec2/lib/security_groups.py
@@ -45,6 +45,13 @@ def check_security_group(
             if _is_cidr_public(ip_ingress_rule["CidrIpv6"], any_address):
                 return True
 
+    if (
+        ingress_rule["IpProtocol"] != "-1"
+        and protocol != "-1"
+        and ingress_rule["IpProtocol"] != protocol
+    ):
+        return False
+
     # Check for specific ports in ingress rules
     if "FromPort" in ingress_rule:
         # If there is a port range

--- a/prowler/providers/aws/services/emr/emr_cluster_publicly_accesible/emr_cluster_publicly_accesible.py
+++ b/prowler/providers/aws/services/emr/emr_cluster_publicly_accesible/emr_cluster_publicly_accesible.py
@@ -39,7 +39,7 @@ class emr_cluster_publicly_accesible(Check):
                         for sg in ec2_client.security_groups.values():
                             if sg.id == master_sg:
                                 for ingress_rule in sg.ingress_rules:
-                                    if check_security_group(ingress_rule, -1):
+                                    if check_security_group(ingress_rule, "-1"):
                                         master_sg_public = True
                                         break
                             if master_sg_public:
@@ -61,7 +61,7 @@ class emr_cluster_publicly_accesible(Check):
                         for sg in ec2_client.security_groups.values():
                             if sg.id == slave_sg:
                                 for ingress_rule in sg.ingress_rules:
-                                    if check_security_group(ingress_rule, -1):
+                                    if check_security_group(ingress_rule, "-1"):
                                         slave_sg_public = True
                                         break
                             if slave_sg_public:

--- a/tests/providers/aws/services/ec2/lib/security_groups_test.py
+++ b/tests/providers/aws/services/ec2/lib/security_groups_test.py
@@ -6,6 +6,7 @@ from prowler.providers.aws.services.ec2.lib.security_groups import (
 )
 
 TRANSPORT_PROTOCOL_TCP = "tcp"
+TRANSPORT_PROTOCOL_UDP = "udp"
 TRANSPORT_PROTOCOL_ALL = "-1"
 
 IP_V4_ALL_CIDRS = "0.0.0.0/0"
@@ -361,6 +362,26 @@ class Test_check_security_group:
             0, 65535, TRANSPORT_PROTOCOL_ALL, [IP_V4_ALL_CIDRS], []
         )
         assert check_security_group(ingress_rule, TRANSPORT_PROTOCOL_ALL, None, True)
+
+    # UDP Protocol - IP_V4_ALL_CIDRS - Any Port - check None - Any Address - Open
+    def test_all_public_ipv4_address_open_any_port_check_none_any_address_udp(
+        self,
+    ):
+        ingress_rule = self.ingress_rule_generator(
+            0, 65535, TRANSPORT_PROTOCOL_UDP, [IP_V4_ALL_CIDRS], []
+        )
+        assert check_security_group(ingress_rule, TRANSPORT_PROTOCOL_UDP, None, True)
+
+    # UDP Protocol - IP_V4_ALL_CIDRS - Any Port - check TCP - Any Address - Open
+    def test_all_public_ipv4_address_open_any_port_udp_protocol_check_tcp_any_address(
+        self,
+    ):
+        ingress_rule = self.ingress_rule_generator(
+            0, 65535, TRANSPORT_PROTOCOL_UDP, [IP_V4_ALL_CIDRS], []
+        )
+        assert not check_security_group(
+            ingress_rule, TRANSPORT_PROTOCOL_TCP, None, True
+        )
 
     # ALL (-1) Protocol - IP_V6_ALL_CIDRS - Any Port - check None - Any Address - Open
     def test_all_public_ipv6_address_open_any_port_check_none_any_address(


### PR DESCRIPTION
### Context

Fix #8373 

### Description

Add a protocol validation check that ensures:
- When checking a specific protocol (not "-1" for all protocols)
- The ingress rule's protocol must match the protocol being checked
- If protocols don't match, return `False` immediately

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
