### PR TITLE
fix(api-keys): update `created` field to never update

### DIFF
--- a/api/src/backend/api/migrations/0048_api_key.py
+++ b/api/src/backend/api/migrations/0048_api_key.py
@@ -44,7 +44,7 @@ class Migration(migrations.Migration):
                         help_text="If the API key is revoked, entities cannot use it anymore. (This cannot be undone.)",
                     ),
                 ),
-                ("created", models.DateTimeField(auto_now=True)),
+                ("created", models.DateTimeField(auto_now_add=True, editable=False)),
                 (
                     "whitelisted_ips",
                     models.JSONField(

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -221,6 +221,7 @@ class Membership(models.Model):
 class TenantAPIKey(AbstractAPIKey, RowLevelSecurityProtectedModel):
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
     name = models.CharField(max_length=100, validators=[MinLengthValidator(3)])
+    created = models.DateTimeField(auto_now_add=True, editable=False)
     prefix = models.CharField(
         max_length=11,
         unique=True,

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -7948,6 +7948,27 @@ class TestTenantApiKeyViewSet:
         api_key.refresh_from_db()
         assert api_key.revoked is True
 
+    def test_api_keys_revoke_preserves_created_field(
+        self, authenticated_client, api_keys_fixture
+    ):
+        """Test that revoking an API key preserves the created timestamp."""
+        api_key = api_keys_fixture[0]  # Not revoked
+        assert api_key.revoked is False
+
+        # Record the original created timestamp
+        original_created = api_key.created
+
+        response = authenticated_client.delete(
+            reverse("api-key-revoke", kwargs={"pk": api_key.id})
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # Verify in database
+        api_key.refresh_from_db()
+        assert api_key.revoked is True
+        # Verify created field has not changed
+        assert api_key.created == original_created
+
     def test_api_keys_revoke_already_revoked(
         self, authenticated_client, api_keys_fixture
     ):


### PR DESCRIPTION
### Context

Since we were using the `created` field from the `drf-api-keys` library, it would update whenever we updated the API key row for either the `name` or `revoked` fields.

### Description

This field will now behave as any other `inserted_at` field in the Prowler App.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
