### PR TITLE
chore(m365): deprecate user auth

### DIFF
--- a/docs/basic-usage/prowler-cli.md
+++ b/docs/basic-usage/prowler-cli.md
@@ -183,7 +183,7 @@ Microsoft 365 requires specifying the auth method:
 prowler m365 --sp-env-auth
 
 # To use both service principal (for MSGraph) and user credentials (for PowerShell modules)
-prowler m365 --env-auth
+prowler m365 --sp-env-auth
 
 # To use az cli authentication
 prowler m365 --az-cli-auth

--- a/docs/basic-usage/prowler-cli.md
+++ b/docs/basic-usage/prowler-cli.md
@@ -182,9 +182,6 @@ Microsoft 365 requires specifying the auth method:
 # To use service principal authentication for MSGraph and PowerShell modules
 prowler m365 --sp-env-auth
 
-# To use both service principal (for MSGraph) and user credentials (for PowerShell modules)
-prowler m365 --sp-env-auth
-
 # To use az cli authentication
 prowler m365 --az-cli-auth
 

--- a/docs/tutorials/microsoft365/authentication.md
+++ b/docs/tutorials/microsoft365/authentication.md
@@ -125,6 +125,50 @@ When using browser authentication, permissions are delegated to the user, so the
 
     ![Grant Admin Consent](../microsoft365/img/grant-external-api-permissions.png)
 
