### PR TITLE
fix(github): GitHub Personal Access Token authentication fails without `user:email` scope

### DIFF
--- a/docs/tutorials/github/getting-started-github.md
+++ b/docs/tutorials/github/getting-started-github.md
@@ -186,7 +186,10 @@ GitHub Apps provide the recommended integration method for accessing multiple re
     - **Account permissions**:
         - Email addresses (Read)
 
-4. **Generate Private Key**
+4. **Where can this GitHub App be installed?**
+    - Select "Any account" to be able to install the GitHub App in any organization.
+
+5. **Generate Private Key**
     - Scroll to the "Private keys" section after app creation
     - Click "Generate a private key"
     - Download the `.pem` file and store securely

--- a/docs/tutorials/github/getting-started-github.md
+++ b/docs/tutorials/github/getting-started-github.md
@@ -11,7 +11,7 @@ This guide explains how to set up authentication with GitHub for Prowler. The do
 
 ### 1. Personal Access Token (PAT)
 
-Personal Access Tokens provide the simplest GitHub authentication method and support individual user authentication or testing scenarios.
+Personal Access Tokens provide the simplest GitHub authentication method, but it can only access resources owned by a single user or organization.
 
 ???+ warning "Classic Tokens Deprecated"
     GitHub has deprecated Personal Access Tokens (classic) in favor of fine-grained Personal Access Tokens. We recommend using fine-grained tokens as they provide better security through more granular permissions and resource-specific access control.

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - GitHub App authentication for GitHub provider [(#8529)](https://github.com/prowler-cloud/prowler/pull/8529)
 - List all accessible organizations in GitHub provider [(#8535)](https://github.com/prowler-cloud/prowler/pull/8535)
 - Only evaluate enabled accounts in `entra_users_mfa_capable` check [(#8544)](https://github.com/prowler-cloud/prowler/pull/8544)
+- GitHub Personal Access Token authentication fails without `user:email` scope [(#8580)](https://github.com/prowler-cloud/prowler/pull/8580)
 
 ---
 

--- a/prowler/providers/github/github_provider.py
+++ b/prowler/providers/github/github_provider.py
@@ -351,11 +351,21 @@ class GithubProvider(Provider):
                 g = Github(auth=auth, retry=retry_config)
                 try:
                     user = g.get_user()
+                    # Try to get email if the token has the necessary scope
+                    account_email = None
+                    try:
+                        emails = user.get_emails()
+                        if emails:
+                            account_email = emails[0].email
+                    except Exception:
+                        # Token doesn't have user:email scope or other API error
+                        pass
+
                     identity = GithubIdentityInfo(
                         account_id=user.id,
                         account_name=user.login,
                         account_url=user.url,
-                        account_email=user.get_emails()[0].email,
+                        account_email=account_email,
                     )
                     return identity
 
@@ -405,9 +415,14 @@ class GithubProvider(Provider):
             report_lines = [
                 f"GitHub Account: {Fore.YELLOW}{self.identity.account_name}{Style.RESET_ALL}",
                 f"GitHub Account ID: {Fore.YELLOW}{self.identity.account_id}{Style.RESET_ALL}",
-                f"GitHub Account Email: {Fore.YELLOW}{self.identity.account_email}{Style.RESET_ALL}",
-                f"Authentication Method: {Fore.YELLOW}{self.auth_method}{Style.RESET_ALL}",
             ]
+            if self.identity.account_email:
+                report_lines.append(
+                    f"GitHub Account Email: {Fore.YELLOW}{self.identity.account_email}{Style.RESET_ALL}"
+                )
+            report_lines.append(
+                f"Authentication Method: {Fore.YELLOW}{self.auth_method}{Style.RESET_ALL}"
+            )
         elif isinstance(self.identity, GithubAppIdentityInfo):
             report_lines = [
                 f"GitHub App ID: {Fore.YELLOW}{self.identity.app_id}{Style.RESET_ALL}",


### PR DESCRIPTION
### Description
PAT for organizations do not include `user:email` scope and were failing.

This changes adds a try-catch block around the email retrieval to solve this issue.

### Steps to review
- Run `prowler github` with both user-scoped and org-scoped PAT.


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
