### PR TITLE
fix(defender): change policies rules key

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -7,11 +7,11 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Added
 - Support for AdditionalURLs in outputs [(#8651)](https://github.com/prowler-cloud/prowler/pull/8651)
 - Support for markdown metadata fields in Dashboard [(#8667)](https://github.com/prowler-cloud/prowler/pull/8667)
-### Changed
-- Update AWS Neptune service metadata to new format [(#8494)](https://github.com/prowler-cloud/prowler/pull/8494)
 
 ### Changed
+- Update AWS Neptune service metadata to new format [(#8494)](https://github.com/prowler-cloud/prowler/pull/8494)
 - Update AWS Config service metadata to new format [(#8641)](https://github.com/prowler-cloud/prowler/pull/8641)
+
 ### Fixed
 
 ## [v5.12.1] (Prowler v5.12.1)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Replaced old check id with new ones for compliance files [(#8682)](https://github.com/prowler-cloud/prowler/pull/8682)
+- Replace defender rules policies key to use old name [(#8702)](https://github.com/prowler-cloud/prowler/pull/8702)
 
 ## [v5.12.0] (Prowler v5.12.0)
 

--- a/prowler/providers/m365/services/defender/defender_service.py
+++ b/prowler/providers/m365/services/defender/defender_service.py
@@ -91,7 +91,7 @@ class Defender(M365Service):
                 malware_rule = [malware_rule]
             for rule in malware_rule:
                 if rule:
-                    malware_rules[rule.get("Name", "")] = MalwareRule(
+                    malware_rules[rule.get("MalwareFilterPolicy", "")] = MalwareRule(
                         state=rule.get("State", ""),
                         priority=rule.get("Priority", 0),
                         users=rule.get("SentTo", None),
@@ -152,12 +152,14 @@ class Defender(M365Service):
                 antiphishing_rule = [antiphishing_rule]
             for rule in antiphishing_rule:
                 if rule:
-                    antiphishing_rules[rule.get("Name", "")] = AntiphishingRule(
-                        state=rule.get("State", ""),
-                        priority=rule.get("Priority", 0),
-                        users=rule.get("SentTo", None),
-                        groups=rule.get("SentToMemberOf", None),
-                        domains=rule.get("RecipientDomainIs", None),
+                    antiphishing_rules[rule.get("AntiPhishPolicy", "")] = (
+                        AntiphishingRule(
+                            state=rule.get("State", ""),
+                            priority=rule.get("Priority", 0),
+                            users=rule.get("SentTo", None),
+                            groups=rule.get("SentToMemberOf", None),
+                            domains=rule.get("RecipientDomainIs", None),
+                        )
                     )
         except Exception as error:
             logger.error(
@@ -250,7 +252,9 @@ class Defender(M365Service):
                 outbound_spam_rule = [outbound_spam_rule]
             for rule in outbound_spam_rule:
                 if rule:
-                    outbound_spam_rules[rule.get("Name", "")] = OutboundSpamRule(
+                    outbound_spam_rules[
+                        rule.get("HostedOutboundSpamFilterPolicy", "")
+                    ] = OutboundSpamRule(
                         state=rule.get("State", "Disabled"),
                         priority=rule.get("Priority", 0),
                         users=rule.get("From", None),
@@ -330,12 +334,14 @@ class Defender(M365Service):
                 inbound_spam_rule = [inbound_spam_rule]
             for rule in inbound_spam_rule:
                 if rule:
-                    inbound_spam_rules[rule.get("Name", "")] = InboundSpamRule(
-                        state=rule.get("State", "Disabled"),
-                        priority=rule.get("Priority", 0),
-                        users=rule.get("SentTo", None),
-                        groups=rule.get("SentToMemberOf", None),
-                        domains=rule.get("RecipientDomainIs", None),
+                    inbound_spam_rules[rule.get("HostedContentFilterPolicy", "")] = (
+                        InboundSpamRule(
+                            state=rule.get("State", "Disabled"),
+                            priority=rule.get("Priority", 0),
+                            users=rule.get("SentTo", None),
+                            groups=rule.get("SentToMemberOf", None),
+                            domains=rule.get("RecipientDomainIs", None),
+                        )
                     )
         except Exception as error:
             logger.error(


### PR DESCRIPTION
### Context

Microsoft 365 Defender checks were failing with KeyError when accessing policy rules using policy names. The issue occurred when:

1. Policy names were changed using PowerShell Set-AntiPhishRule -Name "New Name"
2. Microsoft Powershell cmdlet is not working as expected, because while Name and Identity fields updated correctly, the AntiPhishPolicy field retained the original name
3. Code tried to access antiphishing_rules[policy.name] using the new name, but the rule was still stored with the original name in the AntiPhishPolicy field

### Description

Modified defender_service.py to use the Old Policy Name field instead of the Name field when mapping rules.

### Steps to review

Review new code and test it with M365 policies.
### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
