### PR TITLE
feat(mcp): add GitHub Action to publish MCP Server container to DockerHub

### DIFF
--- a/.github/workflows/mcp-server-build-push-containers.yml
+++ b/.github/workflows/mcp-server-build-push-containers.yml
@@ -27,7 +27,7 @@ env:
 
   # Container Registries
   PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
-  PROWLERCLOUD_DOCKERHUB_IMAGE: prowler-mcp-server
+  PROWLERCLOUD_DOCKERHUB_IMAGE: prowler-mcp
 
 jobs:
   repository-check:

--- a/.github/workflows/mcp-server-build-push-containers.yml
+++ b/.github/workflows/mcp-server-build-push-containers.yml
@@ -1,0 +1,90 @@
+name: MCP Server - Build and Push containers
+
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "mcp_server/**"
+      - ".github/workflows/mcp-server-build-push-containers.yml"
+
+  # Uncomment the below code to test this action on PRs
+  # pull_request:
+  #   branches:
+  #     - "master"
+  #   paths:
+  #     - "mcp_server/**"
+  #     - ".github/workflows/mcp-server-build-push-containers.yml"
+
+  release:
+    types: [published]
+
+env:
+  # Tags
+  LATEST_TAG: latest
+
+  WORKING_DIRECTORY: ./mcp_server
+
+  # Container Registries
+  PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
+  PROWLERCLOUD_DOCKERHUB_IMAGE: prowler-mcp-server
+
+jobs:
+  repository-check:
+    name: Repository check
+    runs-on: ubuntu-latest
+    outputs:
+      is_repo: ${{ steps.repository_check.outputs.is_repo }}
+    steps:
+      - name: Repository check
+        id: repository_check
+        working-directory: /tmp
+        run: |
+          if [[ ${{ github.repository }} == "prowler-cloud/prowler" ]]
+          then
+            echo "is_repo=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "This action only runs for prowler-cloud/prowler"
+            echo "is_repo=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+  container-build-push:
+    needs: repository-check
+    if: needs.repository-check.outputs.is_repo == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set short git commit SHA
+        id: vars
+        run: |
+          shortSha=$(git rev-parse --short ${{ github.sha }})
+          echo "SHORT_SHA=${shortSha}" >> $GITHUB_ENV
+
+      - name: Login to DockerHub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build and push container image (latest)
+        # Comment the following line for testing
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ${{ env.WORKING_DIRECTORY }}
+          # Set push: false for testing
+          push: true
+          tags: |
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.LATEST_TAG }}
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.SHORT_SHA }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
### Context

This PR adds a GitHub Action workflow to automate the building and publishing of the MCP Server container image to DockerHub.

### Description

A new workflow `.github/workflows/mcp-server-build-push-containers.yml` has been created following the same pattern as the UI container workflow. The workflow:

- Triggers on pushes to `master` when files in `mcp_server/` or the workflow file itself change
- Triggers on release events (currently disabled for versioned tags)
- Builds and pushes the container image to `prowlercloud/prowler-mcp-server`
- Tags images with `latest` and the short commit SHA on push events
- Uses Docker Buildx with GitHub Actions cache for optimized builds
- Only runs on the official `prowler-cloud/prowler` repository

The workflow does not include stable/release version tags as the versioning strategy for the MCP Server component is pending definition.

### Steps to review

1. Review the workflow file at `.github/workflows/mcp-server-build-push-containers.yml`
2. Compare with the existing UI workflow at `.github/workflows/ui-build-lint-push-containers.yml` to verify consistency
3. Verify that the workflow only triggers for the correct paths and repository
4. Confirm that DockerHub secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`) are properly configured in the repository

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.