### PR TITLE
fix: Don't invoke tools if no providers or completed scans

### DIFF
--- a/ui/lib/lighthouse/data.ts
+++ b/ui/lib/lighthouse/data.ts
@@ -77,9 +77,12 @@ Email: ${userData.email}
 Company: ${userData.company}
 
 **CURRENT PROVIDER DATA:**
-${providersWithScans
-  .map(
-    (provider, index) => `
+${
+  providersWithScans.length === 0
+    ? "No Providers Connected"
+    : providersWithScans
+        .map(
+          (provider, index) => `
 Provider ${index + 1}:
 - Name: ${provider.name}
 - Type: ${provider.provider_type}
@@ -94,8 +97,9 @@ ${
     : "- No completed scans found"
 }
 `,
-  )
-  .join("\n")}
+        )
+        .join("\n")
+}
 `;
   } catch (error) {
     console.error("Failed to retrieve current data:", error);

--- a/ui/lib/lighthouse/prompts.ts
+++ b/ui/lib/lighthouse/prompts.ts
@@ -47,6 +47,7 @@ You use Prowler tool's capabilities to answer the user's query.
 - Always use business context and goals before answering questions on improving cloud security posture.
 - When the user asks questions without mentioning a specific provider or scan ID, pass all relevant data to downstream agents as an array of objects.
 - If the necessary data (like the latest scan ID, provider ID, etc) is already in the prompt, don't use tools to retrieve it.
+- Queries on resource/findings can be only answered if there are providers connected and these providers have completed scans.
 
 ## Operation Steps
 


### PR DESCRIPTION
### Context

Lighthouse invokes tools to fetch providers and latest scans even if the description of connected providers is empty.

### Description

This prompt change will ensure queries on findings and resources can be accessible only when there are completed scans for providers. 

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
