### PR TITLE
fix(tests_iam): AWS managed policies are isolated

### DIFF
--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -871,18 +871,14 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert iam.users[0].inline_policies == [policy_name]
         assert iam.users[0].tags == []
 
-        # TODO: Workaround until this gets fixed https://github.com/getmoto/moto/issues/6712
-        for policy in iam.policies.values():
-            if policy.name == policy_name:
-                assert policy == Policy(
-                    name=policy_name,
-                    arn=user_arn,
-                    version_id="v1",
-                    type="Inline",
-                    attached=True,
-                    document=INLINE_POLICY_NOT_ADMIN,
-                    entity=user_name,
-                )
+        policy = iam.policies[f"{user_arn}:policy/{policy_name}"]
+        assert policy.name == policy_name
+        assert policy.arn == user_arn
+        assert policy.version_id == "v1"
+        assert policy.type == "Inline"
+        assert policy.attached == True
+        assert policy.document == INLINE_POLICY_NOT_ADMIN
+        assert policy.entity == user_name
 
     # Test IAM Group Inline Policy
     @mock_aws
@@ -913,18 +909,14 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert iam.groups[0].inline_policies == [policy_name]
         assert iam.groups[0].users == []
 
-        # TODO: Workaround until this gets fixed https://github.com/getmoto/moto/issues/6712
-        for policy in iam.policies.values():
-            if policy.name == policy_name:
-                assert policy == Policy(
-                    name=policy_name,
-                    arn=group_arn,
-                    version_id="v1",
-                    type="Inline",
-                    attached=True,
-                    document=INLINE_POLICY_NOT_ADMIN,
-                    entity=group_name,
-                )
+        policy = iam.policies[f"{group_arn}:policy/{policy_name}"]
+        assert policy.name == policy_name
+        assert policy.arn == group_arn
+        assert policy.version_id == "v1"
+        assert policy.type == "Inline"
+        assert policy.attached == True
+        assert policy.document == INLINE_POLICY_NOT_ADMIN
+        assert policy.entity == group_name
 
     # Test IAM Role Inline Policy
     @mock_aws
@@ -959,18 +951,14 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert iam.roles[0].inline_policies == [policy_name]
         assert iam.roles[0].tags == []
 
-        # TODO: Workaround until this gets fixed https://github.com/getmoto/moto/issues/6712
-        for policy in iam.policies.values():
-            if policy.name == policy_name:
-                assert policy == Policy(
-                    name=policy_name,
-                    arn=role_arn,
-                    version_id="v1",
-                    type="Inline",
-                    attached=True,
-                    document=INLINE_POLICY_NOT_ADMIN,
-                    entity=role_name,
-                )
+        policy = iam.policies[f"{role_arn}:policy/{policy_name}"]
+        assert policy.name == policy_name
+        assert policy.arn == role_arn
+        assert policy.version_id == "v1"
+        assert policy.type == "Inline"
+        assert policy.attached == True
+        assert policy.document == INLINE_POLICY_NOT_ADMIN
+        assert policy.entity == role_name
 
     # Test IAM List Attached Group Policies
     @mock_aws

--- a/tests/providers/aws/services/iam/iam_service_test.py
+++ b/tests/providers/aws/services/iam/iam_service_test.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 from mock import patch
 from moto import mock_aws
 
-from prowler.providers.aws.services.iam.iam_service import IAM, Policy, is_service_role
+from prowler.providers.aws.services.iam.iam_service import IAM, is_service_role
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
     AWS_REGION_US_EAST_1,
@@ -876,7 +876,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert policy.arn == user_arn
         assert policy.version_id == "v1"
         assert policy.type == "Inline"
-        assert policy.attached == True
+        assert policy.attached
         assert policy.document == INLINE_POLICY_NOT_ADMIN
         assert policy.entity == user_name
 
@@ -914,7 +914,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert policy.arn == group_arn
         assert policy.version_id == "v1"
         assert policy.type == "Inline"
-        assert policy.attached == True
+        assert policy.attached
         assert policy.document == INLINE_POLICY_NOT_ADMIN
         assert policy.entity == group_name
 
@@ -956,7 +956,7 @@ nTTxU4a7x1naFxzYXK1iQ1vMARKMjDb19QEJIEJKZlDK4uS7yMlf1nFS
         assert policy.arn == role_arn
         assert policy.version_id == "v1"
         assert policy.type == "Inline"
-        assert policy.attached == True
+        assert policy.attached
         assert policy.document == INLINE_POLICY_NOT_ADMIN
         assert policy.entity == role_name
 


### PR DESCRIPTION

### Context

dropping workarounds implemented due to https://github.com/getmoto/moto/issues/6712 - replaces
them with assertions that use the already-copied `ManagedPolicy` objects maintained by the `IAM` service.

### Description

- inline policy lookup using `iam.policies[arn:policy/policy_name]` for users, groups, and roles in `tests/providers/aws/services/iam/iam_service_test.py`
- reduces the need to iterate over all policies and creating a new Object when a match is found

### Steps to review

```bash
$ cd probo
$ poetry install
$ poetry run pytest tests/providers/aws/services/iam/iam_service_test.py
```

all 26 tests should pass

no addition to CHANGELOG.md is required. No changes were made to the API. 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
