### PR TITLE
ref(actions): remove xmlsec step

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -132,12 +132,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
 
-      - name: Install system dependencies for xmlsec
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl pkg-config
-
       - name: Install dependencies
         working-directory: ./api
         if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'


### PR DESCRIPTION
### Context

This pull request removes the steps related to the installation and management of the ‎`xmlsec` system dependencies from the ‎`api-pull-request.yml` GitHub Actions workflow. The motivation for this change is to streamline the workflow by eliminating unnecessary dependencies that are no longer required for the project’s operation.

### Description

The following changes have been made:
- All steps responsible for installing ‎`libxml2-dev`, ‎`libxmlsec1-dev`, ‎`libxmlsec1-openssl`, and ‎`pkg-config` via ‎`apt-get` have been removed from the workflow.
- The step that previously updated the ‎`poetry.lock` file after a branch name change has been consolidated and simplified.
- The workflow now focuses on updating ‎`poetry.lock` only when there are relevant changes, and ensures this process is consistent for both pull request and push events.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
