### PR TITLE
fix: changelog for backport 5.12

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
-## [1.14.0] (Prowler UNRELEASED)
-
-### Added
-- Default JWT keys are generated and stored if they are missing from configuration [(#8655)](https://github.com/prowler-cloud/prowler/pull/8655)
-- `compliance_name` for each compliance [(#7920)](https://github.com/prowler-cloud/prowler/pull/7920)
-
-### Changed
-- Now the MANAGE_ACCOUNT permission is required to modify or read user permissions instead of MANAGE_USERS [(#8281)](https://github.com/prowler-cloud/prowler/pull/8281)
-- Now at least one user with MANAGE_ACCOUNT permission is required in the tenant [(#8729)](https://github.com/prowler-cloud/prowler/pull/8729)
-
----
-
 ## [1.13.1] (Prowler 5.12.2)
 
 ### Security


### PR DESCRIPTION
### Description

Fixing CHANGELOG to making it up to 5.12.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
