### PR TITLE
chore(ui): render attributes as markdown

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.11.1] (Prowler v5.11.1)
+
+### 🐞 Changed
+
+- Markdown rendering in finding details page [(#8604)](https://github.com/prowler-cloud/prowler/pull/8604)
+
 ## [1.11.0] (Prowler v5.11.0)
 
 ### 🚀 Added

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -14,6 +14,14 @@ import { FindingProps, ProviderType } from "@/types";
 import { Muted } from "../muted";
 import { DeltaIndicator } from "./delta-indicator";
 
+const MarkdownContainer = ({ children }: { children: string }) => {
+  return (
+    <div className="prose prose-sm max-w-none dark:prose-invert">
+      <ReactMarkdown>{children}</ReactMarkdown>
+    </div>
+  );
+};
+
 const renderValue = (value: string | null | undefined) => {
   return value && value.trim() !== "" ? value : "-";
 };
@@ -123,21 +131,17 @@ export const FindingDetail = ({
               hideCopyButton
               hideSymbol
             >
-              {/* eslint-disable-next-line */}
-              <div className="prose prose-sm max-w-none dark:prose-invert">
-                <ReactMarkdown>{attributes.check_metadata.risk}</ReactMarkdown>
-              </div>
+              <MarkdownContainer>
+                {attributes.check_metadata.risk}
+              </MarkdownContainer>
             </Snippet>
           </InfoField>
         )}
 
         <InfoField label="Description">
-          {/* eslint-disable-next-line */}
-          <div className="prose prose-sm max-w-none dark:prose-invert">
-            <ReactMarkdown>
-              {attributes.check_metadata.description}
-            </ReactMarkdown>
-          </div>
+          <MarkdownContainer>
+            {attributes.check_metadata.description}
+          </MarkdownContainer>
         </InfoField>
 
         <InfoField label="Status Extended">
@@ -154,15 +158,9 @@ export const FindingDetail = ({
             {attributes.check_metadata.remediation.recommendation.text && (
               <InfoField label="Recommendation">
                 <div className="flex flex-col gap-2">
-                  {/* eslint-disable-next-line */}
-                  <div className="prose prose-sm max-w-none dark:prose-invert">
-                    <ReactMarkdown>
-                      {
-                        attributes.check_metadata.remediation.recommendation
-                          .text
-                      }
-                    </ReactMarkdown>
-                  </div>
+                  <MarkdownContainer>
+                    {attributes.check_metadata.remediation.recommendation.text}
+                  </MarkdownContainer>
                   {attributes.check_metadata.remediation.recommendation.url && (
                     <CustomLink
                       href={
@@ -191,12 +189,9 @@ export const FindingDetail = ({
             {/* Additional Resources section */}
             {attributes.check_metadata.remediation.code.other && (
               <InfoField label="Additional Resources">
-                {/* eslint-disable-next-line */}
-                <div className="prose prose-sm max-w-none dark:prose-invert">
-                  <ReactMarkdown>
-                    {attributes.check_metadata.remediation.code.other}
-                  </ReactMarkdown>
-                </div>
+                <MarkdownContainer>
+                  {attributes.check_metadata.remediation.code.other}
+                </MarkdownContainer>
               </InfoField>
             )}
           </div>

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Snippet } from "@nextui-org/react";
+import ReactMarkdown from "react-markdown";
 
 import { CodeSnippet } from "@/components/ui/code-snippet/code-snippet";
 import { CustomSection } from "@/components/ui/custom";
@@ -122,15 +123,21 @@ export const FindingDetail = ({
               hideCopyButton
               hideSymbol
             >
-              <p className="whitespace-pre-line">
-                {attributes.check_metadata.risk}
-              </p>
+              {/* eslint-disable-next-line */}
+              <div className="prose prose-sm max-w-none dark:prose-invert">
+                <ReactMarkdown>{attributes.check_metadata.risk}</ReactMarkdown>
+              </div>
             </Snippet>
           </InfoField>
         )}
 
         <InfoField label="Description">
-          {renderValue(attributes.check_metadata.description)}
+          {/* eslint-disable-next-line */}
+          <div className="prose prose-sm max-w-none dark:prose-invert">
+            <ReactMarkdown>
+              {attributes.check_metadata.description}
+            </ReactMarkdown>
+          </div>
         </InfoField>
 
         <InfoField label="Status Extended">
@@ -147,9 +154,15 @@ export const FindingDetail = ({
             {attributes.check_metadata.remediation.recommendation.text && (
               <InfoField label="Recommendation">
                 <div className="flex flex-col gap-2">
-                  <p>
-                    {attributes.check_metadata.remediation.recommendation.text}
-                  </p>
+                  {/* eslint-disable-next-line */}
+                  <div className="prose prose-sm max-w-none dark:prose-invert">
+                    <ReactMarkdown>
+                      {
+                        attributes.check_metadata.remediation.recommendation
+                          .text
+                      }
+                    </ReactMarkdown>
+                  </div>
                   {attributes.check_metadata.remediation.recommendation.url && (
                     <CustomLink
                       href={
@@ -178,12 +191,12 @@ export const FindingDetail = ({
             {/* Additional Resources section */}
             {attributes.check_metadata.remediation.code.other && (
               <InfoField label="Additional Resources">
-                <CustomLink
-                  href={attributes.check_metadata.remediation.code.other}
-                  size="sm"
-                >
-                  View documentation
-                </CustomLink>
+                {/* eslint-disable-next-line */}
+                <div className="prose prose-sm max-w-none dark:prose-invert">
+                  <ReactMarkdown>
+                    {attributes.check_metadata.remediation.code.other}
+                  </ReactMarkdown>
+                </div>
               </InfoField>
             )}
           </div>

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -16,7 +16,7 @@ import { DeltaIndicator } from "./delta-indicator";
 
 const MarkdownContainer = ({ children }: { children: string }) => {
   return (
-    <div className="prose prose-sm max-w-none dark:prose-invert">
+    <div className="prose prose-sm max-w-none dark:prose-invert whitespace-normal break-words">
       <ReactMarkdown>{children}</ReactMarkdown>
     </div>
   );

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -16,7 +16,7 @@ import { DeltaIndicator } from "./delta-indicator";
 
 const MarkdownContainer = ({ children }: { children: string }) => {
   return (
-    <div className="prose prose-sm max-w-none dark:prose-invert whitespace-normal break-words">
+    <div className="prose prose-sm max-w-none whitespace-normal break-words dark:prose-invert">
       <ReactMarkdown>{children}</ReactMarkdown>
     </div>
   );
@@ -186,9 +186,9 @@ export const FindingDetail = ({
               </InfoField>
             )}
 
-            {/* Additional Resources section */}
+            {/* Remediation Steps section */}
             {attributes.check_metadata.remediation.code.other && (
-              <InfoField label="Additional Resources">
+              <InfoField label="Remediation Steps">
                 <MarkdownContainer>
                   {attributes.check_metadata.remediation.code.other}
                 </MarkdownContainer>


### PR DESCRIPTION
### Context

For the new metadata specification, we need to change some parameters in the UI so they are displayed as Markdown instead of plain text.

### Description

This PR includes the necessary changes to render the required parameters as Markdown, such as risk, description, recommendation, and others.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
