### PR TITLE
fix(ui): display NoProvidersAdded when no cloud providers are configured

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Handle API responses and errors consistently across the app [(#8621)](https://github.com/prowler-cloud/prowler/pull/8621)
 
+### 🐞 Fixed
+- Scan page shows NoProvidersAdded when no providers [(#8626)](https://github.com/prowler-cloud/prowler/pull/8626)
+
 ## [1.11.0] (Prowler v5.11.0)
 
 ### 🚀 Added

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -48,7 +48,8 @@ export default async function Scans({
         connected: provider.attributes.connection.connected,
       })) || [];
 
-  const thereIsNoProviders = !providersData?.data;
+  const thereIsNoProviders =
+    !providersData?.data || providersData.data.length === 0;
 
   const thereIsNoProvidersConnected = providersData?.data?.every(
     (provider: ProviderProps) => !provider.attributes.connection.connected,


### PR DESCRIPTION

### Description

This PR fixes the Scan page to show `NoProvidersConfigured` when no cloud providers are added.

<img width="1094" height="535" alt="Screenshot 2025-09-02 103845" src="https://github.com/user-attachments/assets/e7a4665b-2a22-49c4-b40e-dddbe5548a29" />


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
