### PR TITLE
chore(actions): update docs comment with link

### DIFF
--- a/.github/workflows/build-documentation-on-pr.yml
+++ b/.github/workflows/build-documentation-on-pr.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find existing documentation comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f6e # v3.1.0
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
         id: find-comment
         with:
           issue-number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/build-documentation-on-pr.yml
+++ b/.github/workflows/build-documentation-on-pr.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/build-documentation-on-pr.yml'
-      
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-documentation-on-pr.yml
+++ b/.github/workflows/build-documentation-on-pr.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/build-documentation-on-pr.yml'
+      
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/build-documentation-on-pr.yml
+++ b/.github/workflows/build-documentation-on-pr.yml
@@ -7,6 +7,7 @@ on:
       - 'v3'
     paths:
       - 'docs/**'
+      - '.github/workflows/build-documentation-on-pr.yml'
 
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -16,9 +17,20 @@ jobs:
     name: Documentation Link
     runs-on: ubuntu-latest
     steps:
-      - name: Leave PR comment with the Prowler Documentation URI
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      - name: Find existing documentation comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f6e # v3.1.0
+        id: find-comment
         with:
           issue-number: ${{ env.PR_NUMBER }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- prowler-docs-link -->'
+
+      - name: Create or update PR comment with the Prowler Documentation URI
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ env.PR_NUMBER }}
           body: |
+            <!-- prowler-docs-link -->
             You can check the documentation for this PR here -> [Prowler Documentation](https://prowler-prowler-docs--${{ env.PR_NUMBER }}.com.readthedocs.build/projects/prowler-open-source/en/${{ env.PR_NUMBER }}/)
+          edit-mode: replace


### PR DESCRIPTION
### Description

Update Prowler's bot documentation link instead of sending one message per matching commit.

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
