### PR TITLE
fix(actions): lock poetry after changes

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -102,12 +102,6 @@ jobs:
           python -m pip install --upgrade pip
           pipx install poetry==2.1.1
 
-      - name: Update poetry.lock after the branch name change
-        working-directory: ./api
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
-        run: |
-          poetry lock
-
       - name: Update SDK's poetry.lock resolved_reference to latest commit - Only for push events to `master`
         working-directory: ./api
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true' && github.event_name == 'push'
@@ -124,6 +118,12 @@ jobs:
           # Verify the change was made
           echo "Updated resolved_reference:"
           grep -A2 -B2 "resolved_reference" poetry.lock
+
+      - name: Update poetry.lock
+        working-directory: ./api
+        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
+        run: |
+          poetry lock
 
       - name: Set up Python ${{ matrix.python-version }}
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'


### PR DESCRIPTION
### Description

Lock poetry after changes to prevent install outdated SDK dependencies. See https://github.com/prowler-cloud/prowler/actions/runs/16803718564/job/47590793498

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
