### PR TITLE
fix(s3): use enabled to filter

### DIFF
--- a/api/src/backend/tasks/jobs/connection.py
+++ b/api/src/backend/tasks/jobs/connection.py
@@ -95,7 +95,12 @@ def check_integration_connection(integration_id: str):
     Args:
         integration_id (str): The primary key of the Integration instance to check.
     """
-    integration = Integration.objects.get(pk=integration_id, enabled=True)
+    integration = Integration.objects.filter(pk=integration_id, enabled=True).first()
+
+    if not integration:
+        logger.info(f"Integration {integration_id} is not enabled")
+        return {"connected": False, "error": "Integration is not enabled"}
+
     try:
         result = prowler_integration_connection_test(integration)
     except Exception as e:

--- a/api/src/backend/tasks/jobs/connection.py
+++ b/api/src/backend/tasks/jobs/connection.py
@@ -95,7 +95,7 @@ def check_integration_connection(integration_id: str):
     Args:
         integration_id (str): The primary key of the Integration instance to check.
     """
-    integration = Integration.objects.get(pk=integration_id)
+    integration = Integration.objects.get(pk=integration_id, enabled=True)
     try:
         result = prowler_integration_connection_test(integration)
     except Exception as e:

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -71,6 +71,7 @@ def upload_s3_integration(
                 Integration.objects.filter(
                     integrationproviderrelationship__provider_id=provider_id,
                     integration_type=Integration.IntegrationChoices.AMAZON_S3,
+                    enabled=True,
                 )
             )
 

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -387,6 +387,7 @@ def generate_outputs_task(scan_id: str, provider_id: str, tenant_id: str):
         s3_integrations = Integration.objects.filter(
             integrationproviderrelationship__provider_id=provider_id,
             integration_type=Integration.IntegrationChoices.AMAZON_S3,
+            enabled=True,
         )
 
     if s3_integrations:

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -487,7 +487,8 @@ def check_integrations_task(tenant_id: str, provider_id: str):
     try:
         with rls_transaction(tenant_id):
             integrations = Integration.objects.filter(
-                integrationproviderrelationship__provider_id=provider_id
+                integrationproviderrelationship__provider_id=provider_id,
+                enabled=True,
             )
 
             if not integrations.exists():

--- a/api/src/backend/tasks/tests/test_connection.py
+++ b/api/src/backend/tasks/tests/test_connection.py
@@ -2,9 +2,13 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
-from tasks.jobs.connection import check_lighthouse_connection, check_provider_connection
+from tasks.jobs.connection import (
+    check_integration_connection,
+    check_lighthouse_connection,
+    check_provider_connection,
+)
 
