### PR TITLE
fix(gcp): Updated iam_audit_logs_enabled to check for default configuration

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ## [v5.11.1] (Prowler UNRELEASED)
 
 ### Fixed
+- `iam_audit_logs_enabled` check for GCP provider [(#8633)](https://github.com/prowler-cloud/prowler/pull/8633)
 
 ---
 

--- a/prowler/providers/gcp/services/cloudresourcemanager/cloudresourcemanager_service.py
+++ b/prowler/providers/gcp/services/cloudresourcemanager/cloudresourcemanager_service.py
@@ -24,9 +24,9 @@ class CloudResourceManager(GCPService):
                     .getIamPolicy(resource=project_id)
                     .execute(num_retries=DEFAULT_RETRY_ATTEMPTS)
                 )
-                audit_logging = False
+                audit_logging = []
                 if policy.get("auditConfigs"):
-                    audit_logging = True
+                    audit_logging = policy.get("auditConfigs")
                 self.cloud_resource_manager_projects.append(
                     Project(id=project_id, audit_logging=audit_logging)
                 )
@@ -71,7 +71,7 @@ class Binding(BaseModel):
 
 class Project(BaseModel):
     id: str
-    audit_logging: bool
+    audit_logging: list
 
 
 class Organization(BaseModel):

--- a/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
+++ b/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
@@ -14,13 +14,28 @@ class iam_audit_logs_enabled(Check):
                 project_id=project.id,
                 location=cloudresourcemanager_client.region,
             )
-            report.status = "PASS"
-            report.status_extended = f"Audit Logs are enabled for project {project.id}."
-            if not project.audit_logging:
-                report.status = "FAIL"
-                report.status_extended = (
-                    f"Audit Logs are not enabled for project {project.id}."
-                )
+            report.status = "FAIL"
+            report.status_extended = (
+                f"Default Audit Logs are not enabled for project {project.id}."
+            )
+            if project.audit_logging != []:
+                for policy in project.audit_logging:
+                    DEFAULT_AUDIT_LOGS = [
+                        "ADMIN_READ",
+                        "DATA_READ",
+                        "DATA_WRITE",
+                    ]
+                    if policy.get("service") == "allServices" and all(
+                        log
+                        in [
+                            log_config.get("logType")
+                            for log_config in policy.get("auditLogConfigs", [])
+                        ]
+                        for log in DEFAULT_AUDIT_LOGS
+                    ):
+                        report.status = "PASS"
+                        report.status_extended = f"Default Audit Logs are enabled for all services in project {project.id}."
+                        break
             findings.append(report)
 
         return findings

--- a/tests/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled_test.py
+++ b/tests/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled_test.py
@@ -35,7 +35,19 @@ class Test_iam_audit_logs_enabled:
             Project,
         )
 
-        project1 = Project(id=GCP_PROJECT_ID, audit_logging=True)
+        project1 = Project(
+            id=GCP_PROJECT_ID,
+            audit_logging=[
+                {
+                    "service": "allServices",
+                    "auditLogConfigs": [
+                        {"logType": "ADMIN_READ"},
+                        {"logType": "DATA_READ"},
+                        {"logType": "DATA_WRITE"},
+                    ],
+                }
+            ],
+        )
 
         cloudresourcemanager_client = mock.MagicMock()
         cloudresourcemanager_client.project_ids = [GCP_PROJECT_ID]
@@ -72,7 +84,7 @@ class Test_iam_audit_logs_enabled:
             for idx, r in enumerate(result):
                 assert r.status == "PASS"
                 assert search(
-                    "Audit Logs are enabled for project",
+                    "Default Audit Logs are enabled for all services in project",
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID
@@ -85,7 +97,18 @@ class Test_iam_audit_logs_enabled:
             Project,
         )
 
-        project1 = Project(id=GCP_PROJECT_ID, audit_logging=False)
+        project1 = Project(
+            id=GCP_PROJECT_ID,
+            audit_logging=[
+                {
+                    "service": "allServices",
+                    "auditLogConfigs": [
+                        {"logType": "ADMIN_READ"},
+                        # Missing DATA_READ and DATA_WRITE
+                    ],
+                }
+            ],
+        )
 
         cloudresourcemanager_client = mock.MagicMock()
         cloudresourcemanager_client.project_ids = [GCP_PROJECT_ID]
