### PR TITLE
fix(scans): update link disable condition for findings table

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -16,6 +16,14 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ---
 
+## [1.12.2] (Prowler v5.12.3)
+
+### 🐞 Fixed
+
+- Disable "See Findings" button until scan completes [(#8762)](https://github.com/prowler-cloud/prowler/pull/8762)
+
+---
+
 ## [1.12.2] (Prowler v5.12.2)
 
 ### 🐞 Fixed

--- a/ui/components/scans/table/scans/column-get-scans.tsx
+++ b/ui/components/scans/table/scans/column-get-scans.tsx
@@ -108,7 +108,7 @@ export const ColumnGetScans: ColumnDef<ScanProps>[] = [
       return (
         <TableLink
           href={`/findings?filter[scan__in]=${id}&filter[status__in]=FAIL`}
-          isDisabled={!["completed", "executing"].includes(scanState)}
+          isDisabled={scanState !== "completed"}
           label="See Findings"
         />
       );


### PR DESCRIPTION
### Context

We need to disable the “See Findings” button on the scans page while the scan is in progress.

### Description

- Condition inside the findings table

### Steps to review

<img width="2072" height="487" alt="Screenshot 2025-09-25 at 10 08 13" src="https://github.com/user-attachments/assets/fb1ef9df-4235-4ad2-98f8-17c39b595a9a" />


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [X] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
