### PR TITLE
chore(aws): enhance metadata for `efs` service

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -34,7 +34,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Deprecate user authentication for M365 provider [(#8865)](https://github.com/prowler-cloud/prowler/pull/8865)
 - Update AWS EFS service metadata to new format [(#8889)](https://github.com/prowler-cloud/prowler/pull/8889)
 
-
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)
 - Fix HTML Markdown output for long strings [(#8803)](https://github.com/prowler-cloud/prowler/pull/8803)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -32,6 +32,8 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update AWS CloudFormation service metadata to new format [(#8828)](https://github.com/prowler-cloud/prowler/pull/8828)
 - Update AWS Lambda service metadata to new format [(#8825)](https://github.com/prowler-cloud/prowler/pull/8825)
 - Deprecate user authentication for M365 provider [(#8865)](https://github.com/prowler-cloud/prowler/pull/8865)
+- Update AWS EFS service metadata to new format [(#8889)](https://github.com/prowler-cloud/prowler/pull/8889)
+
 
 ### Fixed
 - Fix SNS topics showing empty AWS_ResourceID in Quick Inventory output [(#8762)](https://github.com/prowler-cloud/prowler/issues/8762)

--- a/prowler/providers/aws/services/efs/efs_access_point_enforce_root_directory/efs_access_point_enforce_root_directory.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_access_point_enforce_root_directory/efs_access_point_enforce_root_directory.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "aws",
   "CheckID": "efs_access_point_enforce_root_directory",
-  "CheckTitle": "EFS file system has no access points allowing access to the root directory (/)",
+  "CheckTitle": "EFS file system has no access points allowing access to the root directory",
   "CheckType": [
     "Software and Configuration Checks/AWS Security Best Practices",
     "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
@@ -17,10 +17,7 @@
   "RelatedUrl": "",
   "AdditionalURLs": [
     "https://docs.aws.amazon.com/efs/latest/ug/enforce-root-directory-access-point.html",
-    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-3",
-    "https://docs.aws.amazon.com/config/latest/developerguide/efs-access-point-enforce-root-directory.html",
-    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html",
-    "https://hub.powerpipe.io/mods/turbot/steampipe-mod-aws-compliance/benchmarks/benchmark.pci_dss_v40_requirement_3_5"
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-3"
   ],
   "Remediation": {
     "Code": {
@@ -35,7 +32,7 @@
     }
   },
   "Categories": [
-    "identity-access"
+    "vulnerabilities"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/efs/efs_access_point_enforce_root_directory/efs_access_point_enforce_root_directory.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_access_point_enforce_root_directory/efs_access_point_enforce_root_directory.metadata.json
@@ -1,32 +1,41 @@
 {
   "Provider": "aws",
   "CheckID": "efs_access_point_enforce_root_directory",
-  "CheckTitle": "EFS access points should enforce a root directory",
+  "CheckTitle": "EFS file system has no access points allowing access to the root directory (/)",
   "CheckType": [
-    "Software and Configuration Checks/AWS Security Best Practices"
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "Effects/Data Exposure"
   ],
   "ServiceName": "efs",
-  "SubServiceName": "access-point",
-  "ResourceIdTemplate": "arn:aws:elasticfilesystem:{region}:{account-id}:access-point/{access-point-id}",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "AwsEfsAccessPoint",
-  "Description": "This control checks if Amazon EFS access points are configured to enforce a root directory. The control fails if the value of Path is set to / (the default root directory of the file system).",
-  "Risk": "Access points without enforced root directories can potentially expose the entire file system's root directory to clients, which may result in unauthorized access.",
-  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/efs-access-point-enforce-root-directory.html",
+  "Description": "**Amazon EFS access points** are evaluated to ensure they enforce a non-root directory. The check identifies access points whose configured root directory `Path` is `/`, meaning clients would mount the file system's root instead of a scoped subdirectory.",
+  "Risk": "Exposing the file system root via an access point undermines **confidentiality** and **integrity** by allowing traversal beyond intended datasets. Attackers or misconfigured apps could:\n- Read sensitive directories\n- Modify or delete shared data\n- Pivot across tenants, impacting **availability**",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/efs/latest/ug/enforce-root-directory-access-point.html",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-3",
+    "https://docs.aws.amazon.com/config/latest/developerguide/efs-access-point-enforce-root-directory.html",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html",
+    "https://hub.powerpipe.io/mods/turbot/steampipe-mod-aws-compliance/benchmarks/benchmark.pci_dss_v40_requirement_3_5"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws efs update-access-point --access-point-id <access-point-id> --root-directory Path=<non-root-directory-path>",
-      "NativeIaC": "",
-      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-3",
-      "Terraform": ""
+      "CLI": "aws efs delete-access-point --access-point-id <access-point-id>",
+      "NativeIaC": "```yaml\n# CloudFormation: EFS access point enforcing a non-root directory\nResources:\n  <example_resource_name>:\n    Type: AWS::EFS::AccessPoint\n    Properties:\n      FileSystemId: <example_resource_id>\n      RootDirectory:\n        Path: /data  # Critical: set to a non-root path to avoid \"/\" and pass the check\n        # This enforces the access point root to /data instead of the file system root\n```",
+      "Other": "1. In the AWS Console, go to EFS > Access points\n2. Select the access point showing Root directory as /\n3. Click Delete and confirm\n4. Click Create access point\n5. Select the file system and set Root directory Path to a non-root path (for example, /data)\n6. Click Create access point",
+      "Terraform": "```hcl\n# Terraform: EFS access point enforcing a non-root directory\nresource \"aws_efs_access_point\" \"<example_resource_name>\" {\n  file_system_id = \"<example_resource_id>\"\n\n  root_directory {\n    path = \"/data\"  # Critical: not \"/\"; enforces a subdirectory as root to pass the check\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Update the EFS access point to enforce a non-root directory. This ensures clients can only access a specified subdirectory.",
-      "Url": "https://docs.aws.amazon.com/efs/latest/ug/enforce-root-directory-access-point.html"
+      "Text": "Apply **least privilege**: set each access point `Path` to a dedicated subdirectory and avoid `/`.\n- Use per-application access points\n- Enforce POSIX identity and directory permissions\n- Layer controls (network segmentation, monitoring) for **defense in depth**",
+      "Url": "https://hub.prowler.com/check/efs_access_point_enforce_root_directory"
     }
   },
   "Categories": [
-    "vulnerabilities"
+    "identity-access"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/efs/efs_access_point_enforce_user_identity/efs_access_point_enforce_user_identity.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_access_point_enforce_user_identity/efs_access_point_enforce_user_identity.metadata.json
@@ -1,32 +1,44 @@
 {
   "Provider": "aws",
   "CheckID": "efs_access_point_enforce_user_identity",
-  "CheckTitle": "EFS access points should enforce a user identity",
+  "CheckTitle": "EFS file system has all access points with a defined POSIX user",
   "CheckType": [
-    "Software and Configuration Checks/AWS Security Best Practices"
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "Effects/Data Exposure",
+    "TTPs/Privilege Escalation"
   ],
   "ServiceName": "efs",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:aws:elasticfilesystem:{region}:{account-id}:access-point/{access-point-id}",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "AwsEfsAccessPoint",
-  "Description": "This control checks whether Amazon EFS access points are configured to enforce a user identity. This control fails if a POSIX user identity is not defined while creating the EFS access point.",
-  "Risk": "Without enforcing a user identity, access to the file system can become less controlled, leading to potential unauthorized access or modifications.",
-  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/efs-access-point-enforce-user-identity.html",
+  "Description": "**Amazon EFS access points** are evaluated for a defined **POSIX user** (`uid`, `gid`, optional secondary groups). The check inspects each access point on a file system and flags those without a configured POSIX user identity.",
+  "Risk": "Without enforced **POSIX identity**, NFS clients can supply arbitrary UIDs/GIDs, enabling impersonation, unauthorized reads/writes, and ownership spoofing. This undermines **confidentiality** and **integrity** of shared data and can enable **lateral movement** across applications sharing the file system.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html",
+    "https://repost.aws/knowledge-center/efs-access-points-directory-access",
+    "https://www.plerion.com/cloud-knowledge-base/efs-access-points-should-be-configured-to-enforce-a-user-identity",
+    "https://docs.aws.amazon.com/efs/latest/ug/enforce-identity-access-points.html",
+    "https://docs.aws.amazon.com/config/latest/developerguide/efs-access-point-enforce-user-identity.html",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-4"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws efs create-access-point --file-system-id <file-system-id> --posix-user Uid=<uid>,Gid=<gid>",
-      "NativeIaC": "",
-      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-4",
-      "Terraform": ""
+      "CLI": "",
+      "NativeIaC": "```yaml\nResources:\n  ExampleAccessPoint:\n    Type: AWS::EFS::AccessPoint\n    Properties:\n      FileSystemId: \"<example_resource_id>\"\n      PosixUser:               # Critical: enforces a POSIX user for all requests via this access point\n        Uid: \"<uid>\"          # Critical: POSIX user ID enforced\n        Gid: \"<gid>\"          # Critical: POSIX group ID enforced\n```",
+      "Other": "1. In the AWS Console, go to Amazon EFS > Access points\n2. Click Create access point, select the file system, and set POSIX user: enter User ID and Group ID\n3. Click Create access point\n4. Update clients to mount using the new access point ID\n5. Delete the old access point(s) that lack a POSIX user",
+      "Terraform": "```hcl\nresource \"aws_efs_access_point\" \"example\" {\n  file_system_id = \"<example_resource_id>\"\n\n  # Critical: enforces a POSIX user for all requests via this access point\n  posix_user {\n    uid = 1000  # Critical: user ID enforced\n    gid = 1000  # Critical: group ID enforced\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Create or update the EFS access point to enforce a user identity using POSIX attributes for Uid and Gid.",
-      "Url": "https://docs.aws.amazon.com/efs/latest/ug/enforce-identity-access-points.html"
+      "Text": "Enforce a **POSIX user identity** on every access point using least-privilege `uid`/`gid` (avoid `0`). Apply **separation of duties** with dedicated access points per application and minimal groups. Use **IAM** to require access point usage and add **defense in depth** by enforcing a restricted root directory.",
+      "Url": "https://hub.prowler.com/check/efs_access_point_enforce_user_identity"
     }
   },
   "Categories": [
-    "trustboundaries"
+    "identity-access"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/efs/efs_access_point_enforce_user_identity/efs_access_point_enforce_user_identity.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_access_point_enforce_user_identity/efs_access_point_enforce_user_identity.metadata.json
@@ -21,8 +21,6 @@
     "https://repost.aws/knowledge-center/efs-access-points-directory-access",
     "https://www.plerion.com/cloud-knowledge-base/efs-access-points-should-be-configured-to-enforce-a-user-identity",
     "https://docs.aws.amazon.com/efs/latest/ug/enforce-identity-access-points.html",
-    "https://docs.aws.amazon.com/config/latest/developerguide/efs-access-point-enforce-user-identity.html",
-    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html",
     "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-4"
   ],
   "Remediation": {

--- a/prowler/providers/aws/services/efs/efs_encryption_at_rest_enabled/efs_encryption_at_rest_enabled.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_encryption_at_rest_enabled/efs_encryption_at_rest_enabled.metadata.json
@@ -16,18 +16,14 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsAccessPoint",
+  "ResourceType": "AwsEfsFileSystem",
   "Description": "**Amazon EFS file system** has **encryption at rest** enabled using AWS KMS to protect file data and metadata stored on the service",
   "Risk": "Without encryption at rest, EFS contents can be read from storage media, backups, or compromised hosts, eroding **confidentiality** and enabling offline exfiltration. Privileged compromise also allows covert data harvesting or manipulation, threatening **integrity** of files.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.prowler.com/checks/aws/general-policies/general_17/",
     "https://repost.aws/knowledge-center/efs-turn-on-encryption-at-rest",
     "https://docs.aws.amazon.com/efs/latest/ug/EFSKMS.html",
-    "https://docs.prowler.com/checks/aws/general-policies/general_17#terraform",
-    "https://docs.aws.amazon.com/efs/latest/ug/managing-encrypt.html",
-    "https://docs.aws.amazon.com/efs/latest/ug/encryption-at-rest.html",
-    "https://d1.awsstatic.com/whitepapers/amazon-efs-encrypted-filesystems.pdf"
+    "https://docs.aws.amazon.com/efs/latest/ug/encryption-at-rest.html"
   ],
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/efs/efs_encryption_at_rest_enabled/efs_encryption_at_rest_enabled.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_encryption_at_rest_enabled/efs_encryption_at_rest_enabled.metadata.json
@@ -1,30 +1,44 @@
 {
   "Provider": "aws",
   "CheckID": "efs_encryption_at_rest_enabled",
-  "CheckTitle": "Check if EFS protects sensitive data with encryption at rest",
+  "CheckTitle": "EFS file system has encryption at rest enabled",
   "CheckType": [
-    "Protect",
-    "Data protection",
-    "Encryption of data at rest"
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/NIST 800-53 Controls (USA)",
+    "Software and Configuration Checks/Industry and Regulatory Standards/NIST CSF Controls (USA)",
+    "Software and Configuration Checks/Industry and Regulatory Standards/PCI-DSS",
+    "Software and Configuration Checks/Industry and Regulatory Standards/HIPAA Controls (USA)",
+    "Software and Configuration Checks/Industry and Regulatory Standards/ISO 27001 Controls",
+    "Effects/Data Exposure"
   ],
   "ServiceName": "efs",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsFileSystem",
-  "Description": "Check if EFS protects sensitive data with encryption at rest",
-  "Risk": "EFS should be encrypted at rest to prevent exposure of sensitive data to bad actors",
+  "ResourceType": "AwsEfsAccessPoint",
+  "Description": "**Amazon EFS file system** has **encryption at rest** enabled using AWS KMS to protect file data and metadata stored on the service",
+  "Risk": "Without encryption at rest, EFS contents can be read from storage media, backups, or compromised hosts, eroding **confidentiality** and enabling offline exfiltration. Privileged compromise also allows covert data harvesting or manipulation, threatening **integrity** of files.",
   "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.prowler.com/checks/aws/general-policies/general_17/",
+    "https://repost.aws/knowledge-center/efs-turn-on-encryption-at-rest",
+    "https://docs.aws.amazon.com/efs/latest/ug/EFSKMS.html",
+    "https://docs.prowler.com/checks/aws/general-policies/general_17#terraform",
+    "https://docs.aws.amazon.com/efs/latest/ug/managing-encrypt.html",
+    "https://docs.aws.amazon.com/efs/latest/ug/encryption-at-rest.html",
+    "https://d1.awsstatic.com/whitepapers/amazon-efs-encrypted-filesystems.pdf"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws efs create-file-system --creation-token $(uuidgen) --performance-mode generalPurpose --encrypted --kms-key-id user/customer-managedCMKalias",
-      "NativeIaC": "https://docs.prowler.com/checks/aws/general-policies/general_17#cloudformation",
-      "Other": "",
-      "Terraform": "https://docs.prowler.com/checks/aws/general-policies/general_17#terraform"
+      "CLI": "",
+      "NativeIaC": "```yaml\n# CloudFormation: Create an EFS file system with encryption at rest enabled\nResources:\n  <example_resource_name>:\n    Type: AWS::EFS::FileSystem\n    Properties:\n      Encrypted: true  # Critical: enables encryption at rest so the check passes\n```",
+      "Other": "1. In the AWS Console, go to Amazon EFS\n2. Click Create file system\n3. Check Enable encryption (leave default key or choose a KMS key if required)\n4. Click Create\n5. Migrate data from the unencrypted file system to the new encrypted one\n6. Delete the unencrypted file system to clear the failing finding",
+      "Terraform": "```hcl\n# Terraform: Create an EFS file system with encryption at rest enabled\nresource \"aws_efs_file_system\" \"<example_resource_name>\" {\n  encrypted = true  # Critical: enables encryption at rest so the check passes\n}\n```"
     },
     "Recommendation": {
-      "Text": "Ensure that encryption at rest is enabled for EFS file systems. Encryption at rest can only be enabled during the file system creation.",
-      "Url": "https://docs.aws.amazon.com/efs/latest/ug/encryption-at-rest.html"
+      "Text": "Enable **encryption at rest** for all EFS file systems and prefer **customer-managed KMS keys** for control, rotation, and audit. Apply **least privilege** to key policies and separate key management duties. *For existing unencrypted data*, migrate to a new encrypted file system. Enforce creation policies (IAM/SCP) to prevent non-encrypted deployments.",
+      "Url": "https://hub.prowler.com/check/efs_encryption_at_rest_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/efs/efs_have_backup_enabled/efs_have_backup_enabled.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_have_backup_enabled/efs_have_backup_enabled.metadata.json
@@ -1,33 +1,38 @@
 {
   "Provider": "aws",
   "CheckID": "efs_have_backup_enabled",
-  "CheckTitle": "Check if EFS File systems have backup enabled",
+  "CheckTitle": "EFS file system has backup enabled",
   "CheckType": [
-    "Recover",
-    "Resilience",
-    "Backup"
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Software and Configuration Checks/Industry and Regulatory Standards/AWS Foundational Security Best Practices",
+    "Effects/Data Destruction"
   ],
   "ServiceName": "efs",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsFileSystem",
-  "Description": "Check if EFS File systems have backup enabled",
-  "Risk": "If backup is not enabled, data is vulnerable. Human error or bad actors could erase or modify data.",
+  "ResourceType": "Other",
+  "Description": "**Amazon EFS file systems** are assessed for automated backups configured via the `backup policy`. The finding highlights file systems where backups are not enabled or are being disabled.",
+  "Risk": "Absence of EFS backups degrades **availability** and **integrity**. Accidental deletion, ransomware, or misconfiguration can wipe or corrupt data with no recovery path. Without point-in-time copies, RPO/RTO suffer and localized incidents can become prolonged outages and irreversible loss.",
   "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/efs/latest/ug/whatisefs.html"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "CLI": "aws efs put-backup-policy --file-system-id <FILE_SYSTEM_ID> --backup-policy Status=ENABLED",
+      "NativeIaC": "```yaml\n# CloudFormation: Enable automatic backups for EFS\nResources:\n  <example_resource_name>:\n    Type: AWS::EFS::FileSystem\n    Properties:\n      BackupPolicy:\n        Status: ENABLED  # Critical: turns on EFS automatic backups via AWS Backup\n```",
+      "Other": "1. In the AWS Console, go to Amazon EFS > File systems\n2. Select the target file system\n3. Click Edit (or Update)\n4. Set Automatic backups to Enabled\n5. Save changes",
+      "Terraform": "```hcl\n# Enable automatic backups for EFS\nresource \"aws_efs_file_system\" \"<example_resource_name>\" {\n  backup_policy {\n    status = \"ENABLED\"  # Critical: turns on EFS automatic backups\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Enable automated backup for production data. Define a retention period and periodically test backup restoration. A Disaster Recovery process should be in place to govern Data Protection approach.",
-      "Url": "https://docs.aws.amazon.com/efs/latest/ug/whatisefs.html"
+      "Text": "Enable automated EFS backups by setting the file system `backup policy` to `ENABLED` and applying defense-in-depth:\n- Schedule frequent jobs with tiered retention\n- Use immutable vaults and cross-Region copies\n- Restrict delete/restore via **least privilege** and **separation of duties**\n- Regularly test restores and document DR objectives",
+      "Url": "https://hub.prowler.com/check/efs_have_backup_enabled"
     }
   },
-  "Categories": [],
+  "Categories": [
+    "resilience"
+  ],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": ""

--- a/prowler/providers/aws/services/efs/efs_have_backup_enabled/efs_have_backup_enabled.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_have_backup_enabled/efs_have_backup_enabled.metadata.json
@@ -11,12 +11,13 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "Other",
+  "ResourceType": "AwsEfsFileSystem",
   "Description": "**Amazon EFS file systems** are assessed for automated backups configured via the `backup policy`. The finding highlights file systems where backups are not enabled or are being disabled.",
   "Risk": "Absence of EFS backups degrades **availability** and **integrity**. Accidental deletion, ransomware, or misconfiguration can wipe or corrupt data with no recovery path. Without point-in-time copies, RPO/RTO suffer and localized incidents can become prolonged outages and irreversible loss.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.aws.amazon.com/efs/latest/ug/whatisefs.html"
+    "https://docs.aws.amazon.com/efs/latest/ug/awsbackup.html",
+    "https://docs.aws.amazon.com/efs/latest/ug/automatic-backups.html"
   ],
   "Remediation": {
     "Code": {

--- a/prowler/providers/aws/services/efs/efs_mount_target_not_publicly_accessible/efs_mount_target_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_mount_target_not_publicly_accessible/efs_mount_target_not_publicly_accessible.metadata.json
@@ -11,12 +11,11 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "Other",
+  "ResourceType": "AwsEfsFileSystem",
   "Description": "**EFS mount targets** associated with VPC subnets that auto-assign public IPv4 addresses (`mapPublicIpOnLaunch=true`) are identified per file system.\n\nThe evaluation focuses on the subnet attribute linked to each mount target.",
   "Risk": "Publicly addressable mount targets expose NFS to Internet scanning and exploit attempts.\n- **Confidentiality**: unauthorized reads\n- **Integrity**: illicit writes or deletion\n- **Availability**: DDoS/resource exhaustion\n\n*Even with tight rules*, a public IP weakens isolation and eases recon.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.aws.amazon.com/config/latest/developerguide/efs-mount-target-public-accessible.html",
     "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-6",
     "https://docs.aws.amazon.com/efs/latest/ug/accessing-fs.html"
   ],

--- a/prowler/providers/aws/services/efs/efs_mount_target_not_publicly_accessible/efs_mount_target_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_mount_target_not_publicly_accessible/efs_mount_target_not_publicly_accessible.metadata.json
@@ -1,28 +1,35 @@
 {
   "Provider": "aws",
   "CheckID": "efs_mount_target_not_publicly_accessible",
-  "CheckTitle": "EFS mount targets should not be publicly accessible",
+  "CheckTitle": "EFS file system has no publicly accessible mount targets",
   "CheckType": [
-    "Software and Configuration Checks/AWS Security Best Practices"
+    "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
+    "TTPs/Initial Access",
+    "Effects/Data Exposure"
   ],
   "ServiceName": "efs",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:aws:elasticfilesystem:{region}:{account-id}:file-system/{filesystem-id}",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsFileSystem",
-  "Description": "This control checks whether an Amazon EFS mount target is associated with a public subnet since it can be accessed from the internet.",
-  "Risk": "Mount targets in public subnets may expose your EFS to unauthorized access or attacks.",
-  "RelatedUrl": "https://docs.aws.amazon.com/config/latest/developerguide/efs-mount-target-public-accessible.html",
+  "ResourceType": "Other",
+  "Description": "**EFS mount targets** associated with VPC subnets that auto-assign public IPv4 addresses (`mapPublicIpOnLaunch=true`) are identified per file system.\n\nThe evaluation focuses on the subnet attribute linked to each mount target.",
+  "Risk": "Publicly addressable mount targets expose NFS to Internet scanning and exploit attempts.\n- **Confidentiality**: unauthorized reads\n- **Integrity**: illicit writes or deletion\n- **Availability**: DDoS/resource exhaustion\n\n*Even with tight rules*, a public IP weakens isolation and eases recon.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/config/latest/developerguide/efs-mount-target-public-accessible.html",
+    "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-6",
+    "https://docs.aws.amazon.com/efs/latest/ug/accessing-fs.html"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "aws efs create-mount-target --file-system-id <filesystem-id> --subnet-id <private-subnet-id> --security-groups <sg-ids>",
-      "NativeIaC": "",
-      "Other": "https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-6",
-      "Terraform": ""
+      "CLI": "",
+      "NativeIaC": "```yaml\n# Create an EFS mount target in a private subnet\nResources:\n  <example_resource_name>:\n    Type: AWS::EFS::MountTarget\n    Properties:\n      FileSystemId: <example_resource_id>\n      SubnetId: <example_resource_id>  # FIX: Use a private subnet (no route to an Internet Gateway)\n      SecurityGroups:\n        - <example_resource_id>  # Required SG for the mount target\n```",
+      "Other": "1. Open the AWS Console > EFS > File systems > select your file system\n2. Go to Networking and click Create mount target\n3. Choose a subnet that is private (no route to an Internet Gateway) and select a security group\n4. Click Create\n5. In Networking, select any mount targets in public subnets and click Delete to remove them",
+      "Terraform": "```hcl\n# Create an EFS mount target in a private subnet\nresource \"aws_efs_mount_target\" \"<example_resource_name>\" {\n  file_system_id  = \"<example_resource_id>\"\n  subnet_id       = \"<example_resource_id>\"  # FIX: Use a private subnet (no route to an Internet Gateway)\n  security_groups = [\"<example_resource_id>\"]\n}\n```"
     },
     "Recommendation": {
-      "Text": "Recreate the EFS mount target in a private subnet to ensure it is not publicly accessible.",
-      "Url": "https://docs.aws.amazon.com/efs/latest/ug/accessing-fs.html"
+      "Text": "Place mount targets in **private subnets** that do not auto-assign public IPs (`mapPublicIpOnLaunch=false`). Apply **least privilege**: restrict NFS via security groups to known sources, avoid Internet routes, and use **defense in depth** with NACLs. Prefer private connectivity (VPN/Direct Connect or peering) for access.",
+      "Url": "https://hub.prowler.com/check/efs_mount_target_not_publicly_accessible"
     }
   },
   "Categories": [

--- a/prowler/providers/aws/services/efs/efs_multi_az_enabled/efs_multi_az_enabled.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_multi_az_enabled/efs_multi_az_enabled.metadata.json
@@ -1,30 +1,41 @@
 {
   "Provider": "aws",
   "CheckID": "efs_multi_az_enabled",
-  "CheckTitle": "Check if EFS File systems are configured with Multi-AZ.",
-  "CheckType": [],
+  "CheckTitle": "EFS file system is Multi-AZ with more than one mount target",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "Effects/Denial of Service"
+  ],
   "ServiceName": "efs",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsFileSystem",
-  "Description": "Check if EFS File systems has Multi-AZ enabled.",
-  "Risk": "Ensure that your Amazon EFS are using Multi-AZ deployment configurations to provide High Availability (HA).",
-  "RelatedUrl": "https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html#availabiltydurability",
+  "ResourceType": "AwsEfsAccessPoint",
+  "Description": "**Amazon EFS** file systems are assessed for **multi-AZ resilience**: Regional type (no `availability_zone_id`) with mount targets in more than one Availability Zone. Single-AZ (One Zone) or Regional with only one mount target is identified for attention.",
+  "Risk": "Concentrating access through a single AZ or a lone mount target reduces **availability**. An AZ outage can sever client connectivity, causing downtime and I/O errors. A single mount target also forces cross-AZ traffic, increasing latency and costs and undermining **resilience** and seamless failover.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://overmind.tech/types/efs-mount-target",
+    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/efs/client/create_mount_target.html",
+    "https://nimtechnology.com/2024/12/10/aws-filtering-subnets-in-different-availability-zones-for-efs-mount-targets-with-terraform/",
+    "https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html#availabiltydurability",
+    "https://docs.aws.amazon.com/efs/latest/ug/accessing-fs.html",
+    "https://ops.tips/gists/how-aws-efs-multiple-availability-zones-terraform/"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "CLI": "aws efs create-mount-target --file-system-id <FILE_SYSTEM_ID> --subnet-id <SUBNET_ID>",
+      "NativeIaC": "```yaml\n# CloudFormation: add an extra EFS mount target to another AZ\nResources:\n  <example_resource_name>:\n    Type: AWS::EFS::MountTarget\n    Properties:\n      FileSystemId: fs-<example_resource_id>  # FIX: adds another mount target for this EFS\n      SubnetId: subnet-<example_resource_id>  # FIX: choose a subnet in a different AZ\n      SecurityGroups:\n        - <example_security_group_id>         # Required by CFN\n```",
+      "Other": "1. In AWS Console, go to EFS > File systems > select your file system\n2. If File system type shows Regional: open the Network tab > Mount targets > Manage mount targets > Add mount target\n3. Select a subnet in a different Availability Zone and save\n4. If File system type shows One Zone: create a new EFS with File system type = Regional and create mount targets in at least two AZs; remount clients to the new file system and decommission the old one",
+      "Terraform": "```hcl\n# Add an extra EFS mount target in a different AZ/subnet\nresource \"aws_efs_mount_target\" \"<example_resource_name>\" {\n  file_system_id = \"<example_resource_id>\"  # FIX: target EFS\n  subnet_id      = \"<example_resource_id>\"  # FIX: subnet in another AZ to make targets > 1\n}\n```"
     },
     "Recommendation": {
-      "Text": "Enable EFS file systems Multi-AZ with mount targets in multiple AZs.",
-      "Url": "https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html#availabiltydurability"
+      "Text": "Use **Regional EFS** and create mount targets in each required **Availability Zone** to remove single points of failure and keep clients local to their AZ. Avoid One Zone for critical data. Periodically review mount target distribution to uphold **high availability** and **fault tolerance**.",
+      "Url": "https://hub.prowler.com/check/efs_multi_az_enabled"
     }
   },
   "Categories": [
-    "redundancy"
+    "resilience"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/efs/efs_multi_az_enabled/efs_multi_az_enabled.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_multi_az_enabled/efs_multi_az_enabled.metadata.json
@@ -10,14 +10,11 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsAccessPoint",
+  "ResourceType": "AwsEfsFileSystem",
   "Description": "**Amazon EFS** file systems are assessed for **multi-AZ resilience**: Regional type (no `availability_zone_id`) with mount targets in more than one Availability Zone. Single-AZ (One Zone) or Regional with only one mount target is identified for attention.",
   "Risk": "Concentrating access through a single AZ or a lone mount target reduces **availability**. An AZ outage can sever client connectivity, causing downtime and I/O errors. A single mount target also forces cross-AZ traffic, increasing latency and costs and undermining **resilience** and seamless failover.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://overmind.tech/types/efs-mount-target",
-    "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/efs/client/create_mount_target.html",
-    "https://nimtechnology.com/2024/12/10/aws-filtering-subnets-in-different-availability-zones-for-efs-mount-targets-with-terraform/",
     "https://docs.aws.amazon.com/efs/latest/ug/creating-using-create-fs.html#availabiltydurability",
     "https://docs.aws.amazon.com/efs/latest/ug/accessing-fs.html",
     "https://ops.tips/gists/how-aws-efs-multiple-availability-zones-terraform/"

--- a/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
@@ -1,33 +1,36 @@
 {
   "Provider": "aws",
   "CheckID": "efs_not_publicly_accessible",
-  "CheckTitle": "Check if EFS have policies which allow access to any client within the VPC",
+  "CheckTitle": "EFS file system policy does not allow access to any client within the VPC",
   "CheckType": [
-    "Protect",
-    "Data protection"
+    "Software and Configuration Checks/AWS Security Best Practices/Network Reachability",
+    "Effects/Data Exposure"
   ],
   "ServiceName": "efs",
   "SubServiceName": "",
-  "ResourceIdTemplate": "arn:partition:service:region:account-id:resource-id",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsFileSystem",
-  "Description": "Check if EFS have policies which allow access to any client within the VPC",
-  "Risk": "Restricting access to EFS file systems is a security best practice. Allowing access to any client within the VPC can lead to unauthorized access to the file system.",
+  "ResourceType": "AwsEfsAccessPoint",
+  "Description": "**Amazon EFS** file system policy is assessed for **public or VPC-wide access**. Policies with broad `Principal` values or that permit any client in the VPC without the `elasticfilesystem:AccessedViaMountTarget` condition are identified.\n\n*An absent or empty policy is treated as open to VPC clients.*",
+  "Risk": "Broad EFS access lets any VPC client-or a compromised workload-mount the share, impacting CIA:\n- Confidentiality: bulk data exfiltration\n- Integrity: unauthorized writes or ransomware\n- Availability: deletion or lockout via elevated client access\nAlso facilitates lateral movement within the VPC.",
   "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/efs/latest/ug/access-control-block-public-access.html"
+  ],
   "Remediation": {
     "Code": {
-      "CLI": "",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": ""
+      "CLI": "aws efs put-file-system-policy --file-system-id <example_resource_id> --policy '{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"elasticfilesystem:ClientMount\",\"Condition\":{\"Bool\":{\"elasticfilesystem:AccessedViaMountTarget\":\"true\"}}}]}'",
+      "NativeIaC": "```yaml\n# CloudFormation: attach a non-public EFS file system policy\nResources:\n  EFSFileSystemPolicy:\n    Type: AWS::EFS::FileSystemPolicy\n    Properties:\n      FileSystemId: <example_resource_id>\n      Policy:\n        Version: \"2012-10-17\"\n        Statement:\n          - Effect: Allow\n            Principal: \"*\"\n            Action: elasticfilesystem:ClientMount\n            Condition:\n              Bool:\n                elasticfilesystem:AccessedViaMountTarget: \"true\"  # Critical: restrict access to mount targets only to avoid public access\n```",
+      "Other": "1. In the AWS Console, go to EFS > File systems and select <example_resource_id>\n2. Open the File system policy tab and click Edit\n3. Replace the policy with one that requires access via mount targets only:\n   ```json\n   {\n     \"Version\": \"2012-10-17\",\n     \"Statement\": [\n       {\n         \"Effect\": \"Allow\",\n         \"Principal\": \"*\",\n         \"Action\": \"elasticfilesystem:ClientMount\",\n         \"Condition\": {\"Bool\": {\"elasticfilesystem:AccessedViaMountTarget\": \"true\"}}\n       }\n     ]\n   }\n   ```\n4. Save changes",
+      "Terraform": "```hcl\n# Attach a non-public EFS file system policy\nresource \"aws_efs_file_system_policy\" \"<example_resource_name>\" {\n  file_system_id = \"<example_resource_id>\"\n  policy = jsonencode({\n    Version   = \"2012-10-17\"\n    Statement = [{\n      Effect    = \"Allow\"\n      Principal = \"*\"\n      Action    = \"elasticfilesystem:ClientMount\"\n      Condition = {\n        Bool = {\n          \"elasticfilesystem:AccessedViaMountTarget\" = \"true\" # Critical: require mount target to make policy non-public\n        }\n      }\n    }]\n  })\n}\n```"
     },
     "Recommendation": {
-      "Text": "Ensure efs has some policy but it does not have principle as *",
-      "Url": "https://docs.aws.amazon.com/efs/latest/ug/access-control-block-public-access.html"
+      "Text": "Apply **least privilege** to EFS resource policies:\n- Avoid wildcard `Principal` or `*`\n- Require `elasticfilesystem:AccessedViaMountTarget=true`\n- Constrain with `aws:SourceVpc`, `aws:SourceAccount`, or org IDs\n- Use EFS access points per app/role\n- Enable EFS **Block Public Access** for defense in depth",
+      "Url": "https://hub.prowler.com/check/efs_not_publicly_accessible"
     }
   },
   "Categories": [
-    "internet-exposed"
+    "identity-access"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
@@ -10,12 +10,13 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "AwsEfsAccessPoint",
+  "ResourceType": "AwsEfsFileSystem",
   "Description": "**Amazon EFS** file system policy is assessed for **public or VPC-wide access**. Policies with broad `Principal` values or that permit any client in the VPC without the `elasticfilesystem:AccessedViaMountTarget` condition are identified.\n\n*An absent or empty policy is treated as open to VPC clients.*",
   "Risk": "Broad EFS access lets any VPC client-or a compromised workload-mount the share, impacting CIA:\n- Confidentiality: bulk data exfiltration\n- Integrity: unauthorized writes or ransomware\n- Availability: deletion or lockout via elevated client access\nAlso facilitates lateral movement within the VPC.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "https://docs.aws.amazon.com/efs/latest/ug/access-control-block-public-access.html"
+    "https://docs.aws.amazon.com/efs/latest/ug/access-control-block-public-access.html",
+    "https://support.icompaas.com/support/solutions/articles/62000233324-efs-should-not-have-policies-allowing-unrestricted-access-within-vpc"
   ],
   "Remediation": {
     "Code": {


### PR DESCRIPTION
### Context

Updating aws efs service metadata to conform with the new standardized metadata format used across Prowler checks, defined in #8411.

### Description

This PR updates all metadata files for AWS EFS checks to adapt to the new metadata format. The changes ensure consistency with the metadata structure being adopted across all Prowler services. The modified checks are:

- `efs_access_point_enforce_root_directory`
- `efs_access_point_enforce_user_identity`
- `efs_encryption_at_rest_enabled`
- `efs_have_backup_enabled`
- `efs_mount_target_not_publicly_accessible`
- `efs_multi_az_enabled`
- `efs_not_publicly_accessible`


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.