### PR TITLE
chore: add M365 provider to PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,11 @@ provider/kubernetes:
       - any-glob-to-any-file: "prowler/providers/kubernetes/**"
       - any-glob-to-any-file: "tests/providers/kubernetes/**"
 
+provider/m365:
+  - changed-files:
+      - any-glob-to-any-file: "prowler/providers/m365/**"
+      - any-glob-to-any-file: "tests/providers/m365/**"
+
 provider/github:
   - changed-files:
       - any-glob-to-any-file: "prowler/providers/github/**"


### PR DESCRIPTION
### Context

This PR adds the M365 provider to the GitHub Actions labeler configuration to automatically label pull requests that modify Microsoft 365 related code. This ensures consistency with other provider labels and helps with PR categorization and review assignment.

### Description

This change adds the `provider/m365` label configuration to the `.github/labeler.yml` file. The labeler will now automatically apply the `provider/m365` label to pull requests that modify files in:
- `prowler/providers/m365/**`
- `tests/providers/m365/**`

This maintains consistency with other provider labels (AWS, Azure, GCP, Kubernetes, GitHub, IAC) and ensures M365-related PRs are properly categorized for review assignment.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.