### PR TITLE
feat(aws): add Resource Explorer enumeration actions

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Remove standalone iam:PassRole from privesc detection and add missing patterns [(#8530)](https://github.com/prowler-cloud/prowler/pull/8530)
 - `eks_cluster_deletion_protection_enabled` check for AWS provider [(#8536)](https://github.com/prowler-cloud/prowler/pull/8536)
 - ECS privilege escalation patterns (StartTask and RunTask) for AWS provider [(#8541)](https://github.com/prowler-cloud/prowler/pull/8541)
+- Resource Explorer enumeration v2 API actions in `cloudtrail_threat_detection_enumeration` check [(#8557)](https://github.com/prowler-cloud/prowler/pull/8557)
 
 
 ### Changed

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration.py
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_threat_detection_enumeration/cloudtrail_threat_detection_enumeration.py
@@ -6,6 +6,7 @@ from prowler.providers.aws.services.cloudtrail.cloudtrail_client import (
 )
 
 default_threat_detection_enumeration_actions = [
+    "CreateIndex",
     "DescribeAccessEntry",
     "DescribeAccountAttributes",
     "DescribeAvailabilityZones",
@@ -86,6 +87,7 @@ default_threat_detection_enumeration_actions = [
     "ListOrganizationalUnitsForParent",
     "ListOriginationNumbers",
     "ListPolicyVersions",
+    "ListResources",
     "ListRoles",
     "ListRoles",
     "ListRules",


### PR DESCRIPTION
### Description

This PR enhances the CloudTrail threat detection enumeration check by adding comprehensive monitoring for Resource Explorer v2 APIs that are commonly used in reconnaissance activities.

Added the following Resource Explorer v2 API actions to the `default_threat_detection_enumeration_actions` list:

- `resource-explorer-2:ListResources` - Lists resources across AWS services
- `resource-explorer-2:CreateIndex` - Creates resource indexes for discovery
- `resource-explorer-2:Search` - Performs resource searches across the organization

The addition of these APIs aligns with recent security research highlighting Resource Explorer as a potential vector for "quiet" AWS enumeration attacks, as documented in the [Datadog Security Labs research](https://securitylabs.datadoghq.com/articles/enumerating-aws-the-quiet-way-cloudtrail-free-discovery-with-resource-explorer/).
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
