### PR TITLE
feat: add compatiblitity with multiplaftorm docker builds arm64 

### DIFF
--- a/.github/workflows/sdk-build-lint-push-containers.yml
+++ b/.github/workflows/sdk-build-lint-push-containers.yml
@@ -28,6 +28,7 @@ env:
   # Container's configuration
   IMAGE_NAME: prowler
   DOCKERFILE_PATH: ./Dockerfile
+  MULTIARCH_PLATFORMS: linux/amd64,linux/arm64
 
   # Tags
   LATEST_TAG: latest
@@ -107,6 +108,12 @@ jobs:
               ;;
           esac
 
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx for multi-arch builds
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to DockerHub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
@@ -130,6 +137,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           push: true
+          platforms: ${{ env.MULTIARCH_PLATFORMS }}
           tags: |
             ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
             ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.LATEST_TAG }}
@@ -146,6 +154,7 @@ jobs:
           # https://github.com/docker/build-push-action#path-context
           context: .
           push: true
+          platforms: ${{ env.MULTIARCH_PLATFORMS }}
           tags: |
             ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.PROWLER_VERSION }}
             ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ env.STABLE_TAG }}


### PR DESCRIPTION
### Context

The motivation of this PR is to change the way docker images are generated including multiarchitecture builds.

### Description

Added QEMU emulation and buildx step required to add multiarchitecture builds.

### Steps to review

Review the release and deploy feature, it should include in the same name (tag) both architectures. This can be seen on dockerhub.com on the tag section. Also I've checked that the FROM image inside the Dockerfile already have an arcitecture arm64 build so the process should compile both architectures (arm64 and amd64) in the same step.

### Checklist
- [X] base image (Dockerfile FROM) includes an image of linux/arm64/v8
- [X] compile same Dockerfile in arm64 architecture to review if in arm64 the full build is generated.
- [ ] once published, review the release/deployment process it should include both architectures in dockerhub / tags section (linux/amd64 and linux/arm64/v8)

#### API

- N/A

### Issues

#8912 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
