### PR TITLE
feat(integrations): integrations enabled by default

### DIFF
--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -5167,6 +5167,7 @@ paths:
           - aws
           - azure
           - gcp
+          - github
           - kubernetes
           - m365
         description: |-
@@ -5175,6 +5176,7 @@ paths:
           * `gcp` - GCP
           * `kubernetes` - Kubernetes
           * `m365` - M365
+          * `github` - GitHub
       - in: query
         name: filter[provider_type__in]
         schema:
@@ -5185,6 +5187,7 @@ paths:
             - aws
             - azure
             - gcp
+            - github
             - kubernetes
             - m365
         description: |-
@@ -5195,6 +5198,7 @@ paths:
           * `gcp` - GCP
           * `kubernetes` - Kubernetes
           * `m365` - M365
+          * `github` - GitHub
         explode: false
         style: form
       - in: query
@@ -5427,6 +5431,7 @@ paths:
           - aws
           - azure
           - gcp
+          - github
           - kubernetes
           - m365
         description: |-
@@ -5435,6 +5440,7 @@ paths:
           * `gcp` - GCP
           * `kubernetes` - Kubernetes
           * `m365` - M365
+          * `github` - GitHub
       - in: query
         name: filter[provider_type__in]
         schema:
@@ -5445,6 +5451,7 @@ paths:
             - aws
             - azure
             - gcp
+            - github
             - kubernetes
             - m365
         description: |-
@@ -5455,6 +5462,7 @@ paths:
           * `gcp` - GCP
           * `kubernetes` - Kubernetes
           * `m365` - M365
+          * `github` - GitHub
         explode: false
         style: form
       - in: query
@@ -5693,6 +5701,7 @@ paths:
           - aws
           - azure
           - gcp
+          - github
           - kubernetes
           - m365
         description: |-
@@ -5701,6 +5710,7 @@ paths:
           * `gcp` - GCP
           * `kubernetes` - Kubernetes
           * `m365` - M365
+          * `github` - GitHub
       - in: query
         name: filter[provider_type__in]
         schema:
@@ -5711,6 +5721,7 @@ paths:
             - aws
             - azure
             - gcp
+            - github
             - kubernetes
             - m365
         description: |-
@@ -5721,6 +5732,7 @@ paths:
           * `gcp` - GCP
           * `kubernetes` - Kubernetes
           * `m365` - M365
+          * `github` - GitHub
         explode: false
         style: form
       - in: query
@@ -8865,7 +8877,6 @@ components:
               readOnly: true
             enabled:
               type: boolean
-              readOnly: true
             connected:
               type: boolean
               readOnly: true
@@ -8897,8 +8908,12 @@ components:
                     description: The name of the S3 bucket where files will be stored.
                   output_directory:
                     type: string
-                    description: The directory path within the bucket where files
-                      will be saved.
+                    description: 'The directory path within the bucket where files
+                      will be saved. Path will be normalized to remove excessive slashes
+                      and invalid characters are not allowed (< > : " | ? *). Maximum
+                      length is 900 characters.'
+                    maxLength: 900
+                    pattern: ^[^<>:"|?*]+$
                 required:
                 - bucket_name
                 - output_directory
@@ -9006,7 +9021,6 @@ components:
                   readOnly: true
                 enabled:
                   type: boolean
-                  readOnly: true
                 connected:
                   type: boolean
                   readOnly: true
@@ -9039,8 +9053,12 @@ components:
                           stored.
                       output_directory:
                         type: string
-                        description: The directory path within the bucket where files
-                          will be saved.
+                        description: 'The directory path within the bucket where files
+                          will be saved. Path will be normalized to remove excessive
+                          slashes and invalid characters are not allowed (< > : "
+                          | ? *). Maximum length is 900 characters.'
+                        maxLength: 900
+                        pattern: ^[^<>:"|?*]+$
                     required:
                     - bucket_name
                     - output_directory
@@ -9195,8 +9213,12 @@ components:
                     description: The name of the S3 bucket where files will be stored.
                   output_directory:
                     type: string
-                    description: The directory path within the bucket where files
-                      will be saved.
+                    description: 'The directory path within the bucket where files
+                      will be saved. Path will be normalized to remove excessive slashes
+                      and invalid characters are not allowed (< > : " | ? *). Maximum
+                      length is 900 characters.'
+                    maxLength: 900
+                    pattern: ^[^<>:"|?*]+$
                 required:
                 - bucket_name
                 - output_directory
@@ -10549,8 +10571,12 @@ components:
                           stored.
                       output_directory:
                         type: string
-                        description: The directory path within the bucket where files
-                          will be saved.
+                        description: 'The directory path within the bucket where files
+                          will be saved. Path will be normalized to remove excessive
+                          slashes and invalid characters are not allowed (< > : "
+                          | ? *). Maximum length is 900 characters.'
+                        maxLength: 900
+                        pattern: ^[^<>:"|?*]+$
                     required:
                     - bucket_name
                     - output_directory

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -5679,6 +5679,7 @@ class TestIntegrationViewSet:
                     "integration_type": integration_type,
                     "configuration": configuration,
                     "credentials": credentials,
+                    "enabled": True,
                 },
                 "relationships": {
                     "providers": {
@@ -5696,6 +5697,7 @@ class TestIntegrationViewSet:
         assert Integration.objects.count() == 1
         integration = Integration.objects.first()
         assert integration.configuration == data["data"]["attributes"]["configuration"]
+        assert integration.enabled == data["data"]["attributes"]["enabled"]
         assert (
             integration.integration_type
             == data["data"]["attributes"]["integration_type"]

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -2068,7 +2068,6 @@ class IntegrationCreateSerializer(BaseWriteIntegrationSerializer):
             "inserted_at": {"read_only": True},
             "updated_at": {"read_only": True},
             "connected": {"read_only": True},
-            "enabled": {"read_only": True},
             "connection_last_checked_at": {"read_only": True},
         }
 

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -2072,16 +2072,15 @@ class IntegrationCreateSerializer(BaseWriteIntegrationSerializer):
         }
 
     def validate(self, attrs):
-        super().validate(attrs)
         integration_type = attrs.get("integration_type")
         providers = attrs.get("providers")
         configuration = attrs.get("configuration")
         credentials = attrs.get("credentials")
 
-        validated_attrs = super().validate(attrs)
         self.validate_integration_data(
             integration_type, providers, configuration, credentials
         )
+        validated_attrs = super().validate(attrs)
         return validated_attrs
 
     def create(self, validated_data):

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -293,7 +293,7 @@ class SchemaView(SpectacularAPIView):
 
     def get(self, request, *args, **kwargs):
         spectacular_settings.TITLE = "Prowler API"
-        spectacular_settings.VERSION = "1.10.2"
+        spectacular_settings.VERSION = "1.11.0"
         spectacular_settings.DESCRIPTION = (
             "Prowler API specification.\n\nThis file is auto-generated."
         )


### PR DESCRIPTION
### Context

This pull request introduces a modification to the integrations functionality, ensuring that integrations are enabled by default upon creation. This change aims to improve the user experience by reducing the need for manual intervention after an integration is created.

### Description

The following changes have been made:
- The integration creation process now sets the “enabled” attribute to True by default.
- Corresponding tests in ‎`test_views.py` have been updated to verify that integrations are enabled upon creation.
- The serializer in ‎`serializers.py` has been updated to remove the “enabled” field from read-only attributes, allowing it to be set during creation.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
