### PR TITLE
fix: add default values for S3 class

### DIFF
--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -269,7 +269,6 @@ class AwsProvider(Provider):
             # Store a new current session using the assumed IAM Role
             self._session.current_session = self.setup_assumed_session(
                 self._identity,
-                assumed_role_configuration.credentials,
                 assumed_role_configuration,
                 self._session,
             )
@@ -321,7 +320,6 @@ class AwsProvider(Provider):
             # Get a new session using the AWS Organizations IAM Role assumed
             aws_organizations_session = self.setup_assumed_session(
                 self._identity,
-                organizations_assumed_role_configuration.credentials,
                 organizations_assumed_role_configuration,
                 self._session,
             )
@@ -582,10 +580,8 @@ class AwsProvider(Provider):
                 file=pathlib.Path(__file__).name,
             )
 
-    # TODO: Pass the assumed role configuration and session into a single argument
     def setup_assumed_session(
         identity: AWSIdentityInfo,
-        assumed_role_credentials: AWSCredentials,
         assumed_role_configuration: AWSAssumeRoleConfiguration,
         session: AWSSession,
     ) -> Session:
@@ -617,10 +613,10 @@ class AwsProvider(Provider):
             # that needs to be a method without arguments that retrieves a new set of fresh credentials
             # assuming the role again.
             assumed_refreshable_credentials = RefreshableCredentials(
-                access_key=assumed_role_credentials.aws_access_key_id,
-                secret_key=assumed_role_credentials.aws_secret_access_key,
-                token=assumed_role_credentials.aws_session_token,
-                expiry_time=assumed_role_credentials.expiration,
+                access_key=assumed_role_configuration.credentials.aws_access_key_id,
+                secret_key=assumed_role_configuration.credentials.aws_secret_access_key,
+                token=assumed_role_configuration.credentials.aws_session_token,
+                expiry_time=assumed_role_configuration.credentials.expiration,
                 refresh_using=lambda: AwsProvider.refresh_credentials(
                     assumed_role_configuration, session
                 ),

--- a/prowler/providers/aws/aws_provider.py
+++ b/prowler/providers/aws/aws_provider.py
@@ -268,7 +268,10 @@ class AwsProvider(Provider):
 
             # Store a new current session using the assumed IAM Role
             self._session.current_session = self.setup_assumed_session(
-                self._identity, assumed_role_configuration.credentials
+                self._identity,
+                assumed_role_configuration.credentials,
+                assumed_role_configuration,
+                self._session,
             )
             logger.info("Audit session is the new session created assuming an IAM Role")
 
@@ -317,7 +320,10 @@ class AwsProvider(Provider):
             )
             # Get a new session using the AWS Organizations IAM Role assumed
             aws_organizations_session = self.setup_assumed_session(
-                self._identity, organizations_assumed_role_configuration.credentials
+                self._identity,
+                organizations_assumed_role_configuration.credentials,
+                organizations_assumed_role_configuration,
+                self._session,
             )
             logger.info(
                 "Generated new session for to get the AWS Organizations metadata"
@@ -576,10 +582,12 @@ class AwsProvider(Provider):
                 file=pathlib.Path(__file__).name,
             )
 
-    @staticmethod
+    # TODO: Pass the assumed role configuration and session into a single argument
     def setup_assumed_session(
         identity: AWSIdentityInfo,
         assumed_role_credentials: AWSCredentials,
+        assumed_role_configuration: AWSAssumeRoleConfiguration,
+        session: AWSSession,
     ) -> Session:
         """
         Sets up an assumed session using the provided assumed role credentials.
@@ -613,7 +621,9 @@ class AwsProvider(Provider):
                 secret_key=assumed_role_credentials.aws_secret_access_key,
                 token=assumed_role_credentials.aws_session_token,
                 expiry_time=assumed_role_credentials.expiration,
-                refresh_using=AwsProvider.refresh_credentials,
+                refresh_using=lambda: AwsProvider.refresh_credentials(
+                    assumed_role_configuration, session
+                ),
                 method="sts-assume-role",
             )
 
@@ -632,7 +642,10 @@ class AwsProvider(Provider):
             raise error
 
     # TODO: maybe this can be improved with botocore.credentials.DeferredRefreshableCredentials https://stackoverflow.com/a/75576540
-    def refresh_credentials(self) -> dict:
+    @staticmethod
+    def refresh_credentials(
+        assumed_role_configuration: AWSAssumeRoleConfiguration, session: AWSSession
+    ) -> dict:
         """
         Refresh credentials method using AWS STS Assume Role.
 