@@ -122,7 +145,7 @@ class Test_iam_audit_logs_enabled:
             for idx, r in enumerate(result):
                 assert r.status == "FAIL"
                 assert search(
-                    "Audit Logs are not enabled for project",
+                    "Default Audit Logs are not enabled for project",
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID
@@ -135,7 +158,19 @@ class Test_iam_audit_logs_enabled:
             Project,
         )
 
-        project1 = Project(id=GCP_PROJECT_ID, audit_logging=True)
+        project1 = Project(
+            id=GCP_PROJECT_ID,
+            audit_logging=[
+                {
+                    "service": "allServices",
+                    "auditLogConfigs": [
+                        {"logType": "ADMIN_READ"},
+                        {"logType": "DATA_READ"},
+                        {"logType": "DATA_WRITE"},
+                    ],
+                }
+            ],
+        )
 
         cloudresourcemanager_client = mock.MagicMock()
         cloudresourcemanager_client.project_ids = [GCP_PROJECT_ID]
@@ -172,7 +207,7 @@ class Test_iam_audit_logs_enabled:
             for idx, r in enumerate(result):
                 assert r.status == "PASS"
                 assert search(
-                    "Audit Logs are enabled for project",
+                    "Default Audit Logs are enabled for all services in project",
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID
@@ -185,7 +220,7 @@ class Test_iam_audit_logs_enabled:
             Project,
         )
 
-        project1 = Project(id=GCP_PROJECT_ID, audit_logging=False)
+        project1 = Project(id=GCP_PROJECT_ID, audit_logging=[])
 
         cloudresourcemanager_client = mock.MagicMock()
         cloudresourcemanager_client.project_ids = [GCP_PROJECT_ID]
@@ -222,7 +257,7 @@ class Test_iam_audit_logs_enabled:
             for idx, r in enumerate(result):
                 assert r.status == "FAIL"
                 assert search(
-                    "Audit Logs are not enabled for project",
+                    "Default Audit Logs are not enabled for project",
                     r.status_extended,
                 )
                 assert r.resource_id == GCP_PROJECT_ID


### PR DESCRIPTION
### Context

The current check `iam_audit_logs_enabled` will pass if any audit log is enabled.
The recommended configuration is to enable audit logging for every service in GCP.
The proposed changes ensure that all audit logging is enabled for every service.

### Description

- Updated `cloudresourcemanager_service` to store the audit log configuration instead of a boolean
- Changed `iam_audit_logs_enabled` to fail by default
- Added logic to check for all 3 audit log types under `allServices`

### Steps to review

To test this change, we need to create a fresh GCP project and modify the audit log settings under IAM - Audit Logs.
#### Original
First, to test if the check passes when all audit logging is enabled
- Set the default configuration to enable all audit logs and run the check
- Notice the check passes - Expected

To test if the check fails when partial audit logging is disabled
- Set the default configuration to disable audit logs for data write
- Run the existing check and notice the check passes - Unexpected

To test if the check fails when all audit logging is disabled
- Set the default configuration to disable all audit logs and re-run the check
- Notice the check fails - Expected

To test if the check fails when only a service's audit logging is enabled
- Now enable audit logs for a single service
- Run the existing check and notice the check passes - Unexpected

#### Proposed Changes
Now we will test the proposed changes
First, to test if the check passes when all audit logging is enabled
- Set the default configuration to enable all audit logs and run the check
- Notice the check passes - Expected

To test if the check fails when partial audit logging is disabled
- Set the default configuration to disable audit logs for data write
- Run the check and notice it fails - Expected

To test if the check fails when all audit logging is disabled
**Make sure to disable the single service audit logs**
- Set the default configuration to disable all audit logs and run the check
- Notice the check fails - Expected

To test if the check fails when only a service's audit logging is enabled
- Now enable audit logs for a single service
- Run the check and notice it fails - Expected

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
