### PR TITLE
chore(ui): remove browse all resources from the sidebar

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Rename `Memberships` to `Organization` in the sidebar [(#8415)](https://github.com/prowler-cloud/prowler/pull/8415)
+- Removed `Browse all resources` from the sidebar, sidebar now shows a single `Resources` entry [(#8418)](https://github.com/prowler-cloud/prowler/pull/8418)
 ___
 
 ## [v1.9.3] (Prowler v5.9.3)

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -8,7 +8,6 @@ import {
   Group,
   LayoutGrid,
   Mail,
-  Package,
   Settings,
   ShieldCheck,
   SquareChartGantt,
@@ -137,17 +136,9 @@ export const getMenuList = (pathname: string): GroupProps[] => {
       groupLabel: "",
       menus: [
         {
-          href: "",
+          href: "/resources",
           label: "Resources",
           icon: Warehouse,
-          submenus: [
-            {
-              href: "/resources",
-              label: "Browse all resources",
-              icon: Package,
-            },
-          ],
-          defaultOpen: true,
         },
       ],
     },


### PR DESCRIPTION

### Description

- Removed `Browse all resources`  from the sidebar as it's redundant
- Sidebar now shows a single `Resources` entry

<img width="1871" height="924" alt="image" src="https://github.com/user-attachments/assets/6a758f2a-9b42-41ee-a2be-327814924bed" />



### Checklist

- Are there new checks included in this PR?  No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
