### PR TITLE
chore(findings): change `References` display in UI

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Updated LangChain to latest versions with API improvements [(#8748)](https://github.com/prowler-cloud/prowler/pull/8748)
 - Migrated all page components to async `params`/`searchParams` API [(#8748)](https://github.com/prowler-cloud/prowler/pull/8748)
 - Migrated from `useFormState` to `useActionState` for React 19 compatibility [(#8748)](https://github.com/prowler-cloud/prowler/pull/8748)
+- References display in findings detail page now shows as a proper bulleted list [(#8793)](https://github.com/prowler-cloud/prowler/pull/8793)
 
 ---
 

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -209,20 +209,21 @@ export const FindingDetail = ({
             {attributes.check_metadata.additionalurls &&
               attributes.check_metadata.additionalurls.length > 0 && (
                 <InfoField label="References">
-                  <div className="flex flex-col gap-1">
+                  <ul className="list-disc list-inside space-y-1">
                     {attributes.check_metadata.additionalurls.map(
                       (link, idx) => (
-                        <CustomLink
-                          key={idx}
-                          href={link}
-                          size="sm"
-                          className="break-all whitespace-normal!"
-                        >
-                          {link}
-                        </CustomLink>
+                        <li key={idx}>
+                          <CustomLink
+                            href={link}
+                            size="sm"
+                            className="break-all whitespace-normal!"
+                          >
+                            {link}
+                          </CustomLink>
+                        </li>
                       ),
                     )}
-                  </div>
+                  </ul>
                 </InfoField>
               )}
           </div>

--- a/ui/components/findings/table/finding-detail.tsx
+++ b/ui/components/findings/table/finding-detail.tsx
@@ -209,7 +209,7 @@ export const FindingDetail = ({
             {attributes.check_metadata.additionalurls &&
               attributes.check_metadata.additionalurls.length > 0 && (
                 <InfoField label="References">
-                  <ul className="list-disc list-inside space-y-1">
+                  <ul className="list-inside list-disc space-y-1">
                     {attributes.check_metadata.additionalurls.map(
                       (link, idx) => (
                         <li key={idx}>


### PR DESCRIPTION
### Context

The AdditionalUrls field in the UI finding was displayed in a way that could be improved.

### Description

- Replaced the div with flex flex-col with a proper `<ul>` element
- Added Tailwind classes for proper list styling
- Wrapped each link in `<li>` elements to create proper list items

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
