### PR TITLE
fix(ui): assume role fields shown

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🐞 Fixed
 
-- Switch in AWS role credentials form shown when adding a role [(#8484)](https://github.com/prowler-cloud/prowler/pull/8484)
+- Field for `Assume Role` in AWS role credentials form shown again [(#8484)](https://github.com/prowler-cloud/prowler/pull/8484)
 
 ### ❌ Removed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to the **Prowler UI** are documented in this file.
 ## [1.11.0] (Prowler v5.11.0 - UNRELEASED)
 
 ### 🚀 Added
--  `Cloud Provider` type filter to providers page [(#8473)](https://github.com/prowler-cloud/prowler/pull/8473)
+
+- `Cloud Provider` type filter to providers page [(#8473)](https://github.com/prowler-cloud/prowler/pull/8473)
+
 ### 🔄 Changed
 
 ### 🐞 Fixed
+
+- Switch in AWS role credentials form shown when adding a role [(#8484)](https://github.com/prowler-cloud/prowler/pull/8484)
 
 ### ❌ Removed
 

--- a/ui/components/providers/workflow/forms/select-credentials-type/aws/credentials-type/aws-role-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/aws/credentials-type/aws-role-credentials-form.tsx
@@ -35,7 +35,9 @@ export const AWSRoleCredentialsForm = ({
   });
   const [showOptionalRole, setShowOptionalRole] = useState(false);
   const showRoleSection =
-    (isCloudEnv && credentialsType === "aws-sdk-default") || showOptionalRole;
+    type === "providers" ||
+    (isCloudEnv && credentialsType === "aws-sdk-default") ||
+    showOptionalRole;
 
   return (
     <>
@@ -144,21 +146,23 @@ export const AWSRoleCredentialsForm = ({
       )}
       <Divider className="" />
 
-      <div className="flex items-center justify-between">
-        <span className="text-xs font-bold text-default-500">
-          {type === "providers"
-            ? "Assume Role"
-            : isCloudEnv && credentialsType === "aws-sdk-default"
+      {type === "providers" ? (
+        <span className="text-xs font-bold text-default-500">Assume Role</span>
+      ) : (
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-bold text-default-500">
+            {isCloudEnv && credentialsType === "aws-sdk-default"
               ? "Adding a role is required"
               : "Optionally add a role"}
-        </span>
-        <Switch
-          size="sm"
-          isSelected={showRoleSection}
-          onValueChange={setShowOptionalRole}
-          isDisabled={isCloudEnv && credentialsType === "aws-sdk-default"}
-        />
-      </div>
+          </span>
+          <Switch
+            size="sm"
+            isSelected={showRoleSection}
+            onValueChange={setShowOptionalRole}
+            isDisabled={isCloudEnv && credentialsType === "aws-sdk-default"}
+          />
+        </div>
+      )}
 
       {showRoleSection && (
         <>

--- a/ui/components/providers/workflow/forms/select-credentials-type/aws/credentials-type/aws-role-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/aws/credentials-type/aws-role-credentials-form.tsx
@@ -144,23 +144,21 @@ export const AWSRoleCredentialsForm = ({
       )}
       <Divider className="" />
 
-      {type === "providers" ? (
-        <span className="text-xs font-bold text-default-500">Assume Role</span>
-      ) : (
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-bold text-default-500">
-            {isCloudEnv && credentialsType === "aws-sdk-default"
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-bold text-default-500">
+          {type === "providers"
+            ? "Assume Role"
+            : isCloudEnv && credentialsType === "aws-sdk-default"
               ? "Adding a role is required"
               : "Optionally add a role"}
-          </span>
-          <Switch
-            size="sm"
-            isSelected={showRoleSection}
-            onValueChange={setShowOptionalRole}
-            isDisabled={isCloudEnv && credentialsType === "aws-sdk-default"}
-          />
-        </div>
-      )}
+        </span>
+        <Switch
+          size="sm"
+          isSelected={showRoleSection}
+          onValueChange={setShowOptionalRole}
+          isDisabled={isCloudEnv && credentialsType === "aws-sdk-default"}
+        />
+      </div>
 
       {showRoleSection && (
         <>


### PR DESCRIPTION
### Context

Assume the role fields in the providers' AWS form are not shown.

### Description

- The switch is not shown, but role fields are
<img width="1010" height="669" alt="Screenshot 2025-08-07 at 17 34 56" src="https://github.com/user-attachments/assets/cb6380df-06da-4af7-910a-f8889a2f0ad6" />

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
