### PR TITLE
fix(doc): document about using the same .env as the code version

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -18,9 +18,11 @@ Valkey exposes a Redis 7.2 compliant API. Any service that exposes the Redis API
 
 # Modify environment variables
 
-Under the root path of the project, you can find a file called `.env.example`. This file shows all the environment variables that the project uses. You *must* create a new file called `.env` and set the values for the variables.
+Under the root path of the project, you can find a file called `.env`. This file shows all the environment variables that the project uses. You should review it and set the values for the variables you want to change.
 
 If you don’t set `DJANGO_TOKEN_SIGNING_KEY` or `DJANGO_TOKEN_VERIFYING_KEY`, the API will generate them at `~/.config/prowler-api/` with `0600` and `0644` permissions; back up these files to persist identity across redeploys.
+
+**Important note**: Every Prowler version (or repository branches and tags) could have different variables set in its `.env` file. Please use the `.env` file that corresponds with each version.
 
 ## Local deployment
 Keep in mind if you export the `.env` file to use it with local deployment that you will have to do it within the context of the Poetry interpreter, not before. Otherwise, variables will not be loaded properly.

--- a/docs/installation/prowler-app.md
+++ b/docs/installation/prowler-app.md
@@ -4,6 +4,9 @@ Prowler App supports multiple installation methods based on your environment.
 
 Refer to the [Prowler App Tutorial](../tutorials/prowler-app.md) for detailed usage instructions.
 
+???+ warning
+    Prowler configuration is based in `.env` files. Every version of Prowler can have differences on that file, so, please, use the file that corresponds with that version or repository branch or tag.
+
 === "Docker Compose"
 
     _Requirements_:


### PR DESCRIPTION
### Description

Just some little doc about using the same `.env` from the version of the code for avoiding any problem with mismatching configurations.

This doc fixes https://github.com/prowler-cloud/prowler/issues/8756

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