+
+## Service Principal Authentication (Recommended)
+
+*Available for both Prowler App and Prowler CLI*
+
+**Authentication flag for CLI:** `--sp-env-auth`
+
+Authenticate using the **Service Principal Application** by configuring the following environment variables:
+
+```console
+export AZURE_CLIENT_ID="XXXXXXXXX"
+export AZURE_CLIENT_SECRET="XXXXXXXXX"
+export AZURE_TENANT_ID="XXXXXXXXX"
+```
+
+If these variables are not set or exported, execution using `--sp-env-auth` will fail.
+
+Refer to the [Step-by-Step Permission Assignment](#step-by-step-permission-assignment) section below for setup instructions.
+
+If the external API permissions described in the mentioned section above are not added only checks that work through MS Graph will be executed. This means that the full provider will not be executed.
+
+???+ note
+    In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [PowerShell Module Permissions](#grant-powershell-module-permissions-for-service-principal-authentication) section for more information.
+
+
+## Interactive Browser Authentication
+
+*Available only for Prowler CLI*
+
+**Authentication flag:** `--browser-auth`
+
+Authenticate against Azure using the default browser to start the scan. The `--tenant-id` flag is also required.
+
+These credentials only enable checks that rely on Microsoft Graph. The entire provider cannot be run with this method. To perform a full M365 security scan, use the **recommended authentication method**.
+
+Since this is a **delegated permission** authentication method, necessary permissions should be assigned to the user rather than the application.
+
+## Supported PowerShell Versions
+
+PowerShell is required to run certain M365 checks.
+
+**Supported versions:**
+- **PowerShell 7.4 or higher** (7.5 is recommended)
+
 #### Why Is PowerShell 7.4+ Required?
 
 - **PowerShell 5.1** (default on some Windows systems) does not support required cmdlets.

--- a/docs/tutorials/microsoft365/authentication.md
+++ b/docs/tutorials/microsoft365/authentication.md
@@ -5,16 +5,12 @@ Prowler for Microsoft 365 supports multiple authentication types. Authentication
 **Prowler App:**
 
 - [**Service Principal Application**](#service-principal-authentication-recommended) (**Recommended**)
-- [**Service Principal with User Credentials**](#service-principal-and-user-credentials-authentication) (Being deprecated)
+- [**Service Principal with User Credentials**](#service-principal-and-user-credentials-authentication) (Deprecated)
 
 **Prowler CLI:**
 
 - [**Service Principal Application**](#service-principal-authentication-recommended) (**Recommended**)
-- [**Service Principal with User Credentials**](#service-principal-and-user-credentials-authentication) (Being deprecated)
 - [**Interactive browser authentication**](#interactive-browser-authentication)
-
-???+ warning
-    The Service Principal with User Credentials method will be deprecated in October 2025 when Microsoft enforces MFA in all tenants, which will not allow user authentication without interactive methods.
 
 ## Required Permissions
 
@@ -30,7 +26,6 @@ When using service principal authentication, add these **Application Permissions
 - `Directory.Read.All`: Required for all services.
 - `Policy.Read.All`: Required for all services.
 - `SharePointTenantSettings.Read.All`: Required for SharePoint service.
-- `User.Read` (IMPORTANT: this must be set as **delegated**): Required for the sign-in.
 
 **External API Permissions:**
 
@@ -42,20 +37,6 @@ When using service principal authentication, add these **Application Permissions
 
 ???+ note
     This is the **recommended authentication method** because it allows running the full M365 provider including PowerShell checks, providing complete coverage of all available security checks.
-
-### Service Principal + User Credentials Authentication Permissions
-
-When using service principal with user credentials authentication, you need **both** sets of permissions:
-
-**1. Service Principal Application Permissions**:
-
-- All the Microsoft Graph API permissions listed above are required.
-- External API permissions listed above are **not needed**.
-
-**2. User-Level Permissions**: These are set at the `M365_USER` level, so the user used to run Prowler must have one of the following roles:
-
-- `Global Reader` (recommended): Allows reading all required information.
-- `Exchange Administrator` and `Teams Administrator`: User needs both roles for the same access as Global Reader.
 
 ### Browser Authentication Permissions
 
@@ -143,116 +124,6 @@ When using browser authentication, permissions are delegated to the user, so the
 3. Click "Grant admin consent for <your-tenant-name>" to grant admin consent
 
     ![Grant Admin Consent](../microsoft365/img/grant-external-api-permissions.png)
-
-#### Assign User Roles (For User Authentication)
-
-When using Service Principal with User Credentials authentication, assign the following roles to the user:
-
-1. Go to Users > All Users > Click on the email for the user
-
-    ![User Overview](../microsoft365/img/user-info-page.png)
-
-2. Click "Assigned Roles"
-
-    ![User Roles](../microsoft365/img/user-role-page.png)
-
-3. Click "Add assignments", then search and select:
-
-    - `Global Reader` (recommended)
-    - OR `Exchange Administrator` and `Teams Administrator` (both required)
-
-    ![Global Reader Screenshots](../microsoft365/img/global-reader.png)
-
-4. Click next, assign the role as "Active", and click "Assign"
-
-    ![Grant Admin Consent for Role](../microsoft365/img/grant-admin-consent-for-role.png)
-
----
-
-## Service Principal Authentication (Recommended)
-
-*Available for both Prowler App and Prowler CLI*
-
-**Authentication flag for CLI:** `--sp-env-auth`
-
-Authenticate using the **Service Principal Application** by configuring the following environment variables:
-
-```console
-export AZURE_CLIENT_ID="XXXXXXXXX"
-export AZURE_CLIENT_SECRET="XXXXXXXXX"
-export AZURE_TENANT_ID="XXXXXXXXX"
-```
-
-If these variables are not set or exported, execution using `--sp-env-auth` will fail.
-
-Refer to the [Step-by-Step Permission Assignment](#step-by-step-permission-assignment) section below for setup instructions.
-
-If the external API permissions described in the mentioned section above are not added only checks that work through MS Graph will be executed. This means that the full provider will not be executed.
-
-???+ note
-    In order to scan all the checks from M365 required permissions to the service principal application must be added. Refer to the [PowerShell Module Permissions](#grant-powershell-module-permissions-for-service-principal-authentication) section for more information.
-
-## Service Principal and User Credentials Authentication
-
-*Available for both Prowler App and Prowler CLI*
-
-**Authentication flag for CLI:** `--env-auth`
-
-???+ warning
-    This method is not recommended and will be deprecated in October 2025. Use the **Service Principal Application** authentication method instead.
-
-This method builds upon Service Principal authentication by adding User Credentials. Configure the following environment variables: `M365_USER` and `M365_PASSWORD`.
-
-```console
-export AZURE_CLIENT_ID="XXXXXXXXX"
-export AZURE_CLIENT_SECRET="XXXXXXXXX"
-export AZURE_TENANT_ID="XXXXXXXXX"
-export M365_USER="your_email@example.com"
-export M365_PASSWORD="examplepassword"
-```
-
-These two new environment variables are **required** in this authentication method to execute the PowerShell modules needed to retrieve information from M365 services. Prowler uses Service Principal authentication to access Microsoft Graph and user credentials to authenticate to Microsoft PowerShell modules.
-
-- `M365_USER` should be your Microsoft account email using the **assigned domain in the tenant**. This means it must look like `example@YourCompany.onmicrosoft.com` or `example@YourCompany.com`, but it must be the exact domain assigned to that user in the tenant.
-
-    ???+ warning
-        Newly created users must sign in with the account first, as Microsoft prompts for password change. Without completing this step, user authentication fails because Microsoft marks the initial password as expired.
-
-    ???+ warning
-        The user must not be MFA capable. Microsoft does not allow MFA capable users to authenticate programmatically. See [Microsoft documentation](https://learn.microsoft.com/en-us/entra/identity-platform/scenario-desktop-acquire-token-username-password?tabs=dotnet) for more information.
-
-    ???+ warning
-        Using a tenant domain other than the one assigned — even if it belongs to the same tenant — will cause Prowler to fail, as Microsoft authentication will not succeed.
-
-    Ensure the correct domain is used for the authenticating user.
-
-    ![User Domains](img/user-domains.png)
-
-- `M365_PASSWORD` must be the user password.
-
-    ???+ note
-        Previously an encrypted password was required, but now the user password is accepted directly. Prowler handles the password encryption.
-
-
-
-## Interactive Browser Authentication
-
-*Available only for Prowler CLI*
-
-**Authentication flag:** `--browser-auth`
-
-Authenticate against Azure using the default browser to start the scan. The `--tenant-id` flag is also required.
-
-These credentials only enable checks that rely on Microsoft Graph. The entire provider cannot be run with this method. To perform a full M365 security scan, use the **recommended authentication method**.
-
-Since this is a **delegated permission** authentication method, necessary permissions should be assigned to the user rather than the application.
-
-## Supported PowerShell Versions
-
-PowerShell is required to run certain M365 checks.
-
-**Supported versions:**
-- **PowerShell 7.4 or higher** (7.5 is recommended)
 
 #### Why Is PowerShell 7.4+ Required?
 
@@ -471,7 +342,7 @@ The required modules are automatically installed when running Prowler with the `
 Example command:
 
 ```console
-python3 prowler-cli.py m365 --verbose --log-level ERROR --env-auth --init-modules
+python3 prowler-cli.py m365 --verbose --log-level ERROR --sp-env-auth --init-modules
 ```
 If the modules are already installed, running this command will not cause issues—it will simply verify that the necessary modules are available.
 

--- a/docs/tutorials/microsoft365/getting-started-m365.md
+++ b/docs/tutorials/microsoft365/getting-started-m365.md
@@ -55,11 +55,6 @@ Configure authentication for Microsoft 365 by following the [Microsoft 365 Authe
     - Tenant ID
     - `AZURE_CLIENT_SECRET` from the Service Principal setup
 
-    If using user authentication, also add:
-
-    - `M365_USER` (email using the assigned domain in tenant)
-    - `M365_PASSWORD` (user password)
-
     ![Prowler Cloud M365 Credentials](./img/m365-credentials.png)
 
 3. Click "Next"
@@ -85,7 +80,6 @@ PowerShell 7.4+ is required for comprehensive Microsoft 365 security coverage. I
 Select an authentication method from the [Microsoft 365 Authentication](authentication.md) guide:
 
 - **Service Principal Application** (recommended): `--sp-env-auth`
-- **Service Principal with User Credentials**: `--env-auth`
 - **Interactive Browser Authentication**: `--browser-auth`
 
 ### Basic Usage

--- a/docs/tutorials/prowler-app.md
+++ b/docs/tutorials/prowler-app.md
@@ -194,10 +194,10 @@ If you are adding an **EKS**, **GKE**, **AKS** or external cluster, follow these
 For M365, you must enter your Domain ID and choose the authentication method you want to use:
 
 - Service Principal Authentication (Recommended)
-- User Authentication (only works if the user does not have MFA enabled)
+- User Authentication (Deprecated)
 
-???+ note
-    User authentication with M365_USER and M365_PASSWORD is optional and will only work if the account does not enforce MFA.
+???+ warning
+    User authentication with M365_USER and M365_PASSWORD is deprecated and will be removed.
 
 For full setup instructions and requirements, check the [Microsoft 365 provider requirements](./microsoft365/getting-started-m365.md).
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update AWS API Gateway service metadata to new format [(#8788)](https://github.com/prowler-cloud/prowler/pull/8788)
 - Update AWS Athena service metadata to new format [(#8790)](https://github.com/prowler-cloud/prowler/pull/8790)
 - Update AWS Lambda service metadata to new format [(#8825)](https://github.com/prowler-cloud/prowler/pull/8825)
+- Deprecate user authentication for M365 provider [(#8865)](https://github.com/prowler-cloud/prowler/pull/8865)
 
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)

--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -220,7 +220,6 @@ class Provider(ABC):
                         config_path=arguments.config_file,
                         mutelist_path=arguments.mutelist_file,
                         sp_env_auth=arguments.sp_env_auth,
-                        env_auth=arguments.env_auth,
                         az_cli_auth=arguments.az_cli_auth,
                         browser_auth=arguments.browser_auth,
                         certificate_auth=arguments.certificate_auth,

--- a/prowler/providers/m365/exceptions/exceptions.py
+++ b/prowler/providers/m365/exceptions/exceptions.py
@@ -94,26 +94,6 @@ class M365BaseException(ProwlerException):
             "message": "Tenant Id is required for Microsoft 365 static credentials. Make sure you are using the correct credentials.",
             "remediation": "Check the Microsoft 365 Tenant ID and ensure it is properly set up.",
         },
-        (6022, "M365MissingEnvironmentCredentialsError"): {
-            "message": "User and Password environment variables are needed to use Credentials authentication method.",
-            "remediation": "Ensure your environment variables are properly set up.",
-        },
-        (6023, "M365UserCredentialsError"): {
-            "message": "The provided User credentials are not valid.",
-            "remediation": "Check the User credentials and ensure they are valid.",
-        },
-        (6024, "M365NotValidUserError"): {
-            "message": "The provided User is not valid.",
-            "remediation": "Check the User and ensure it is a valid user.",
-        },
-        (6025, "M365NotValidPasswordError"): {
-            "message": "The provided Password is not valid.",
-            "remediation": "Check the Password and ensure it is a valid password.",
-        },
-        (6026, "M365UserNotBelongingToTenantError"): {
-            "message": "The provided User does not belong to the specified tenant.",
-            "remediation": "Check the User email domain and ensure it belongs to the specified tenant.",
-        },
         (6027, "M365GraphConnectionError"): {
             "message": "Failed to establish connection to Microsoft Graph API.",
             "remediation": "Check your Microsoft Application credentials and ensure the app has proper permissions.",
@@ -312,41 +292,6 @@ class M365NotTenantIdButClientIdAndClientSecretError(M365CredentialsError):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             6021, file=file, original_exception=original_exception, message=message
-        )
-
-
-class M365MissingEnvironmentCredentialsError(M365CredentialsError):
-    def __init__(self, file=None, original_exception=None, message=None):
-        super().__init__(
-            6022, file=file, original_exception=original_exception, message=message
-        )
-
-
-class M365UserCredentialsError(M365CredentialsError):
-    def __init__(self, file=None, original_exception=None, message=None):
-        super().__init__(
-            6023, file=file, original_exception=original_exception, message=message
-        )
-
-
-class M365NotValidUserError(M365CredentialsError):
-    def __init__(self, file=None, original_exception=None, message=None):
-        super().__init__(
-            6024, file=file, original_exception=original_exception, message=message
-        )
-
-
-class M365NotValidPasswordError(M365CredentialsError):
-    def __init__(self, file=None, original_exception=None, message=None):
-        super().__init__(
-            6025, file=file, original_exception=original_exception, message=message
-        )
-
-
-class M365UserNotBelongingToTenantError(M365CredentialsError):
-    def __init__(self, file=None, original_exception=None, message=None):
-        super().__init__(
-            6026, file=file, original_exception=original_exception, message=message
         )
 
 

--- a/prowler/providers/m365/lib/arguments/arguments.py
+++ b/prowler/providers/m365/lib/arguments/arguments.py
@@ -19,7 +19,7 @@ def init_parser(self):
     m365_auth_modes_group.add_argument(
         "--sp-env-auth",
         action="store_true",
-        help="Use Azure Service Principal environment variables authentication to log in against Microsoft 365",
+        help="Use Service Principal environment variables authentication to log in against Microsoft 365",
     )
     m365_auth_modes_group.add_argument(
         "--env-auth",

--- a/prowler/providers/m365/lib/arguments/arguments.py
+++ b/prowler/providers/m365/lib/arguments/arguments.py
@@ -1,3 +1,6 @@
+import argparse
+
+
 def init_parser(self):
     """Init the M365 Provider CLI parser"""
     m365_parser = self.subparsers.add_parser(
@@ -14,14 +17,15 @@ def init_parser(self):
         help="Use Azure CLI authentication to log in against Microsoft 365",
     )
     m365_auth_modes_group.add_argument(
-        "--env-auth",
-        action="store_true",
-        help="Use User and Password environment variables authentication to log in against Microsoft 365",
-    )
-    m365_auth_modes_group.add_argument(
         "--sp-env-auth",
         action="store_true",
         help="Use Azure Service Principal environment variables authentication to log in against Microsoft 365",
+    )
+    m365_auth_modes_group.add_argument(
+        "--env-auth",
+        dest="sp_env_auth",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
     m365_auth_modes_group.add_argument(
         "--browser-auth",

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -1,13 +1,10 @@
 import os
-import platform
 
 from prowler.lib.logger import logger
 from prowler.lib.powershell.powershell import PowerShellSession
 from prowler.providers.m365.exceptions.exceptions import (
     M365CertificateCreationError,
     M365GraphConnectionError,
-    M365UserCredentialsError,
-    M365UserNotBelongingToTenantError,
 )
 from prowler.providers.m365.lib.jwt.jwt_decoder import decode_jwt, decode_msal_token
 from prowler.providers.m365.models import M365Credentials, M365IdentityInfo
@@ -76,10 +73,9 @@ class M365PowerShell(PowerShellSession):
         """
         Initialize PowerShell credential object for Microsoft 365 authentication.
 
-        Supports three authentication methods:
-        1. User authentication (username/password) - Will be deprecated in October 2025
-        2. Application authentication (client_id/client_secret)
-        3. Certificate authentication (certificate_content in base64/application_id)
+        Supports two authentication methods:
+        1. Application authentication (client_id/client_secret)
+        2. Certificate authentication (certificate_content in base64/client_id)
 
         Args:
             credentials (M365Credentials): The credentials object containing
@@ -115,22 +111,6 @@ class M365PowerShell(PowerShellSession):
             self.execute(f'$tenantID = "{sanitized_tenant_id}"')
             self.execute(f'$tenantDomain = "{credentials.tenant_domains[0]}"')
 
-        # User Auth (Will be deprecated in October 2025)
-        elif credentials.user and credentials.passwd:
-            credentials.encrypted_passwd = self.encrypt_password(credentials.passwd)
-
-            # Sanitize user and password
-            sanitized_user = self.sanitize(credentials.user)
-            sanitized_encrypted_passwd = self.sanitize(credentials.encrypted_passwd)
-
-            # Securely convert encrypted password to SecureString
-            self.execute(f'$user = "{sanitized_user}"')
-            self.execute(
-                f'$secureString = "{sanitized_encrypted_passwd}" | ConvertTo-SecureString'
-            )
-            self.execute(
-                "$credential = New-Object System.Management.Automation.PSCredential ($user, $secureString)"
-            )
         else:
             # Application Auth
             self.execute(f'$clientID = "{credentials.client_id}"')
@@ -143,51 +123,13 @@ class M365PowerShell(PowerShellSession):
                 '$graphToken = Invoke-RestMethod -Uri "https://login.microsoftonline.com/$tenantID/oauth2/v2.0/token" -Method POST -Body $graphtokenBody | Select-Object -ExpandProperty Access_Token'
             )
 
-    def encrypt_password(self, password: str) -> str:
-        """
-        Encrypts a password using Windows CryptProtectData on Windows systems
-        or UTF-16LE encoding on other systems.
-
-        Args:
-        password (str): The password to encrypt
-
-        Returns:
-        str: The encrypted password in hexadecimal format
-
-        Raises:
-        ValueError: If password is None or empty
-        """
-        try:
-            if platform.system() == "Windows":
-                import win32crypt
-
-                encrypted_blob = win32crypt.CryptProtectData(
-                    password.encode("utf-16le"), None, None, None, None, 0
-                )
-
-                encrypted_bytes = encrypted_blob
-                if isinstance(encrypted_blob, tuple):
-                    encrypted_bytes = encrypted_blob[1]
-                elif hasattr(encrypted_blob, "data"):
-                    encrypted_bytes = encrypted_blob.data
-
-                return encrypted_bytes.hex()
-
-            else:
-                return password.encode("utf-16le").hex()
-        except Exception as error:
-            raise Exception(
-                f"[{os.path.basename(__file__)}] Error encrypting password: {str(error)}"
-            )
-
     def test_credentials(self, credentials: M365Credentials) -> bool:
         """
         Test Microsoft 365 credentials by attempting to authenticate against Entra ID.
 
-        Supports testing three authentication methods:
-        1. User authentication (username/password)
-        2. Application authentication (client_id/client_secret)
-        3. Certificate authentication (certificate_content in base64/application_id)
+        Supports testing two authentication methods:
+        1. Application authentication (client_id/client_secret)
+        2. Certificate authentication (certificate_content in base64/client_id)
 
         Args:
             credentials (M365Credentials): The credentials object containing
@@ -203,50 +145,6 @@ class M365PowerShell(PowerShellSession):
                 return True
             except Exception as e:
                 logger.error(f"Exchange Online Certificate connection failed: {e}")
-
-        # Test User Auth
-        elif credentials.user and credentials.passwd:
-            self.execute(
-                f'$securePassword = "{credentials.encrypted_passwd}" | ConvertTo-SecureString'  # encrypted password already sanitized
-            )
-            self.execute(
-                f'$credential = New-Object System.Management.Automation.PSCredential("{self.sanitize(credentials.user)}", $securePassword)'
-            )
-
-            user_domain = credentials.user.split("@")[1]
-            if not any(
-                user_domain.endswith(domain)
-                for domain in self.tenant_identity.tenant_domains
-            ):
-                raise M365UserNotBelongingToTenantError(
-                    file=os.path.basename(__file__),
-                    message=f"The user domain {user_domain} does not match any of the tenant domains: {', '.join(self.tenant_identity.tenant_domains)}",
-                )
-
-            # Validate credentials
-            # Test Exchange Online connection
-            result = self.execute("Connect-ExchangeOnline -Credential $credential")
-            if "https://aka.ms/exov3-module" not in result:
-                if "AADSTS" in result:  # Entra Security Token Service Error
-                    raise M365UserCredentialsError(
-                        file=os.path.basename(__file__),
-                        message=result,
-                    )
-                # Test Microsoft Teams connection
-                result = self.execute("Connect-MicrosoftTeams -Credential $credential")
-                if self.tenant_identity.user not in result:
-                    if "AADSTS" in result:  # Entra Security Token Service Error
-                        raise M365UserCredentialsError(
-                            file=os.path.basename(__file__),
-                            message=result,
-                        )
-                    else:  # Unknown error, could be a permission issue or modules not installed
-                        raise M365UserCredentialsError(
-                            file=os.path.basename(__file__),
-                            message=f"Error connecting to PowerShell modules: {result if result else 'Unknown error'}",
-                        )
-
-            return True
 
         else:
             # Test Microsoft Graph connection
@@ -317,21 +215,6 @@ class M365PowerShell(PowerShellSession):
             return False
         return True
 
-    def test_teams_user_connection(self) -> bool:
-        """Test Microsoft Teams API connection using user authentication and raise exception if it fails."""
-        result = self.execute("Connect-MicrosoftTeams -Credential $credential")
-        if self.tenant_identity.user not in result:
-            logger.error(f"Microsoft Teams User Auth connection failed: {result}.")
-            return False
-
-        connection = self.execute("Get-CsTeamsClientConfiguration")
-        if not connection:
-            logger.error(
-                "Microsoft Teams User Auth connection failed: Please check your permissions and try again."
-            )
-            return False
-        return True
-
     def test_exchange_connection(self) -> bool:
         """Test Exchange Online API connection and raise exception if it fails."""
         try:
@@ -368,30 +251,14 @@ class M365PowerShell(PowerShellSession):
             return False
         return True
 
-    def test_exchange_user_connection(self) -> bool:
-        """Test Exchange Online API connection using user authentication and raise exception if it fails."""
-        result = self.execute("Connect-ExchangeOnline -Credential $credential")
-        if "https://aka.ms/exov3-module" not in result:
-            logger.error(f"Exchange Online User Auth connection failed: {result}.")
-            return False
-
-        connection = self.execute("Get-OrganizationConfig")
-        if not connection:
-            logger.error(
-                "Exchange Online User Auth connection failed: Please check your permissions and try again."
-            )
-            return False
-        return True
-
     def connect_microsoft_teams(self) -> dict:
         """
         Connect to Microsoft Teams Module PowerShell Module.
 
         Establishes a connection to Microsoft Teams using the initialized credentials.
-        Supports three authentication methods:
-        1. User authentication (username/password)
-        2. Application authentication (client_id/client_secret)
-        3. Certificate authentication (certificate_content in base64/application_id)
+        Supports two authentication methods:
+        1. Application authentication (client_id/client_secret)
+        2. Certificate authentication (certificate_content in base64/client_id)
 
         Returns:
             dict: Connection status information in JSON format.
@@ -402,12 +269,8 @@ class M365PowerShell(PowerShellSession):
         # Certificate Auth
         if self.execute("Write-Output $certificate") != "":
             return self.test_teams_certificate_connection()
-        # User Auth
-        if self.execute("Write-Output $credential") != "":
-            return self.test_teams_user_connection()
         # Application Auth
-        else:
-            return self.test_teams_connection()
+        return self.test_teams_connection()
 
     def get_teams_settings(self) -> dict:
         """
@@ -494,10 +357,9 @@ class M365PowerShell(PowerShellSession):
         Connect to Exchange Online PowerShell Module.
 
         Establishes a connection to Exchange Online using the initialized credentials.
-        Supports three authentication methods:
-        1. User authentication (username/password)
-        2. Application authentication (client_id/client_secret)
-        3. Certificate authentication (certificate_content in base64/application_id)
+        Supports two authentication methods:
+        1. Application authentication (client_id/client_secret)
+        2. Certificate authentication (certificate_content in base64/client_id)
 
         Returns:
             dict: Connection status information in JSON format.
@@ -508,12 +370,8 @@ class M365PowerShell(PowerShellSession):
         # Certificate Auth
         if self.execute("Write-Output $certificate") != "":
             return self.test_exchange_certificate_connection()
-        # User Auth
-        if self.execute("Write-Output $credential") != "":
-            return self.test_exchange_user_connection()
         # Application Auth
-        else:
-            return self.test_exchange_connection()
+        return self.test_exchange_connection()
 
     def get_audit_log_config(self) -> dict:
         """

--- a/prowler/providers/m365/models.py
+++ b/prowler/providers/m365/models.py
@@ -25,9 +25,6 @@ class M365RegionConfig(BaseModel):
 
 
 class M365Credentials(BaseModel):
-    user: Optional[str] = None
-    passwd: Optional[str] = None
-    encrypted_passwd: Optional[str] = None
     client_id: str = ""
     client_secret: Optional[str] = None
     tenant_id: str = ""

--- a/tests/providers/m365/lib/arguments/m365_arguments_test.py
+++ b/tests/providers/m365/lib/arguments/m365_arguments_test.py
@@ -168,7 +168,7 @@ class TestM365Arguments:
         # Check argument configuration
         kwargs = sp_env_call[1]
         assert kwargs["action"] == "store_true"
-        assert "Azure Service Principal environment variables" in kwargs["help"]
+        assert "Service Principal environment variables" in kwargs["help"]
 
     def test_browser_auth_argument_configuration(self):
         """Test that browser-auth argument is configured correctly"""

--- a/tests/providers/m365/lib/arguments/m365_arguments_test.py
+++ b/tests/providers/m365/lib/arguments/m365_arguments_test.py
@@ -147,29 +147,6 @@ class TestM365Arguments:
         assert kwargs["action"] == "store_true"
         assert "Azure CLI authentication" in kwargs["help"]
 
-    def test_env_auth_argument_configuration(self):
-        """Test that env-auth argument is configured correctly"""
-        mock_m365_args = MagicMock()
-        mock_m365_args.subparsers = self.mock_subparsers
-        mock_m365_args.common_providers_parser = MagicMock()
-
-        arguments.init_parser(mock_m365_args)
-
-        # Find the env-auth argument call
-        calls = self.mock_auth_modes_group.add_argument.call_args_list
-        env_auth_call = None
-        for call in calls:
-            if call[0][0] == "--env-auth":
-                env_auth_call = call
-                break
-
-        assert env_auth_call is not None
-
-        # Check argument configuration
-        kwargs = env_auth_call[1]
-        assert kwargs["action"] == "store_true"
-        assert "User and Password environment variables" in kwargs["help"]
-
     def test_sp_env_auth_argument_configuration(self):
         """Test that sp-env-auth argument is configured correctly"""
         mock_m365_args = MagicMock()
@@ -336,28 +313,7 @@ class TestM365ArgumentsIntegration:
         args = parser.parse_args(["m365", "--az-cli-auth"])
 
         assert args.az_cli_auth is True
-        assert args.env_auth is False
-        assert args.sp_env_auth is False
-        assert args.browser_auth is False
-        assert args.certificate_auth is False
-
-    def test_real_argument_parsing_env_auth(self):
-        """Test parsing arguments with environment authentication"""
-        parser = argparse.ArgumentParser()
-        subparsers = parser.add_subparsers()
-        common_parser = argparse.ArgumentParser(add_help=False)
-
-        mock_m365_args = MagicMock()
-        mock_m365_args.subparsers = subparsers
-        mock_m365_args.common_providers_parser = common_parser
-
-        arguments.init_parser(mock_m365_args)
-
-        # Parse arguments with environment auth
-        args = parser.parse_args(["m365", "--env-auth"])
-
-        assert args.az_cli_auth is False
-        assert args.env_auth is True
+        assert not hasattr(args, "env_auth")
         assert args.sp_env_auth is False
         assert args.browser_auth is False
         assert args.certificate_auth is False
@@ -378,7 +334,7 @@ class TestM365ArgumentsIntegration:
         args = parser.parse_args(["m365", "--sp-env-auth"])
 
         assert args.az_cli_auth is False
-        assert args.env_auth is False
+        assert not hasattr(args, "env_auth")
         assert args.sp_env_auth is True
         assert args.browser_auth is False
         assert args.certificate_auth is False
@@ -406,7 +362,7 @@ class TestM365ArgumentsIntegration:
         )
 
         assert args.az_cli_auth is False
-        assert args.env_auth is False
+        assert not hasattr(args, "env_auth")
         assert args.sp_env_auth is False
         assert args.browser_auth is True
         assert args.certificate_auth is False
@@ -428,7 +384,7 @@ class TestM365ArgumentsIntegration:
         args = parser.parse_args(["m365", "--certificate-auth"])
 
         assert args.az_cli_auth is False
-        assert args.env_auth is False
+        assert not hasattr(args, "env_auth")
         assert args.sp_env_auth is False
         assert args.browser_auth is False
         assert args.certificate_auth is True
@@ -495,7 +451,7 @@ class TestM365ArgumentsIntegration:
         args = parser.parse_args(["m365"])
 
         assert args.az_cli_auth is False
-        assert args.env_auth is False
+        assert not hasattr(args, "env_auth")
         assert args.sp_env_auth is False
         assert args.browser_auth is False
         assert args.certificate_auth is False
@@ -547,7 +503,7 @@ class TestM365ArgumentsIntegration:
 
         # This should raise SystemExit due to mutually exclusive group
         try:
-            parser.parse_args(["m365", "--az-cli-auth", "--env-auth"])
+            parser.parse_args(["m365", "--az-cli-auth", "--sp-env-auth"])
             assert False, "Expected SystemExit due to mutually exclusive arguments"
         except SystemExit:
             # This is expected
@@ -636,6 +592,6 @@ class TestM365ArgumentsIntegration:
         assert args.certificate_path == "/home/user/cert.pem"
         assert args.tenant_id == "12345678-1234-1234-1234-123456789012"
         assert args.az_cli_auth is False
-        assert args.env_auth is False
+        assert not hasattr(args, "env_auth")
         assert args.sp_env_auth is False
         assert args.browser_auth is False

--- a/tests/providers/m365/m365_fixtures.py
+++ b/tests/providers/m365/m365_fixtures.py
@@ -23,7 +23,9 @@ LOCATION = "global"
 def set_mocked_m365_provider(
     session_credentials: DefaultAzureCredential = DefaultAzureCredential(),
     credentials: M365Credentials = M365Credentials(
-        user="user@email.com", passwd="111111aa111111aaa1111"
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        tenant_id=TENANT_ID,
     ),
     identity: M365IdentityInfo = M365IdentityInfo(
         identity_id=IDENTITY_ID,


### PR DESCRIPTION
### Context

`Microsoft` has dropped support for username/password flows in `M365` due to the need of `MFA` (breaking the non interactive auth flow with those variables), so the CLI flag `--env-auth` (user credentials) had to go.

This PR removes that path and keeps `--sp-env-auth` as the only environment based option by treating it as the legacy alias internally. Documentation and tests are updated accordingly.

### Description

- remove `--env-auth` and user/password handling from the CLI parser, provider code, models, exceptions, and fixtures; hide the legacy flag as an alias to `--sp-env-auth`.
- tighten `PowerShell` setup to only load service-principal or certificate credentials, updating the companion tests to patch at the `M365` provider level instead of invoking real `PowerShell` sessions.
- scrub docs (tutorials, basic usage, prowler app) of --env-auth, `M365_USER`, and other user/password references; add deprecation `TODOs` where applicable.

### Steps to review

1. Inspect `prowler/providers/m365/m365_provider.py`, `prowler/providers/m365/lib/arguments/arguments.py`, and `prowler/providers/m365/lib/powershell/m365_powershell.py` to confirm all user/password logic and the visible `--env-auth` flag are gone, while the alias still maps to `sp_env_auth`.
2. Check `docs/basic-usage/prowler-cli.md`, `docs/tutorials/microsoft365/*`, and `docs/tutorials/prowler-app.md` to ensure documentation only references `--sp-env-auth` and no longer mentions `M365_USER`/ `M365_PASSWORD`.
3. Review updated tests in `tests/providers/m365/...` to make sure they no longer rely on user credentials, and that the `PowerShell` tests mock `M365PowerShell` rather than invoking subprocess I/O.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
