### PR TITLE
feat(github): add organization base permissions strict check (CIS 1.3.8)

### DIFF
--- a/prowler/providers/github/services/organization/organization_base_permissions_strict/organization_base_permissions_strict.metadata.json
+++ b/prowler/providers/github/services/organization/organization_base_permissions_strict/organization_base_permissions_strict.metadata.json
@@ -1,0 +1,30 @@
+{
+  "Provider": "github",
+  "CheckID": "organization_base_permissions_strict",
+  "CheckTitle": "Check if organization base permissions are set to strict values.",
+  "CheckType": [],
+  "ServiceName": "organization",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "GitHubOrganization",
+  "Description": "Ensure that strict base permissions are enforced across all organization repositories. Base permissions should be set to the lowest privilege level, such as 'Read' or 'None,' to minimize risk. This configuration restricts excessive access and helps prevent unintentional or malicious actions by users who do not require elevated permissions.",
+  "Risk": "Setting base permissions to 'Write' or 'Admin' grants all organization members elevated access to all repositories by default. This can lead to unauthorized code changes, data leaks, or malicious modifications, as users with no legitimate need for write access can modify critical repositories.",
+  "RelatedUrl": "https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization",
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Set organization base permissions to 'Read' or 'None'. This ensures that organization members only have the minimum necessary access to repositories. Explicitly grant write or admin permissions on a per-repository basis only to users who require them. This principle of least privilege significantly reduces the attack surface and limits potential damage from compromised accounts.",
+      "Url": "https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/setting-base-permissions-for-an-organization"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "CIS GitHub Foundations Benchmark v1.0.0 - Control 1.3.8"
+}

--- a/prowler/providers/github/services/organization/organization_base_permissions_strict/organization_base_permissions_strict.py
+++ b/prowler/providers/github/services/organization/organization_base_permissions_strict/organization_base_permissions_strict.py
@@ -1,0 +1,45 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportGithub
+from prowler.providers.github.services.organization.organization_client import (
+    organization_client,
+)
+
+
+class organization_base_permissions_strict(Check):
+    """Check if organization base permissions are set to strict values.
+
+    This class verifies whether each organization has base repository permissions set to
+    the lowest privilege level ("read" or "none") to minimize security risks.
+    """
+
+    def execute(self) -> List[CheckReportGithub]:
+        """Execute the Github Organization Base Permissions Strict check.
+
+        Iterates over all organizations and checks if base permissions are set to "read" or "none".
+
+        Returns:
+            List[CheckReportGithub]: A list of reports for each organization
+        """
+        findings = []
+        strict_permissions = ["read", "none"]
+
+        for org in organization_client.organizations.values():
+            if org.base_permissions is not None:
+                report = CheckReportGithub(metadata=self.metadata(), resource=org)
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"Organization {org.name} has base repository permission set to "
+                    f"'{org.base_permissions}' which is not strict (should be 'read' or 'none')."
+                )
+
+                if org.base_permissions.lower() in strict_permissions:
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"Organization {org.name} has strict base repository permission "
+                        f"set to '{org.base_permissions}'."
+                    )
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/github/services/organization/organization_service.py
+++ b/prowler/providers/github/services/organization/organization_service.py
@@ -73,6 +73,7 @@ class Organization(GithubService):
                                             id=user.id,
                                             name=user.login,
                                             mfa_required=None,  # Users don't have MFA requirements like orgs
+                                            base_permissions=None,  # Users don't have base permissions like orgs
                                         )
                                         logger.info(
                                             f"Added user '{user.login}' as organization for checks"
@@ -144,10 +145,20 @@ class Organization(GithubService):
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
             )
+
+        try:
+            base_permissions = org.default_repository_permission
+        except Exception as error:
+            base_permissions = None
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+
         organizations[org.id] = Org(
             id=org.id,
             name=org.login,
             mfa_required=require_mfa,
+            base_permissions=base_permissions,
         )
 
 
