### PR TITLE
fix(s3): Use HeadBucket instead of GetBucketLocation

### DIFF
--- a/permissions/templates/cloudformation/prowler-scan-role.yml
+++ b/permissions/templates/cloudformation/prowler-scan-role.yml
@@ -156,7 +156,7 @@ Resources:
                       "s3:ResourceAccount": !Sub ${S3IntegrationBucketAccountId}
                 - Effect: Allow
                   Action:
-                    - "s3:GetBucketLocation"
+                    - "s3:ListBucket"
                   Resource:
                     - !Sub "arn:${AWS::Partition}:s3:::${S3IntegrationBucketName}"
                   Condition:

--- a/permissions/templates/terraform/s3-integration/main.tf
+++ b/permissions/templates/terraform/s3-integration/main.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role_policy" "prowler_s3_integration" {
       {
         Effect = "Allow"
         Action = [
-          "s3:GetBucketLocation"
+          "s3:ListBucket"
         ]
         Resource = [
           "arn:${data.aws_partition.current.partition}:s3:::${var.s3_integration_bucket_name}"

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Use the correct default value for `role_session_name` and `session_duration` in AwsSetUpSession [(#8056)](https://github.com/prowler-cloud/prowler/pull/8056)
 - Use the correct default value for `role_session_name` and `session_duration` in S3 [(#8417)](https://github.com/prowler-cloud/prowler/pull/8417)
 - GitHub App authentication fails to generate output files and HTML header sections [(#8423)](https://github.com/prowler-cloud/prowler/pull/8423)
+- S3 `test_connection` uses AWS S3 API `HeadBucket` instead of `GetBucketLocation` [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Use the correct default value for `role_session_name` and `session_duration` in AwsSetUpSession [(#8056)](https://github.com/prowler-cloud/prowler/pull/8056)
 - Use the correct default value for `role_session_name` and `session_duration` in S3 [(#8417)](https://github.com/prowler-cloud/prowler/pull/8417)
 - GitHub App authentication fails to generate output files and HTML header sections [(#8423)](https://github.com/prowler-cloud/prowler/pull/8423)
-- S3 `test_connection` uses AWS S3 API `HeadBucket` instead of `GetBucketLocation` [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
+- S3 `test_connection` uses AWS S3 API `HeadBucket` instead of `GetBucketLocation` [(#8456)](https://github.com/prowler-cloud/prowler/pull/8456)
 
 ---
 

--- a/prowler/providers/aws/lib/s3/exceptions/exceptions.py
+++ b/prowler/providers/aws/lib/s3/exceptions/exceptions.py
@@ -26,6 +26,10 @@ class S3BaseException(ProwlerException):
             "message": "The specified location constraint is not valid.",
             "remediation": "Check the location constraint.",
         },
+        (6005, "S3InvalidBucketRegionError"): {
+            "message": "The specified bucket region is invalid.",
+            "remediation": "Check the bucket region.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -74,4 +78,11 @@ class S3IllegalLocationConstraintError(S3BaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             6004, file=file, original_exception=original_exception, message=message
+        )
+
+
+class S3InvalidBucketRegionError(S3BaseException):
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            6005, file=file, original_exception=original_exception, message=message
         )

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -476,8 +476,7 @@ class S3:
                 if (
                     "specified bucket does not exist"
                     or "An error occurred (404) when calling the HeadBucket operation: Not Found"
-                    in client_error.response["Error"]["Message"]
-                ):
+                ) in client_error.response["Error"]["Message"]:
                     raise S3InvalidBucketNameError(original_exception=client_error)
                 elif (
                     "IllegalLocationConstraintException"

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -475,8 +475,9 @@ class S3:
             if raise_on_exception:
                 if (
                     "specified bucket does not exist"
-                    or "An error occurred (404) when calling the HeadBucket operation: Not Found"
-                ) in client_error.response["Error"]["Message"]:
+                    in client_error.response["Error"]["Message"]
+                    or "Not Found" in client_error.response["Error"]["Message"]
+                ):
                     raise S3InvalidBucketNameError(original_exception=client_error)
                 elif (
                     "IllegalLocationConstraintException"

--- a/prowler/providers/aws/lib/s3/s3.py
+++ b/prowler/providers/aws/lib/s3/s3.py
@@ -39,6 +39,7 @@ from prowler.providers.aws.lib.s3.exceptions.exceptions import (
     S3ClientError,
     S3IllegalLocationConstraintError,
     S3InvalidBucketNameError,
+    S3InvalidBucketRegionError,
     S3TestConnectionError,
 )
 from prowler.providers.aws.lib.session.aws_set_up_session import (
@@ -312,28 +313,25 @@ class S3:
                     region_name=aws_region,
                     profile_name=profile,
                 )
-
             s3_client = session.client(__class__.__name__.lower())
             if "s3://" in bucket_name:
                 bucket_name = bucket_name.removeprefix("s3://")
-            # Check for the bucket location
-            bucket_location = s3_client.get_bucket_location(Bucket=bucket_name)
-            if bucket_location["LocationConstraint"] == "EU":
-                bucket_location["LocationConstraint"] = "eu-west-1"
-            if (
-                bucket_location["LocationConstraint"] == ""
-                or bucket_location["LocationConstraint"] is None
-            ):
-                bucket_location["LocationConstraint"] = "us-east-1"
+            # Check bucket location, requires s3:ListBucket permission
+            # https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html
+            bucket_region = s3_client.head_bucket(Bucket=bucket_name).get(
+                "BucketRegion"
+            )
+            if bucket_region is None:
+                exception = S3InvalidBucketRegionError()
+                if raise_on_exception:
+                    raise exception
+                return Connection(error=exception)
 
             # If the bucket location is not the same as the session region, change the session region
-            if (
-                session.region_name != bucket_location["LocationConstraint"]
-                and bucket_location["LocationConstraint"] is not None
-            ):
+            if session.region_name != bucket_region:
                 s3_client = session.client(
                     __class__.__name__.lower(),
-                    region_name=bucket_location["LocationConstraint"],
+                    region_name=bucket_region,
                 )
             # Set a Temp file to upload
             with tempfile.TemporaryFile() as temp_file:
@@ -466,11 +464,18 @@ class S3:
             if raise_on_exception:
                 raise session_token_expired
             return Connection(error=session_token_expired)
-
+        except S3InvalidBucketRegionError as invalid_bucket_region_error:
+            logger.error(
+                f"{invalid_bucket_region_error.__class__.__name__}[{invalid_bucket_region_error.__traceback__.tb_lineno}]: {invalid_bucket_region_error}"
+            )
+            if raise_on_exception:
+                raise invalid_bucket_region_error
+            return Connection(error=invalid_bucket_region_error)
         except ClientError as client_error:
             if raise_on_exception:
                 if (
                     "specified bucket does not exist"
+                    or "An error occurred (404) when calling the HeadBucket operation: Not Found"
                     in client_error.response["Error"]["Message"]
                 ):
                     raise S3InvalidBucketNameError(original_exception=client_error)


### PR DESCRIPTION
### Context

AWS S3 API [GetBucketLocation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) does not support cross-account requests. This was confirmed by the AWS S3 Support team and they are working to reflect that in the documentation. Instead S3 API [HeadBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html) must be used.

### Description

- Replace `GetBucketLocation` by `HeadBucket` in `S3.test_connection`.
- Change `s3:GetBucketLocation` by `s3:ListBucket`, as it's the permission required for `HeadBucket`
- Cover changes with tests
<img width="810" height="151" alt="Screenshot 2025-08-06 at 13 10 25" src="https://github.com/user-attachments/assets/74eda940-e25f-4a2b-b47a-b82dec105e80" />

### How to test it
Having two AWS accounts, let's call it `AWS_ACCOUNT_A` and `AWS_ACCOUNT_B`
1. Create an S3 bucket in `AWS_ACCOUNT_A`
2. Create an IAM role in `AWS_ACCOUNT_B` with the following permissions:
	```json
	{
	    "Version": "2012-10-17",
	    "Statement": [
	        {
	            "Condition": {
	                "StringEquals": {
	                    "s3:ResourceAccount": "AWS_ACCOUNT_A"
	                }
	            },
	            "Action": [
	                "s3:PutObject"
	            ],
	            "Resource": [
	                "arn:aws:s3:::BUCKET_NAME/*"
	            ],
	            "Effect": "Allow"
	        },
	        {
	            "Condition": {
	                "StringEquals": {
	                    "s3:ResourceAccount": "AWS_ACCOUNT_A"
	                }
	            },
	            "Action": [
	                "s3:ListBucket"
	            ],
	            "Resource": [
	                "arn:aws:s3:::BUCKET_NAME"
	            ],
	            "Effect": "Allow"
	        },
	        {
	            "Condition": {
	                "StringEquals": {
	                    "s3:ResourceAccount": "AWS_ACCOUNT_A"
	                }
	            },
	            "Action": [
	                "s3:DeleteObject"
	            ],
	            "Resource": [
	                "arn:aws:s3:::BUCKET_NAME/*test-prowler-connection.txt"
	            ],
	            "Effect": "Allow"
	        }
	    ]
	}
	```
3. Configure IAM Role trust relationship in `AWS_ACCOUNT_B` with an `EXTERNAL_ID`
4. Update `BUCKET_NAME` policy in `AWS_ACCOUNT_A` with:
	```json
	{
	    "Version": "2012-10-17",
	    "Statement": [
	        {
	            "Effect": "Allow",
	            "Principal": {
	                "AWS": "arn:aws:iam::AWS_ACCOUNT_B:role/AWS_ACCOUNT_B_IAM_ROLE"
	            },
	            "Action": "s3:PutObject",
	            "Resource": "arn:aws:s3:::BUCKET_NAME/*"
	        },
	        {
	            "Effect": "Allow",
	            "Principal": {
	                "AWS": "arn:aws:iam::AWS_ACCOUNT_B:role/AWS_ACCOUNT_B_IAM_ROLE"
	            },
	            "Action": "s3:DeleteObject",
	            "Resource": "arn:aws:s3:::BUCKET_NAME/*test-prowler-connection.txt"
	        },
	        {
	            "Effect": "Allow",
	            "Principal": {
	                "AWS": "arn:aws:iam::AWS_ACCOUNT_B:role/AWS_ACCOUNT_B_IAM_ROLE"
	            },
	            "Action": "s3:ListBucket",
	            "Resource": "arn:aws:s3:::BUCKET_NAME"
	        }
	    ]
	}
	```
5. Run the following script to test the connection
	```python
	from prowler.providers.aws.lib.s3.s3 import S3
	
	s3 = S3.test_connection(
	    bucket_name="BUCKET_NAME",
	    aws_access_key_id="XXXXX",
	    aws_secret_access_key="XXXXX",
	    aws_session_token="XXXXX",
	    role_arn="arn:aws:iam::AWS_ACCOUNT_B:AWS_ACCOUNT_B_IAM_ROLE",
	    external_id="EXTERNAL_ID",
	    )
	
	print(s3.is_connected)
	```

### Checklist

- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. -> No, as this will be included in v5.10
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
