### PR TITLE
fix(ui): update authorization logic to match right paths

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🐞 Fixed
 
+- Auth callback route checking working as expected [(#8556)](https://github.com/prowler-cloud/prowler/pull/8556)
 - DataTable column headers set to single-line [(#8480)](https://github.com/prowler-cloud/prowler/pull/8480)
 
 ### ❌ Removed

--- a/ui/auth.config.ts
+++ b/ui/auth.config.ts
@@ -142,18 +142,17 @@ export const authConfig = {
   callbacks: {
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user;
-      const isOnDashboard = nextUrl.pathname.startsWith("/");
       const isSignUpPage = nextUrl.pathname === "/sign-up";
+      const isSignInPage = nextUrl.pathname === "/sign-in";
 
-      // Allow access to sign-up page
-      if (isSignUpPage) return true;
+      // Allow access to sign-up and sign-in pages
+      if (isSignUpPage || isSignInPage) return true;
 
-      if (isOnDashboard) {
-        if (isLoggedIn) return true;
-        return false; // Redirect users who are not logged in to the login page
-      } else if (isLoggedIn) {
-        return Response.redirect(new URL("/", nextUrl));
+      // For all other routes, require authentication
+      if (!isLoggedIn) {
+        return false; // Will redirect to signIn page defined in pages config
       }
+
       return true;
     },
 


### PR DESCRIPTION
### Context

E2E tests fail sometimes because of a race condition when matching routes in the auth config.

### Description

- Improve the route matching: `const isOnDashboard = nextUrl.pathname.startsWith("/");` was always true even in /sign-in.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
