### PR TITLE
fix: Refactor getting lighthouse config

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - DataTable column headers set to single-line [(#8480)](https://github.com/prowler-cloud/prowler/pull/8480)
+- Lighthouse using default config instead of backend config [(#8546)](https://github.com/prowler-cloud/prowler/pull/8546)
 
 ### ❌ Removed
 

--- a/ui/actions/lighthouse/lighthouse.ts
+++ b/ui/actions/lighthouse/lighthouse.ts
@@ -104,7 +104,7 @@ export const getLighthouseConfig = async () => {
 
     // Check if data array exists and has at least one item
     if (data?.data && data.data.length > 0) {
-      return data.data[0];
+      return data.data[0].attributes;
     }
 
     return undefined;

--- a/ui/app/(prowler)/lighthouse/config/page.tsx
+++ b/ui/app/(prowler)/lighthouse/config/page.tsx
@@ -5,12 +5,12 @@ import { ContentLayout } from "@/components/ui";
 export const dynamic = "force-dynamic";
 
 export default async function ChatbotConfigPage() {
-  const response = await getLighthouseConfig();
-  const initialValues = response?.attributes
+  const lighthouseConfig = await getLighthouseConfig();
+  const initialValues = lighthouseConfig
     ? {
-        model: response.attributes.model,
-        apiKey: response.attributes.api_key || "",
-        businessContext: response.attributes.business_context || "",
+        model: lighthouseConfig.model,
+        apiKey: lighthouseConfig.api_key || "",
+        businessContext: lighthouseConfig.business_context || "",
       }
     : {
         model: "gpt-4o",
@@ -18,7 +18,7 @@ export default async function ChatbotConfigPage() {
         businessContext: "",
       };
 
-  const configExists = !!response;
+  const configExists = !!lighthouseConfig;
 
   return (
     <ContentLayout title="Configure Lighthouse AI" icon="lucide:settings">

--- a/ui/app/(prowler)/lighthouse/page.tsx
+++ b/ui/app/(prowler)/lighthouse/page.tsx
@@ -4,10 +4,10 @@ import { Chat } from "@/components/lighthouse";
 import { ContentLayout } from "@/components/ui";
 
 export default async function AIChatbot() {
-  const config = await getLighthouseConfig();
+  const lighthouseConfig = await getLighthouseConfig();
 
-  const hasConfig = !!config;
-  const isActive = config?.attributes?.is_active ?? false;
+  const hasConfig = !!lighthouseConfig;
+  const isActive = lighthouseConfig.is_active ?? false;
 
   return (
     <ContentLayout title="Lighthouse AI" icon={<LighthouseIcon />}>

--- a/ui/app/api/lighthouse/analyst/route.ts
+++ b/ui/app/api/lighthouse/analyst/route.ts
@@ -25,8 +25,8 @@ export async function POST(req: Request) {
     const processedMessages = [...messages];
 
     // Get AI configuration to access business context
-    const aiConfig = await getLighthouseConfig();
-    const businessContext = aiConfig?.attributes?.business_context;
+    const lighthouseConfig = await getLighthouseConfig();
+    const businessContext = lighthouseConfig.business_context;
 
     // Get current user data
     const currentData = await getCurrentDataSection();

--- a/ui/lib/lighthouse/workflow.ts
+++ b/ui/lib/lighthouse/workflow.ts
@@ -50,22 +50,21 @@ import {
 
 export async function initLighthouseWorkflow() {
   const apiKey = await getAIKey();
-  const aiConfig = await getLighthouseConfig();
-  const modelConfig = aiConfig?.data?.attributes;
+  const lighthouseConfig = await getLighthouseConfig();
 
   // Initialize models without API keys
   const llm = new ChatOpenAI({
-    model: modelConfig?.model || "gpt-4o",
-    temperature: modelConfig?.temperature || 0,
-    maxTokens: modelConfig?.max_tokens || 4000,
+    model: lighthouseConfig.model,
+    temperature: lighthouseConfig.temperature,
+    maxTokens: lighthouseConfig.max_tokens,
     apiKey: apiKey,
     tags: ["agent"],
   });
 
   const supervisorllm = new ChatOpenAI({
-    model: modelConfig?.model || "gpt-4o",
-    temperature: modelConfig?.temperature || 0,
-    maxTokens: modelConfig?.max_tokens || 4000,
+    model: lighthouseConfig.model,
+    temperature: lighthouseConfig.temperature,
+    maxTokens: lighthouseConfig.max_tokens,
     apiKey: apiKey,
     streaming: true,
     tags: ["supervisor"],


### PR DESCRIPTION
### Context

Lighthouse config from `getLighthouseConfig()` was returned as just `data.data[0]` and the NextJS functions that consumed the response had to access config with `config?.attributes?.`. This created confusion and has led to some places using variables which were always undefined even if Lighthouse config existed.

Refactored code so Lighthouse config can be directly used.

### Description

This PR fixes using correct Lighthouse config when chatting with OpenAI.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
