### PR TITLE
chore(ui): remove misconfigurations from Top Failed Findings in the s…

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Rename `Memberships` to `Organization` in the sidebar [(#8415)](https://github.com/prowler-cloud/prowler/pull/8415)
 - Removed `Browse all resources` from the sidebar, sidebar now shows a single `Resources` entry [(#8418)](https://github.com/prowler-cloud/prowler/pull/8418)
+- Removed `Misconfigurations` from the `Top Failed Findings` section in the sidebar [(#8426)](https://github.com/prowler-cloud/prowler/pull/8426)
 ___
 
 ## [v1.9.3] (Prowler v5.9.3)

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  AlertCircle,
   Bookmark,
   CloudCog,
   Cog,
@@ -79,11 +78,6 @@ export const getMenuList = (pathname: string): GroupProps[] => {
           label: "Top failed findings",
           icon: Bookmark,
           submenus: [
-            {
-              href: "/findings?filter[status__in]=FAIL&sort=severity,-inserted_at",
-              label: "Misconfigurations",
-              icon: AlertCircle,
-            },
             {
               href: "/findings?filter[status__in]=FAIL&filter[severity__in]=critical%2Chigh%2Cmedium&filter[provider_type__in]=aws%2Cazure%2Cgcp%2Ckubernetes&filter[service__in]=iam%2Crbac&sort=-inserted_at",
               label: "IAM Issues",


### PR DESCRIPTION

### Description

- Removed `Misconfigurations` from `Top failed findings` in the sidebar. 

<img width="1919" height="659" alt="image" src="https://github.com/user-attachments/assets/9b59b04d-ce1e-4794-8fdf-7de030258ab1" />


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
