### PR TITLE
fix(gcp): no resource_name errors

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Prowler ThreatScore scoring calculation CLI [(#8582)](https://github.com/prowler-cloud/prowler/pull/8582)
 - Add missing attributes for Mitre Attack AWS, Azure and GCP [(#8907)](https://github.com/prowler-cloud/prowler/pull/8907)
 - Fix KeyError in CloudSQL and Monitoring services in GCP provider [(#8909)](https://github.com/prowler-cloud/prowler/pull/8909)
+- Fix ResourceName in GCP provider [(#8928)](https://github.com/prowler-cloud/prowler/pull/8928)
 
 ---
 

--- a/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
+++ b/prowler/providers/gcp/services/compute/compute_project_os_login_enabled/compute_project_os_login_enabled.py
@@ -11,6 +11,11 @@ class compute_project_os_login_enabled(Check):
                 resource=compute_client.projects[project.id],
                 project_id=project.id,
                 location=compute_client.region,
+                resource_name=(
+                    compute_client.projects[project.id].name
+                    if compute_client.projects[project.id].name
+                    else "GCP Project"
+                ),
             )
             report.status = "PASS"
             report.status_extended = f"Project {project.id} has OS Login enabled."

--- a/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
+++ b/prowler/providers/gcp/services/iam/iam_audit_logs_enabled/iam_audit_logs_enabled.py
@@ -13,6 +13,11 @@ class iam_audit_logs_enabled(Check):
                 resource=cloudresourcemanager_client.projects[project.id],
                 project_id=project.id,
                 location=cloudresourcemanager_client.region,
+                resource_name=(
+                    cloudresourcemanager_client.projects[project.id].name
+                    if cloudresourcemanager_client.projects[project.id].name
+                    else "GCP Project"
+                ),
             )
             report.status = "PASS"
             report.status_extended = f"Audit Logs are enabled for project {project.id}."

--- a/prowler/providers/gcp/services/iam/iam_role_kms_enforce_separation_of_duties/iam_role_kms_enforce_separation_of_duties.py
+++ b/prowler/providers/gcp/services/iam/iam_role_kms_enforce_separation_of_duties/iam_role_kms_enforce_separation_of_duties.py
@@ -15,6 +15,11 @@ class iam_role_kms_enforce_separation_of_duties(Check):
                 resource=cloudresourcemanager_client.projects[project],
                 project_id=project,
                 location=cloudresourcemanager_client.region,
+                resource_name=(
+                    cloudresourcemanager_client.projects[project].name
+                    if cloudresourcemanager_client.projects[project].name
+                    else "GCP Project"
+                ),
             )
             report.status = "PASS"
             report.status_extended = f"Principle of separation of duties was enforced for KMS-Related Roles in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_audit_configuration_changes_enabled.py
@@ -40,6 +40,11 @@ class logging_log_metric_filter_and_alert_for_audit_configuration_changes_enable
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled.py
@@ -38,6 +38,11 @@ class logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled(
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled/logging_log_metric_filter_and_alert_for_custom_role_changes_enabled.py
@@ -38,6 +38,11 @@ class logging_log_metric_filter_and_alert_for_custom_role_changes_enabled(Check)
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.py
@@ -38,6 +38,11 @@ class logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled(
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled/logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes_enabled.py
@@ -37,6 +37,11 @@ class logging_log_metric_filter_and_alert_for_sql_instance_configuration_changes
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled.py
@@ -38,6 +38,11 @@ class logging_log_metric_filter_and_alert_for_vpc_firewall_rule_changes_enabled(
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled.py
@@ -38,6 +38,11 @@ class logging_log_metric_filter_and_alert_for_vpc_network_changes_enabled(Check)
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled/logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled.py
@@ -38,6 +38,11 @@ class logging_log_metric_filter_and_alert_for_vpc_network_route_changes_enabled(
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/prowler/providers/gcp/services/logging/logging_sink_created/logging_sink_created.py
+++ b/prowler/providers/gcp/services/logging/logging_sink_created/logging_sink_created.py
@@ -17,6 +17,11 @@ class logging_sink_created(Check):
                     resource=logging_client.projects[project],
                     project_id=project,
                     location=logging_client.region,
+                    resource_name=(
+                        logging_client.projects[project].name
+                        if logging_client.projects[project].name
+                        else "GCP Project"
+                    ),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no logging sinks to export copies of all the log entries in project {project}."


### PR DESCRIPTION
### Context

Several GCP checks were reporting "Check has no resource_name" errors, despite previous fixes to handle empty project names at both the provider and model levels.

Added explicit resource_name parameter with fallback at the check level to ensure 100% coverage:

- resource_name=client.projects[project].name if client.projects[project].name else "GCP Project"

This defense-in-depth approach guarantees that resource_name is always set, regardless of upstream fallback mechanisms.

### Description

- 12 GCP checks modified (9 Logging, 2 IAM, 1 Compute)
- Added explicit resource_name parameter to all Check_Report_GCP instantiations that report on projects

### Steps to review

Review the new code and test if needed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