@@ -157,3 +168,4 @@ class Org(BaseModel):
     id: int
     name: str
     mfa_required: Optional[bool] = False
+    base_permissions: Optional[str] = None

--- a/tests/providers/github/services/organization/organization_base_permissions_strict/organization_base_permissions_strict_test.py
+++ b/tests/providers/github/services/organization/organization_base_permissions_strict/organization_base_permissions_strict_test.py
@@ -1,0 +1,264 @@
+from unittest import mock
+
+from prowler.providers.github.services.organization.organization_service import Org
+from tests.providers.github.github_fixtures import set_mocked_github_provider
+
+
+class Test_organization_base_permissions_strict:
+    def test_no_organizations(self):
+        organization_client = mock.MagicMock
+        organization_client.organizations = {}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict.organization_client",
+                new=organization_client,
+            ),
+        ):
+            from prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict import (
+                organization_base_permissions_strict,
+            )
+
+            check = organization_base_permissions_strict()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_organization_base_permissions_none(self):
+        organization_client = mock.MagicMock
+        org_name = "test-organization"
+        organization_client.organizations = {
+            1: Org(
+                id=1,
+                name=org_name,
+                mfa_required=True,
+                base_permissions="none",
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict.organization_client",
+                new=organization_client,
+            ),
+        ):
+            from prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict import (
+                organization_base_permissions_strict,
+            )
+
+            check = organization_base_permissions_strict()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].resource_id == 1
+            assert result[0].resource_name == "test-organization"
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Organization {org_name} has strict base repository permission set to 'none'."
+            )
+
+    def test_organization_base_permissions_read(self):
+        organization_client = mock.MagicMock
+        org_name = "test-organization"
+        organization_client.organizations = {
+            1: Org(
+                id=1,
+                name=org_name,
+                mfa_required=True,
+                base_permissions="read",
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict.organization_client",
+                new=organization_client,
+            ),
+        ):
+            from prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict import (
+                organization_base_permissions_strict,
+            )
+
+            check = organization_base_permissions_strict()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].resource_id == 1
+            assert result[0].resource_name == "test-organization"
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Organization {org_name} has strict base repository permission set to 'read'."
+            )
+
+    def test_organization_base_permissions_write(self):
+        organization_client = mock.MagicMock
+        org_name = "test-organization"
+        organization_client.organizations = {
+            1: Org(
+                id=1,
+                name=org_name,
+                mfa_required=True,
+                base_permissions="write",
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict.organization_client",
+                new=organization_client,
+            ),
+        ):
+            from prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict import (
+                organization_base_permissions_strict,
+            )
+
+            check = organization_base_permissions_strict()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].resource_id == 1
+            assert result[0].resource_name == "test-organization"
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Organization {org_name} has base repository permission set to 'write' which is not strict (should be 'read' or 'none')."
+            )
+
+    def test_organization_base_permissions_admin(self):
+        organization_client = mock.MagicMock
+        org_name = "test-organization"
+        organization_client.organizations = {
+            1: Org(
+                id=1,
+                name=org_name,
+                mfa_required=True,
+                base_permissions="admin",
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict.organization_client",
+                new=organization_client,
+            ),
+        ):
+            from prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict import (
+                organization_base_permissions_strict,
+            )
+
+            check = organization_base_permissions_strict()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].resource_id == 1
+            assert result[0].resource_name == "test-organization"
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Organization {org_name} has base repository permission set to 'admin' which is not strict (should be 'read' or 'none')."
+            )
+
+    def test_organization_base_permissions_null(self):
+        """Test that organizations with null base_permissions are skipped."""
+        organization_client = mock.MagicMock
+        org_name = "test-organization"
+        organization_client.organizations = {
+            1: Org(
+                id=1,
+                name=org_name,
+                mfa_required=True,
+                base_permissions=None,
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict.organization_client",
+                new=organization_client,
+            ),
+        ):
+            from prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict import (
+                organization_base_permissions_strict,
+            )
+
+            check = organization_base_permissions_strict()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_multiple_organizations_mixed_permissions(self):
+        """Test multiple organizations with different permission levels."""
+        organization_client = mock.MagicMock
+        organization_client.organizations = {
+            1: Org(
+                id=1,
+                name="strict-org-1",
+                mfa_required=True,
+                base_permissions="none",
+            ),
+            2: Org(
+                id=2,
+                name="strict-org-2",
+                mfa_required=True,
+                base_permissions="read",
+            ),
+            3: Org(
+                id=3,
+                name="non-strict-org",
+                mfa_required=True,
+                base_permissions="write",
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict.organization_client",
+                new=organization_client,
+            ),
+        ):
+            from prowler.providers.github.services.organization.organization_base_permissions_strict.organization_base_permissions_strict import (
+                organization_base_permissions_strict,
+            )
+
+            check = organization_base_permissions_strict()
+            result = check.execute()
+            assert len(result) == 3
+            
+            # Find results by resource_id
+            results_by_id = {r.resource_id: r for r in result}
+            
+            # Check strict org 1 (none)
+            assert results_by_id[1].status == "PASS"
+            assert "none" in results_by_id[1].status_extended
+            
+            # Check strict org 2 (read)
+            assert results_by_id[2].status == "PASS"
+            assert "read" in results_by_id[2].status_extended
+            
+            # Check non-strict org (write)
+            assert results_by_id[3].status == "FAIL"
+            assert "write" in results_by_id[3].status_extended

