### PR TITLE
fix(aws): cover SNS ResourceID in Quick Inventory output

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update `moto` dependency from 5.0.28 to 5.1.11 [(#7100)](https://github.com/prowler-cloud/prowler/pull/7100)
 
 ### Fixed
+- Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)
 
 ## [v5.12.1] (Prowler v5.12.1)
 

--- a/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
+++ b/prowler/providers/aws/lib/quick_inventory/quick_inventory.py
@@ -267,6 +267,9 @@ def create_output(resources: list, provider: AwsProvider, args):
                 resource["AWS_ResourceID"] = "/".join(
                     item["arn"].split(":")[-1].split("/")[1:]
                 )
+            # Cover SNS case
+            if resource["AWS_Service"] == "sns":
+                resource["AWS_ResourceID"] = item["arn"].split(":")[-1]
             resource["AWS_Tags"] = item["tags"]
             json_output.append(resource)
 


### PR DESCRIPTION
### Context
Solves #8760

### Description
SNS topic ARNs have the format arn:aws:sns:region:account-id:topic-name (exactly 6 colon-separated parts), which didn't match the existing logic in quick_inventory.py that extracts ResourceID for services.

Solution: Added a specific case for SNS topics in the create_output function at `prowler/providers/aws/lib/quick_inventory/quick_inventory.py:270-272`

<img width="1462" height="378" alt="image" src="https://github.com/user-attachments/assets/d20e3ebc-d1d1-4b30-adc4-0fc0c6a8a713" />


### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
