### PR TITLE
chore(sentry): add powershell user auth module connection errors to ignored list

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the **Prowler API** are documented in this file.
 - Github provider support [(#8271)](https://github.com/prowler-cloud/prowler/pull/8271)
 - Integration with Amazon S3, enabling storage and retrieval of scan data via S3 buckets [(#8056)](https://github.com/prowler-cloud/prowler/pull/8056)
 
+### Fixed
+- Avoid sending errors to Sentry in M365 provider when user authentication fails [(#8420)](https://github.com/prowler-cloud/prowler/pull/8420)
+
 ---
 
 ## [1.10.2] (Prowler v5.9.2)

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -69,6 +69,9 @@ IGNORED_EXCEPTIONS = [
     "AzureClientIdAndClientSecretNotBelongingToTenantIdError",
     "AzureHTTPResponseError",
     "Error with credentials provided",
+    # PowerShell Errors in User Authentication
+    "Microsoft Teams User Auth connection failed: Please check your permissions and try again.",
+    "Exchange Online User Auth connection failed: Please check your permissions and try again.",
 ]
 
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Way of counting FAILED/PASS reqs from `kisa_isms_p_2023_aws` table [(#8382)](https://github.com/prowler-cloud/prowler/pull/8382)
 - Use default tenant domain instead of first domain in list for Azure and M365 providers [(#8402)](https://github.com/prowler-cloud/prowler/pull/8402)
 - Avoid multiple module error calls in M365 provider [(#8353)](https://github.com/prowler-cloud/prowler/pull/8353)
+- Avoid sending errors to Sentry in M365 provider when user authentication fails [(#8420)](https://github.com/prowler-cloud/prowler/pull/8420)
 - Tweaks from Prowler ThreatScore in order to handle the correct reqs [(#8401)](https://github.com/prowler-cloud/prowler/pull/8401)
 ---
 

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -286,7 +286,7 @@ class M365PowerShell(PowerShellSession):
                 return True
             else:
                 logger.error(
-                    "Microsoft Teams connection failed: Please check your permissions and try again."
+                    "Microsoft Teams User Auth connection failed: Please check your permissions and try again."
                 )
             return connection
         # Application Auth
@@ -398,7 +398,7 @@ class M365PowerShell(PowerShellSession):
                 return True
             else:
                 logger.error(
-                    "Exchange Online connection failed: Please check your permissions and try again."
+                    "Exchange Online User Auth connection failed: Please check your permissions and try again."
                 )
                 return False
         # Application Auth


### PR DESCRIPTION
### Context

Currently, we face unnecessary and unavoidable Sentry alerts with user authentication for PowerShell modules.

### Description

This PR addresses this by making a subtle change in user errors and adding them to the ignore list.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
