### PR TITLE
feat(iam): remove standalone iam:PassRole from privesc detection and add missing patterns

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `vm_sufficient_daily_backup_retention_period` check for Azure provider [(#8200)](https://github.com/prowler-cloud/prowler/pull/8200)
 - `vm_jit_access_enabled` check for Azure provider [(#8202)](https://github.com/prowler-cloud/prowler/pull/8202)
 - Bedrock AgentCore privilege escalation combination for AWS provider [(#8526)](https://github.com/prowler-cloud/prowler/pull/8526)
+- Remove standalone iam:PassRole from privesc detection and add missing patterns [(#8530)](https://github.com/prowler-cloud/prowler/pull/8530)
 
 ### Changed
 - Refine kisa isms-p compliance mapping [(#8479)](https://github.com/prowler-cloud/prowler/pull/8479)

--- a/prowler/providers/aws/services/iam/lib/privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/lib/privilege_escalation.py
@@ -24,7 +24,6 @@ privilege_escalation_policies_combination = {
     "IAMPut": {"iam:Put*"},
     "CreatePolicyVersion": {"iam:CreatePolicyVersion"},
     "SetDefaultPolicyVersion": {"iam:SetDefaultPolicyVersion"},
-    "iam:PassRole": {"iam:PassRole"},
     "PassRole+EC2": {
         "iam:PassRole",
         "ec2:RunInstances",
@@ -69,6 +68,21 @@ privilege_escalation_policies_combination = {
     },
     "GlueUpdateDevEndpoint": {"glue:UpdateDevEndpoint"},
     "lambda:UpdateFunctionCode": {"lambda:UpdateFunctionCode"},
+    "lambda:UpdateFunctionConfiguration": {"lambda:UpdateFunctionConfiguration"},
+    "PassRole+CodeStar": {
+        "iam:PassRole",
+        "codestar:CreateProject",
+    },
+    "PassRole+CreateAutoScaling": {
+        "iam:PassRole",
+        "autoscaling:CreateAutoScalingGroup",
+        "autoscaling:CreateLaunchConfiguration",
+    },
+    "PassRole+UpdateAutoScaling": {
+        "iam:PassRole",
+        "autoscaling:UpdateAutoScalingGroup",
+        "autoscaling:CreateLaunchConfiguration",
+    },
     "iam:CreateAccessKey": {"iam:CreateAccessKey"},
     "iam:CreateLoginProfile": {"iam:CreateLoginProfile"},
     "iam:UpdateLoginProfile": {"iam:UpdateLoginProfile"},

--- a/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/iam_inline_policy_allows_privilege_escalation_test.py
@@ -362,17 +362,16 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             check = iam_inline_policy_allows_privilege_escalation()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_name} does not allow privilege escalation",
                 result[0].status_extended,
             )
-            assert search("iam:PassRole", result[0].status_extended)
 
     @mock_aws
     def test_iam_inline_policy_allows_privilege_escalation_two_combinations(
@@ -511,17 +510,16 @@ class Test_iam_inline_policy_allows_privilege_escalation:
             check = iam_inline_policy_allows_privilege_escalation()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert result[0].resource_id == f"test_role/{policy_name}"
             assert result[0].resource_arn == role_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Inline policy {policy_name} attached to role {role_name} allows privilege escalation using the following actions: ",
+                f"Inline policy {policy_name} attached to role {role_name} does not allow privilege escalation",
                 result[0].status_extended,
             )
-            assert search("iam:PassRole", result[0].status_extended)
 
     @mock_aws
     def test_iam_inline_policy_allows_privilege_escalation_policies_combination(

--- a/tests/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation_test.py
@@ -322,17 +322,16 @@ class Test_iam_policy_allows_privilege_escalation:
             check = iam_policy_allows_privilege_escalation()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert result[0].resource_id == policy_name
             assert result[0].resource_arn == policy_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Custom Policy {policy_arn} allows privilege escalation using the following actions: ",
+                f"Custom Policy {policy_arn} does not allow privilege escalation",
                 result[0].status_extended,
             )
-            assert search("iam:PassRole", result[0].status_extended)
 
     @mock_aws
     def test_iam_policy_allows_privilege_escalation_iam_PassRole_using_wildcard(
@@ -375,17 +374,16 @@ class Test_iam_policy_allows_privilege_escalation:
             check = iam_policy_allows_privilege_escalation()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert result[0].resource_id == policy_name
             assert result[0].resource_arn == policy_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Custom Policy {policy_arn} allows privilege escalation using the following actions: ",
+                f"Custom Policy {policy_arn} does not allow privilege escalation",
                 result[0].status_extended,
             )
-            assert search("iam:PassRole", result[0].status_extended)
 
     @mock_aws
     def test_iam_policy_allows_privilege_escalation_two_combinations(
@@ -508,17 +506,16 @@ class Test_iam_policy_allows_privilege_escalation:
             check = iam_policy_allows_privilege_escalation()
             result = check.execute()
             assert len(result) == 1
-            assert result[0].status == "FAIL"
+            assert result[0].status == "PASS"
             assert result[0].resource_id == policy_name
             assert result[0].resource_arn == policy_arn
             assert result[0].region == AWS_REGION_US_EAST_1
             assert result[0].resource_tags == []
 
             assert search(
-                f"Custom Policy {policy_arn} allows privilege escalation using the following actions: ",
+                f"Custom Policy {policy_arn} does not allow privilege escalation",
                 result[0].status_extended,
             )
-            assert search("iam:PassRole", result[0].status_extended)
 
     @mock_aws
     def test_iam_policy_allows_privilege_escalation_policies_combination(

--- a/tests/providers/aws/services/iam/lib/privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/lib/privilege_escalation_test.py
@@ -79,7 +79,7 @@ class Test_PrivilegeEscalation:
         result = check_privilege_escalation(policy)
         assert result == ""
 
-    def test_check_privilege_escalation_priv_escalation_iam_PassRole_using_wildcard(
+    def test_check_privilege_escalation_priv_escalation_iam_wildcard(
         self,
     ):
         policy = {
@@ -95,9 +95,8 @@ class Test_PrivilegeEscalation:
             ],
         }
         result = check_privilege_escalation(policy)
-        # iam:* should expand to include UpdateAssumeRolePolicy and other privilege escalation actions
-        assert "iam:UpdateAssumeRolePolicy" in result
-        assert "iam:CreateAccessKey" in result
+        # iam:* should expand to include PutUserPolicy and other privilege escalation actions
+        assert "iam:PutUserPolicy" in result
 
     def test_check_privilege_escalation_priv_escalation_not_action(
         self,

--- a/tests/providers/aws/services/iam/lib/privilege_escalation_test.py
+++ b/tests/providers/aws/services/iam/lib/privilege_escalation_test.py
@@ -52,7 +52,6 @@ class Test_PrivilegeEscalation:
         assert "iam:Put*" in result
         assert "iam:AddUserToGroup" in result
         assert "iam:AttachRolePolicy" in result
-        assert "iam:PassRole" in result
         assert "iam:CreateLoginProfile" in result
         assert "iam:CreateAccessKey" in result
         assert "iam:AttachGroupPolicy" in result
@@ -78,7 +77,7 @@ class Test_PrivilegeEscalation:
             ],
         }
         result = check_privilege_escalation(policy)
-        assert "iam:PassRole" in result
+        assert result == ""
 
     def test_check_privilege_escalation_priv_escalation_iam_PassRole_using_wildcard(
         self,
@@ -88,13 +87,17 @@ class Test_PrivilegeEscalation:
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Action": ["iam:*Role"],  # Should expand to include PassRole
+                    "Action": [
+                        "iam:*"
+                    ],  # Should expand to include multiple IAM actions
                     "Resource": ["*"],
                 }
             ],
         }
         result = check_privilege_escalation(policy)
-        assert "iam:PassRole" in result
+        # iam:* should expand to include UpdateAssumeRolePolicy and other privilege escalation actions
+        assert "iam:UpdateAssumeRolePolicy" in result
+        assert "iam:CreateAccessKey" in result
 
     def test_check_privilege_escalation_priv_escalation_not_action(
         self,
@@ -117,7 +120,6 @@ class Test_PrivilegeEscalation:
         assert "'iam:PutGroupPolicy'" not in result
         assert "iam:AddUserToGroup" in result
         assert "iam:AttachRolePolicy" in result
-        assert "iam:PassRole" in result
         assert "iam:CreateLoginProfile" in result
         assert "iam:CreateAccessKey" in result
         assert "iam:AttachGroupPolicy" in result


### PR DESCRIPTION
### Context
iam:PassRole is flagged as risky but shouldn't be, as it requires additional execution permissions to be exploitable.

### Description
- Remove standalone iam:PassRole
- Add missing patterns:
  - lambda:UpdateFunctionConfiguration
  - PassRole+CodeStar
  - PassRole+AutoScaling.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
