### PR TITLE
fix(kafka): false positives in `kafka_cluster_is_public` check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Validation errors in Azure and M365 providers [(#8353)](https://github.com/prowler-cloud/prowler/pull/8353)
 - Azure `app_http_logs_enabled` check false positives [(#8507)](https://github.com/prowler-cloud/prowler/pull/8507)
 - Azure `storage_geo_redundant_enabled` check false positives [(#8504)](https://github.com/prowler-cloud/prowler/pull/8504)
+- AWS `kafka_cluster_is_public` check false positives [(#8514)](https://github.com/prowler-cloud/prowler/pull/8514)
 
 ---
 

--- a/prowler/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached.py
@@ -18,13 +18,10 @@ class elbv2_waf_acl_attached(Check):
                     if lb.arn in acl.albs:
                         report.status = "PASS"
                         report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv2 Web ACL {acl.name}."
-                        break
-                if report.status == "FAIL":
-                    for acl in wafregional_client.web_acls.values():
-                        if lb.arn in acl.albs:
-                            report.status = "PASS"
-                            report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv1 Web ACL {acl.name}."
-                            break
+                for acl in wafregional_client.web_acls.values():
+                    if lb.arn in acl.albs:
+                        report.status = "PASS"
+                        report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv1 Web ACL {acl.name}."
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached.py
+++ b/prowler/providers/aws/services/elbv2/elbv2_waf_acl_attached/elbv2_waf_acl_attached.py
@@ -18,10 +18,13 @@ class elbv2_waf_acl_attached(Check):
                     if lb.arn in acl.albs:
                         report.status = "PASS"
                         report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv2 Web ACL {acl.name}."
-                for acl in wafregional_client.web_acls.values():
-                    if lb.arn in acl.albs:
-                        report.status = "PASS"
-                        report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv1 Web ACL {acl.name}."
+                        break
+                if report.status == "FAIL":
+                    for acl in wafregional_client.web_acls.values():
+                        if lb.arn in acl.albs:
+                            report.status = "PASS"
+                            report.status_extended = f"ELBv2 ALB {lb.name} is protected by WAFv1 Web ACL {acl.name}."
+                            break
 
                 findings.append(report)
 

--- a/prowler/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public.py
+++ b/prowler/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public.py
@@ -10,13 +10,13 @@ class kafka_cluster_is_public(Check):
             report = Check_Report_AWS(metadata=self.metadata(), resource=cluster)
             report.status = "FAIL"
             report.status_extended = (
-                f"Kafka cluster '{cluster.name}' is publicly accessible."
+                f"Kafka cluster {cluster.name} is publicly accessible."
             )
 
             if not cluster.public_access:
                 report.status = "PASS"
                 report.status_extended = (
-                    f"Kafka cluster '{cluster.name}' is not publicly accessible."
+                    f"Kafka cluster {cluster.name} is not publicly accessible."
                 )
 
             findings.append(report)

--- a/prowler/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public.py
+++ b/prowler/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public.py
@@ -13,7 +13,7 @@ class kafka_cluster_is_public(Check):
                 f"Kafka cluster '{cluster.name}' is publicly accessible."
             )
 
-            if cluster.public_access:
+            if not cluster.public_access:
                 report.status = "PASS"
                 report.status_extended = (
                     f"Kafka cluster '{cluster.name}' is not publicly accessible."

--- a/prowler/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public.py
+++ b/prowler/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public.py
@@ -13,7 +13,7 @@ class kafka_cluster_is_public(Check):
                 f"Kafka cluster '{cluster.name}' is publicly accessible."
             )
 
-            if not cluster.public_access:
+            if cluster.public_access:
                 report.status = "PASS"
                 report.status_extended = (
                     f"Kafka cluster '{cluster.name}' is not publicly accessible."

--- a/tests/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public_test.py
+++ b/tests/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public_test.py
@@ -72,10 +72,10 @@ class Test_kafka_cluster_is_public:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "Kafka cluster 'demo-cluster-1' is publicly accessible."
+                == "Kafka cluster 'demo-cluster-1' is not publicly accessible."
             )
             assert (
                 result[0].resource_arn
@@ -126,10 +126,10 @@ class Test_kafka_cluster_is_public:
             result = check.execute()
 
             assert len(result) == 1
-            assert result[0].status == "PASS"
+            assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "Kafka cluster 'demo-cluster-1' is not publicly accessible."
+                == "Kafka cluster 'demo-cluster-1' is publicly accessible."
             )
             assert (
                 result[0].resource_arn

--- a/tests/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public_test.py
+++ b/tests/providers/aws/services/kafka/kafka_cluster_is_public/kafka_cluster_is_public_test.py
@@ -75,7 +75,7 @@ class Test_kafka_cluster_is_public:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "Kafka cluster 'demo-cluster-1' is not publicly accessible."
+                == "Kafka cluster demo-cluster-1 is not publicly accessible."
             )
             assert (
                 result[0].resource_arn
@@ -129,7 +129,7 @@ class Test_kafka_cluster_is_public:
             assert result[0].status == "FAIL"
             assert (
                 result[0].status_extended
-                == "Kafka cluster 'demo-cluster-1' is publicly accessible."
+                == "Kafka cluster demo-cluster-1 is publicly accessible."
             )
             assert (
                 result[0].resource_arn


### PR DESCRIPTION
### Context

An user reported false positives in `kafka_cluster_is_public` check.
Fix #8502

### Description

Check logic has been updated to avoid false positives.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
