### PR TITLE
fix(sh): reset regions information if connection fails

### DIFF
--- a/api/src/backend/api/tests/test_utils.py
+++ b/api/src/backend/api/tests/test_utils.py
@@ -6,16 +6,18 @@ from rest_framework.exceptions import NotFound, ValidationError
 
 from api.db_router import MainRouter
 from api.exceptions import InvitationTokenExpiredException
-from api.models import Invitation, Provider
+from api.models import Integration, Invitation, Provider
 from api.utils import (
     get_prowler_provider_kwargs,
     initialize_prowler_provider,
     merge_dicts,
+    prowler_integration_connection_test,
     prowler_provider_connection_test,
     return_prowler_provider,
     validate_invitation,
 )
 from prowler.providers.aws.aws_provider import AwsProvider
+from prowler.providers.aws.lib.security_hub.security_hub import SecurityHubConnection
 from prowler.providers.azure.azure_provider import AzureProvider
 from prowler.providers.gcp.gcp_provider import GcpProvider
 from prowler.providers.kubernetes.kubernetes_provider import KubernetesProvider
@@ -390,3 +392,109 @@ class TestValidateInvitation:
             mock_db.get.assert_called_once_with(
                 token="VALID_TOKEN", email__iexact="user@example.com"
             )
+
+
+class TestProwlerIntegrationConnectionTest:
+    """Test prowler_integration_connection_test function for SecurityHub regions reset."""
+
+    @patch("api.utils.SecurityHub")
+    def test_security_hub_connection_failure_resets_regions(
+        self, mock_security_hub_class
+    ):
+        """Test that SecurityHub connection failure resets regions to empty dict."""
+        # Create integration with existing regions configuration
+        integration = MagicMock()
+        integration.integration_type = Integration.IntegrationChoices.AWS_SECURITY_HUB
+        integration.credentials = {
+            "aws_access_key_id": "test_key",
+            "aws_secret_access_key": "test_secret",
+        }
+        integration.configuration = {
+            "send_only_fails": True,
+            "regions": {
+                "us-east-1": True,
+                "us-west-2": True,
+                "eu-west-1": False,
+                "ap-south-1": False,
+            },
+        }
+
+        # Mock provider relationship
+        mock_provider = MagicMock()
+        mock_provider.uid = "123456789012"
+        mock_relationship = MagicMock()
+        mock_relationship.provider = mock_provider
+        integration.integrationproviderrelationship_set.first.return_value = (
+            mock_relationship
+        )
+
+        # Mock failed SecurityHub connection
+        mock_connection = SecurityHubConnection(
+            is_connected=False,
+            error=Exception("SecurityHub testing"),
+            enabled_regions=set(),
+            disabled_regions=set(),
+        )
+        mock_security_hub_class.test_connection.return_value = mock_connection
+
+        # Call the function
+        result = prowler_integration_connection_test(integration)
+
+        # Assertions
+        assert result.is_connected is False
+        assert str(result.error) == "SecurityHub testing"
+
+        # Verify regions were completely reset to empty dict
+        assert integration.configuration["regions"] == {}
+
+        # Verify save was called to persist the change
+        integration.save.assert_called_once()
+
+        # Verify test_connection was called with correct parameters
+        mock_security_hub_class.test_connection.assert_called_once_with(
+            aws_account_id="123456789012",
+            raise_on_exception=False,
+            aws_access_key_id="test_key",
+            aws_secret_access_key="test_secret",
+        )
+
+    @patch("api.utils.SecurityHub")
+    def test_security_hub_connection_success_saves_regions(
+        self, mock_security_hub_class
+    ):
+        """Test that successful SecurityHub connection saves regions correctly."""
+        integration = MagicMock()
+        integration.integration_type = Integration.IntegrationChoices.AWS_SECURITY_HUB
+        integration.credentials = {
+            "aws_access_key_id": "valid_key",
+            "aws_secret_access_key": "valid_secret",
+        }
+        integration.configuration = {"send_only_fails": False}
+
+        # Mock provider relationship
+        mock_provider = MagicMock()
+        mock_provider.uid = "123456789012"
+        mock_relationship = MagicMock()
+        mock_relationship.provider = mock_provider
+        integration.integrationproviderrelationship_set.first.return_value = (
+            mock_relationship
+        )
+
+        # Mock successful SecurityHub connection with regions
+        mock_connection = SecurityHubConnection(
+            is_connected=True,
+            error=None,
+            enabled_regions={"us-east-1", "eu-west-1"},
+            disabled_regions={"ap-south-1"},
+        )
+        mock_security_hub_class.test_connection.return_value = mock_connection
+
+        result = prowler_integration_connection_test(integration)
+
+        assert result.is_connected is True
+
+        # Verify regions were saved correctly
+        assert integration.configuration["regions"]["us-east-1"] is True
+        assert integration.configuration["regions"]["eu-west-1"] is True
+        assert integration.configuration["regions"]["ap-south-1"] is False
+        integration.save.assert_called_once()

--- a/api/src/backend/api/utils.py
+++ b/api/src/backend/api/utils.py
@@ -223,6 +223,10 @@ def prowler_integration_connection_test(integration: Integration) -> Connection:
             # Save regions information in the integration configuration
             integration.configuration["regions"] = regions_status
             integration.save()
+        else:
+            # Reset regions information if connection fails
+            integration.configuration["regions"] = {}
+            integration.save()
 
         return connection
     elif integration.integration_type == Integration.IntegrationChoices.JIRA:

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -220,6 +220,11 @@ def get_security_hub_client_from_integration(
             **credentials,
         )
         return True, security_hub
+    else:
+        # Reset regions information if connection fails
+        with rls_transaction(tenant_id):
+            integration.configuration["regions"] = {}
+            integration.save()
 
     return False, connection
 


### PR DESCRIPTION
### Context

This pull request addresses the handling of AWS Security Hub integration regions information when a connection attempt fails. Previously, if the connection to Security Hub failed, the existing regions configuration could remain outdated or misleading. This change ensures that such scenarios are handled more robustly by resetting the regions information to an empty dictionary upon any connection failure.

### Description

The main update in this PR is to reset the `regions` field in the integration configuration to an empty dictionary whenever a connection to AWS Security Hub cannot be established. This prevents the persistence of stale or incorrect region data, which could otherwise lead to confusion or misconfiguration.

- Modified `prowler_integration_connection_test` in `api/utils.py` and `get_security_hub_client_from_integration` in `tasks/jobs/integrations.py` to clear the `regions` field and save the integration when a connection test fails.
- Updated and expanded related unit tests in `api/tests/test_utils.py` and `tasks/tests/test_integrations.py` to verify that regions are properly reset on connection failure, including scenarios with pre-existing or complex regions configurations.
- Ensured that successful connections still save the correct regions information as before.

### Steps to review

1. Force a disconnection
2. check that the regions information were removed

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
