### PR TITLE
fix: remove maxTokens for gpt-5

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -24,6 +24,12 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ---
 
+## [1.12.4] (Prowler v5.12.4)
+
+### 🐞 Fixed
+
+- Remove maxTokens model param for GPT-5 models [(#8843)](https://github.com/prowler-cloud/prowler/pull/8843)
+
 ## [1.12.3] (Prowler v5.12.3)
 
 ### 🐞 Fixed

--- a/ui/lib/lighthouse/utils.ts
+++ b/ui/lib/lighthouse/utils.ts
@@ -61,6 +61,7 @@ export const getModelParams = (config: any): ModelParams => {
   if (modelId.startsWith("gpt-5")) {
     params.temperature = undefined;
     params.reasoningEffort = "minimal" as const;
+    params.maxTokens = undefined;
   }
 
   return params;


### PR DESCRIPTION
### Context

GPT-5 errors out when `maxTokens` is sent.

<img width="1589" height="238" alt="image" src="https://github.com/user-attachments/assets/2cded911-6751-4f77-86c4-3f6f0d5dd00d" />

### Description

This fix removes sending maxtokens when GPT-5 selected.

### Steps to review

1. Configure Lighthouse and select GPT-5 model.
2. Send message in Lighthouse chatbox
3. You should receive a response from GPT-5 model

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
