### PR TITLE
feat(iam): add ECS privilege escalation patterns to IAM checks

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `vm_jit_access_enabled` check for Azure provider [(#8202)](https://github.com/prowler-cloud/prowler/pull/8202)
 - Bedrock AgentCore privilege escalation combination for AWS provider [(#8526)](https://github.com/prowler-cloud/prowler/pull/8526)
 - Remove standalone iam:PassRole from privesc detection and add missing patterns [(#8530)](https://github.com/prowler-cloud/prowler/pull/8530)
+- ECS privilege escalation patterns (StartTask and RunTask) for AWS provider
 
 ### Changed
 - Refine kisa isms-p compliance mapping [(#8479)](https://github.com/prowler-cloud/prowler/pull/8479)

--- a/prowler/providers/aws/services/iam/lib/privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/lib/privilege_escalation.py
@@ -106,6 +106,18 @@ privilege_escalation_policies_combination = {
         "bedrock-agentcore:CreateCodeInterpreter",
         "bedrock-agentcore:InvokeCodeInterpreter",
     },
+    # ECS-based privilege escalation patterns
+    # Reference: https://labs.reversec.com/posts/2025/08/another-ecs-privilege-escalation-path
+    "PassRole+ECS+StartTask": {
+        "iam:PassRole",
+        "ecs:StartTask",
+        "ecs:RegisterContainerInstance",
+        "ecs:DeregisterContainerInstance",
+    },
+    "PassRole+ECS+RunTask": {
+        "iam:PassRole",
+        "ecs:RunTask",
+    },
     # TO-DO: We have to handle AssumeRole just if the resource is * and without conditions
     # "sts:AssumeRole": {"sts:AssumeRole"},
 }


### PR DESCRIPTION
### Context

Following the research from ReverseC Labs about ECS-based privilege escalation paths, this PR adds detection for two new privilege escalation patterns that were missing from Prowler's IAM checks.

### Description

This PR adds two new ECS-based privilege escalation patterns to detect potential security risks through ECS task execution with command overrides:

1. **PassRole+ECS+StartTask**: Detects EC2-based ECS exploitation where attackers can self-register a compromised EC2 instance to an ECS cluster and use StartTask API with command overrides to extract task credentials.

2. **PassRole+ECS+RunTask**: Detects Fargate-based ECS exploitation where attackers can use RunTask API to launch Fargate tasks with command overrides and exfiltrate task role credentials.

Reference: https://labs.reversec.com/posts/2025/08/another-ecs-privilege-escalation-path

### Checklist

- Are there new checks included in this PR? No (extending existing checks)
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.