### PR TITLE
fix(memorydb): handle clusters with no security groups

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - TypeError from Python 3.9 in Security Hub module by updating type annotations [(#8619)](https://github.com/prowler-cloud/prowler/pull/8619)
+- KeyError when SecurityGroups field is missing in MemoryDB check [(#8666)](https://github.com/prowler-cloud/prowler/pull/8666)
 
 ---
 

--- a/prowler/providers/aws/services/memorydb/memorydb_service.py
+++ b/prowler/providers/aws/services/memorydb/memorydb_service.py
@@ -36,7 +36,7 @@ class MemoryDB(AWSService):
                                 region=regional_client.region,
                                 security_groups=[
                                     sg["SecurityGroupId"]
-                                    for sg in cluster["SecurityGroups"]
+                                    for sg in cluster.get("SecurityGroups", [])
                                     if sg["Status"] == "active"
                                 ],
                                 tls_enabled=cluster["TLSEnabled"],


### PR DESCRIPTION
### Context

This PR solve Key Error problem when we try to scan a Memory DB cluster that does not have a Security Group.

### Description

- Used a get instead of [] to ensure that when a cluster does not have Security Groups we assign an empty list.
- Added unit tests.

### Steps to review

Review code and test on infra if needed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
