### PR TITLE
fix(prowler-threatscore): remove and add requirements

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Remove typo from description req 1.2.3 - Prowler ThreatScore m365 [(#8384)](https://github.com/prowler-cloud/prowler/pull/8384)
 - Way of counting FAILED/PASS reqs from `kisa_isms_p_2023_aws` table [(#8382)](https://github.com/prowler-cloud/prowler/pull/8382)
 - Avoid multiple module error calls in M365 provider [(#8353)](https://github.com/prowler-cloud/prowler/pull/8353)
-
+- Tweaks from Prowler ThreatScore in order to handle the correct reqs [(#8401)](https://github.com/prowler-cloud/prowler/pull/8401)
 ---
 
 ## [v5.9.2] (Prowler v5.9.2)

--- a/prowler/compliance/azure/prowler_threatscore_azure.json
+++ b/prowler/compliance/azure/prowler_threatscore_azure.json
@@ -6,24 +6,6 @@
   "Requirements": [
     {
       "Id": "1.1.1",
-      "Description": "Ensure Security Defaults is enabled on Microsoft Entra ID",
-      "Checks": [
-        "entra_security_defaults_enabled"
-      ],
-      "Attributes": [
-        {
-          "Title": "Security Defaults enabled on Entra ID",
-          "Section": "1. IAM",
-          "SubSection": "1.1 Authentication",
-          "AttributeDescription": "Microsoft Entra ID Security Defaults offer preconfigured security settings designed to protect organizations from common identity attacks at no additional cost. These settings enforce basic security measures such as MFA registration, risk-based authentication prompts, and blocking legacy authentication clients that do not support MFA. Security defaults are available to all organizations and can be enabled via the Azure portal to strengthen authentication security.",
-          "AdditionalInformation": "Security defaults provide built-in protections to reduce the risk of unauthorized access until organizations configure their own identity security policies. By requiring MFA, blocking weak authentication methods, and adapting authentication challenges based on risk factors, these settings create a stronger security foundation without additional licensing requirements.",
-          "LevelOfRisk": 4,
-          "Weight": 100
-        }
-      ]
-    },
-    {
-      "Id": "1.1.2",
       "Description": "Ensure that 'Multi-Factor Auth Status' is 'Enabled' for all Privileged Users",
       "Checks": [
         "entra_privileged_user_has_mfa"
@@ -41,7 +23,7 @@
       ]
     },
     {
-      "Id": "1.1.3",
+      "Id": "1.1.2",
       "Description": "Ensure that 'Multi-Factor Auth Status' is 'Enabled' for all Non-Privileged Users",
       "Checks": [
         "entra_non_privileged_user_has_mfa"
@@ -59,7 +41,7 @@
       ]
     },
     {
-      "Id": "1.1.4",
+      "Id": "1.1.3",
       "Description": "Ensure Multi-factor Authentication is Required for Windows Azure Service Management API",
       "Checks": [
         "entra_conditional_access_policy_require_mfa_for_management_api"
@@ -77,7 +59,7 @@
       ]
     },
     {
-      "Id": "1.1.5",
+      "Id": "1.1.4",
       "Description": "Ensure Multi-factor Authentication is Required to access Microsoft Admin Portals",
       "Checks": [
         "defender_ensure_defender_for_server_is_on"
@@ -95,7 +77,7 @@
       ]
     },
     {
-      "Id": "1.1.6",
+      "Id": "1.1.5",
       "Description": "Ensure only MFA enabled identities can access privileged Virtual Machine",
       "Checks": [
         "entra_user_with_vm_access_has_mfa"

--- a/prowler/compliance/m365/prowler_threatscore_m365.json
+++ b/prowler/compliance/m365/prowler_threatscore_m365.json
@@ -311,6 +311,24 @@
       ]
     },
     {
+      "Id": "1.1.18",
+      "Description": "Ensure that only administrative roles have access to Microsoft Admin Portals",
+      "Checks": [
+        "entra_admin_portals_access_restriction"
+      ],
+      "Attributes": [
+        {
+          "Title": "Only administrative roles have access to Microsoft Admin Portals",
+          "Section": "1. IAM",
+          "SubSection": "1.1 Authentication",
+          "AttributeDescription": "Restrict access to Microsoft Admin Portals exclusively to administrative roles to prevent unauthorized modifications, privilege escalation, and security misconfigurations",
+          "AdditionalInformation": "Granting non-administrative users access to Microsoft Admin Portals exposes the environment to unauthorized changes, potential elevation of privileges, and misconfigured security settings. This could allow attackers to alter configurations, disable protections, or gain access to sensitive information.",
+          "LevelOfRisk": 4,
+          "Weight": 100
+        }
+      ]
+    },
+    {
       "Id": "1.2.1",
       "Description": "Ensure that only organizationally managed/approved public groups exist",
       "Checks": [


### PR DESCRIPTION
### Description

#### Prowler ThreatScore Azure Changes
Remove `ReqId: 1.1.1` -> entra_security_defaults_enabled since in newer compliances they recommend to turn it off since it's very basic and limits yourself to apply more secure measurements.

#### Prowler ThreatScore M365 Changes
A check related with restrictions for admin portals was missing (`entra_admin_portals_access_restriction `). New requirement `1.1.18` has been added to handle it.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
