### PR TITLE
fix(kisa): change the way of counting the PASS/FAILED reqs

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Add more validations to Azure Storage models when some values are None to avoid serialization issues [(#8325)](https://github.com/prowler-cloud/prowler/pull/8325)
 - `sns_topics_not_publicly_accessible` false positive with `aws:SourceArn` conditions [(#8326)](https://github.com/prowler-cloud/prowler/issues/8326)
+- Way of counting FAILED/PASS reqs from `kisa_isms_p_2023_aws` table [(#8382)](https://github.com/prowler-cloud/prowler/pull/8382)
 
 ---
 

--- a/prowler/lib/outputs/compliance/kisa_ismsp/kisa_ismsp.py
+++ b/prowler/lib/outputs/compliance/kisa_ismsp/kisa_ismsp.py
@@ -13,6 +13,7 @@ def get_kisa_ismsp_table(
     compliance_overview: bool,
 ):
     sections = {}
+    sections_status = {}
     kisa_ismsp_compliance_table = {
         "Provider": [],
         "Section": [],
@@ -36,7 +37,10 @@ def get_kisa_ismsp_table(
                         # Check if Section exists
                         if section not in sections:
                             sections[section] = {
-                                "Status": f"{Fore.GREEN}PASS{Style.RESET_ALL}",
+                                "Status": {
+                                    "PASS": 0,
+                                    "FAIL": 0,
+                                },
                                 "Muted": 0,
                             }
                         if finding.muted:
@@ -46,14 +50,29 @@ def get_kisa_ismsp_table(
                         else:
                             if finding.status == "FAIL" and index not in fail_count:
                                 fail_count.append(index)
+                                sections[section]["Status"]["FAIL"] += 1
                             elif finding.status == "PASS" and index not in pass_count:
                                 pass_count.append(index)
+                                sections[section]["Status"]["PASS"] += 1
 
     # Add results to table
     sections = dict(sorted(sections.items()))
     for section in sections:
+        if sections[section]["Status"]["FAIL"] > 0:
+            sections_status[section] = (
+                f"{Fore.RED}FAIL({sections[section]['Status']['FAIL']}){Style.RESET_ALL}"
+            )
+        else:
+            if sections[section]["Status"]["PASS"] > 0:
+                sections_status[section] = (
+                    f"{Fore.GREEN}PASS({sections[section]['Status']['PASS']}){Style.RESET_ALL}"
+                )
+            else:
+                sections_status[section] = f"{Fore.GREEN}PASS{Style.RESET_ALL}"
+    for section in sections:
         kisa_ismsp_compliance_table["Provider"].append(compliance.Provider)
         kisa_ismsp_compliance_table["Section"].append(section)
+        kisa_ismsp_compliance_table["Status"].append(sections_status[section])
         kisa_ismsp_compliance_table["Muted"].append(
             f"{orange_color}{sections[section]['Muted']}{Style.RESET_ALL}"
         )


### PR DESCRIPTION
### Description

This PR fixes the way we're counting the FAIL/PASS requirements from the table that we get after running a Prowler Scan against `kisa_isms_p_2023_aws` and `kisa_isms_p_2023_korean_aws` compliance.
<img width="766" height="409" alt="Screenshot 2025-07-28 at 15 57 37" src="https://github.com/user-attachments/assets/284ac978-8a46-446f-a66a-8f5517e318fa" />

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
