### PR TITLE
feat(ui): output_directory default value

### DIFF
--- a/ui/components/integrations/s3/s3-integration-form.tsx
+++ b/ui/components/integrations/s3/s3-integration-form.tsx
@@ -63,7 +63,7 @@ export const S3IntegrationForm = ({
       integration_type: "amazon_s3" as const,
       bucket_name: integration?.attributes.configuration.bucket_name || "",
       output_directory:
-        integration?.attributes.configuration.output_directory || "",
+        integration?.attributes.configuration.output_directory || "output",
       providers:
         integration?.relationships?.providers?.data?.map((p) => p.id) || [],
       credentials_type: "access-secret-key" as const,
@@ -146,7 +146,7 @@ export const S3IntegrationForm = ({
     // For creation mode, include all fields
     if (!isPartial) {
       configuration.bucket_name = values.bucket_name;
-      configuration.output_directory = values.output_directory;
+      configuration.output_directory = values.output_directory || "output";
     } else {
       // For edit mode, only include fields that have actually changed
       const originalBucketName =
@@ -314,7 +314,7 @@ export const S3IntegrationForm = ({
               type="text"
               label="Output directory"
               labelPlacement="inside"
-              placeholder="/prowler-findings/"
+              placeholder="output"
               variant="bordered"
               isRequired
               isInvalid={!!form.formState.errors.output_directory}


### PR DESCRIPTION
### Context

Update the user interface so that the bucket path field displays “output” as the default value

### Description

- Default value in the form for `output_directory`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
