### PR TITLE
fix: move delete user 500 error fix to its right version

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the **Prowler API** are documented in this file.
 - Now the MANAGE_ACCOUNT permission is required to modify or read user permissions instead of MANAGE_USERS [(#8281)](https://github.com/prowler-cloud/prowler/pull/8281)
 - Now at least one user with MANAGE_ACCOUNT permission is required in the tenant [(#8729)](https://github.com/prowler-cloud/prowler/pull/8729)
 
+---
+
+## [1.13.2] (Prowler 5.12.3)
+
 ### Fixed
 - 500 error when deleting user [(#8731)](https://github.com/prowler-cloud/prowler/pull/8731)
 


### PR DESCRIPTION
### Description

Setting the changelog for https://github.com/prowler-cloud/prowler/pull/8731 in its right place.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
