### PR TITLE
fix(organization): list all accessible organizations

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Refine kisa isms-p compliance mapping [(#8479)](https://github.com/prowler-cloud/prowler/pull/8479)
 
 ### Fixed
-- Call error in app context for Github organization [(#8535)](https://github.com/prowler-cloud/prowler/pull/8535)
 
 ---
 
@@ -24,6 +23,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - AWS resource-arn filtering [(#8533)](https://github.com/prowler-cloud/prowler/pull/8533)
 - GitHub App authentication for GitHub provider [(#8529)](https://github.com/prowler-cloud/prowler/pull/8529)
+- List all accessible organizations in GitHub provider [(#8535)](https://github.com/prowler-cloud/prowler/pull/8535)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Refine kisa isms-p compliance mapping [(#8479)](https://github.com/prowler-cloud/prowler/pull/8479)
 
 ### Fixed
+- Call error in app context for Github organization [(#8535)](https://github.com/prowler-cloud/prowler/pull/8535)
 
 ---
 

--- a/prowler/providers/github/services/organization/organization_service.py
+++ b/prowler/providers/github/services/organization/organization_service.py
@@ -116,18 +116,13 @@ class Organization(GithubService):
                     # Only when no repositories are specified
                     if isinstance(self.provider.identity, GithubIdentityInfo):
                         orgs = client.get_user().get_orgs()
-                        if orgs.totalCount > 0:
-                            for org in orgs:
-                                self._process_organization(org, organizations)
-                        else:
-                            logger.warning("No organizations found for the user.")
+                        for org in orgs:
+                            self._process_organization(org, organizations)
                     elif isinstance(self.provider.identity, GithubAppIdentityInfo):
                         orgs = client.get_organizations()
                         if orgs.totalCount > 0:
                             for org in orgs:
                                 self._process_organization(org, organizations)
-                        else:
-                            logger.warning("No organizations found for the app.")
 
         except github.RateLimitExceededException as error:
             logger.error(f"GitHub API rate limit exceeded: {error}")


### PR DESCRIPTION
### Context

Currently we're facing the following error:
`ERROR: GitHub API error while listing organizations: 403 {"message": "Resource not accessible by integration", "documentation_url": "https://docs.github.com/rest/orgs/orgs#list-organizations-for-the-authenticated-user", "status": "403"}`

### Description

The error has been fixed making the correct calls for each context.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