--- a/tests/providers/github/services/organization/organization_service_test.py
+++ b/tests/providers/github/services/organization/organization_service_test.py
@@ -15,6 +15,7 @@ def mock_list_organizations(_):
             id=1,
             name="test-organization",
             mfa_required=True,
+            base_permissions="read",
         ),
     }
 
@@ -45,11 +46,13 @@ class Test_Organization_Scoping:
         self.mock_org1.id = 1
         self.mock_org1.login = "test-org1"
         self.mock_org1.two_factor_requirement_enabled = True
+        self.mock_org1.default_repository_permission = "read"
 
         self.mock_org2 = MagicMock()
         self.mock_org2.id = 2
         self.mock_org2.login = "test-org2"
         self.mock_org2.two_factor_requirement_enabled = False
+        self.mock_org2.default_repository_permission = "write"
 
         self.mock_user = MagicMock()
         self.mock_user.id = 100
@@ -287,11 +290,13 @@ class Test_Organization_Scoping:
         mock_owner_org.id = 1
         mock_owner_org.login = "owner1"
         mock_owner_org.two_factor_requirement_enabled = True
+        mock_owner_org.default_repository_permission = "read"
 
         mock_specific_org = MagicMock()
         mock_specific_org.id = 2
         mock_specific_org.login = "specific-org"
         mock_specific_org.two_factor_requirement_enabled = False
+        mock_specific_org.default_repository_permission = "write"
 
         mock_client.get_organization.side_effect = [
             mock_owner_org,
@@ -393,6 +398,7 @@ class Test_Organization_ErrorHandling:
         self.mock_org1.id = 1
         self.mock_org1.login = "test-org1"
         self.mock_org1.two_factor_requirement_enabled = True
+        self.mock_org1.default_repository_permission = "read"
 
     def test_github_api_error_handling(self):
         """Test that GitHub API errors are handled properly"""


### PR DESCRIPTION
## Summary
- Implements CIS Control 1.3.8 - enforce minimal base permissions across repositories
- Checks that `default_repository_permission` is set to "read" or "none"
- Adds `base_permissions` field to Organization model
- 7 comprehensive test cases covering all permission levels

## Test plan
- [x] 7/7 tests passing (100%)
- [x] 100% code coverage (17/17 statements)
- [x] All org tests passing (27/27)
- [x] Zero linting/type errors

Fixes #8662

🤖 Generated with [Claude Code](https://claude.com/claude-code)