### PR TITLE
chore(api): open PR with API prowler version

### DIFF
--- a/.github/workflows/prowler-release-preparation.yml
+++ b/.github/workflows/prowler-release-preparation.yml
@@ -144,27 +144,34 @@ jobs:
         fi
         echo "✓ api/src/backend/api/v1/views.py version: $CURRENT_API_VERSION"
 
-    - name: Create release branch for minor release
+    - name: Checkout existing release branch for minor release
       if: ${{ env.PATCH_VERSION == '0' }}
       run: |
-        echo "Minor release detected (patch = 0), creating new branch $BRANCH_NAME..."
-        if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME" || git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
-          echo "ERROR: Branch $BRANCH_NAME already exists for minor release $PROWLER_VERSION"
+        echo "Minor release detected (patch = 0), checking out existing branch $BRANCH_NAME..."
+        if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+          echo "Branch $BRANCH_NAME exists remotely, checking out..."
+          git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME"
+        else
+          echo "ERROR: Branch $BRANCH_NAME should exist for minor release $PROWLER_VERSION. Please create it manually first."
           exit 1
         fi
-        git checkout -b "$BRANCH_NAME"
-        
-        # Push the new branch first so it exists remotely
-        git push origin "$BRANCH_NAME"
 
-    - name: Update prowler dependency in api/pyproject.toml
+    - name: Prepare prowler dependency update for minor release
       if: ${{ env.PATCH_VERSION == '0' }}
       run: |
         CURRENT_PROWLER_REF=$(grep 'prowler @ git+https://github.com/prowler-cloud/prowler.git@' api/pyproject.toml | sed -E 's/.*@([^"]+)".*/\1/' | tr -d '[:space:]')
         BRANCH_NAME_TRIMMED=$(echo "$BRANCH_NAME" | tr -d '[:space:]')
 
-        # Minor release: update the dependency to use the new branch
-        echo "Minor release detected - updating prowler dependency from '$CURRENT_PROWLER_REF' to '$BRANCH_NAME_TRIMMED'"
+        # Create a temporary branch for the PR
+        TEMP_BRANCH="update-api-dependency-$BRANCH_NAME_TRIMMED-$(date +%s)"
+        echo "TEMP_BRANCH=$TEMP_BRANCH" >> $GITHUB_ENV
+
+        # Switch back to master and create temp branch
+        git checkout master
+        git checkout -b "$TEMP_BRANCH"
+
+        # Minor release: update the dependency to use the release branch
+        echo "Updating prowler dependency from '$CURRENT_PROWLER_REF' to '$BRANCH_NAME_TRIMMED'"
         sed -i "s|prowler @ git+https://github.com/prowler-cloud/prowler.git@[^\"]*\"|prowler @ git+https://github.com/prowler-cloud/prowler.git@$BRANCH_NAME_TRIMMED\"|" api/pyproject.toml
 
         # Verify the change was made
@@ -180,12 +187,39 @@ jobs:
         poetry lock
         cd ..
 
-        # Commit and push the changes
+        # Commit and push the temporary branch
         git add api/pyproject.toml api/poetry.lock
         git commit -m "chore(api): update prowler dependency to $BRANCH_NAME_TRIMMED for release $PROWLER_VERSION"
-        git push origin "$BRANCH_NAME"
+        git push origin "$TEMP_BRANCH"
 
-        echo "✓ api/pyproject.toml prowler dependency updated to: $UPDATED_PROWLER_REF"
+        echo "✓ Prepared prowler dependency update to: $UPDATED_PROWLER_REF"
+
+    - name: Create Pull Request against release branch
+      if: ${{ env.PATCH_VERSION == '0' }}
+      uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+      with:
+        token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
+        branch: ${{ env.TEMP_BRANCH }}
+        base: ${{ env.BRANCH_NAME }}
+        title: "chore(api): Update prowler dependency to ${{ env.BRANCH_NAME }} for release ${{ env.PROWLER_VERSION }}"
+        body: |
+          ### Description
+
+          Updates the API prowler dependency for release ${{ env.PROWLER_VERSION }}.
+
+          **Changes:**
+          - Updates `api/pyproject.toml` prowler dependency from `@master` to `@${{ env.BRANCH_NAME }}`
+          - Updates `api/poetry.lock` file with resolved dependencies
+
+          This PR should be merged into the `${{ env.BRANCH_NAME }}` release branch.
+
+          ### License
+
+          By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+        author: prowler-bot <179230569+prowler-bot@users.noreply.github.com>
+        labels: |
+          component/api
+          no-changelog
 
     - name: Extract changelog entries
       run: |


### PR DESCRIPTION
### Context

Push to branch is not working due to branch protection

### Description

Create PR to previously created branch release

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
