### PR TITLE
chore(aws): enhance metadata for `awslambda` service

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - HTML output now properly renders markdown syntax in Risk and Recommendation fields [(#8727)](https://github.com/prowler-cloud/prowler/pull/8727)
 - Update `moto` dependency from 5.0.28 to 5.1.11 [(#7100)](https://github.com/prowler-cloud/prowler/pull/7100)
 - Update AWS Athena service metadata to new format [(#8790)](https://github.com/prowler-cloud/prowler/pull/8790)
+- Update AWS Lambda service metadata to new format [(#8825)](https://github.com/prowler-cloud/prowler/pull/8825)
+
 
 
 ### Fixed

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -27,8 +27,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update AWS Athena service metadata to new format [(#8790)](https://github.com/prowler-cloud/prowler/pull/8790)
 - Update AWS Lambda service metadata to new format [(#8825)](https://github.com/prowler-cloud/prowler/pull/8825)
 
-
-
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)
 - Fix HTML Markdown output for long strings [(#8803)](https://github.com/prowler-cloud/prowler/pull/8803)

--- a/prowler/providers/aws/services/awslambda/awslambda_function_inside_vpc/awslambda_function_inside_vpc.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_inside_vpc/awslambda_function_inside_vpc.metadata.json
@@ -1,29 +1,48 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_inside_vpc",
-  "CheckTitle": "Ensure AWS Lambda Functions Are Deployed Inside a VPC",
-  "CheckType": [],
+  "CheckTitle": "Lambda function is deployed inside a VPC",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "low",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "This check verifies whether an AWS Lambda function is deployed within a Virtual Private Cloud (VPC). Deploying Lambda functions inside a VPC improves security by allowing control over the network environment, reducing the exposure to public internet threats.",
-  "Risk": "Lambda functions not deployed in a VPC may expose your application to increased security risks, including unauthorized access and data breaches. Without the network isolation provided by a VPC, your Lambda functions are more vulnerable to attacks.",
-  "RelatedUrl": "https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html",
+  "Description": "**AWS Lambda function** uses **VPC networking** with specified subnets and security groups, rather than the default Lambda-managed network.\n\nPresence of a VPC association (`vpc_id`) indicates private connectivity to VPC resources.",
+  "Risk": "Without VPC attachment, functions lack network isolation and granular egress control, weakening **confidentiality** and **integrity**.\n\nTraffic must use public endpoints, raising risks of data exfiltration and SSRF via unrestricted outbound. If private databases are required, missing VPC access can impact **availability**.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html",
+    "https://docs.prowler.com/checks/aws/general-policies/ensure-that-aws-lambda-function-is-configured-inside-a-vpc-1/",
+    "https://repost.aws/pt/knowledge-center/lambda-dedicated-vpc",
+    "https://www.getorchestra.io/guides/networking-and-vpc-configurations-in-aws-lambda",
+    "https://notes.kodekloud.com/docs/AWS-Certified-Developer-Associate/Serverless/Lambda-Networking",
+    "https://www.linkedin.com/pulse/unlocking-aws-lambda-networking-guide-software-filip-konkowski-chtre",
+    "https://dev.to/chinmay13/configuring-a-lambda-function-in-a-vpc-to-access-external-api-via-nat-gateway-and-store-in-dynamodb-1b29",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html#lambda-3",
+    "https://stackoverflow.com/questions/55074793/how-can-we-force-aws-lamda-to-run-securely-in-a-vpc",
+    "https://www.techtarget.com/searchCloudComputing/answer/How-do-I-configure-AWS-Lambda-functions-in-a-VPC/",
+    "https://medium.com/@arunasilva86/how-to-use-vpc-networking-effectively-for-lambda-445abefdf8cf",
+    "https://docs.datadoghq.com/security/default_rules/9ga-poq-w7v/"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws lambda update-function-configuration --region <region-name> --function-name <function-name> --vpc-config SubnetIds=<subnet-id-1>,<subnet-id-2>,SecurityGroupIds=<security-group-id>",
-      "NativeIaC": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/function-in-vpc.html",
-      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html#lambda-3",
-      "Terraform": "https://docs.prowler.com/checks/aws/general-policies/ensure-that-aws-lambda-function-is-configured-inside-a-vpc-1/"
+      "CLI": "aws lambda update-function-configuration --function-name <example_resource_name> --vpc-config SubnetIds=<example_subnet_id>,SecurityGroupIds=<example_security_group_id>",
+      "NativeIaC": "```yaml\nAWSTemplateFormatVersion: '2010-09-09'\nResources:\n  LambdaFunction:\n    Type: AWS::Lambda::Function\n    Properties:\n      FunctionName: <example_resource_name>\n      Role: <example_role_arn>\n      Handler: index.handler\n      Runtime: python3.12\n      Code:\n        S3Bucket: <example_code_bucket>\n        S3Key: <example_code_key>\n      # Critical: Attach the function to a VPC by specifying at least one subnet and one security group\n      # This sets VpcConfig, which gives the function a VPC ID and makes the check PASS\n      VpcConfig:\n        SubnetIds:\n          - <example_subnet_id>\n        SecurityGroupIds:\n          - <example_security_group_id>\n```",
+      "Other": "1. In the AWS Lambda console, open your function\n2. Go to Configuration > VPC and click Edit\n3. Select the target VPC\n4. Choose at least one Subnet and one Security group\n5. Click Save",
+      "Terraform": "```hcl\nresource \"aws_lambda_function\" \"example\" {\n  function_name = \"<example_resource_name>\"\n  role          = \"<example_role_arn>\"\n  handler       = \"index.handler\"\n  runtime       = \"python3.12\"\n  filename      = \"<example_package.zip>\"\n\n  # Critical: VPC config attaches the function to a VPC, providing a VPC ID so the check passes\n  vpc_config {\n    subnet_ids         = [\"<example_subnet_id>\"]      # at least one subnet\n    security_group_ids = [\"<example_security_group_id>\"]\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Configure your AWS Lambda functions to operate within a Virtual Private Cloud (VPC) to enhance security and control network access.",
-      "Url": ""
+      "Text": "Attach functions to a VPC with private subnets and restrictive security groups to enforce **least privilege** and egress control.\n- Prefer **VPC endpoints** for AWS services\n- Use NAT only when necessary\n- Spread subnets across AZs for resilience\n- Govern with IAM conditions requiring `VpcIds`, `SubnetIds`, and `SecurityGroupIds`.",
+      "Url": "https://hub.prowler.com/check/awslambda_function_inside_vpc"
     }
   },
-  "Categories": [],
+  "Categories": [
+    "trust-boundaries"
+  ],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": ""

--- a/prowler/providers/aws/services/awslambda/awslambda_function_inside_vpc/awslambda_function_inside_vpc.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_inside_vpc/awslambda_function_inside_vpc.metadata.json
@@ -16,17 +16,11 @@
   "RelatedUrl": "",
   "AdditionalURLs": [
     "https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html",
-    "https://docs.prowler.com/checks/aws/general-policies/ensure-that-aws-lambda-function-is-configured-inside-a-vpc-1/",
     "https://repost.aws/pt/knowledge-center/lambda-dedicated-vpc",
-    "https://www.getorchestra.io/guides/networking-and-vpc-configurations-in-aws-lambda",
-    "https://notes.kodekloud.com/docs/AWS-Certified-Developer-Associate/Serverless/Lambda-Networking",
-    "https://www.linkedin.com/pulse/unlocking-aws-lambda-networking-guide-software-filip-konkowski-chtre",
-    "https://dev.to/chinmay13/configuring-a-lambda-function-in-a-vpc-to-access-external-api-via-nat-gateway-and-store-in-dynamodb-1b29",
+    "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/function-in-vpc.html",
     "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html#lambda-3",
     "https://stackoverflow.com/questions/55074793/how-can-we-force-aws-lamda-to-run-securely-in-a-vpc",
-    "https://www.techtarget.com/searchCloudComputing/answer/How-do-I-configure-AWS-Lambda-functions-in-a-VPC/",
-    "https://medium.com/@arunasilva86/how-to-use-vpc-networking-effectively-for-lambda-445abefdf8cf",
-    "https://docs.datadoghq.com/security/default_rules/9ga-poq-w7v/"
+    "https://www.techtarget.com/searchCloudComputing/answer/How-do-I-configure-AWS-Lambda-functions-in-a-VPC/"
   ],
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.metadata.json
@@ -1,31 +1,38 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_invoke_api_operations_cloudtrail_logging_enabled",
-  "CheckTitle": "Check if Lambda functions invoke API operations are being recorded by CloudTrail.",
-  "CheckType": [],
+  "CheckTitle": "Lambda function Invoke API calls are recorded by CloudTrail",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "TTPs/Defense Evasion/Disable Security Tools"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "low",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "Check if Lambda functions invoke API operations are being recorded by CloudTrail.",
-  "Risk": "If logs are not enabled, monitoring of service use and threat analysis is not possible.",
-  "RelatedUrl": "https://docs.aws.amazon.com/lambda/latest/dg/logging-using-cloudtrail.html",
+  "Description": "**AWS Lambda** function invocations are recorded as **CloudTrail data events** when trails include `AWS::Lambda::Function` resources.\n\nThe finding reflects whether a function's `Invoke` activity is being logged by an eligible trail.",
+  "Risk": "Without Lambda `Invoke` data events, per-invocation accountability is lost. Adversaries or misused automation can run code without an audit trail, obscuring actor, time, and source. This hinders forensics and enables covert exfiltration or unauthorized changes, impacting **confidentiality** and **integrity**.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/lambda/latest/dg/logging-using-cloudtrail.html"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "CLI": "aws cloudtrail put-event-selectors --trail-name <example_resource_name> --advanced-event-selectors '[{\"FieldSelectors\":[{\"Field\":\"eventCategory\",\"Equals\":[\"Data\"]},{\"Field\":\"resources.type\",\"Equals\":[\"AWS::Lambda::Function\"]}]}]'",
+      "NativeIaC": "```yaml\nResources:\n  <example_resource_name>:\n    Type: AWS::CloudTrail::Trail\n    Properties:\n      S3BucketName: <example_resource_name>\n      IsLogging: true\n      EventSelectors:\n        - DataResources:\n            - Type: AWS::Lambda::Function  # Critical: enables Lambda data event logging\n              Values:\n                - arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function  # Critical: logs Invoke events for all functions in the specified account/region\n```",
+      "Other": "1. In the AWS Console, go to CloudTrail > Trails\n2. Select your trail and click Edit or Event logging\n3. Under Data events, choose Add data event selector (or Edit)\n4. Select Lambda function and choose to log data events for all functions (or specify functions)\n5. Save changes",
+      "Terraform": "```hcl\nresource \"aws_cloudtrail\" \"<example_resource_name>\" {\n  name           = \"<example_resource_name>\"\n  s3_bucket_name = \"<example_resource_name>\"\n\n  event_selector {\n    data_resource {\n      type   = \"AWS::Lambda::Function\"  # Critical: enable Lambda data events\n      values = [\"arn:aws:lambda:<REGION>:<ACCOUNT_ID>:function\"]  # Critical: capture Invoke for all functions in this account/region\n    }\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Make sure you are logging information about Lambda operations. Create a lifecycle and use cases for each trail.",
-      "Url": "https://docs.aws.amazon.com/lambda/latest/dg/logging-using-cloudtrail.html"
+      "Text": "Enable **CloudTrail data event logging** for `AWS::Lambda::Function` to capture `Invoke` calls across required Regions and accounts. Apply **least privilege** selectors to scope events, centralize logs with strong retention, and integrate alerts for anomalous invokes as part of **defense in depth**.",
+      "Url": "https://hub.prowler.com/check/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled"
     }
   },
   "Categories": [
-    "forensics-ready",
-    "logging"
+    "logging",
+    "forensics-ready"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled/awslambda_function_invoke_api_operations_cloudtrail_logging_enabled.metadata.json
@@ -5,7 +5,7 @@
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices",
     "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
-    "TTPs/Defense Evasion/Disable Security Tools"
+    "TTPs/Defense Evasion"
   ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
@@ -16,7 +16,8 @@
   "Risk": "Without Lambda `Invoke` data events, per-invocation accountability is lost. Adversaries or misused automation can run code without an audit trail, obscuring actor, time, and source. This hinders forensics and enables covert exfiltration or unauthorized changes, impacting **confidentiality** and **integrity**.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.aws.amazon.com/lambda/latest/dg/logging-using-cloudtrail.html"
+    "https://docs.aws.amazon.com/lambda/latest/dg/logging-using-cloudtrail.html",
+    "https://support.icompaas.com/support/solutions/articles/62000127055-ensure-lambda-functions-invoke-api-operations-are-being-recorded-by-cloudtrail"
   ],
   "Remediation": {
     "Code": {
@@ -31,8 +32,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "forensics-ready"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code.metadata.json
@@ -1,26 +1,40 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_no_secrets_in_code",
-  "CheckTitle": "Find secrets in Lambda functions code.",
-  "CheckType": [],
+  "CheckTitle": "Lambda function code contains no hardcoded secrets",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Sensitive Data Identifications/Passwords",
+    "Effects/Data Exposure"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "critical",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "Find secrets in Lambda functions code.",
-  "Risk": "The use of a hard-coded password increases the possibility of password guessing.  If hard-coded passwords are used, it is possible that malicious users gain access through the account in question.",
-  "RelatedUrl": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
+  "Description": "**Lambda function code** is analyzed for **embedded secrets** across files in the deployment package, detecting patterns like API keys, passwords, tokens, and connection strings. Findings reference file names and line numbers where potential secrets appear.",
+  "Risk": "**Hardcoded secrets** undermine confidentiality and integrity: if code, layers, or artifacts are exposed, attackers can reuse credentials to access databases, APIs, or cloud resources, enabling data exfiltration and unauthorized changes.\n\nRotation is harder, increasing dwell time and blast radius of compromises.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html",
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html",
+    "https://aws.amazon.com/blogs/security/how-to-securely-provide-database-credentials-to-lambda-functions-by-using-aws-secrets-manager/",
+    "https://medium.com/@dhamodhar474/secrets-management-in-aws-best-practices-with-aws-secrets-manager-71f11b33a2bb",
+    "https://www.cloudcurls.com/2025/08/how-to-manage-secrets-securely-with-aws-secrets-manager.html",
+    "https://aws.amazon.com/blogs/compute/securely-retrieving-secrets-with-aws-lambda/",
+    "https://www.doppler.com/guides/aws-guides/lambda-secrets-manager",
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+  ],
   "Remediation": {
     "Code": {
       "CLI": "",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "NativeIaC": "```yaml\n# Create a secret and allow the Lambda role to read it instead of hardcoding in code\nResources:\n  <example_resource_name>:\n    Type: AWS::SecretsManager::Secret\n    Properties:\n      Name: <example_resource_name>\n      GenerateSecretString:\n        PasswordLength: 32  # Critical: creates a managed secret so code can fetch at runtime\n\n  <example_resource_name>AccessPolicy:\n    Type: AWS::IAM::Policy\n    Properties:\n      PolicyName: allow-get-secret\n      Roles:\n        - <example_resource_name>  # Lambda execution role name\n      PolicyDocument:\n        Version: \"2012-10-17\"\n        Statement:\n          - Effect: Allow\n            Action: secretsmanager:GetSecretValue  # Critical: permits runtime retrieval of the secret\n            Resource: !Ref <example_resource_name>  # Critical: restrict access to only this secret\n```",
+      "Other": "1. In AWS Secrets Manager, click Store a new secret and create a secret for the value you hardcoded. Note the secret name/ARN.\n2. In IAM > Roles, open your Lambda execution role and add an inline policy allowing secretsmanager:GetSecretValue on that secret only.\n3. Edit your Lambda function code to remove the hardcoded value and retrieve it at runtime using the AWS SDK (GetSecretValue) with the secret name/ARN.\n4. Deploy the updated function code.",
+      "Terraform": "```hcl\n# Store secret in Secrets Manager instead of hardcoding in Lambda code\nresource \"aws_secretsmanager_secret\" \"<example_resource_name>\" {\n  name = \"<example_resource_name>\"  # Critical: secret to be fetched at runtime\n}\n\n# Allow the Lambda execution role to read the secret\nresource \"aws_iam_role_policy\" \"<example_resource_name>_allow_get_secret\" {\n  name = \"allow-get-secret\"\n  role = \"<example_resource_name>\"  # Lambda execution role name\n  policy = jsonencode({\n    Version = \"2012-10-17\"\n    Statement = [{\n      Effect   = \"Allow\"\n      Action   = \"secretsmanager:GetSecretValue\"  # Critical: permits runtime retrieval\n      Resource = aws_secretsmanager_secret.<example_resource_name>.arn  # Critical: scope to this secret only\n    }]\n  })\n}\n```"
     },
     "Recommendation": {
-      "Text": "Use Secrets Manager to securely provide database credentials to Lambda functions and secure the databases as well as use the credentials to connect and query them without hardcoding the secrets in code or passing them through environmental variables.",
-      "Url": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+      "Text": "Use **AWS Secrets Manager** (or Parameter Store) to store secrets and retrieve at runtime; never put them in code or Lambda env vars.\n- Apply **least privilege** IAM\n- Enable **rotation**\n- Prevent secret logging; encrypt\n- Add CI/CD secret scanning",
+      "Url": "https://hub.prowler.com/check/awslambda_function_no_secrets_in_code"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_code/awslambda_function_no_secrets_in_code.metadata.json
@@ -16,21 +16,16 @@
   "Risk": "**Hardcoded secrets** undermine confidentiality and integrity: if code, layers, or artifacts are exposed, attackers can reuse credentials to access databases, APIs, or cloud resources, enabling data exfiltration and unauthorized changes.\n\nRotation is harder, increasing dwell time and blast radius of compromises.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html",
     "https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html",
     "https://aws.amazon.com/blogs/security/how-to-securely-provide-database-credentials-to-lambda-functions-by-using-aws-secrets-manager/",
-    "https://medium.com/@dhamodhar474/secrets-management-in-aws-best-practices-with-aws-secrets-manager-71f11b33a2bb",
-    "https://www.cloudcurls.com/2025/08/how-to-manage-secrets-securely-with-aws-secrets-manager.html",
-    "https://aws.amazon.com/blogs/compute/securely-retrieving-secrets-with-aws-lambda/",
-    "https://www.doppler.com/guides/aws-guides/lambda-secrets-manager",
-    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+    "https://www.cloudcurls.com/2025/08/how-to-manage-secrets-securely-with-aws-secrets-manager.html"
   ],
   "Remediation": {
     "Code": {
       "CLI": "",
-      "NativeIaC": "```yaml\n# Create a secret and allow the Lambda role to read it instead of hardcoding in code\nResources:\n  <example_resource_name>:\n    Type: AWS::SecretsManager::Secret\n    Properties:\n      Name: <example_resource_name>\n      GenerateSecretString:\n        PasswordLength: 32  # Critical: creates a managed secret so code can fetch at runtime\n\n  <example_resource_name>AccessPolicy:\n    Type: AWS::IAM::Policy\n    Properties:\n      PolicyName: allow-get-secret\n      Roles:\n        - <example_resource_name>  # Lambda execution role name\n      PolicyDocument:\n        Version: \"2012-10-17\"\n        Statement:\n          - Effect: Allow\n            Action: secretsmanager:GetSecretValue  # Critical: permits runtime retrieval of the secret\n            Resource: !Ref <example_resource_name>  # Critical: restrict access to only this secret\n```",
+      "NativeIaC": "",
       "Other": "1. In AWS Secrets Manager, click Store a new secret and create a secret for the value you hardcoded. Note the secret name/ARN.\n2. In IAM > Roles, open your Lambda execution role and add an inline policy allowing secretsmanager:GetSecretValue on that secret only.\n3. Edit your Lambda function code to remove the hardcoded value and retrieve it at runtime using the AWS SDK (GetSecretValue) with the secret name/ARN.\n4. Deploy the updated function code.",
-      "Terraform": "```hcl\n# Store secret in Secrets Manager instead of hardcoding in Lambda code\nresource \"aws_secretsmanager_secret\" \"<example_resource_name>\" {\n  name = \"<example_resource_name>\"  # Critical: secret to be fetched at runtime\n}\n\n# Allow the Lambda execution role to read the secret\nresource \"aws_iam_role_policy\" \"<example_resource_name>_allow_get_secret\" {\n  name = \"allow-get-secret\"\n  role = \"<example_resource_name>\"  # Lambda execution role name\n  policy = jsonencode({\n    Version = \"2012-10-17\"\n    Statement = [{\n      Effect   = \"Allow\"\n      Action   = \"secretsmanager:GetSecretValue\"  # Critical: permits runtime retrieval\n      Resource = aws_secretsmanager_secret.<example_resource_name>.arn  # Critical: scope to this secret only\n    }]\n  })\n}\n```"
+      "Terraform": ""
     },
     "Recommendation": {
       "Text": "Use **AWS Secrets Manager** (or Parameter Store) to store secrets and retrieve at runtime; never put them in code or Lambda env vars.\n- Apply **least privilege** IAM\n- Enable **rotation**\n- Prevent secret logging; encrypt\n- Add CI/CD secret scanning",

--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.metadata.json
@@ -5,7 +5,6 @@
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices",
     "Sensitive Data Identifications/Passwords",
-    "Sensitive Data Identifications/Security",
     "Effects/Data Exposure"
   ],
   "ServiceName": "awslambda",
@@ -17,9 +16,8 @@
   "Risk": "Secrets in Lambda environment variables weaken **confidentiality**: users with config read access, runtime introspection, or logs may obtain them. Exposure can grant access to downstream systems, enable **lateral movement**, and allow tampering, impacting **integrity** and **availability**.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_3",
-    "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_3#terraform",
-    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/best-practices.html",
+    "https://support.icompaas.com/support/solutions/articles/62000129505-ensure-there-are-no-secrets-in-lambda-functions-variables"
   ],
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_no_secrets_in_variables/awslambda_function_no_secrets_in_variables.metadata.json
@@ -1,26 +1,36 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_no_secrets_in_variables",
-  "CheckTitle": "Find secrets in Lambda functions variables.",
-  "CheckType": [],
+  "CheckTitle": "Lambda function environment variables do not contain secrets",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Sensitive Data Identifications/Passwords",
+    "Sensitive Data Identifications/Security",
+    "Effects/Data Exposure"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "critical",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "Find secrets in Lambda functions variables.",
-  "Risk": "The use of a hard-coded password increases the possibility of password guessing. If hard-coded passwords are used, it is possible that malicious users gain access through the account in question.",
-  "RelatedUrl": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
+  "Description": "AWS Lambda function environment variables are analyzed for content that resembles **secrets** (API keys, tokens, passwords). Pattern-based detection highlights potential hardcoded credentials present in the function's environment.",
+  "Risk": "Secrets in Lambda environment variables weaken **confidentiality**: users with config read access, runtime introspection, or logs may obtain them. Exposure can grant access to downstream systems, enable **lateral movement**, and allow tampering, impacting **integrity** and **availability**.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_3",
+    "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_3#terraform",
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws lambda get-function-configuration --region <REGION> --function-name <FUNCTION_NAME> --query Environment.Variables",
-      "NativeIaC": "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_3#cloudformation",
-      "Other": "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_3",
-      "Terraform": "https://docs.prowler.com/checks/aws/secrets-policies/bc_aws_secrets_3#terraform"
+      "CLI": "aws lambda update-function-configuration --region <REGION> --function-name <FUNCTION_NAME> --environment \"Variables={}\"",
+      "NativeIaC": "```yaml\nResources:\n  <example_resource_name>:\n    Type: AWS::Lambda::Function\n    Properties:\n      Environment:\n        Variables: {}  # CRITICAL: clears environment variables to ensure no secrets are stored\n```",
+      "Other": "1. Open the AWS Lambda console and select the function\n2. Go to Configuration > Environment variables\n3. Click Edit\n4. Delete variables that contain secrets (or remove all variables)\n5. Click Save",
+      "Terraform": "```hcl\nresource \"aws_lambda_function\" \"<example_resource_name>\" {\n  environment {\n    variables = {} # CRITICAL: remove all env vars so no secrets are present\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Use Secrets Manager to securely provide database credentials to Lambda functions and secure the databases as well as use the credentials to connect and query them without hardcoding the secrets in code or passing them through environmental variables.",
-      "Url": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+      "Text": "Do not store secrets in environment variables or code. Use **AWS Secrets Manager** or **Parameter Store** with encryption, fetch at runtime using **least privilege** IAM, and prefer short-lived creds via **IAM roles**.\n\nRotate keys, limit configuration read access, and apply **defense in depth** with logging and alerts for secret access.",
+      "Url": "https://hub.prowler.com/check/awslambda_function_no_secrets_in_variables"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.metadata.json
@@ -4,8 +4,7 @@
   "CheckTitle": "Lambda function resource-based policy does not allow public access",
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
-    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
-    "TTPs/Initial Access"
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
   ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
@@ -16,15 +15,9 @@
   "Risk": "**Public invocation** lets outsiders run code under the function's IAM role.\n\nImpacts:\n- **Confidentiality**: data exfiltration via backend access\n- **Integrity**: unauthorized state changes from side effects\n- **Availability/cost**: invocation floods causing throttling and spend spikes",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://asecure.cloud/a/lambda-function-public-access-prohibited/",
-    "https://repost.aws/knowledge-center/security-hub-lambda-finding",
-    "https://docs.aws.amazon.com/es_es/config/latest/developerguide/lambda-function-public-access-prohibited.html",
-    "https://repost.aws/questions/QUral69ir8Tk-xlXljT-FufQ/confusion-with-aws-config-rule-lambda-function-public-access-prohibited",
-    "https://www.clouddefense.ai/compliance-rules/aws-fs-practices/lambda/foundational-security-lambda-1",
     "https://docs.aws.amazon.com/config/latest/developerguide/lambda-function-public-access-prohibited.html",
     "https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html",
     "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html",
-    "https://github.com/cloud-custodian/cloud-custodian/issues/8147",
     "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/function-exposed.html"
   ],
   "Remediation": {

--- a/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_not_publicly_accessible/awslambda_function_not_publicly_accessible.metadata.json
@@ -1,26 +1,42 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_not_publicly_accessible",
-  "CheckTitle": "Check if Lambda functions have resource-based policy set as Public.",
-  "CheckType": [],
+  "CheckTitle": "Lambda function resource-based policy does not allow public access",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "TTPs/Initial Access"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "critical",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "Check if Lambda functions have resource-based policy set as Public.",
-  "Risk": "Publicly accessible services could expose sensitive data to bad actors.",
-  "RelatedUrl": "https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html",
+  "Description": "**AWS Lambda** function resource-based policies are assessed for **public access**. The finding identifies policies with wildcard or empty `Principal` that allow actions like `lambda:InvokeFunction` to any principal.",
+  "Risk": "**Public invocation** lets outsiders run code under the function's IAM role.\n\nImpacts:\n- **Confidentiality**: data exfiltration via backend access\n- **Integrity**: unauthorized state changes from side effects\n- **Availability/cost**: invocation floods causing throttling and spend spikes",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://asecure.cloud/a/lambda-function-public-access-prohibited/",
+    "https://repost.aws/knowledge-center/security-hub-lambda-finding",
+    "https://docs.aws.amazon.com/es_es/config/latest/developerguide/lambda-function-public-access-prohibited.html",
+    "https://repost.aws/questions/QUral69ir8Tk-xlXljT-FufQ/confusion-with-aws-config-rule-lambda-function-public-access-prohibited",
+    "https://www.clouddefense.ai/compliance-rules/aws-fs-practices/lambda/foundational-security-lambda-1",
+    "https://docs.aws.amazon.com/config/latest/developerguide/lambda-function-public-access-prohibited.html",
+    "https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html",
+    "https://github.com/cloud-custodian/cloud-custodian/issues/8147",
+    "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/function-exposed.html"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws lambda remove-permission --region <REGION> --function-name <QUEUE_NAME> --statement-id FullAccess",
-      "NativeIaC": "",
-      "Other": "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/function-exposed.html",
-      "Terraform": ""
+      "CLI": "aws lambda remove-permission --function-name <example_function_name> --statement-id <example_statement_id>",
+      "NativeIaC": "```yaml\n# CloudFormation: restrict Lambda permission to a non-public principal\nResources:\n  <example_resource_name>Permission:\n    Type: AWS::Lambda::Permission\n    Properties:\n      Action: lambda:InvokeFunction\n      FunctionName: <example_resource_name>\n      Principal: 123456789012  # Critical: not \"*\"; limits invoke permission to a specific account to prevent public access\n```",
+      "Other": "1. Open the AWS Lambda console and select the function\n2. Go to Configuration > Permissions\n3. Under Resource-based policy, view the policy statements\n4. Find any statement with Principal set to \"*\" (or { \"AWS\": \"*\" })\n5. Delete that statement and save\n6. If access is needed, re-add a permission for a specific principal only (for example, an AWS account ID or a service principal)",
+      "Terraform": "```hcl\n# Restrict Lambda permission to a non-public principal\nresource \"aws_lambda_permission\" \"<example_resource_name>\" {\n  statement_id  = \"AllowSpecificPrincipal\"\n  action        = \"lambda:InvokeFunction\"\n  function_name = \"<example_resource_name>\"\n  principal     = \"123456789012\"  # Critical: not \"*\"; prevents public access\n}\n```"
     },
     "Recommendation": {
-      "Text": "Grant usage permission on a per-resource basis and applying least privilege principle.",
-      "Url": "https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html"
+      "Text": "Remove public principals from function policies. Grant access only to specific accounts, roles, or services using fixed ARNs and **least privilege**. Add conditions like `AWS:SourceAccount` and `AWS:SourceArn` to constrain service triggers. Enforce **separation of duties** and monitor access for **defense in depth**.",
+      "Url": "https://hub.prowler.com/check/awslambda_function_not_publicly_accessible"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy.metadata.json
@@ -1,29 +1,48 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_url_cors_policy",
-  "CheckTitle": "Check Lambda Function URL CORS configuration.",
-  "CheckType": [],
+  "CheckTitle": "Lambda function URL CORS does not allow wildcard origins (*)",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
+    "Effects/Data Exposure"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "Check Lambda Function URL CORS configuration.",
-  "Risk": "Publicly accessible services could expose sensitive data to bad actors.",
-  "RelatedUrl": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
+  "Description": "**Lambda function URL** CORS policy is reviewed for `AllowOrigins`. The presence of `*` indicates a wide origin allowance in the CORS configuration.",
+  "Risk": "**Wildcard origins** allow any website to call the endpoint from a browser and read responses, weakening origin isolation.\n\nThis can lead to data exposure (C) and unauthorized actions (I) if state-changing methods are reachable, enabling scripted abuse and cross-origin attacks.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://boto3.amazonaws.com/v1/documentation/api/1.27.1/reference/services/lambda/client/create_function_url_config.html",
+    "https://support.icompaas.com/support/solutions/articles/62000229584-ensure-lambda-function-url-cors-configurations-were-checked",
+    "https://www.serverless.com/blog/aws-lambda-function-urls-with-serverless-framework",
+    "https://medium.com/@mb20261/aws-cli-v2-by-examples-master-lambda-function-urls-9b4837224cb7",
+    "https://docs.aws.amazon.com/lambda/latest/api/API_Cors.html",
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
+    "https://tutorialsdojo.com/how-to-configure-aws-lambda-function-url-with-cross-origin-resource-sharing/",
+    "https://dev.to/rimutaka/aws-lambda-function-url-with-cors-explained-by-example-14df",
+    "https://www.examcollection.com/blog/a-deep-dive-into-aws-lambda-function-urls-with-cross-origin-resource-sharing/",
+    "https://stackoverflow.com/questions/76944724/aws-lambda-function-url-cors-allow-origin-is-not-working-properly",
+    "https://mastra.ai/en/docs/deployment/cloud-providers/aws-lambda",
+    "https://www.example.com,AllowMethods=*,ExposeHeaders=keep-alive,MaxAge=3600,AllowCredentials=false'"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws lambda update-function-url-config --region AWS_REGION --function-name FUNCTION-NAME --auth-type AWS_IAM --cors 'AllowOrigins=https://www.example.com,AllowMethods=*,ExposeHeaders=keep-alive,MaxAge=3600,AllowCredentials=false'",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "CLI": "aws lambda update-function-url-config --function-name <example_resource_name> --cors AllowOrigins=https://www.example.com",
+      "NativeIaC": "```yaml\n# CloudFormation: restrict Lambda Function URL CORS to a specific origin\nResources:\n  FunctionUrl:\n    Type: AWS::Lambda::Url\n    Properties:\n      TargetFunctionArn: <example_resource_arn>\n      AuthType: AWS_IAM\n      Cors:\n        AllowOrigins:\n          - https://www.example.com  # Critical: removes '*' wildcard by allowing only this origin\n```",
+      "Other": "1. In the AWS Console, go to Lambda > Functions and select <example_resource_name>\n2. Open Configuration > Function URL > Edit\n3. In CORS, remove '*' from Allowed origins and enter https://www.example.com\n4. Save changes",
+      "Terraform": "```hcl\n# Terraform: restrict Lambda Function URL CORS to a specific origin\nresource \"aws_lambda_function_url\" \"example\" {\n  function_name      = \"<example_resource_name>\"\n  authorization_type = \"AWS_IAM\"\n  cors {\n    allow_origins = [\"https://www.example.com\"] # Critical: removes '*' wildcard by allowing only this origin\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Grant usage permission on a per-resource basis and applying least privilege principle.",
-      "Url": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+      "Text": "Apply least privilege to CORS:\n- Restrict `AllowOrigins` to trusted domains; avoid `*`\n- Limit `AllowMethods`/`AllowHeaders`; disable `AllowCredentials` unless required\n- Prefer authenticated access (e.g., `AWS_IAM`) and enforce resource policies for defense in depth",
+      "Url": "https://hub.prowler.com/check/awslambda_function_url_cors_policy"
     }
   },
-  "Categories": [],
+  "Categories": [
+    "internet-exposed"
+  ],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": ""

--- a/prowler/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_url_cors_policy/awslambda_function_url_cors_policy.metadata.json
@@ -15,18 +15,10 @@
   "Risk": "**Wildcard origins** allow any website to call the endpoint from a browser and read responses, weakening origin isolation.\n\nThis can lead to data exposure (C) and unauthorized actions (I) if state-changing methods are reachable, enabling scripted abuse and cross-origin attacks.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://boto3.amazonaws.com/v1/documentation/api/1.27.1/reference/services/lambda/client/create_function_url_config.html",
     "https://support.icompaas.com/support/solutions/articles/62000229584-ensure-lambda-function-url-cors-configurations-were-checked",
-    "https://www.serverless.com/blog/aws-lambda-function-urls-with-serverless-framework",
-    "https://medium.com/@mb20261/aws-cli-v2-by-examples-master-lambda-function-urls-9b4837224cb7",
     "https://docs.aws.amazon.com/lambda/latest/api/API_Cors.html",
-    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
     "https://tutorialsdojo.com/how-to-configure-aws-lambda-function-url-with-cross-origin-resource-sharing/",
-    "https://dev.to/rimutaka/aws-lambda-function-url-with-cors-explained-by-example-14df",
-    "https://www.examcollection.com/blog/a-deep-dive-into-aws-lambda-function-urls-with-cross-origin-resource-sharing/",
-    "https://stackoverflow.com/questions/76944724/aws-lambda-function-url-cors-allow-origin-is-not-working-properly",
-    "https://mastra.ai/en/docs/deployment/cloud-providers/aws-lambda",
-    "https://www.example.com,AllowMethods=*,ExposeHeaders=keep-alive,MaxAge=3600,AllowCredentials=false'"
+    "https://dev.to/rimutaka/aws-lambda-function-url-with-cors-explained-by-example-14df"
   ],
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public.metadata.json
@@ -1,26 +1,44 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_url_public",
-  "CheckTitle": "Check Public Lambda Function URL.",
-  "CheckType": [],
+  "CheckTitle": "Lambda function URL is not publicly accessible",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
+    "TTPs/Initial Access/Unauthorized Access",
+    "Effects/Data Exposure",
+    "Effects/Resource Consumption"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "high",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "Check Public Lambda Function URL.",
-  "Risk": "Publicly accessible services could expose sensitive data to bad actors.",
-  "RelatedUrl": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
+  "Description": "**AWS Lambda function URLs** are assessed to determine whether `AuthType` enforces **AWS IAM authentication** or permits **public invocation**.\n\nApplies to functions with a function URL and highlights when requests must be authenticated and authorized via IAM principals.",
+  "Risk": "An unauthenticated function URL lets anyone invoke code:\n- Confidentiality: data exposure\n- Integrity: unintended changes via over-privileged logic\n- Availability: DoS/denial-of-wallet through high request rates\n\nAttackers can script calls, exfiltrate data, and pivot using the function's permissions.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://aws.amazon.com/th/blogs/compute/protecting-an-aws-lambda-function-url-with-amazon-cloudfront-and-lambdaedge/?nc1=f_ls",
+    "https://medium.com/@dimuthuarangala/securing-lambda-function-url-using-iam-authentication-5ccbc7c839ab",
+    "https://rianbk.com/aws-lambda-function-urls/",
+    "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/iam-auth-function-url.html",
+    "https://www.roastdev.com/post/aws-lambda-url-invocations-with-iam-authentication-and-throttling-limits",
+    "https://docs.cgn.portal.checkpoint.com/docs/d9_aws_iam_107",
+    "https://www.wiz.io/blog/securing-aws-lambda-function-urls",
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
+    "https://engineering.teknasyon.com/fine-details-of-aws-lambda-function-url-feature-f3b65b894c5f",
+    "https://dev.to/aws-builders/hands-on-aws-lambda-function-url-with-aws-iam-authentication-type-180g",
+    "https://www.rahulpnath.com/blog/how-to-secure-and-authenticate-lambda-function-urls/"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws lambda update-function-url-config --region AWS_REGION --function-name FUNCTION-NAME --auth-type AWS_IAM",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "CLI": "aws lambda update-function-url-config --function-name <FUNCTION_NAME> --auth-type AWS_IAM",
+      "NativeIaC": "```yaml\n# CloudFormation: set Lambda Function URL to require IAM auth\nResources:\n  FunctionUrl:\n    Type: AWS::Lambda::Url\n    Properties:\n      TargetFunctionArn: arn:aws:lambda:<region>:<account-id>:function/<example_resource_name>\n      AuthType: AWS_IAM  # CRITICAL: requires IAM authentication, preventing public access\n```",
+      "Other": "1. In AWS Console, go to Lambda > Functions and open <example_resource_name>\n2. Select Configuration > Function URL > Edit\n3. Set Auth type to AWS_IAM\n4. Click Save",
+      "Terraform": "```hcl\n# Set Lambda Function URL to require IAM authentication\nresource \"aws_lambda_function_url\" \"example\" {\n  function_name      = \"<example_resource_name>\"\n  authorization_type = \"AWS_IAM\"  # CRITICAL: blocks public access by requiring IAM auth\n}\n```"
     },
     "Recommendation": {
-      "Text": "Grant usage permission on a per-resource basis and applying least privilege principle.",
-      "Url": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html"
+      "Text": "Enforce `AWS_IAM` on function URLs and apply **least privilege**:\n- Grant `lambda:InvokeFunctionUrl` only to required principals\n- Avoid `*` principals or broad conditions\n- Limit CORS to trusted origins and methods\n- Set reserved concurrency to contain abuse\n\nConsider **defense in depth** (WAF/CDN or private access) for Internet use.",
+      "Url": "https://hub.prowler.com/check/awslambda_function_url_public"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_url_public/awslambda_function_url_public.metadata.json
@@ -4,9 +4,7 @@
   "CheckTitle": "Lambda function URL is not publicly accessible",
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
-    "TTPs/Initial Access/Unauthorized Access",
-    "Effects/Data Exposure",
-    "Effects/Resource Consumption"
+    "Effects/Data Exposure"
   ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
@@ -17,15 +15,9 @@
   "Risk": "An unauthenticated function URL lets anyone invoke code:\n- Confidentiality: data exposure\n- Integrity: unintended changes via over-privileged logic\n- Availability: DoS/denial-of-wallet through high request rates\n\nAttackers can script calls, exfiltrate data, and pivot using the function's permissions.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://aws.amazon.com/th/blogs/compute/protecting-an-aws-lambda-function-url-with-amazon-cloudfront-and-lambdaedge/?nc1=f_ls",
-    "https://medium.com/@dimuthuarangala/securing-lambda-function-url-using-iam-authentication-5ccbc7c839ab",
-    "https://rianbk.com/aws-lambda-function-urls/",
     "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/iam-auth-function-url.html",
     "https://www.roastdev.com/post/aws-lambda-url-invocations-with-iam-authentication-and-throttling-limits",
-    "https://docs.cgn.portal.checkpoint.com/docs/d9_aws_iam_107",
-    "https://www.wiz.io/blog/securing-aws-lambda-function-urls",
     "https://docs.aws.amazon.com/secretsmanager/latest/userguide/lambda-functions.html",
-    "https://engineering.teknasyon.com/fine-details-of-aws-lambda-function-url-feature-f3b65b894c5f",
     "https://dev.to/aws-builders/hands-on-aws-lambda-function-url-with-aws-iam-authentication-type-180g",
     "https://www.rahulpnath.com/blog/how-to-secure-and-authenticate-lambda-function-urls/"
   ],

--- a/prowler/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes.metadata.json
@@ -1,29 +1,47 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_using_supported_runtimes",
-  "CheckTitle": "Find obsolete Lambda runtimes.",
-  "CheckType": [],
+  "CheckTitle": "Lambda function uses a supported runtime",
+  "CheckType": [
+    "Software and Configuration Checks/Patch Management",
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "Find obsolete Lambda runtimes.",
-  "Risk": "If you have functions running on a runtime that will be deprecated in the next 60 days, Lambda notifies you by email that you should prepare by migrating your function to a supported runtime. In some cases, such as security issues that require a backwards-incompatible update, or software that does not support a long-term support (LTS) schedule, advance notice might not be possible. After a runtime is deprecated, Lambda might retire it completely at any time by disabling invocation. Deprecated runtimes are not eligible for security updates or technical support.",
-  "RelatedUrl": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html",
+  "Description": "**Lambda functions** using **obsolete runtimes**-such as `python3.8`, `nodejs14.x`, `go1.x`, `ruby2.7`-are identified against a curated list of deprecated runtime identifiers.",
+  "Risk": "Unmaintained runtimes lack security patches, exposing code and libraries to known CVEs (**confidentiality, integrity**).\n\nDeprecation can block create/update and break builds, causing failed deployments or runtime errors (**availability**). Tooling may stop supporting builds, slowing fixes and recovery.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://github.com/aws/aws-lambda-builders/issues/577",
+    "https://aws.amazon.com/blogs/compute/managing-aws-lambda-runtime-upgrades/",
+    "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html",
+    "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/supported-runtime-environment.html",
+    "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html",
+    "https://github.com/aws/aws-sam-cli/issues/6298",
+    "https://github.com/awsdocs/aws-lambda-developer-guide/blob/master/doc_source/runtime-support-policy.md",
+    "https://aws.amazon.com/blogs/compute/announcing-end-of-support-for-python-2-7-in-aws-lambda/",
+    "https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/",
+    "https://endoflife.date/aws-lambda"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws lambda update-function-configuration --region AWS-REGION --function-name FUNCTION-NAME --runtime 'RUNTIME'",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "CLI": "aws lambda update-function-configuration --function-name <FUNCTION_NAME> --runtime <SUPPORTED_RUNTIME>",
+      "NativeIaC": "```yaml\n# CloudFormation: set Lambda to a supported runtime\nResources:\n  <example_resource_name>:\n    Type: AWS::Lambda::Function\n    Properties:\n      Role: <example_role_arn>\n      Handler: <example_handler>\n      Runtime: <SUPPORTED_RUNTIME>  # FIX: change to a supported runtime (e.g., python3.12) to pass the check\n      Code:\n        S3Bucket: <example_bucket_name>\n        S3Key: <example_object_key>\n```",
+      "Other": "1. Open the AWS Lambda console and select the function\n2. Go to Configuration > Runtime settings > Edit\n3. In Runtime, choose a supported runtime (e.g., python3.12) and click Save",
+      "Terraform": "```hcl\n# Set Lambda to a supported runtime\nresource \"aws_lambda_function\" \"<example_resource_name>\" {\n  function_name = \"<example_resource_name>\"\n  role          = \"<example_role_arn>\"\n  handler       = \"<example_handler>\"\n  runtime       = \"<SUPPORTED_RUNTIME>\" # FIX: use a supported runtime (e.g., python3.12) to pass the check\n  filename      = \"<example_package.zip>\"\n}\n```"
     },
     "Recommendation": {
-      "Text": "Test new runtimes as they are made available. Implement them in production as soon as possible.",
-      "Url": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
+      "Text": "Upgrade to **supported LTS runtimes** (AL2/AL2023) and include runtime upgrades in a secure SDLC.\n\nTest in staging, deploy via versions/aliases, and keep dependencies current. Monitor deprecation notices. Apply guardrails to block deprecated `runtime` values and allow only approved runtimes, aligning with **defense in depth**.",
+      "Url": "https://hub.prowler.com/check/awslambda_function_using_supported_runtimes"
     }
   },
-  "Categories": [],
+  "Categories": [
+    "vulnerabilities"
+  ],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": ""

--- a/prowler/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_using_supported_runtimes/awslambda_function_using_supported_runtimes.metadata.json
@@ -4,8 +4,7 @@
   "CheckTitle": "Lambda function uses a supported runtime",
   "CheckType": [
     "Software and Configuration Checks/Patch Management",
-    "Software and Configuration Checks/AWS Security Best Practices",
-    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices"
+    "Software and Configuration Checks/AWS Security Best Practices"
   ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
@@ -16,16 +15,10 @@
   "Risk": "Unmaintained runtimes lack security patches, exposing code and libraries to known CVEs (**confidentiality, integrity**).\n\nDeprecation can block create/update and break builds, causing failed deployments or runtime errors (**availability**). Tooling may stop supporting builds, slowing fixes and recovery.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://github.com/aws/aws-lambda-builders/issues/577",
     "https://aws.amazon.com/blogs/compute/managing-aws-lambda-runtime-upgrades/",
     "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html",
     "https://www.trendmicro.com/cloudoneconformity/knowledge-base/aws/Lambda/supported-runtime-environment.html",
-    "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html",
-    "https://github.com/aws/aws-sam-cli/issues/6298",
-    "https://github.com/awsdocs/aws-lambda-developer-guide/blob/master/doc_source/runtime-support-policy.md",
-    "https://aws.amazon.com/blogs/compute/announcing-end-of-support-for-python-2-7-in-aws-lambda/",
-    "https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/",
-    "https://endoflife.date/aws-lambda"
+    "https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html"
   ],
   "Remediation": {
     "Code": {
@@ -40,7 +33,7 @@
     }
   },
   "Categories": [
-    "vulnerabilities"
+    "container-security"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/awslambda/awslambda_function_vpc_multi_az/awslambda_function_vpc_multi_az.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_vpc_multi_az/awslambda_function_vpc_multi_az.metadata.json
@@ -14,15 +14,9 @@
   "Risk": "Single-AZ placement limits **availability**. An AZ outage or subnet/IP exhaustion can block ENI creation and VPC access, causing failed invocations, timeouts, and event backlogs.\n\nThis degrades uptime and can delay processing of critical events.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html",
-    "https://www.clouddefense.ai/compliance-rules/aws-fs-practices/cloudtrail/foundational-security-lambda-5",
     "https://docs.aws.amazon.com/lambda/latest/operatorguide/networking-vpc.html",
     "https://stackzonecom.tawk.help/article/aws-config-rule-lambda-vpc-multi-az-check",
-    "https://www.clouddefense.ai/compliance-rules/aws-fs-practices/lambda/foundational-security-lambda-5",
-    "https://serverlessland.com/content/service/lambda/guides/aws-lambda-operator-guide/networking-vpc",
-    "https://d1.awsstatic.com/events/reinvent/2020/AWS_Lambda_networking_best_practices_SVS312.pdf",
     "https://stackoverflow.com/questions/62052490/why-aws-lambda-suggests-to-set-up-two-subnets-if-vpc-is-configured",
-    "https://medium.com/@arunasilva86/how-to-use-vpc-networking-effectively-for-lambda-445abefdf8cf",
     "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html#lambda-5"
   ],
   "Remediation": {

--- a/prowler/providers/aws/services/awslambda/awslambda_function_vpc_multi_az/awslambda_function_vpc_multi_az.metadata.json
+++ b/prowler/providers/aws/services/awslambda/awslambda_function_vpc_multi_az/awslambda_function_vpc_multi_az.metadata.json
@@ -1,29 +1,45 @@
 {
   "Provider": "aws",
   "CheckID": "awslambda_function_vpc_multi_az",
-  "CheckTitle": "Check if AWS Lambda Function VPC is deployed Across Multiple Availability Zones",
-  "CheckType": [],
+  "CheckTitle": "Lambda function is configured with VPC subnets in at least two Availability Zones",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices/Network Reachability"
+  ],
   "ServiceName": "awslambda",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:lambda:region:account-id:function/function-name",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "AwsLambdaFunction",
-  "Description": "This control checks whether an AWS Lambda function connected to a VPC operates in at least the specified number of Availability Zones (AZs). A failure occurs if the function does not operate in the required number of AZs, which by default is two.",
-  "Risk": "A Lambda function not deployed across multiple AZs increases the risk of a single point of failure, which can result in a complete disruption of the function's operations if an AZ becomes unavailable.",
-  "RelatedUrl": "https://docs.aws.amazon.com/lambda/latest/operatorguide/networking-vpc.html",
+  "Description": "**AWS Lambda** functions attached to a VPC use subnets that span at least the required number of **Availability Zones** (`2` by default).\n\nThe evaluation counts the unique AZs of the function's configured subnets.",
+  "Risk": "Single-AZ placement limits **availability**. An AZ outage or subnet/IP exhaustion can block ENI creation and VPC access, causing failed invocations, timeouts, and event backlogs.\n\nThis degrades uptime and can delay processing of critical events.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html",
+    "https://www.clouddefense.ai/compliance-rules/aws-fs-practices/cloudtrail/foundational-security-lambda-5",
+    "https://docs.aws.amazon.com/lambda/latest/operatorguide/networking-vpc.html",
+    "https://stackzonecom.tawk.help/article/aws-config-rule-lambda-vpc-multi-az-check",
+    "https://www.clouddefense.ai/compliance-rules/aws-fs-practices/lambda/foundational-security-lambda-5",
+    "https://serverlessland.com/content/service/lambda/guides/aws-lambda-operator-guide/networking-vpc",
+    "https://d1.awsstatic.com/events/reinvent/2020/AWS_Lambda_networking_best_practices_SVS312.pdf",
+    "https://stackoverflow.com/questions/62052490/why-aws-lambda-suggests-to-set-up-two-subnets-if-vpc-is-configured",
+    "https://medium.com/@arunasilva86/how-to-use-vpc-networking-effectively-for-lambda-445abefdf8cf",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html#lambda-5"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "",
-      "NativeIaC": "",
-      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/lambda-controls.html#lambda-5",
-      "Terraform": ""
+      "CLI": "aws lambda update-function-configuration --function-name <example_resource_name> --vpc-config SubnetIds=<subnet_id_az1>,<subnet_id_az2>,SecurityGroupIds=<example_security_group_id>",
+      "NativeIaC": "```yaml\nResources:\n  <example_resource_name>:\n    Type: AWS::Lambda::Function\n    Properties:\n      Role: <example_role_arn>\n      Handler: index.handler\n      Runtime: python3.12\n      Code:\n        ZipFile: |\n          def handler(event, context):\n            return \"\"\n      VpcConfig:\n        SecurityGroupIds:\n          - <example_security_group_id>\n        SubnetIds:\n          - <subnet_id_az1>  # Critical: select subnets in different AZs\n          - <subnet_id_az2>  # Critical: ensures function operates in >=2 AZs\n```",
+      "Other": "1. Open the Lambda console and select the function\n2. Go to Configuration > VPC > Edit\n3. Select the target VPC and choose at least two subnets in different Availability Zones\n4. Select a security group\n5. Click Save",
+      "Terraform": "```hcl\nresource \"aws_lambda_function\" \"<example_resource_name>\" {\n  function_name = \"<example_resource_name>\"\n  role          = \"<example_role_arn>\"\n  handler       = \"index.handler\"\n  runtime       = \"python3.12\"\n  filename      = \"function.zip\"\n\n  vpc_config {\n    subnet_ids         = [\"<subnet_id_az1>\", \"<subnet_id_az2>\"] # Critical: subnets in different AZs\n    security_group_ids = [\"<example_security_group_id>\"]\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Ensure that your AWS Lambda functions connected to a VPC are distributed across multiple Availability Zones (AZs) to enhance availability and resilience.",
-      "Url": "https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html"
+      "Text": "Distribute VPC-connected functions across subnets in `2` distinct AZs to ensure **fault tolerance**.\n- Choose subnets from different AZs\n- Avoid AZ-pinned configs or fixed IPs\n- Provide per-AZ egress/endpoints and routing\n- Regularly test AZ failover\nAligns with **resilience** and **defense in depth**.",
+      "Url": "https://hub.prowler.com/check/awslambda_function_vpc_multi_az"
     }
   },
-  "Categories": [],
+  "Categories": [
+    "resilience"
+  ],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": ""


### PR DESCRIPTION
### Context

Updating aws awslambda service metadata to conform with the new standardized metadata format used across Prowler checks, defined in #8411.

### Description

This PR updates all metadata files for AWS Lambda checks to adapt to the new metadata format. The changes ensure consistency with the metadata structure being adopted across all Prowler services. The modified checks are:

- `awslambda_function_inside_vpc`
- `awslambda_function_invoke_api_operations_cloudtrail_logging_enabled`
- `awslambda_function_no_secrets_in_code`
- `awslambda_function_no_secrets_in_variables`
- `awslambda_function_not_publicly_accessible`
- `awslambda_function_url_cors_policy`
- `awslambda_function_url_public`
- `awslambda_function_using_supported_runtimes`
- `awslambda_function_vpc_multi_az`


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.