### PR TITLE
feat(ui): add GitHub submenu under High Risk Findings

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - `Cloud Provider` type filter to providers page [(#8473)](https://github.com/prowler-cloud/prowler/pull/8473)
 - New menu item under Configuration section for quick access to the Mutelist [(#8444)](https://github.com/prowler-cloud/prowler/pull/8444)
+- `GitHub` submenu to High Risk Findings [(#8488)](https://github.com/prowler-cloud/prowler/pull/8488)
 
 
 ### 🔄 Changed

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - `Cloud Provider` type filter to providers page [(#8473)](https://github.com/prowler-cloud/prowler/pull/8473)
 - New menu item under Configuration section for quick access to the Mutelist [(#8444)](https://github.com/prowler-cloud/prowler/pull/8444)
-- `GitHub` submenu to High Risk Findings [(#8488)](https://github.com/prowler-cloud/prowler/pull/8488)
 
 ### 🔄 Changed
 
@@ -23,6 +22,8 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - Field for `Assume Role` in AWS role credentials form shown again [(#8484)](https://github.com/prowler-cloud/prowler/pull/8484)
+- `GitHub` submenu to High Risk Findings [(#8488)](https://github.com/prowler-cloud/prowler/pull/8488)
+
   
 ## [1.10.0] (Prowler v5.10.0)
 

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -28,6 +28,7 @@ import {
   CircleHelpIcon,
   DocIcon,
   GCPIcon,
+  GithubIcon,
   KubernetesIcon,
   LighthouseIcon,
   M365Icon,
@@ -122,6 +123,11 @@ export const getMenuList = ({
               href: "/findings?filter[status__in]=FAIL&filter[severity__in]=critical%2Chigh%2Cmedium&filter[provider_type__in]=gcp&sort=severity,-inserted_at",
               label: "Google Cloud",
               icon: GCPIcon,
+            },
+            {
+              href: "/findings?filter[status__in]=FAIL&filter[severity__in]=critical%2Chigh%2Cmedium&filter[provider_type__in]=github&sort=severity,-inserted_at",
+              label: "Github",
+              icon: GithubIcon,
             },
             {
               href: "/findings?filter[status__in]=FAIL&filter[severity__in]=critical%2Chigh%2Cmedium&filter[provider_type__in]=kubernetes&sort=severity,-inserted_at",

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -125,14 +125,14 @@ export const getMenuList = ({
               icon: GCPIcon,
             },
             {
-              href: "/findings?filter[status__in]=FAIL&filter[severity__in]=critical%2Chigh%2Cmedium&filter[provider_type__in]=github&sort=severity,-inserted_at",
-              label: "Github",
-              icon: GithubIcon,
-            },
-            {
               href: "/findings?filter[status__in]=FAIL&filter[severity__in]=critical%2Chigh%2Cmedium&filter[provider_type__in]=kubernetes&sort=severity,-inserted_at",
               label: "Kubernetes",
               icon: KubernetesIcon,
+            },
+            {
+              href: "/findings?filter[status__in]=FAIL&filter[severity__in]=critical%2Chigh%2Cmedium&filter[provider_type__in]=github&sort=severity,-inserted_at",
+              label: "Github",
+              icon: GithubIcon,
             },
           ],
           defaultOpen: false,


### PR DESCRIPTION
### Description

This PR adds a new `GitHub` submenu item under the High Risk Findings section in the sidebar.

<img width="213" height="180" alt="image" src="https://github.com/user-attachments/assets/e7876ab5-258b-443b-b269-9390f431fbf9" />

<img width="213" height="180" alt="image" src="https://github.com/user-attachments/assets/38beb56c-2f10-4438-9898-22c38035006f" />



### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
