### PR TITLE
fix(ui): adjust table headers to be single-line and consistent

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 ### 🐞 Fixed
+- DataTable column headers set to single-line [(#8480)](https://github.com/prowler-cloud/prowler/pull/8480)
 
 ### ❌ Removed
 

--- a/ui/components/findings/table/column-findings.tsx
+++ b/ui/components/findings/table/column-findings.tsx
@@ -228,7 +228,7 @@ export const ColumnFindings: ColumnDef<FindingProps>[] = [
   },
   {
     accessorKey: "cloudProvider",
-    header: "Cloud provider",
+    header: "Cloud Provider",
     cell: ({ row }) => {
       const provider = getProviderData(row, "provider");
       const alias = getProviderData(row, "alias");

--- a/ui/components/overview/new-findings-table/table/column-new-findings-to-date.tsx
+++ b/ui/components/overview/new-findings-table/table/column-new-findings-to-date.tsx
@@ -174,7 +174,7 @@ export const ColumnNewFindingsToDate: ColumnDef<FindingProps>[] = [
   },
   {
     accessorKey: "cloudProvider",
-    header: "Cloud provider",
+    header: "Cloud Provider",
     cell: ({ row }) => {
       const provider = getProviderData(row, "provider");
       const alias = getProviderData(row, "alias");

--- a/ui/components/scans/table/scans/column-get-scans.tsx
+++ b/ui/components/scans/table/scans/column-get-scans.tsx
@@ -47,7 +47,7 @@ export const ColumnGetScans: ColumnDef<ScanProps>[] = [
   },
   {
     accessorKey: "cloudProvider",
-    header: () => <p className="pr-8">Cloud provider</p>,
+    header: () => <p className="pr-8">Cloud Provider</p>,
     cell: ({ row }) => {
       const providerInfo = row.original.providerInfo;
 

--- a/ui/components/ui/table/data-table-column-header.tsx
+++ b/ui/components/ui/table/data-table-column-header.tsx
@@ -83,7 +83,7 @@ export const DataTableColumnHeader = <TData, TValue>({
       className="flex h-10 w-full items-center justify-between whitespace-nowrap bg-transparent px-0 text-left align-middle text-tiny font-semibold text-foreground-500 outline-none dark:text-slate-400"
       onPress={getToggleSortingHandler}
     >
-      <span className="block whitespace-normal break-normal">{title}</span>
+      <span className="block whitespace-nowrap break-normal">{title}</span>
       {renderSortIcon()}
     </Button>
   );


### PR DESCRIPTION
### Description

- Updated `DataTableColumnHeader` to ensure all column headers use a consistent, single-line layout.
- Also corrected `Cloud provider` to `Cloud Provider` for naming consistency.

<img width="1918" height="433" alt="image" src="https://github.com/user-attachments/assets/f2b10d7b-00e6-41d2-80b6-e248b09ab6e4" /> <br>

@paabloLC, I changed `whitespace-normal` to `whitespace-nowrap` in the `DataTableColumnHeader`. With this change, if a column title has long text, it won’t break into multiple lines, even on smaller devices. I've attached an image below. Please let me know if anything needs to be changed.

<img width="1686" height="564" alt="image" src="https://github.com/user-attachments/assets/63a1e35a-bb18-4629-a796-a20d33fe7427" /> <br>

Ex (Long text):-

<img width="1379" height="421" alt="image" src="https://github.com/user-attachments/assets/bdb96fa7-508b-4be7-89df-d5054b7e7137" /> <br>

Ex (small device):-

<img width="1909" height="739" alt="image" src="https://github.com/user-attachments/assets/978b0917-d833-4600-8784-0acc3eb30126" />




### Checklist

- Are there new checks included in this PR?  No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
