### PR TITLE
feat(login): add throttling option for the `/api/v1/tokens` endpoint

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -19,6 +19,8 @@ DJANGO_REFRESH_TOKEN_LIFETIME=1440
 DJANGO_CACHE_MAX_AGE=3600
 DJANGO_STALE_WHILE_REVALIDATE=60
 DJANGO_SECRETS_ENCRYPTION_KEY=""
+# Throttle, two options: Empty means no throttle; or if desired use one in DRF format: https://www.django-rest-framework.org/api-guide/throttling/#setting-the-throttling-policy
+DJANGO_TOKEN_OBTAIN_THROTTLE=
 # Decide whether to allow Django manage database table partitions
 DJANGO_MANAGE_DB_PARTITIONS=[True|False]
 DJANGO_CELERY_DEADLOCK_ATTEMPTS=5

--- a/api/.env.example
+++ b/api/.env.example
@@ -20,7 +20,7 @@ DJANGO_CACHE_MAX_AGE=3600
 DJANGO_STALE_WHILE_REVALIDATE=60
 DJANGO_SECRETS_ENCRYPTION_KEY=""
 # Throttle, two options: Empty means no throttle; or if desired use one in DRF format: https://www.django-rest-framework.org/api-guide/throttling/#setting-the-throttling-policy
-DJANGO_TOKEN_OBTAIN_THROTTLE=50/minute
+DJANGO_THROTTLE_TOKEN_OBTAIN=50/minute
 # Decide whether to allow Django manage database table partitions
 DJANGO_MANAGE_DB_PARTITIONS=[True|False]
 DJANGO_CELERY_DEADLOCK_ATTEMPTS=5

--- a/api/.env.example
+++ b/api/.env.example
@@ -20,7 +20,7 @@ DJANGO_CACHE_MAX_AGE=3600
 DJANGO_STALE_WHILE_REVALIDATE=60
 DJANGO_SECRETS_ENCRYPTION_KEY=""
 # Throttle, two options: Empty means no throttle; or if desired use one in DRF format: https://www.django-rest-framework.org/api-guide/throttling/#setting-the-throttling-policy
-DJANGO_TOKEN_OBTAIN_THROTTLE=
+DJANGO_TOKEN_OBTAIN_THROTTLE=50/minute
 # Decide whether to allow Django manage database table partitions
 DJANGO_MANAGE_DB_PARTITIONS=[True|False]
 DJANGO_CELERY_DEADLOCK_ATTEMPTS=5

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### Added
 - Integration with JIRA, enabling sending findings to a JIRA project [(#8622)](https://github.com/prowler-cloud/prowler/pull/8622), [(#8637)](https://github.com/prowler-cloud/prowler/pull/8637)
+- Throttling options for `/api/v1/tokens` using the `DJANGO_TOKEN_OBTAIN_THROTTLE` environment variable [(#8647)](https://github.com/prowler-cloud/prowler/pull/8647)
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### Added
 - Integration with JIRA, enabling sending findings to a JIRA project [(#8622)](https://github.com/prowler-cloud/prowler/pull/8622), [(#8637)](https://github.com/prowler-cloud/prowler/pull/8637)
 - `GET /overviews/findings_severity` now supports `filter[status]` and `filter[status__in]` to aggregate by specific statuses (`FAIL`, `PASS`)[(#8186)](https://github.com/prowler-cloud/prowler/pull/8186)
-- Throttling options for `/api/v1/tokens` using the `DJANGO_TOKEN_OBTAIN_THROTTLE` environment variable [(#8647)](https://github.com/prowler-cloud/prowler/pull/8647)
+- Throttling options for `/api/v1/tokens` using the `DJANGO_THROTTLE_TOKEN_OBTAIN` environment variable [(#8647)](https://github.com/prowler-cloud/prowler/pull/8647)
 
 ---
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -214,6 +214,8 @@ class RelationshipViewSchema(JsonApiAutoSchema):
     description="Obtain a token by providing valid credentials and an optional tenant ID.",
 )
 class CustomTokenObtainView(GenericAPIView):
+    throttle_scope = "token-obtain"
+
     resource_name = "tokens"
     serializer_class = TokenSerializer
     http_method_names = ["post"]

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -113,7 +113,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_THROTTLE_RATES": {
         "token-obtain": env("DJANGO_TOKEN_OBTAIN_THROTTLE", default=None),
-    }
+    },
 }
 
 SPECTACULAR_SETTINGS = {

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -112,7 +112,7 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.ScopedRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {
-        "token-obtain": env("DJANGO_TOKEN_OBTAIN_THROTTLE", default=None),
+        "token-obtain": env("DJANGO_THROTTLE_TOKEN_OBTAIN", default=None),
     },
 }
 

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -108,6 +108,12 @@ REST_FRAMEWORK = {
     ),
     "TEST_REQUEST_DEFAULT_FORMAT": "vnd.api+json",
     "JSON_API_UNIFORM_EXCEPTIONS": True,
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.ScopedRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "token-obtain": env("DJANGO_TOKEN_OBTAIN_THROTTLE", default=None),
+    }
 }
 
 SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
### Context

This prevents brute force attacks when there is no configuration in the reverse proxy for preventing them.

### Description

A throttling configuration has been added as documented in [DRF](https://www.django-rest-framework.org/api-guide/throttling/). Just use the `DJANGO_TOKEN_OBTAIN_THROTTLE` environment variable from the [api/.env.example](api/.env.example) file.

### Steps to review

This can be tested with any tool that can send `POST` requests. For example:
1. Configure `DJANGO_TOKEN_OBTAIN_THROTTLE` to 5 requests per minute, `5/minute`.
2. Call five times to `/api/v1/tokens` as usual to check is working.
3. Call once more just after that, it should not work and return a `429 Too many requests` with the next body:
```json
{
  "errors": [
    {
      "detail": "Request was throttled. Expected available in 57 seconds.",
      "status": "429",
      "source": {
        "pointer": "/data"
      },
      "code": "throttled"
    }
  ]
}
```
4. Wait a minute.
5. Call again to the endpoint and check it's working.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
