### PR TITLE
fix: simplify error handling to use only error.message

### DIFF
--- a/ui/app/api/lighthouse/analyst/route.ts
+++ b/ui/app/api/lighthouse/analyst/route.ts
@@ -86,14 +86,12 @@ export async function POST(req: Request) {
           }
           controller.close();
         } catch (error) {
-          const errorName =
-            error instanceof Error ? error.constructor.name : "UnknownError";
           const errorMessage =
             error instanceof Error ? error.message : String(error);
           controller.enqueue({
             id: "error-" + Date.now(),
             role: "assistant",
-            content: `[LIGHTHOUSE_ANALYST_ERROR]: ${errorName}: ${errorMessage}`,
+            content: `[LIGHTHOUSE_ANALYST_ERROR]: ${errorMessage}`,
           });
           controller.close();
         }


### PR DESCRIPTION
### Context

Error message displayed when running `npm run dev` had the error name correct. However when theres an error in the prod build, the error message would include a minified/obfuscated class name `uQ`.

<img width="774" height="154" alt="image" src="https://github.com/user-attachments/assets/ddacf7ad-febb-4567-aec5-330bb9a10d40" />

### Description

This PR removes usage of `error.constructor.name` so only error message is displayed.

<img width="761" height="142" alt="image" src="https://github.com/user-attachments/assets/b785d6e7-626e-43b1-84f9-824507473850" />

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
