### PR TITLE
chore(gha): fix e2e workflow

### DIFF
--- a/.github/workflows/ui-e2e-tests.yml
+++ b/.github/workflows/ui-e2e-tests.yml
@@ -1,6 +1,7 @@
 name: UI - E2E Tests
 
 on:
+  push:
   pull_request:
     branches:
       - master
@@ -21,6 +22,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Create API data directory with correct permissions
+        run: |
+          # Create the directory and set ownership to match container user (prowler: UID 1000)
+          mkdir -p ./_data/api
+          # Use Docker to set proper ownership, similar to how it works in EC2
+          docker run --rm -v $(pwd)/_data/api:/tmp/api_data alpine:latest chown -R 1000:1000 /tmp/api_data
+          echo "Created API data directory with UID 1000 ownership"
       - name: Start API services
         run: |
           # Override docker-compose image tag to use latest instead of stable

--- a/.github/workflows/ui-e2e-tests.yml
+++ b/.github/workflows/ui-e2e-tests.yml
@@ -1,7 +1,6 @@
 name: UI - E2E Tests
 
 on:
-  push:
   pull_request:
     branches:
       - master
@@ -22,13 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Create API data directory with correct permissions
-        run: |
-          # Create the directory and set ownership to match container user (prowler: UID 1000)
-          mkdir -p ./_data/api
-          # Use Docker to set proper ownership, similar to how it works in EC2
-          docker run --rm -v $(pwd)/_data/api:/tmp/api_data alpine:latest chown -R 1000:1000 /tmp/api_data
-          echo "Created API data directory with UID 1000 ownership"
+      - name: Fix API data directory permissions
+        run: docker run --rm -v $(pwd)/_data/api:/data alpine chown -R 1000:1000 /data
       - name: Start API services
         run: |
           # Override docker-compose image tag to use latest instead of stable


### PR DESCRIPTION
### Context

The UI E2E tests were failing in GitHub Actions due to a permission error when the API container tried to create JWT key files. The container runs as user prowler (UID 1000) but the mounted volume directory _data/api was owned by the GitHub Actions runner user (UID 1001), causing a permission denied error when writing to /home/prowler/.config/prowler-api/jwt_private.pem.
This issue only occurred in CI environments and not in local development because Docker handles volume permissions differently depending on the host environment.

### Description

This PR fixes E2E test failures by adding a step to set correct ownership of the API data directory. The step uses Docker to change the _data/api directory ownership to UID 1000, matching the container user and preventing permission errors when creating JWT key files.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
