### PR TITLE
fix(login): add DRF throttle option for dj-rest-auth lib

### DIFF
--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -113,6 +113,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_THROTTLE_RATES": {
         "token-obtain": env("DJANGO_THROTTLE_TOKEN_OBTAIN", default=None),
+        "dj_rest_auth": None,
     },
 }
 


### PR DESCRIPTION
### Context

Authentication via Google/GitHub (and probably SAML) is currently broken. The error is related  to missing configuration for `dj-rest-auth` in the `DEFAULT_THROTTLE_RATES`.

### Description

`dj-rest-auth` has DRF throttle configuration that has been activated with https://github.com/prowler-cloud/prowler/pull/8647. So as we need to configure it anyways, let's set it to `None`.

### Steps to review

`throttle_scope` has been search in the `site-pacakges` of the project and wasn't found but in `dj-rest-auth`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
