### PR TITLE
feat(ui): add SAML documentation link in config modal

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Github provider support [(#8405)](https://github.com/prowler-cloud/prowler/pull/8405)
 - XML validation for SAML metadata in the UI [(#8429)](https://github.com/prowler-cloud/prowler/pull/8429)
 - Default Mutelist placeholder in the UI [(#8455)](https://github.com/prowler-cloud/prowler/pull/8455)
--  Help link in the SAML configuration modal [(#8461)](https://github.com/prowler-cloud/prowler/pull/8461)
+- Help link in the SAML configuration modal [(#8461)](https://github.com/prowler-cloud/prowler/pull/8461)
 
 ### 🔄 Changed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Github provider support [(#8405)](https://github.com/prowler-cloud/prowler/pull/8405)
 - XML validation for SAML metadata in the UI [(#8429)](https://github.com/prowler-cloud/prowler/pull/8429)
 - Default Mutelist placeholder in the UI [(#8455)](https://github.com/prowler-cloud/prowler/pull/8455)
-- Help link to SAML documentation at the top of the SAML configuration modal [(#8461)](https://github.com/prowler-cloud/prowler/pull/8461)
+-  Help link in the SAML configuration modal [(#8461)](https://github.com/prowler-cloud/prowler/pull/8461)
 
 ### 🔄 Changed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Github provider support [(#8405)](https://github.com/prowler-cloud/prowler/pull/8405)
 - XML validation for SAML metadata in the UI [(#8429)](https://github.com/prowler-cloud/prowler/pull/8429)
 - Default Mutelist placeholder in the UI [(#8455)](https://github.com/prowler-cloud/prowler/pull/8455)
+- Help link to SAML documentation at the top of the SAML configuration modal [(#8461)](https://github.com/prowler-cloud/prowler/pull/8461)
 
 ### 🔄 Changed
 

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -253,7 +253,7 @@ export const SamlConfigForm = ({
   return (
     <form ref={formRef} action={formAction} className="flex flex-col space-y-2">
       <p className="py-1 text-xs text-gray-500">
-        Need help configuring your Amazon S3 integrations?{" "}
+        Need help configuring SAML SSO?{" "}
         <CustomLink
           href={
             "https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app-sso/"

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -252,7 +252,7 @@ export const SamlConfigForm = ({
 
   return (
     <form ref={formRef} action={formAction} className="flex flex-col space-y-2">
-      <p className="py-1 text-xs text-gray-500">
+      <p className="py-1 text-xs">
         Need help configuring SAML SSO?{" "}
         <CustomLink
           href={

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -252,6 +252,16 @@ export const SamlConfigForm = ({
 
   return (
     <form ref={formRef} action={formAction} className="flex flex-col space-y-2">
+      <p className="py-1 text-xs text-gray-500">
+        Need help configuring your Amazon S3 integrations?{" "}
+        <CustomLink
+          href={
+            "https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app-sso/"
+          }
+        >
+          Read the docs
+        </CustomLink>
+      </p>
       <input type="hidden" name="id" value={samlConfig?.id || ""} />
       <CustomServerInput
         name="email_domain"

--- a/ui/components/integrations/saml/saml-config-form.tsx
+++ b/ui/components/integrations/saml/saml-config-form.tsx
@@ -252,7 +252,7 @@ export const SamlConfigForm = ({
 
   return (
     <form ref={formRef} action={formAction} className="flex flex-col space-y-2">
-      <p className="py-1 text-xs">
+      <div className="py-1 text-xs">
         Need help configuring SAML SSO?{" "}
         <CustomLink
           href={
@@ -261,7 +261,7 @@ export const SamlConfigForm = ({
         >
           Read the docs
         </CustomLink>
-      </p>
+      </div>
       <input type="hidden" name="id" value={samlConfig?.id || ""} />
       <CustomServerInput
         name="email_domain"


### PR DESCRIPTION
### Description

This PR adds a help link to the top of the SAML configuration modal, allowing users to quickly access documentation for setting up SAML integrations.


<img width="989" height="1185" alt="image" src="https://github.com/user-attachments/assets/7eb9117c-b28a-45b2-99e7-016f374a937d" />

<img width="989" height="633" alt="image" src="https://github.com/user-attachments/assets/1f358474-8d82-4bd2-851b-a2465f55d153" />

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
