### PR TITLE
fix(compliance): generate file extension correctly

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)
+- Fix file extension parsing for compliance reports [(#8791)](https://github.com/prowler-cloud/prowler/pull/8791)
 
 ## [v5.12.1] (Prowler v5.12.1)
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,7 +22,15 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)
+
+---
+
+## [v5.12.4] (Prowler UNRELEASED)
+
+### Fixed
 - Fix file extension parsing for compliance reports [(#8791)](https://github.com/prowler-cloud/prowler/pull/8791)
+
+---
 
 ## [v5.12.1] (Prowler v5.12.1)
 
@@ -30,6 +38,8 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Replaced old check id with new ones for compliance files [(#8682)](https://github.com/prowler-cloud/prowler/pull/8682)
 - `firehose_stream_encrypted_at_rest` check false positives and new api call in kafka service [(#8599)](https://github.com/prowler-cloud/prowler/pull/8599)
 - Replace defender rules policies key to use old name [(#8702)](https://github.com/prowler-cloud/prowler/pull/8702)
+
+---
 
 ## [v5.12.0] (Prowler v5.12.0)
 

--- a/prowler/lib/outputs/compliance/compliance_output.py
+++ b/prowler/lib/outputs/compliance/compliance_output.py
@@ -42,7 +42,10 @@ class ComplianceOutput(Output):
         self._from_cli = from_cli
 
         if not file_extension and file_path:
-            self._file_extension = "".join(Path(file_path).suffixes)
+            # Compliance reports are always CSV, so just use the last suffix
+            # e.g., "cis_5.0_aws.csv" should have extension ".csv", not ".0_aws.csv"
+            path_obj = Path(file_path)
+            self._file_extension = path_obj.suffix if path_obj.suffix else ""
         if file_extension:
             self._file_extension = file_extension
             self.file_path = f"{file_path}{self.file_extension}"

--- a/tests/lib/outputs/compliance/compliance_test.py
+++ b/tests/lib/outputs/compliance/compliance_test.py
@@ -400,68 +400,40 @@ class TestComplianceOutput:
         """Test that ComplianceOutput correctly parses file extensions when framework names contain dots."""
         from prowler.lib.outputs.compliance.generic.generic import GenericCompliance
 
-        # Create a mock compliance object
         compliance = Compliance(
-            Framework="cis",
-            Version="5.0_aws",
-            Provider="aws",
+            Framework="CIS",
+            Version="5.0",
+            Provider="AWS",
             Name="CIS Amazon Web Services Foundations Benchmark v5.0",
             Description="Test compliance framework",
             Requirements=[],
         )
 
         # Test with problematic file path that contains dots in framework name
+        # This simulates the real scenario from Prowler App S3 integration
         problematic_file_path = "output/compliance/prowler-output-123456789012-20250101120000_cis_5.0_aws.csv"
 
-        # Create GenericCompliance object
+        # Create GenericCompliance object with file_path (no explicit file_extension)
         compliance_output = GenericCompliance(
             findings=[], compliance=compliance, file_path=problematic_file_path
         )
 
-        # Verify that the file extension is correctly parsed as ".csv" not ".0_aws.csv"
         assert compliance_output.file_extension == ".csv"
         assert compliance_output.file_extension != ".0_aws.csv"
-
-    def test_compliance_output_file_extension_simple(self):
-        """Test that ComplianceOutput correctly parses simple file extensions."""
-        from prowler.lib.outputs.compliance.generic.generic import GenericCompliance
-
-        # Create a mock compliance object
-        compliance = Compliance(
-            Framework="cis",
-            Version="1.4_aws",
-            Provider="aws",
-            Name="CIS Amazon Web Services Foundations Benchmark v1.4",
-            Description="Test compliance framework",
-            Requirements=[],
-        )
-
-        # Test with simple file path
-        simple_file_path = "output/compliance/prowler-output-123456789012-20250101120000_cis_1.4_aws.csv"
-
-        # Create GenericCompliance object
-        compliance_output = GenericCompliance(
-            findings=[], compliance=compliance, file_path=simple_file_path
-        )
-
-        # Verify that the file extension is correctly parsed as ".csv"
-        assert compliance_output.file_extension == ".csv"
 
     def test_compliance_output_file_extension_explicit(self):
         """Test that ComplianceOutput uses explicit file_extension when provided."""
         from prowler.lib.outputs.compliance.generic.generic import GenericCompliance
 
-        # Create a mock compliance object
         compliance = Compliance(
-            Framework="cis",
-            Version="5.0_aws",
-            Provider="aws",
+            Framework="CIS",
+            Version="5.0",
+            Provider="AWS",
             Name="CIS Amazon Web Services Foundations Benchmark v5.0",
             Description="Test compliance framework",
             Requirements=[],
         )
 
-        # Test with explicit file_extension
         compliance_output = GenericCompliance(
             findings=[],
             compliance=compliance,
@@ -469,5 +441,4 @@ class TestComplianceOutput:
             file_extension=".csv",
         )
 
-        # Verify that the explicit file_extension is used
         assert compliance_output.file_extension == ".csv"

--- a/tests/lib/outputs/compliance/compliance_test.py
+++ b/tests/lib/outputs/compliance/compliance_test.py
@@ -391,3 +391,83 @@ class TestCompliance:
         assert get_check_compliance(finding, "github", bulk_checks_metadata) == {
             "CIS-1.0": ["1.1.11"],
         }
+
+
+class TestComplianceOutput:
+    """Test ComplianceOutput file extension parsing fix."""
+
+    def test_compliance_output_file_extension_with_dots(self):
+        """Test that ComplianceOutput correctly parses file extensions when framework names contain dots."""
+        from prowler.lib.outputs.compliance.generic.generic import GenericCompliance
+
+        # Create a mock compliance object
+        compliance = Compliance(
+            Framework="cis",
+            Version="5.0_aws",
+            Provider="aws",
+            Name="CIS Amazon Web Services Foundations Benchmark v5.0",
+            Description="Test compliance framework",
+            Requirements=[],
+        )
+
+        # Test with problematic file path that contains dots in framework name
+        problematic_file_path = "output/compliance/prowler-output-123456789012-20250101120000_cis_5.0_aws.csv"
+
+        # Create GenericCompliance object
+        compliance_output = GenericCompliance(
+            findings=[], compliance=compliance, file_path=problematic_file_path
+        )
+
+        # Verify that the file extension is correctly parsed as ".csv" not ".0_aws.csv"
+        assert compliance_output.file_extension == ".csv"
+        assert compliance_output.file_extension != ".0_aws.csv"
+
+    def test_compliance_output_file_extension_simple(self):
+        """Test that ComplianceOutput correctly parses simple file extensions."""
+        from prowler.lib.outputs.compliance.generic.generic import GenericCompliance
+
+        # Create a mock compliance object
+        compliance = Compliance(
+            Framework="cis",
+            Version="1.4_aws",
+            Provider="aws",
+            Name="CIS Amazon Web Services Foundations Benchmark v1.4",
+            Description="Test compliance framework",
+            Requirements=[],
+        )
+
+        # Test with simple file path
+        simple_file_path = "output/compliance/prowler-output-123456789012-20250101120000_cis_1.4_aws.csv"
+
+        # Create GenericCompliance object
+        compliance_output = GenericCompliance(
+            findings=[], compliance=compliance, file_path=simple_file_path
+        )
+
+        # Verify that the file extension is correctly parsed as ".csv"
+        assert compliance_output.file_extension == ".csv"
+
+    def test_compliance_output_file_extension_explicit(self):
+        """Test that ComplianceOutput uses explicit file_extension when provided."""
+        from prowler.lib.outputs.compliance.generic.generic import GenericCompliance
+
+        # Create a mock compliance object
+        compliance = Compliance(
+            Framework="cis",
+            Version="5.0_aws",
+            Provider="aws",
+            Name="CIS Amazon Web Services Foundations Benchmark v5.0",
+            Description="Test compliance framework",
+            Requirements=[],
+        )
+
+        # Test with explicit file_extension
+        compliance_output = GenericCompliance(
+            findings=[],
+            compliance=compliance,
+            file_path="output/compliance/test",
+            file_extension=".csv",
+        )
+
+        # Verify that the explicit file_extension is used
+        assert compliance_output.file_extension == ".csv"


### PR DESCRIPTION
### Context

This PR fixes a KeyError in S3 integration when compliance framework names contain dots (e.g., cis_5.0_aws).

The root case was that Path.suffixes extracted .0_aws.csv instead of .csv for files like prowler-output_cis_5.0_aws.csv, causing KeyError when accessing extension_to_content_type[file_extension] in S3 upload.

As this is only happening when using the s3 integration, this error only occurs in Prowler App with S3 integration enabled, not in CLI.

Fixes #8753

### Description

Modified prowler/lib/outputs/compliance/compliance_output.py file to extract only the last part of the suffixes.

### Steps to review

Review the code and test the new solution to ensure is working as expected.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
