### PR TITLE
fix(export): remove static timestamp

### DIFF
--- a/api/src/backend/tasks/jobs/export.py
+++ b/api/src/backend/tasks/jobs/export.py
@@ -8,11 +8,12 @@ from botocore.exceptions import ClientError, NoCredentialsError, ParamValidation
 from celery.utils.log import get_task_logger
 from django.conf import settings
 
+from api.db_utils import rls_transaction
+from api.models import Scan
 from prowler.config.config import (
     csv_file_suffix,
     html_file_suffix,
     json_ocsf_file_suffix,
-    output_file_timestamp,
 )
 from prowler.lib.outputs.compliance.aws_well_architected.aws_well_architected import (
     AWSWellArchitected,
@@ -248,15 +249,19 @@ def _generate_output_directory(
     # Sanitize the prowler provider name to ensure it is a valid directory name
     prowler_provider_sanitized = re.sub(r"[^\w\-]", "-", prowler_provider)
 
+    with rls_transaction(tenant_id):
+        started_at = Scan.objects.get(id=scan_id).started_at
+
+    timestamp = started_at.strftime("%Y%m%d%H%M%S")
     path = (
         f"{output_directory}/{tenant_id}/{scan_id}/prowler-output-"
-        f"{prowler_provider_sanitized}-{output_file_timestamp}"
+        f"{prowler_provider_sanitized}-{timestamp}"
     )
     os.makedirs("/".join(path.split("/")[:-1]), exist_ok=True)
 
     compliance_path = (
         f"{output_directory}/{tenant_id}/{scan_id}/compliance/prowler-output-"
-        f"{prowler_provider_sanitized}-{output_file_timestamp}"
+        f"{prowler_provider_sanitized}-{timestamp}"
     )
     os.makedirs("/".join(compliance_path.split("/")[:-1]), exist_ok=True)
 


### PR DESCRIPTION
### Context

This pull request addresses the need to ensure that output file paths for exports reflect the actual scan start time, rather than relying on a static timestamp. The previous implementation used a constant value for the timestamp in generated file paths, which could cause confusion and reduce traceability.

### Description

This change removes the use of the static ‎`output_file_timestamp` for naming exported output files and directories. Instead, it retrieves the ‎`started_at` timestamp from the corresponding ‎`Scan` object and formats it appropriately. This ensures that the output directory and file names accurately represent when the scan was initiated.

The implementation updates the ‎`_generate_output_directory` function to fetch and use the real scan start time. The associated tests have also been updated and extended to mock the scan object and verify that the generated paths include the correct timestamp. Additional test cases ensure proper handling of invalid characters in provider names and confirm that the directory structure is created as expected.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
