### PR TITLE
docs(github): clarify GitHub App configuration requirements

### DIFF
--- a/docs/user-guide/providers/github/authentication.mdx
+++ b/docs/user-guide/providers/github/authentication.mdx
@@ -144,10 +144,19 @@ GitHub Apps provide the recommended integration method for accessing multiple re
 2. **Create New GitHub App**
     - Click "New GitHub App"
     - Complete the required fields:
-        - **GitHub App name**: Unique application name
-        - **Homepage URL**: Application homepage
-        - **Webhook URL**: Webhook payload URL (optional)
-        - **Permissions**: Application permission requirements
+        - **GitHub App name**: Choose a unique, descriptive name (e.g., "Prowler Security Scanner")
+        - **Homepage URL**: Enter your organization's website or the Prowler documentation URL (e.g., `https://prowler.com` or `https://docs.prowler.com`). This is just for reference and doesn't affect functionality.
+        - **Webhook URL**: Leave blank or uncheck "Active" under Webhook. Prowler doesn't require webhooks since it performs on-demand scans rather than responding to GitHub events.
+        - **Webhook secret**: Leave blank (not needed for Prowler)
+        - **Permissions**: Configure in the next step (see below)
+
+    <Note>
+    **About Homepage URL and Webhooks**
+
+    The Homepage URL is purely informational and can be any valid URL - it's just displayed to users who view the app. Use your company website, your GitHub organization URL, or even `https://docs.prowler.com`.
+
+    Webhooks are **not required** for Prowler. Since Prowler performs on-demand security scans when you run it (rather than automatically responding to GitHub events), you can safely disable webhooks or leave the URL blank.
+    </Note>
 
 3. **Configure Permissions**
     To enable Prowler functionality, configure these permissions:


### PR DESCRIPTION
### Context

Users found it unclear what values to enter for Homepage URL and Webhook URL when configuring a GitHub App for Prowler scanning.

### Description

Improved the GitHub App configuration documentation by:
- Adding concrete examples for all fields (e.g., "Prowler Security Scanner")
- Clarifying that Homepage URL is informational only and providing example values
- Explaining that Webhook URL can be left blank since Prowler performs on-demand scans, not event-driven operations
- Adding a Note box to clarify these fields don't affect Prowler functionality

Changes are in `docs/user-guide/providers/github/authentication.mdx` lines 144-159.

### Steps to review

1. Review changes in `docs/user-guide/providers/github/authentication.mdx`
2. Verify guidance aligns with `prowler/providers/github/github_provider.py` implementation
3. Confirm the documentation is clear and actionable for users

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following specification
- [x] Review if backport is needed.
- [x] Review if Readme.md needs changes.
- [x] Ensure CHANGELOG.md entries added. 

#### API
- [x] Verify if API specs need regeneration.
- [x] Check if version updates required. 
- [x] Ensure API CHANGELOG.md entries added. 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.