@@ -642,7 +655,7 @@ class AwsProvider(Provider):
         logger.info("Refreshing assumed credentials...")
 
         # Since this method does not accept arguments, we need to get the original_session and the assumed role credentials
-        current_credentials = self._assumed_role_configuration.credentials
+        current_credentials = assumed_role_configuration.credentials
         refreshed_credentials = {
             "access_key": current_credentials.aws_access_key_id,
             "secret_key": current_credentials.aws_secret_access_key,
@@ -657,8 +670,8 @@ class AwsProvider(Provider):
         if datetime.fromisoformat(refreshed_credentials["expiry_time"]) <= datetime.now(
             get_localzone()
         ):
-            assume_role_response = self.assume_role(
-                self._session.original_session, self._assumed_role_configuration.info
+            assume_role_response = AwsProvider.assume_role(
+                session.original_session, assumed_role_configuration.info
             )
             refreshed_credentials = dict(
                 # Keys of the dict has to be the same as those that are being searched in the parent class

--- a/prowler/providers/aws/lib/session/aws_set_up_session.py
+++ b/prowler/providers/aws/lib/session/aws_set_up_session.py
@@ -147,7 +147,6 @@ class AwsSetUpSession:
             # Store a new current session using the assumed IAM Role
             self._session.current_session = AwsProvider.setup_assumed_session(
                 self._identity,
-                assumed_role_configuration.credentials,
                 self._assumed_role_configuration,
                 self._session,
             )

--- a/prowler/providers/aws/lib/session/aws_set_up_session.py
+++ b/prowler/providers/aws/lib/session/aws_set_up_session.py
@@ -146,7 +146,10 @@ class AwsSetUpSession:
 
             # Store a new current session using the assumed IAM Role
             self._session.current_session = AwsProvider.setup_assumed_session(
-                self._identity, assumed_role_configuration.credentials
+                self._identity,
+                assumed_role_configuration.credentials,
+                self._assumed_role_configuration,
+                self._session,
             )
             logger.info("Audit session is the new session created assuming an IAM Role")
 


### PR DESCRIPTION
### Description

This pull request refactors the `setup_assumed_session` and `refresh_credentials` methods in the `prowler/providers/aws/aws_provider.py` file to improve maintainability and flexibility. The changes primarily involve passing additional arguments (`assumed_role_configuration` and `session`) to these methods and updating their implementations accordingly.

### Refactoring of session setup and credential refresh:

* Updated the `setup_assumed_session` method to accept `assumed_role_configuration` and `session` as additional arguments, enabling better encapsulation of session-related data. [[1]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L579-R590) [[2]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L616-R626)
* Modified the `refresh_credentials` method to be a `@staticmethod` and to accept `assumed_role_configuration` and `session` as arguments, removing reliance on instance variables. [[1]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L635-R648) [[2]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L645-R658) [[3]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L660-R674)

### Updates to method calls:

* Adjusted calls to `setup_assumed_session` to include the new arguments (`assumed_role_configuration` and `session`) in both `aws_provider.py` and `aws_set_up_session.py`. [[1]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L271-R274) [[2]](diffhunk://#diff-708b6352eb37f7c1a7482e2631ffdd7300f6fa577234ff56da72d6f63c236371L320-R326) [[3]](diffhunk://#diff-4758f4fc4570d3ceb006d65180af2c78bb2a90fa65c1f20b12034a536c9666d8L149-R152)

### Code improvement notes:

* Added a TODO comment suggesting the possibility of consolidating the new arguments into a single argument for cleaner method signatures.
* Included another TODO comment proposing the use of `botocore.credentials.DeferredRefreshableCredentials` for potential improvement in credential refreshing.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
