### PR TITLE
chore(ui): update connection filter labels to connected/disconnected

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Disable `See Compliance` button until scan completes [(#8487)](https://github.com/prowler-cloud/prowler/pull/8487)
+- Cloud providers page connection filter labels from `true/false` to `connected/disconnected` [(#8505)](https://github.com/prowler-cloud/prowler/pull/8505)
 
 ### 🐞 Fixed
 - DataTable column headers set to single-line [(#8480)](https://github.com/prowler-cloud/prowler/pull/8480)

--- a/ui/components/filters/data-filters.ts
+++ b/ui/components/filters/data-filters.ts
@@ -6,6 +6,12 @@ export const filterProviders = [
     key: "connected",
     labelCheckboxGroup: "Connection",
     values: ["false", "true"],
+    valueLabelMapping: [
+      {
+        false: { label: "Disconnected" },
+        true: { label: "Connected" },
+      },
+    ],
   },
   {
     key: "provider__in",

--- a/ui/components/ui/custom/custom-dropdown-filter.tsx
+++ b/ui/components/ui/custom/custom-dropdown-filter.tsx
@@ -196,6 +196,8 @@ export const CustomDropdownFilter = ({
           (entity as ScanEntity).providerInfo?.uid ||
           value
         );
+      } else if ("label" in entity) {
+        return entity.label;
       } else {
         return (
           (entity as ProviderEntity).alias ||
@@ -206,6 +208,32 @@ export const CustomDropdownFilter = ({
     },
     [filter.valueLabelMapping],
   );
+
+  const renderEntity = (entity: FilterEntity | undefined, value: string) => {
+    if (!entity) return value;
+
+    if (isScanEntity(entity as ScanEntity)) {
+      return <ComplianceScanInfo scan={entity as ScanEntity} />;
+    }
+
+    const maybeProvider = entity as ProviderEntity;
+    if ("provider" in maybeProvider) {
+      return (
+        <EntityInfoShort
+          cloudProvider={maybeProvider.provider}
+          entityAlias={maybeProvider.alias ?? undefined}
+          entityId={maybeProvider.uid}
+          hideCopyButton
+        />
+      );
+    }
+
+    if ("label" in entity) {
+      return <span>{entity.label}</span>;
+    }
+
+    return value;
+  };
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -319,24 +347,7 @@ export const CustomDropdownFilter = ({
                         key={value}
                         value={value}
                       >
-                        {entity ? (
-                          isScanEntity(entity as ScanEntity) ? (
-                            <ComplianceScanInfo scan={entity as ScanEntity} />
-                          ) : (
-                            <EntityInfoShort
-                              cloudProvider={
-                                (entity as ProviderEntity).provider
-                              }
-                              entityAlias={
-                                (entity as ProviderEntity).alias ?? undefined
-                              }
-                              entityId={(entity as ProviderEntity).uid}
-                              hideCopyButton
-                            />
-                          )
-                        ) : (
-                          value
-                        )}
+                        {renderEntity(entity, value)}
                       </Checkbox>
                     );
                   })}

--- a/ui/types/filters.ts
+++ b/ui/types/filters.ts
@@ -1,7 +1,7 @@
 import { ProviderEntity } from "./providers";
 import { ScanEntity } from "./scans";
 
-export type FilterEntity = ProviderEntity | ScanEntity;
+export type FilterEntity = ProviderEntity | ScanEntity | { label: string };
 
 export interface FilterOption {
   key: string;


### PR DESCRIPTION
### Description

This PR updates the connection filter labels on the cloud providers page. Instead of showing boolean values (true/false), the filter now displays the status labels: `connected` and `disconnected`.

<img width="1914" height="801" alt="image" src="https://github.com/user-attachments/assets/c59cf1b1-63ea-4e88-a239-7e938abad42c" /> <br>

<img width="1904" height="840" alt="image" src="https://github.com/user-attachments/assets/9b9c0675-bc21-458f-bdd3-0231335499f4" /> <br>

<img width="1151" height="645" alt="image" src="https://github.com/user-attachments/assets/6c69bfe3-60c9-42f2-a3a7-27cdb58e724e" /> <br>



### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
