### PR TITLE
feat(ui): Add Prowler Hub menu item with tooltip

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🚀 Added
 
 - Jira integration[(#8640)](https://github.com/prowler-cloud/prowler/pull/8640),[(#8649)](https://github.com/prowler-cloud/prowler/pull/8649)
+- `Prowler Hub` menu item with tooltip [(#8692)] (https://github.com/prowler-cloud/prowler/pull/8692)
 
 ### 🔄 Changed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.12.1] (Prowler v5.12.1)
+
+### 🚀 Added
+
+- `Prowler Hub` menu item with tooltip [(#8692)] (https://github.com/prowler-cloud/prowler/pull/8692)
+
 ## [1.12.0] (Prowler v5.12.0)
 
 ### 🚀 Added
 
 - Jira integration[(#8640)](https://github.com/prowler-cloud/prowler/pull/8640),[(#8649)](https://github.com/prowler-cloud/prowler/pull/8649)
-- `Prowler Hub` menu item with tooltip [(#8692)] (https://github.com/prowler-cloud/prowler/pull/8692)
 
 ### 🔄 Changed
 

--- a/ui/components/ui/sidebar/menu.tsx
+++ b/ui/components/ui/sidebar/menu.tsx
@@ -105,9 +105,7 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                 className={cn(
                   "w-full",
                   groupLabel ? "pt-2" : "",
-                  menus.some((menu) => menu.label === "Prowler Hub")
-                    ? "!mt-auto"
-                    : "",
+                  index === filteredMenuList.length - 2 && "!mt-auto",
                 )}
                 key={index}
               >
@@ -143,10 +141,6 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                     target,
                     tooltip,
                   } = menu;
-                  const singleMenuItemTooltipText = isOpen
-                    ? tooltip || ""
-                    : tooltip || label || "";
-
                   return !submenus || submenus.length === 0 ? (
                     <div className="w-full" key={index}>
                       <TooltipProvider disableHoverableContent>
@@ -182,9 +176,9 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                               </Link>
                             </Button>
                           </TooltipTrigger>
-                          {singleMenuItemTooltipText && (
+                          {tooltip && (
                             <TooltipContent side="right">
-                              {singleMenuItemTooltipText}
+                              {tooltip}
                             </TooltipContent>
                           )}
                         </Tooltip>

--- a/ui/components/ui/sidebar/menu.tsx
+++ b/ui/components/ui/sidebar/menu.tsx
@@ -105,7 +105,9 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                 className={cn(
                   "w-full",
                   groupLabel ? "pt-2" : "",
-                  "last:!mt-auto",
+                  menus.some((menu) => menu.label === "Prowler Hub")
+                    ? "!mt-auto"
+                    : "",
                 )}
                 key={index}
               >
@@ -138,7 +140,12 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                     active,
                     submenus,
                     defaultOpen,
+                    target,
+                    tooltip,
                   } = menu;
+                  const singleMenuItemTooltipText = isOpen
+                    ? tooltip || ""
+                    : tooltip || label || "";
 
                   return !submenus || submenus.length === 0 ? (
                     <div className="w-full" key={index}>
@@ -156,7 +163,7 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                               className="mb-1 h-8 w-full justify-start"
                               asChild
                             >
-                              <Link href={href}>
+                              <Link href={href} target={target}>
                                 <span
                                   className={cn(isOpen === false ? "" : "mr-4")}
                                 >
@@ -175,9 +182,9 @@ export const Menu = ({ isOpen }: { isOpen: boolean }) => {
                               </Link>
                             </Button>
                           </TooltipTrigger>
-                          {isOpen === false && (
+                          {singleMenuItemTooltipText && (
                             <TooltipContent side="right">
-                              {label}
+                              {singleMenuItemTooltipText}
                             </TooltipContent>
                           )}
                         </Tooltip>

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -21,6 +21,7 @@ import {
   Warehouse,
 } from "lucide-react";
 
+import { ProwlerShort } from "@/components/icons";
 import {
   APIdocIcon,
   AWSIcon,
@@ -194,6 +195,18 @@ export const getMenuList = ({
             { href: "/invitations", label: "Invitations", icon: Mail },
           ],
           defaultOpen: false,
+        },
+      ],
+    },
+    {
+      groupLabel: "",
+      menus: [
+        {
+          href: "https://hub.prowler.com/",
+          label: "Prowler Hub",
+          icon: ProwlerShort,
+          target: "_blank",
+          tooltip: "Looking for all available checks? learn more.",
         },
       ],
     },

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -31,6 +31,8 @@ export type MenuProps = {
   icon: IconComponent;
   submenus?: SubmenuProps[];
   defaultOpen?: boolean;
+  target?: string;
+  tooltip?: string;
 };
 
 export type GroupProps = {


### PR DESCRIPTION
### Description

This PR adds a new `Prowler Hub` menu item above the `Support & Help` option in the UI.

- Added Prowler Hub menu item above Support & Help
- Added tooltip: `Looking for all available checks? learn more.`
- Opens link in a new tab (external page)

https://github.com/user-attachments/assets/445b99a0-4f0d-47ba-a906-1b3abb8ae4c7



### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.


### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
