### PR TITLE
fix(github): solve Github APP auth method

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -17,7 +17,14 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ---
 
-## [v5.10.2] (Prowler UNRELEASED)
+## [v5.10.3] (Prowler UNRELEASED)
+
+### Fixed
+- GitHub App authentication for GitHub provider [(#8529)](https://github.com/prowler-cloud/prowler/pull/8529)
+
+---
+
+## [v5.10.2] (Prowler v5.10.2)
 
 ### Fixed
 - Order requirements by ID in Prowler ThreatScore AWS compliance framework [(#8495)](https://github.com/prowler-cloud/prowler/pull/8495)

--- a/prowler/providers/github/github_provider.py
+++ b/prowler/providers/github/github_provider.py
@@ -365,8 +365,16 @@ class GithubProvider(Provider):
             elif session.id != 0 and session.key:
                 auth = Auth.AppAuth(session.id, session.key)
                 gi = GithubIntegration(auth=auth, retry=retry_config)
+                installations = []
+                for installation in gi.get_installations():
+                    installations.append(
+                        installation.raw_data.get("account", {}).get("login")
+                    )
                 try:
-                    identity = GithubAppIdentityInfo(app_id=gi.get_app().id)
+                    identity = GithubAppIdentityInfo(
+                        app_id=gi.get_app().id,
+                        installations=installations,
+                    )
                     return identity
 
                 except Exception as error:

--- a/prowler/providers/github/models.py
+++ b/prowler/providers/github/models.py
@@ -18,6 +18,7 @@ class GithubIdentityInfo(BaseModel):
 
 class GithubAppIdentityInfo(BaseModel):
     app_id: str
+    installations: list[str]
 
 
 class GithubOutputOptions(ProviderOutputOptions):

--- a/tests/lib/outputs/finding_test.py
+++ b/tests/lib/outputs/finding_test.py
@@ -585,7 +585,9 @@ class TestFinding:
         provider = MagicMock()
         provider.type = "github"
         # GitHub App identity only has app_id, not account_name/account_id
-        provider.identity = GithubAppIdentityInfo(app_id=APP_ID)
+        provider.identity = GithubAppIdentityInfo(
+            app_id=APP_ID, installations=["test-org"]
+        )
         provider.auth_method = "GitHub App Token"
 
         # Mock check result

--- a/tests/lib/outputs/html/html_test.py
+++ b/tests/lib/outputs/html/html_test.py
@@ -673,7 +673,7 @@ class TestHTML:
 
         provider = set_mocked_github_provider(
             auth_method="GitHub App Token",
-            identity=GithubAppIdentityInfo(app_id=APP_ID),
+            identity=GithubAppIdentityInfo(app_id=APP_ID, installations=["test-org"]),
         )
 
         summary = output.get_assessment_summary(provider)

--- a/tests/providers/github/github_provider_test.py
+++ b/tests/providers/github/github_provider_test.py
@@ -135,6 +135,7 @@ class TestGitHubProvider:
                 "prowler.providers.github.github_provider.GithubProvider.setup_identity",
                 return_value=GithubAppIdentityInfo(
                     app_id=APP_ID,
+                    installations=["test-org"],
                 ),
             ),
         ):
@@ -147,7 +148,9 @@ class TestGitHubProvider:
 
             assert provider._type == "github"
             assert provider.session == GithubSession(token="", id=APP_ID, key=APP_KEY)
-            assert provider.identity == GithubAppIdentityInfo(app_id=APP_ID)
+            assert provider.identity == GithubAppIdentityInfo(
+                app_id=APP_ID, installations=["test-org"]
+            )
             assert provider._audit_config == {
                 "inactive_not_archived_days_threshold": 180,
             }
@@ -206,7 +209,9 @@ class TestGitHubProvider:
             ),
             patch(
                 "prowler.providers.github.github_provider.GithubProvider.setup_identity",
-                return_value=GithubAppIdentityInfo(app_id=APP_ID),
+                return_value=GithubAppIdentityInfo(
+                    app_id=APP_ID, installations=["test-org"]
+                ),
             ),
         ):
             connection = GithubProvider.test_connection(


### PR DESCRIPTION
### Description

The previous methods for discovering App installations were unreliable, leading to persistent `401 Unauthorized` errors with GraphQL.

The final solution centralizes the discovery logic within the `GithubProvider.setup_identity` method. It now reliably determines which organizations/accounts the app is installed in by:

- Calling `gi.get_installations()` to get the list of installation objects.
- Accessing the `installation.raw_data` attribute to directly parse the account login from the raw API response.
- Storing this discovered list of installations in the `GithubAppIdentityInfo` object.

This change allows users to authenticate as a GitHub App without needing to manually specify which organizations to scan, significantly improving the user experience.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
