### PR TITLE
fix(m365): only evaluate enabled users in `entra_users_mfa_capable`

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - AWS resource-arn filtering [(#8533)](https://github.com/prowler-cloud/prowler/pull/8533)
 - GitHub App authentication for GitHub provider [(#8529)](https://github.com/prowler-cloud/prowler/pull/8529)
 - List all accessible organizations in GitHub provider [(#8535)](https://github.com/prowler-cloud/prowler/pull/8535)
+- Only evaluate enabled accounts in `entra_users_mfa_capable` check [(#8544)](https://github.com/prowler-cloud/prowler/pull/8544)
 
 ---
 

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -982,6 +982,20 @@ class M365PowerShell(PowerShellSession):
         """
         return self.execute("Get-SharingPolicy | ConvertTo-Json", json_parse=True)
 
+    def get_user_account_status(self) -> dict:
+        """
+        Get User Account Status.
+
+        Retrieves the current user account status settings for Exchange Online.
+
+        Returns:
+            dict: User account status settings in JSON format.
+        """
+        return self.execute(
+            "$dict=@{}; Get-User -ResultSize Unlimited | ForEach-Object { $dict[$_.Id] = @{ AccountDisabled = $_.AccountDisabled } }; $dict | ConvertTo-Json",
+            json_parse=True,
+        )
+
 
 # This function is used to install the required M365 PowerShell modules in Docker containers
 def initialize_m365_powershell_modules():

--- a/prowler/providers/m365/services/entra/entra_users_mfa_capable/entra_users_mfa_capable.py
+++ b/prowler/providers/m365/services/entra/entra_users_mfa_capable/entra_users_mfa_capable.py
@@ -26,20 +26,21 @@ class entra_users_mfa_capable(Check):
         findings = []
 
         for user in entra_client.users.values():
-            report = CheckReportM365(
-                metadata=self.metadata(),
-                resource=user,
-                resource_name=user.name,
-                resource_id=user.id,
-            )
+            if user.account_enabled:
+                report = CheckReportM365(
+                    metadata=self.metadata(),
+                    resource=user,
+                    resource_name=user.name,
+                    resource_id=user.id,
+                )
 
-            if not user.is_mfa_capable:
-                report.status = "FAIL"
-                report.status_extended = f"User {user.name} is not MFA capable."
-            else:
-                report.status = "PASS"
-                report.status_extended = f"User {user.name} is MFA capable."
+                if not user.is_mfa_capable:
+                    report.status = "FAIL"
+                    report.status_extended = f"User {user.name} is not MFA capable."
+                else:
+                    report.status = "PASS"
+                    report.status_extended = f"User {user.name} is MFA capable."
 
-            findings.append(report)
+                findings.append(report)
 
         return findings


### PR DESCRIPTION
### Context

Currently we are evaluating disabled accounts in `entra_users_mfa_capable` check.

### Description

This behavior has been fixed to only evaluate enabled users.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
