### PR TITLE
fix: add pagination for `m365` and `azure` users retrieval

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Fix KeyError in `elb_ssl_listeners_use_acm_certificate` check and handle None cluster version in `eks_cluster_uses_a_supported_version` check [(#8791)](https://github.com/prowler-cloud/prowler/pull/8791)
 - Fix file extension parsing for compliance reports [(#8791)](https://github.com/prowler-cloud/prowler/pull/8791)
+- Added user pagination to Entra and Admincenter services [(#8858)](https://github.com/prowler-cloud/prowler/pull/8858)
 
 ---
 

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -1,5 +1,5 @@
 import asyncio
-from asyncio import gather, get_event_loop
+from asyncio import gather
 from enum import Enum
 from typing import List, Optional
 from uuid import UUID
@@ -20,7 +20,24 @@ class Entra(M365Service):
             self.user_accounts_status = self.powershell.get_user_account_status()
             self.powershell.close()
 
-        loop = get_event_loop()
+        created_loop = False
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            created_loop = True
+
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            created_loop = True
+
+        if loop.is_running():
+            raise RuntimeError(
+                "Cannot initialize Entra service while event loop is running"
+            )
+
         self.tenant_domain = provider.identity.tenant_domain
         attributes = loop.run_until_complete(
             gather(
@@ -40,6 +57,10 @@ class Entra(M365Service):
         self.organizations = attributes[4]
         self.users = attributes[5]
         self.user_accounts_status = {}
+
+        if created_loop:
+            asyncio.set_event_loop(None)
+            loop.close()
 
     async def _get_authorization_policy(self):
         logger.info("Entra - Getting authorization policy...")
@@ -364,7 +385,7 @@ class Entra(M365Service):
         logger.info("Entra - Getting users...")
         users = {}
         try:
-            users_list = await self.client.users.get()
+            users_response = await self.client.users.get()
             directory_roles = await self.client.directory_roles.get()
 
             async def fetch_role_members(directory_role):
@@ -396,23 +417,29 @@ class Entra(M365Service):
                 )
                 registration_details = {}
 
-            for user in users_list.value:
-                users[user.id] = User(
-                    id=user.id,
-                    name=user.display_name,
-                    on_premises_sync_enabled=(
-                        True if (user.on_premises_sync_enabled) else False
-                    ),
-                    directory_roles_ids=user_roles_map.get(user.id, []),
-                    is_mfa_capable=(
-                        registration_details.get(user.id, {}).is_mfa_capable
-                        if registration_details.get(user.id, None) is not None
-                        else False
-                    ),
-                    account_enabled=not self.user_accounts_status.get(user.id, {}).get(
-                        "AccountDisabled", False
-                    ),
-                )
+            while users_response:
+                for user in getattr(users_response, "value", []) or []:
+                    users[user.id] = User(
+                        id=user.id,
+                        name=user.display_name,
+                        on_premises_sync_enabled=(
+                            True if (user.on_premises_sync_enabled) else False
+                        ),
+                        directory_roles_ids=user_roles_map.get(user.id, []),
+                        is_mfa_capable=(
+                            registration_details.get(user.id, {}).is_mfa_capable
+                            if registration_details.get(user.id, None) is not None
+                            else False
+                        ),
+                        account_enabled=not self.user_accounts_status.get(
+                            user.id, {}
+                        ).get("AccountDisabled", False),
+                    )
+
+                next_link = getattr(users_response, "odata_next_link", None)
+                if not next_link:
+                    break
+                users_response = await self.client.users.with_url(next_link).get()
         except Exception as error:
             logger.error(
                 f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"


### PR DESCRIPTION
### Context

We were lacking pagination in `M365` (`Entra`, `Admincenter`) and `Azure` (`Entra`) leading to an incomplete user fetch.

This PR fixes the previous behavior to return complete user inventories and that their data collectors can be exercised reliably in unit tests.

### Description

- Added resilient event-loop bootstrapping to both `M365` and `Azure` `Entra` services so SDK constructions work after earlier async tests close the global loop.
- Reworked `_get_users` for the `M365` `Entra` service to paginate through `odata_next_link`.
- Updated `Azure` `Entra` and `M365` `Admincenter` services to walk paginated user responses and surface full license / authentication metadata , .
- Expanded unit tests for `Entra` (`Azure` & `M365`) and `Admincenter` to cover pagination, enriched attributes, and new event-loop handling so regressions are caught early.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
