### PR TITLE
feat(sh): create asff of there is an enabled SecurityHub integration

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### Added
 - Lighthouse support for OpenAI GPT-5 [(#8527)](https://github.com/prowler-cloud/prowler/pull/8527)
 - Integration with Amazon Security Hub, enabling sending findings to Security Hub [(#8365)](https://github.com/prowler-cloud/prowler/pull/8365)
+- Generate ASFF output for AWS providers with SecurityHub integration enabled [(#8569)](https://github.com/prowler-cloud/prowler/pull/8569)
 
 ## [1.11.0] (Prowler 5.10.0)
 

--- a/api/src/backend/tasks/jobs/export.py
+++ b/api/src/backend/tasks/jobs/export.py
@@ -13,8 +13,10 @@ from api.models import Scan
 from prowler.config.config import (
     csv_file_suffix,
     html_file_suffix,
+    json_asff_file_suffix,
     json_ocsf_file_suffix,
 )
+from prowler.lib.outputs.asff.asff import ASFF
 from prowler.lib.outputs.compliance.aws_well_architected.aws_well_architected import (
     AWSWellArchitected,
 )
@@ -109,6 +111,7 @@ OUTPUT_FORMATS_MAPPING = {
         "kwargs": {},
     },
     "json-ocsf": {"class": OCSF, "suffix": json_ocsf_file_suffix, "kwargs": {}},
+    "json-asff": {"class": ASFF, "suffix": json_asff_file_suffix, "kwargs": {}},
     "html": {"class": HTML, "suffix": html_file_suffix, "kwargs": {"stats": {}}},
 }
 


### PR DESCRIPTION
### Context

This PR implements conditional generation of the ASFF (AWS Security Finding Format) output when the AWS Security Hub integration is enabled for a given AWS provider. This ensures that ASFF files are only created when relevant, optimizing output and integration behavior.

### Description

- Added the ASFF output format to the output writer mapping in ‎`export.py`.
- Updated the output generation logic in ‎`tasks.py` to:
	- Detect if the provider is AWS and if there is an enabled Security Hub integration.
	- Only generate the ASFF output when the above condition is met.
- Introduced comprehensive tests in ‎`test_tasks.py` to cover:
	- ASFF output is generated for AWS providers with Security Hub integration enabled.
	- ASFF output is not generated for AWS providers without Security Hub integration.
	- ASFF output is not generated for non-AWS providers.
- All other output formats (CSV, OCSF, etc.) remain unaffected and are always generated as before.

### Steps to review

 1. Create an AWS provider and set up both SecurityHub and S3 integrations for it, ensuring that the SecurityHub integration is enabled. Run a scan.
 2. Review the changes in ‎`export.py` to confirm the ASFF writer is correctly registered.
 3. Review the logic in ‎`tasks.py` to ensure ASFF output is only generated when appropriate.
 4. Review the new and updated tests in ‎`test_tasks.py` for coverage and correctness.
 5. Run the test suite to verify all tests pass and the new logic is covered.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