-from api.models import LighthouseConfiguration, Provider
+from api.models import Integration, LighthouseConfiguration, Provider
 
 
 @pytest.mark.parametrize(
@@ -127,3 +131,143 @@ def test_check_lighthouse_connection_missing_api_key(mock_lighthouse_get):
     assert result["available_models"] == []
     assert mock_lighthouse_instance.is_active is False
     mock_lighthouse_instance.save.assert_called_once()
+
+
+@pytest.mark.django_db
+class TestCheckIntegrationConnection:
+    def setup_method(self):
+        self.integration_id = "test-integration-id"
+
+    @patch("tasks.jobs.connection.Integration.objects.get")
+    @patch("tasks.jobs.connection.prowler_integration_connection_test")
+    def test_check_integration_connection_success(
+        self, mock_prowler_test, mock_integration_get
+    ):
+        """Test successful integration connection check with enabled=True filter."""
+        mock_integration = MagicMock()
+        mock_integration.id = self.integration_id
+        mock_integration.integration_type = Integration.IntegrationChoices.AMAZON_S3
+        mock_integration_get.return_value = mock_integration
+
+        mock_connection_result = MagicMock()
+        mock_connection_result.is_connected = True
+        mock_connection_result.error = None
+        mock_prowler_test.return_value = mock_connection_result
+
+        result = check_integration_connection(integration_id=self.integration_id)
+
+        # Verify that Integration.objects.get was called with enabled=True filter
+        mock_integration_get.assert_called_once_with(
+            pk=self.integration_id, enabled=True
+        )
+        mock_prowler_test.assert_called_once_with(mock_integration)
+
+        # Verify the integration properties were updated
+        assert mock_integration.connected is True
+        assert mock_integration.connection_last_checked_at is not None
+        mock_integration.save.assert_called_once()
+
+        # Verify the return value
+        assert result["connected"] is True
+        assert result["error"] is None
+
+    @patch("tasks.jobs.connection.Integration.objects.get")
+    @patch("tasks.jobs.connection.prowler_integration_connection_test")
+    def test_check_integration_connection_failure(
+        self, mock_prowler_test, mock_integration_get
+    ):
+        """Test failed integration connection check."""
+        mock_integration = MagicMock()
+        mock_integration.id = self.integration_id
+        mock_integration_get.return_value = mock_integration
+
+        test_error = Exception("Connection failed")
+        mock_connection_result = MagicMock()
+        mock_connection_result.is_connected = False
+        mock_connection_result.error = test_error
+        mock_prowler_test.return_value = mock_connection_result
+
+        result = check_integration_connection(integration_id=self.integration_id)
+
+        # Verify that Integration.objects.get was called with enabled=True filter
+        mock_integration_get.assert_called_once_with(
+            pk=self.integration_id, enabled=True
+        )
+
+        # Verify the integration properties were updated
+        assert mock_integration.connected is False
+        assert mock_integration.connection_last_checked_at is not None
+        mock_integration.save.assert_called_once()
+
+        # Verify the return value
+        assert result["connected"] is False
+        assert result["error"] == str(test_error)
+
+    @patch("tasks.jobs.connection.Integration.objects.get")
+    def test_check_integration_connection_disabled_integration_not_found(
+        self, mock_integration_get
+    ):
+        """Test that disabled integrations are not processed due to enabled=True filter."""
+        # Simulate Integration.DoesNotExist when trying to get disabled integration
+        mock_integration_get.side_effect = Integration.DoesNotExist(
+            "Integration matching query does not exist."
+        )
+
+        with pytest.raises(Integration.DoesNotExist):
+            check_integration_connection(integration_id=self.integration_id)
+
+        # Verify that Integration.objects.get was called with enabled=True filter
+        mock_integration_get.assert_called_once_with(
+            pk=self.integration_id, enabled=True
+        )
+
+    @patch("tasks.jobs.connection.Integration.objects.get")
+    @patch("tasks.jobs.connection.prowler_integration_connection_test")
+    def test_check_integration_connection_test_exception(
+        self, mock_prowler_test, mock_integration_get
+    ):
+        """Test integration connection check when prowler test raises exception."""
+        mock_integration = MagicMock()
+        mock_integration.id = self.integration_id
+        mock_integration_get.return_value = mock_integration
+
+        test_exception = Exception("Unexpected error during connection test")
+        mock_prowler_test.side_effect = test_exception
+
+        with pytest.raises(Exception, match="Unexpected error during connection test"):
+            check_integration_connection(integration_id=self.integration_id)
+
+        # Verify that Integration.objects.get was called with enabled=True filter
+        mock_integration_get.assert_called_once_with(
+            pk=self.integration_id, enabled=True
+        )
+        mock_prowler_test.assert_called_once_with(mock_integration)
+
+    @patch("tasks.jobs.connection.Integration.objects.get")
+    @patch("tasks.jobs.connection.prowler_integration_connection_test")
+    def test_check_integration_connection_updates_timestamp(
+        self, mock_prowler_test, mock_integration_get
+    ):
+        """Test that connection_last_checked_at timestamp is properly updated."""
+        mock_integration = MagicMock()
+        mock_integration.id = self.integration_id
+        mock_integration_get.return_value = mock_integration
+
+        mock_connection_result = MagicMock()
+        mock_connection_result.is_connected = True
+        mock_connection_result.error = None
+        mock_prowler_test.return_value = mock_connection_result
+
+        before_call = datetime.now(timezone.utc)
+        check_integration_connection(integration_id=self.integration_id)
+        after_call = datetime.now(timezone.utc)
+
+        # Verify that Integration.objects.get was called with enabled=True filter
+        mock_integration_get.assert_called_once_with(
+            pk=self.integration_id, enabled=True
+        )
+
+        # Verify timestamp was updated
+        assert mock_integration.connection_last_checked_at is not None
+        # The timestamp should be between before and after the call
+        assert before_call <= mock_integration.connection_last_checked_at <= after_call


### PR DESCRIPTION
### Context

This pull request addresses the need to handle the enablement and disablement of integrations, specifically for Amazon S3 integrations. The motivation behind this change is to ensure that only enabled integrations are considered during processing, which enhances the accuracy and reliability of integration management.

### Description

This update introduces a filter to include only enabled Amazon S3 integrations in the relevant query within ‎`api/src/backend/tasks/tasks.py`. By adding ‎`enabled=True` to the queryset, the system will now exclude any integrations that are not currently enabled. This change helps prevent unintended processing of disabled integrations and aligns with best practices for integration lifecycle management.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
