### PR TITLE
chore(mcp): add changelog with first version

### DIFF
--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      MONITORED_FOLDERS: "api ui prowler dashboard mcp_server"
+      MONITORED_FOLDERS: "api ui prowler mcp_server"
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/pull-request-check-changelog.yml
+++ b/.github/workflows/pull-request-check-changelog.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
       pull-requests: write
     env:
-      MONITORED_FOLDERS: "api ui prowler dashboard"
+      MONITORED_FOLDERS: "api ui prowler dashboard mcp_server"
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/mcp_server/CHANGELOG.md
+++ b/mcp_server/CHANGELOG.md
@@ -12,6 +12,3 @@ All notable changes to the **Prowler MCP Server** are documented in this file.
 - HTTP transport support [(#8784)](https://github.com/prowler-cloud/prowler/pull/8784)
 - Add new MCP Server for Prowler Documentation [(#8795)](https://github.com/prowler-cloud/prowler/pull/8795)
 - API key support for STDIO mode and enhanced HTTP mode authentication [(#8823)](https://github.com/prowler-cloud/prowler/pull/8823)
-
-### Fixed
-- Accept string type for all parameter types in MCP server [(#8866)](https://github.com/prowler-cloud/prowler/pull/8866)

--- a/mcp_server/CHANGELOG.md
+++ b/mcp_server/CHANGELOG.md
@@ -12,3 +12,4 @@ All notable changes to the **Prowler MCP Server** are documented in this file.
 - HTTP transport support [(#8784)](https://github.com/prowler-cloud/prowler/pull/8784)
 - Add new MCP Server for Prowler Documentation [(#8795)](https://github.com/prowler-cloud/prowler/pull/8795)
 - API key support for STDIO mode and enhanced HTTP mode authentication [(#8823)](https://github.com/prowler-cloud/prowler/pull/8823)
+- Add health check endpoint [(#8905)](https://github.com/prowler-cloud/prowler/pull/8905)

--- a/mcp_server/CHANGELOG.md
+++ b/mcp_server/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Prowler MCP Server Changelog
+
+All notable changes to the **Prowler MCP Server** are documented in this file.
+
+## [0.1.0] (Prowler UNRELEASED)
+
+### Added
+- Initial release of Prowler MCP Server [(#8695)](https://github.com/prowler-cloud/prowler/pull/8695)
+- Set appropiate user-agent in requests [(#8724)](https://github.com/prowler-cloud/prowler/pull/8724)
+- Basic logger functionality [(#8740)](https://github.com/prowler-cloud/prowler/pull/8740)
+- Add new MCP Server for Prowler Cloud and Prowler App (Self-Managed) APIs [(#8744)](https://github.com/prowler-cloud/prowler/pull/8744)
+- HTTP transport support [(#8784)](https://github.com/prowler-cloud/prowler/pull/8784)
+- Add new MCP Server for Prowler Documentation [(#8795)](https://github.com/prowler-cloud/prowler/pull/8795)
+- API key support for STDIO mode and enhanced HTTP mode authentication [(#8823)](https://github.com/prowler-cloud/prowler/pull/8823)
+
+### Fixed
+- Accept string type for all parameter types in MCP server [(#8866)](https://github.com/prowler-cloud/prowler/pull/8866)


### PR DESCRIPTION
### Context

This PR adds a changelog entry for the Prowler MCP Server to document the changes made in version 0.1.0, which includes the initial release and various improvements to the MCP Server functionality.

### Description

This PR adds a new CHANGELOG.md file for the Prowler MCP Server component to track all notable changes. The changelog documents the initial release (v0.1.0) including:

- Initial release of Prowler MCP Server
- User-agent configuration in requests
- Basic logger functionality
- MCP Server for Prowler Cloud and Prowler App APIs
- HTTP transport support
- MCP Server for Prowler Documentation
- API key support for STDIO and HTTP modes
- Bug fix for parameter type handling

This follows the conventional changelog format and provides proper versioning for the MCP Server component.

### Steps to review

1. Review the CHANGELOG.md file in the `mcp_server/` directory
2. Verify the changelog format follows conventional changelog standards
3. Check that all PR references are correctly linked
4. Ensure the version numbering and release status are appropriate
5. Confirm the changelog structure matches other components in the monorepo

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? N/A
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/mcp_server/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.