### PR TITLE
feat(iam): add Bedrock AgentCore privilege escalation combo

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Certificate authentication for M365 provider [(#8404)](https://github.com/prowler-cloud/prowler/pull/8404)
 - `vm_sufficient_daily_backup_retention_period` check for Azure provider [(#8200)](https://github.com/prowler-cloud/prowler/pull/8200)
 - `vm_jit_access_enabled` check for Azure provider [(#8202)](https://github.com/prowler-cloud/prowler/pull/8202)
-- Bedrock AgentCore privilege escalation combination for AWS provider [(#8521)](https://github.com/prowler-cloud/prowler/pull/8521)
+- Bedrock AgentCore privilege escalation combination for AWS provider [(#8526)](https://github.com/prowler-cloud/prowler/pull/8526)
 
 ### Changed
 - Refine kisa isms-p compliance mapping [(#8479)](https://github.com/prowler-cloud/prowler/pull/8479)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Certificate authentication for M365 provider [(#8404)](https://github.com/prowler-cloud/prowler/pull/8404)
 - `vm_sufficient_daily_backup_retention_period` check for Azure provider [(#8200)](https://github.com/prowler-cloud/prowler/pull/8200)
 - `vm_jit_access_enabled` check for Azure provider [(#8202)](https://github.com/prowler-cloud/prowler/pull/8202)
+- Bedrock AgentCore privilege escalation combination for AWS provider [(#8521)](https://github.com/prowler-cloud/prowler/pull/8521)
 
 ### Changed
 - Refine kisa isms-p compliance mapping [(#8479)](https://github.com/prowler-cloud/prowler/pull/8479)

--- a/prowler/providers/aws/services/iam/lib/privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/lib/privilege_escalation.py
@@ -86,6 +86,12 @@ privilege_escalation_policies_combination = {
         "sts:AssumeRole",
         "iam:UpdateAssumeRolePolicy",
     },
+    # AgentCore privilege escalation patterns
+    "PassRole+AgentCoreCreateInterpreter+InvokeInterpreter": {
+        "iam:PassRole",
+        "bedrock-agentcore:CreateCodeInterpreter",
+        "bedrock-agentcore:InvokeCodeInterpreter",
+    },
     # TO-DO: We have to handle AssumeRole just if the resource is * and without conditions
     # "sts:AssumeRole": {"sts:AssumeRole"},
 }

--- a/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
@@ -1219,3 +1219,75 @@ class Test_iam_inline_policy_allows_privilege_escalation:
                         f"Inline Policy '{policy_name}' attached to role {role_arn} allows privilege escalation using the following actions:",
                         finding.status_extended,
                     )
+
+    @mock_aws
+    def test_iam_inline_role_policy_allows_privilege_escalation_agentcore(self):
+        """Test detection of AWS Bedrock AgentCore privilege escalation in inline role policy."""
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        # Create IAM Role
+        role_name = "agentcore_test_role"
+        role_arn = iam_client.create_role(
+            RoleName=role_name,
+            AssumeRolePolicyDocument=dumps(ADMINISTRATOR_ROLE_ASSUME_ROLE_POLICY),
+        )["Role"]["Arn"]
+
+        # Put Role Policy with AgentCore privilege escalation permissions
+        policy_name = "agentcore_policy"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:PassRole",
+                        "bedrock-agentcore:CreateCodeInterpreter",
+                        "bedrock-agentcore:InvokeCodeInterpreter",
+                    ],
+                    "Resource": "*",
+                }
+            ],
+        }
+        _ = iam_client.put_role_policy(
+            RoleName=role_name,
+            PolicyName=policy_name,
+            PolicyDocument=dumps(policy_document),
+        )
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_inline_policy_allows_privilege_escalation.iam_inline_policy_allows_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.iam.iam_inline_policy_allows_privilege_escalation.iam_inline_policy_allows_privilege_escalation import (
+                iam_inline_policy_allows_privilege_escalation,
+            )
+
+            check = iam_inline_policy_allows_privilege_escalation()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_id == f"{role_name}/{policy_name}"
+            assert result[0].resource_arn == role_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
+
+            assert search(
+                f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
+                result[0].status_extended,
+            )
+            assert search("iam:PassRole", result[0].status_extended)
+            assert search(
+                "bedrock-agentcore:CreateCodeInterpreter", result[0].status_extended
+            )
+            assert search(
+                "bedrock-agentcore:InvokeCodeInterpreter", result[0].status_extended
+            )

--- a/tests/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation_test.py
@@ -916,6 +916,71 @@ class Test_iam_policy_allows_privilege_escalation:
                             assert search(permission, finding.status_extended)
 
     @mock_aws
+    def test_iam_policy_allows_privilege_escalation_agentcore_passrole_create_invoke(
+        self,
+    ):
+        """Test detection of AWS Bedrock AgentCore privilege escalation pattern."""
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+        iam_client = client("iam", region_name=AWS_REGION_US_EAST_1)
+        policy_name = "agentcore_privilege_escalation_policy"
+        policy_document = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:PassRole",
+                        "bedrock-agentcore:CreateCodeInterpreter",
+                        "bedrock-agentcore:InvokeCodeInterpreter",
+                    ],
+                    "Resource": "*",
+                }
+            ],
+        }
+
+        policy_arn = iam_client.create_policy(
+            PolicyName=policy_name, PolicyDocument=dumps(policy_document)
+        )["Policy"]["Arn"]
+
+        from prowler.providers.aws.services.iam.iam_service import IAM
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=aws_provider,
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.iam.iam_policy_allows_privilege_escalation.iam_policy_allows_privilege_escalation.iam_client",
+                new=IAM(aws_provider),
+            ),
+        ):
+            # Test Check
+            from prowler.providers.aws.services.iam.iam_policy_allows_privilege_escalation.iam_policy_allows_privilege_escalation import (
+                iam_policy_allows_privilege_escalation,
+            )
+
+            check = iam_policy_allows_privilege_escalation()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_id == policy_name
+            assert result[0].resource_arn == policy_arn
+            assert result[0].region == AWS_REGION_US_EAST_1
+            assert result[0].resource_tags == []
+
+            assert search(
+                f"Custom Policy {policy_arn} allows privilege escalation using the following actions: ",
+                result[0].status_extended,
+            )
+            assert search("iam:PassRole", result[0].status_extended)
+            assert search(
+                "bedrock-agentcore:CreateCodeInterpreter", result[0].status_extended
+            )
+            assert search(
+                "bedrock-agentcore:InvokeCodeInterpreter", result[0].status_extended
+            )
+
+    @mock_aws
     def test_iam_policy_allows_privilege_escalation_iam_put(
         self,
     ):


### PR DESCRIPTION
### Context
AWS Bedrock AgentCore introduces a new privilege escalation vector that allows users with specific IAM permissions to execute arbitrary Python code and escalate privileges to full AWS account access.

The vulnerable permission combination is:
```
iam:PassRole
bedrock-agentcore:CreateCodeInterpreter
bedrock-agentcore:InvokeCodeInterpreter
```

This attack can be executed using boto3 to create and invoke code interpreters that run with elevated permissions.

### Description
Add the new combination to our priv esc checks.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
