### PR TITLE
fix(aws): exact match in resource-arn filtering

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ## [v5.10.3] (Prowler UNRELEASED)
 
 ### Fixed
+- AWS resource-arn filtering [(#8533)](https://github.com/prowler-cloud/prowler/pull/8533)
 - GitHub App authentication for GitHub provider [(#8529)](https://github.com/prowler-cloud/prowler/pull/8529)
 
 ---

--- a/prowler/lib/scan_filters/scan_filters.py
+++ b/prowler/lib/scan_filters/scan_filters.py
@@ -8,7 +8,7 @@ def is_resource_filtered(resource: str, audit_resources: list) -> bool:
     Returns True if it is filtered and False if it does not match the input filters
     """
     try:
-        if resource in str(audit_resources):
+        if resource in audit_resources:
             return True
         return False
     except Exception as error:

--- a/tests/lib/scan_filters/scan_filters_test.py
+++ b/tests/lib/scan_filters/scan_filters_test.py
@@ -13,5 +13,4 @@ class Test_Scan_Filters:
         assert not is_resource_filtered(
             "arn:aws:iam::123456789012:user/test1", audit_resources
         )
-        assert is_resource_filtered("test_bucket", audit_resources)
         assert is_resource_filtered("arn:aws:s3:::test_bucket", audit_resources)


### PR DESCRIPTION
### Description

The `--resource-arn` filtering in Prowler uses substring matching instead of exact ARN matching, causing unintended behavior where similar ARNs are incorrectly included in scan results.

Example:

`--resource-arn "arn:aws:iam::123:policy/test_policy_2"` incorrectly matches both:
`arn:aws:iam::123:policy/test_policy` (unintended)
`arn:aws:iam::123:policy/test_policy_2 `(intended)

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
