### PR TITLE
fix(workflows): load latest SDK only for master

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -87,9 +87,9 @@ jobs:
             .github/workflows/api-pull-request.yml
           files_ignore: ${{ env.IGNORE_FILES }}
 
-      - name: Replace @master with current branch in pyproject.toml
+      - name: Replace @master with current branch in pyproject.toml - Only for pull requests to `master`
         working-directory: ./api
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true'
+        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true' && github.event_name == 'pull_request' && github.base_ref == 'master'
         run: |
           BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
           echo "Using branch: $BRANCH_NAME"
@@ -104,7 +104,7 @@ jobs:
 
       - name: Update SDK's poetry.lock resolved_reference to latest commit - Only for push events to `master`
         working-directory: ./api
-        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true' && github.event_name == 'push'
+        if: steps.are-non-ignored-files-changed.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           # Get the latest commit hash from the prowler-cloud/prowler repository
           LATEST_COMMIT=$(curl -s "https://api.github.com/repos/prowler-cloud/prowler/commits/master" | jq -r '.sha')


### PR DESCRIPTION
### Description

Change conditions on the API PR workflow:
- SDK reference in `pyproject.toml` is changed from `@master` to `@<current_branch>` when running in a PR pointing to the `master` branch.
- SDK resolved reference to point the current commit when merge in `master`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
