### PR TITLE
feat(integrations): add enabled attribute to S3 integration

### DIFF
--- a/ui/actions/integrations/integrations.ts
+++ b/ui/actions/integrations/integrations.ts
@@ -87,8 +87,6 @@ export const createIntegration = async (
       },
     };
 
-    console.log("integrationData", JSON.stringify(integrationData, null, 2));
-
     const response = await fetch(url.toString(), {
       method: "POST",
       headers,

--- a/ui/actions/integrations/integrations.ts
+++ b/ui/actions/integrations/integrations.ts
@@ -68,11 +68,14 @@ export const createIntegration = async (
     const configuration = JSON.parse(formData.get("configuration") as string);
     const credentials = JSON.parse(formData.get("credentials") as string);
     const providers = JSON.parse(formData.get("providers") as string);
+    const enabled = formData.get("enabled")
+      ? JSON.parse(formData.get("enabled") as string)
+      : true;
 
     const integrationData = {
       data: {
         type: "integrations",
-        attributes: { integration_type, configuration, credentials },
+        attributes: { integration_type, configuration, credentials, enabled },
         relationships: {
           providers: {
             data: providers.map((providerId: string) => ({
@@ -83,6 +86,8 @@ export const createIntegration = async (
         },
       },
     };
+
+    console.log("integrationData", JSON.stringify(integrationData, null, 2));
 
     const response = await fetch(url.toString(), {
       method: "POST",

--- a/ui/components/integrations/s3/s3-integration-form.tsx
+++ b/ui/components/integrations/s3/s3-integration-form.tsx
@@ -66,6 +66,7 @@ export const S3IntegrationForm = ({
         integration?.attributes.configuration.output_directory || "output",
       providers:
         integration?.relationships?.providers?.data?.map((p) => p.id) || [],
+      enabled: integration?.attributes.enabled ?? true,
       credentials_type: "access-secret-key" as const,
       aws_access_key_id: "",
       aws_secret_access_key: "",
@@ -194,6 +195,7 @@ export const S3IntegrationForm = ({
       formData.append("configuration", JSON.stringify(configuration));
       formData.append("credentials", JSON.stringify(credentials));
       formData.append("providers", JSON.stringify(values.providers));
+      formData.append("enabled", JSON.stringify(values.enabled ?? true));
     }
 
     return formData;

--- a/ui/components/integrations/s3/s3-integration-form.tsx
+++ b/ui/components/integrations/s3/s3-integration-form.tsx
@@ -141,33 +141,13 @@ export const S3IntegrationForm = ({
     return credentials;
   };
 
-  const buildConfiguration = (values: any, isPartial = false) => {
+  const buildConfiguration = (values: any) => {
     const configuration: any = {};
 
-    // For creation mode, include all fields
-    if (!isPartial) {
-      configuration.bucket_name = values.bucket_name;
-      configuration.output_directory = values.output_directory || "output";
-    } else {
-      // For edit mode, only include fields that have actually changed
-      const originalBucketName =
-        integration?.attributes.configuration.bucket_name || "";
-      const originalOutputDirectory =
-        integration?.attributes.configuration.output_directory || "";
-
-      // Only include bucket_name if it has changed
-      if (values.bucket_name && values.bucket_name !== originalBucketName) {
-        configuration.bucket_name = values.bucket_name;
-      }
-
-      // Only include output_directory if it has changed
-      if (
-        values.output_directory &&
-        values.output_directory !== originalOutputDirectory
-      ) {
-        configuration.output_directory = values.output_directory;
-      }
-    }
+    // Always include all fields for both creation and edit modes
+    // Backend expects complete configuration object
+    configuration.bucket_name = values.bucket_name;
+    configuration.output_directory = values.output_directory || "output";
 
     return configuration;
   };
@@ -178,10 +158,8 @@ export const S3IntegrationForm = ({
     formData.append("integration_type", values.integration_type);
 
     if (isEditingConfig) {
-      const configuration = buildConfiguration(values, true);
-      if (Object.keys(configuration).length > 0) {
-        formData.append("configuration", JSON.stringify(configuration));
-      }
+      const configuration = buildConfiguration(values);
+      formData.append("configuration", JSON.stringify(configuration));
       // Always send providers array, even if empty, to update relationships
       formData.append("providers", JSON.stringify(values.providers || []));
     } else if (isEditingCredentials) {

--- a/ui/types/integrations.ts
+++ b/ui/types/integrations.ts
@@ -37,7 +37,7 @@ const baseS3IntegrationSchema = z.object({
   bucket_name: z.string().min(1, "Bucket name is required"),
   output_directory: z.string().min(1, "Output directory is required"),
   providers: z.array(z.string()).optional(),
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().optional(),
   // AWS Credentials fields compatible with AWSCredentialsRole
   credentials_type: z.enum(["aws-sdk-default", "access-secret-key"]),
   aws_access_key_id: z.string().optional(),
@@ -122,6 +122,7 @@ const s3IntegrationEditValidation = (data: any, ctx: z.RefinementCtx) => {
 
 export const s3IntegrationFormSchema = baseS3IntegrationSchema
   .extend({
+    enabled: z.boolean().default(true),
     credentials_type: z
       .enum(["aws-sdk-default", "access-secret-key"])
       .default("aws-sdk-default"),
@@ -136,7 +137,6 @@ export const editS3IntegrationFormSchema = baseS3IntegrationSchema
       .min(1, "Output directory is required")
       .optional(),
     providers: z.array(z.string()).optional(),
-    enabled: z.boolean().optional(),
     credentials_type: z
       .enum(["aws-sdk-default", "access-secret-key"])
       .optional(),

--- a/ui/types/integrations.ts
+++ b/ui/types/integrations.ts
@@ -37,6 +37,7 @@ const baseS3IntegrationSchema = z.object({
   bucket_name: z.string().min(1, "Bucket name is required"),
   output_directory: z.string().min(1, "Output directory is required"),
   providers: z.array(z.string()).optional(),
+  enabled: z.boolean().default(true),
   // AWS Credentials fields compatible with AWSCredentialsRole
   credentials_type: z.enum(["aws-sdk-default", "access-secret-key"]),
   aws_access_key_id: z.string().optional(),
@@ -135,6 +136,7 @@ export const editS3IntegrationFormSchema = baseS3IntegrationSchema
       .min(1, "Output directory is required")
       .optional(),
     providers: z.array(z.string()).optional(),
+    enabled: z.boolean().optional(),
     credentials_type: z
       .enum(["aws-sdk-default", "access-secret-key"])
       .optional(),


### PR DESCRIPTION
### Context

An AWS S3 integration must be enabled by default.

### Description

- While creating the integration, the `enabled` attribute is set as `true` by default

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
