### PR TITLE
feat: add new provider GitHub and update enum source of truth

### DIFF
--- a/ui/components/filters/custom-provider-inputs.tsx
+++ b/ui/components/filters/custom-provider-inputs.tsx
@@ -4,6 +4,7 @@ import {
   AWSProviderBadge,
   AzureProviderBadge,
   GCPProviderBadge,
+  GitHubProviderBadge,
   KS8ProviderBadge,
   M365ProviderBadge,
 } from "../icons/providers-badge";
@@ -49,6 +50,15 @@ export const CustomProviderInputKubernetes = () => {
     <div className="flex items-center gap-x-2">
       <KS8ProviderBadge width={25} height={25} />
       <p className="text-sm">Kubernetes</p>
+    </div>
+  );
+};
+
+export const CustomProviderInputGitHub = () => {
+  return (
+    <div className="flex items-center gap-x-2">
+      <GitHubProviderBadge width={25} height={25} />
+      <p className="text-sm">GitHub</p>
     </div>
   );
 };

--- a/ui/components/filters/custom-select-provider.tsx
+++ b/ui/components/filters/custom-select-provider.tsx
@@ -4,41 +4,52 @@ import { Select, SelectItem } from "@nextui-org/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useCallback, useMemo } from "react";
 
+import { PROVIDER_TYPES, ProviderType } from "@/types/providers";
+
 import {
   CustomProviderInputAWS,
   CustomProviderInputAzure,
   CustomProviderInputGCP,
+  CustomProviderInputGitHub,
   CustomProviderInputKubernetes,
   CustomProviderInputM365,
 } from "./custom-provider-inputs";
 
-const dataInputsProvider = [
-  {
-    key: "aws",
+const providerDisplayData: Record<
+  ProviderType,
+  { label: string; component: React.ReactElement }
+> = {
+  aws: {
     label: "Amazon Web Services",
-    value: <CustomProviderInputAWS />,
+    component: <CustomProviderInputAWS />,
   },
-  {
-    key: "gcp",
+  gcp: {
     label: "Google Cloud Platform",
-    value: <CustomProviderInputGCP />,
+    component: <CustomProviderInputGCP />,
   },
-  {
-    key: "azure",
+  azure: {
     label: "Microsoft Azure",
-    value: <CustomProviderInputAzure />,
+    component: <CustomProviderInputAzure />,
   },
-  {
-    key: "m365",
+  m365: {
     label: "Microsoft 365",
-    value: <CustomProviderInputM365 />,
+    component: <CustomProviderInputM365 />,
   },
-  {
-    key: "kubernetes",
+  kubernetes: {
     label: "Kubernetes",
-    value: <CustomProviderInputKubernetes />,
+    component: <CustomProviderInputKubernetes />,
   },
-];
+  github: {
+    label: "GitHub",
+    component: <CustomProviderInputGitHub />,
+  },
+};
+
+const dataInputsProvider = PROVIDER_TYPES.map((providerType) => ({
+  key: providerType,
+  label: providerDisplayData[providerType].label,
+  value: providerDisplayData[providerType].component,
+}));
 
 export const CustomSelectProvider: React.FC = () => {
   const router = useRouter();

--- a/ui/components/filters/data-filters.ts
+++ b/ui/components/filters/data-filters.ts
@@ -1,4 +1,5 @@
 import { FilterType } from "@/types/filters";
+import { PROVIDER_TYPES } from "@/types/providers";
 
 export const filterProviders = [
   {
@@ -13,7 +14,7 @@ export const filterScans = [
   {
     key: "provider_type__in",
     labelCheckboxGroup: "Cloud Provider",
-    values: ["aws", "azure", "m365", "gcp", "kubernetes"],
+    values: [...PROVIDER_TYPES],
     index: 0,
   },
   {
@@ -55,7 +56,7 @@ export const filterFindings = [
   {
     key: FilterType.PROVIDER_TYPE,
     labelCheckboxGroup: "Cloud Provider",
-    values: ["aws", "azure", "m365", "gcp", "kubernetes"],
+    values: [...PROVIDER_TYPES],
     index: 5,
   },
   {

--- a/ui/components/overview/provider-overview/provider-overview.tsx
+++ b/ui/components/overview/provider-overview/provider-overview.tsx
@@ -7,11 +7,13 @@ import {
   AWSProviderBadge,
   AzureProviderBadge,
   GCPProviderBadge,
+  GitHubProviderBadge,
   KS8ProviderBadge,
   M365ProviderBadge,
 } from "@/components/icons/providers-badge";
 import { CustomButton } from "@/components/ui/custom/custom-button";
 import { ProviderOverviewProps } from "@/types";
+import { PROVIDER_TYPES, ProviderType } from "@/types/providers";
 
 export const ProvidersOverview = ({
   providersOverview,
@@ -21,7 +23,7 @@ export const ProvidersOverview = ({
   const calculatePassingPercentage = (pass: number, total: number) =>
     total > 0 ? ((pass / total) * 100).toFixed(2) : "0.00";
 
-  const renderProviderBadge = (providerId: string) => {
+  const renderProviderBadge = (providerId: ProviderType) => {
     switch (providerId) {
       case "aws":
         return <AWSProviderBadge width={30} height={30} />;
@@ -33,18 +35,26 @@ export const ProvidersOverview = ({
         return <GCPProviderBadge width={30} height={30} />;
       case "kubernetes":
         return <KS8ProviderBadge width={30} height={30} />;
+      case "github":
+        return <GitHubProviderBadge width={30} height={30} />;
       default:
         return null;
     }
   };
 
-  const providers = [
-    { id: "aws", name: "AWS" },
-    { id: "azure", name: "Azure" },
-    { id: "m365", name: "M365" },
-    { id: "gcp", name: "GCP" },
-    { id: "kubernetes", name: "Kubernetes" },
-  ];
+  const providerDisplayNames: Record<ProviderType, string> = {
+    aws: "AWS",
+    azure: "Azure",
+    m365: "M365",
+    gcp: "GCP",
+    kubernetes: "Kubernetes",
+    github: "GitHub",
+  };
+
+  const providers = PROVIDER_TYPES.map((providerType) => ({
+    id: providerType,
+    name: providerDisplayNames[providerType],
+  }));
 
   if (!providersOverview || !Array.isArray(providersOverview.data)) {
     return (


### PR DESCRIPTION


### Description

  - ✅ Add GitHub provider to all Cloud Provider filters (findings, scans pages)
  - ✅ Add GitHub provider to homepage providers overview table
  - ✅ Centralize provider types using PROVIDER_TYPES enum from @types/providers.ts
  - ✅ Update all hardcoded provider arrays to use the enum for consistency

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
