### PR TITLE
feat(jira): add color for manual status

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add more fields for the Jira ticket and handle custom fields errors [(#8601)](https://github.com/prowler-cloud/prowler/pull/8601)
 - Get Jira projects from test_connection [(#8634)](https://github.com/prowler-cloud/prowler/pull/8634)
 - `AdditionalUrls` field in CheckMetadata [(#8590)](https://github.com/prowler-cloud/prowler/pull/8590)
+- Support color for MANUAL finidngs in Jira tickets [(#8642)](https://github.com/prowler-cloud/prowler/pull/8642)
 
 ### Changed
 

--- a/prowler/lib/outputs/jira/jira.py
+++ b/prowler/lib/outputs/jira/jira.py
@@ -789,6 +789,9 @@ class Jira:
             return "#FF0000"
         if status == "MUTED":
             return "#FFA500"
+        if status == "MANUAL":
+            return "#FFFF00"
+        return "#000000"
 
     @staticmethod
     def get_severity_color(severity: str) -> str:

--- a/tests/lib/outputs/jira/jira_test.py
+++ b/tests/lib/outputs/jira/jira_test.py
@@ -976,7 +976,12 @@ class TestJiraIntegration:
 
     @pytest.mark.parametrize(
         "status, expected_color",
-        [("FAIL", "#FF0000"), ("PASS", "#008000"), ("MUTED", "#FFA500")],
+        [
+            ("FAIL", "#FF0000"),
+            ("PASS", "#008000"),
+            ("MUTED", "#FFA500"),
+            ("MANUAL", "#FFFF00"),
+        ],
     )
     def test_get_color_from_status(self, status, expected_color):
         """Test that get_color_from_status returns the correct color for a status."""


### PR DESCRIPTION
### Description

This PR handles color for `MANUAL` findings inside Jira tickets.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
