### PR TITLE
fix(m365): add framework and name for iso27001

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,12 +25,23 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)
 
+---
+
+## [v5.12.1] (Prowler v5.12.1)
+
+### Fixed
+- Add Framework and Name for ISO27001 M365 provider [(#8792)](https://github.com/prowler-cloud/prowler/pull/8792)
+
+---
+
 ## [v5.12.1] (Prowler v5.12.1)
 
 ### Fixed
 - Replaced old check id with new ones for compliance files [(#8682)](https://github.com/prowler-cloud/prowler/pull/8682)
 - `firehose_stream_encrypted_at_rest` check false positives and new api call in kafka service [(#8599)](https://github.com/prowler-cloud/prowler/pull/8599)
 - Replace defender rules policies key to use old name [(#8702)](https://github.com/prowler-cloud/prowler/pull/8702)
+
+---
 
 ## [v5.12.0] (Prowler v5.12.0)
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,23 +25,12 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)
 
----
-
-## [v5.12.1] (Prowler v5.12.1)
-
-### Fixed
-- Add Framework and Name for ISO27001 M365 provider [(#8792)](https://github.com/prowler-cloud/prowler/pull/8792)
-
----
-
 ## [v5.12.1] (Prowler v5.12.1)
 
 ### Fixed
 - Replaced old check id with new ones for compliance files [(#8682)](https://github.com/prowler-cloud/prowler/pull/8682)
 - `firehose_stream_encrypted_at_rest` check false positives and new api call in kafka service [(#8599)](https://github.com/prowler-cloud/prowler/pull/8599)
 - Replace defender rules policies key to use old name [(#8702)](https://github.com/prowler-cloud/prowler/pull/8702)
-
----
 
 ## [v5.12.0] (Prowler v5.12.0)
 

--- a/prowler/lib/outputs/compliance/iso27001/iso27001_m365.py
+++ b/prowler/lib/outputs/compliance/iso27001/iso27001_m365.py
@@ -58,6 +58,8 @@ class M365ISO27001(ComplianceOutput):
                             CheckId=finding.check_id,
                             Muted=finding.muted,
                             ResourceName=finding.resource_name,
+                            Framework=compliance.Framework,
+                            Name=compliance.Name,
                         )
                         self._data.append(compliance_row)
 
@@ -84,5 +86,7 @@ class M365ISO27001(ComplianceOutput):
                         ResourceName="Manual check",
                         CheckId="manual",
                         Muted=False,
+                        Framework=compliance.Framework,
+                        Name=compliance.Name,
                     )
                     self._data.append(compliance_row)


### PR DESCRIPTION
### Description

This PR adds missing values Framework and Name for ISO27001 - M365 

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
