### PR TITLE
fix: Mutelist view blinks at opening

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - ThreatScore for each pillar in Prowler ThreatScore specific view [(#8582)](https://github.com/prowler-cloud/prowler/pull/8582)
 - Remove maxTokens model param for GPT-5 models [(#8843)](https://github.com/prowler-cloud/prowler/pull/8843)
 - MITRE ATTACK compliance view now shows all requirements in charts [(#8886)](https://github.com/prowler-cloud/prowler/pull/8886)
+- Mutelist menu item now doesn't blink [(#8932)](https://github.com/prowler-cloud/prowler/pull/8932)
 
 ---
 

--- a/ui/app/(prowler)/providers/page.tsx
+++ b/ui/app/(prowler)/providers/page.tsx
@@ -30,10 +30,7 @@ export default async function Providers({
       <Spacer y={8} />
       <ProvidersActions />
       <Spacer y={8} />
-      <Suspense
-        key={searchParamsKey}
-        fallback={<ProvidersTableFallback />}
-      >
+      <Suspense key={searchParamsKey} fallback={<ProvidersTableFallback />}>
         <ProvidersTable searchParams={resolvedSearchParams} />
       </Suspense>
     </ContentLayout>

--- a/ui/app/(prowler)/providers/page.tsx
+++ b/ui/app/(prowler)/providers/page.tsx
@@ -28,31 +28,39 @@ export default async function Providers({
     <ContentLayout title="Cloud Providers" icon="lucide:cloud-cog">
       <FilterControls search customFilters={filterProviders || []} />
       <Spacer y={8} />
+      <ProvidersActions />
+      <Spacer y={8} />
       <Suspense
         key={searchParamsKey}
-        fallback={
-          <>
-            <div className="flex items-center gap-4 md:justify-end">
-              <ManageGroupsButton />
-              <MutedFindingsConfigButton />
-              <AddProviderButton />
-            </div>
-            <Spacer y={8} />
-            <div className="grid grid-cols-12 gap-4">
-              <div className="col-span-12">
-                <SkeletonTableProviders />
-              </div>
-            </div>
-          </>
-        }
+        fallback={<ProvidersTableFallback />}
       >
-        <ProvidersContent searchParams={resolvedSearchParams} />
+        <ProvidersTable searchParams={resolvedSearchParams} />
       </Suspense>
     </ContentLayout>
   );
 }
 
-const ProvidersContent = async ({
+const ProvidersActions = () => {
+  return (
+    <div className="flex items-center gap-4 md:justify-end">
+      <ManageGroupsButton />
+      <MutedFindingsConfigButton />
+      <AddProviderButton />
+    </div>
+  );
+};
+
+const ProvidersTableFallback = () => {
+  return (
+    <div className="grid grid-cols-12 gap-4">
+      <div className="col-span-12">
+        <SkeletonTableProviders />
+      </div>
+    </div>
+  );
+};
+
+const ProvidersTable = async ({
   searchParams,
 }: {
   searchParams: SearchParamsProps;
@@ -97,13 +105,6 @@ const ProvidersContent = async ({
 
   return (
     <>
-      <div className="flex items-center gap-4 md:justify-end">
-        <ManageGroupsButton />
-        <MutedFindingsConfigButton />
-        <AddProviderButton />
-      </div>
-      <Spacer y={8} />
-
       <div className="grid grid-cols-12 gap-4">
         <div className="col-span-12">
           <DataTable

--- a/ui/components/providers/muted-findings-config-button.tsx
+++ b/ui/components/providers/muted-findings-config-button.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { SettingsIcon } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
 
 import { CustomAlertModal, CustomButton } from "@/components/ui/custom";
 import { useUIStore } from "@/store/ui/store";
@@ -8,12 +10,37 @@ import { useUIStore } from "@/store/ui/store";
 import { MutedFindingsConfigForm } from "./forms";
 
 export const MutedFindingsConfigButton = () => {
+  const pathname = usePathname();
   const {
     isMutelistModalOpen,
     openMutelistModal,
     closeMutelistModal,
     hasProviders,
+    shouldAutoOpenMutelist,
+    resetMutelistModalRequest,
   } = useUIStore();
+
+  useEffect(() => {
+    if (!shouldAutoOpenMutelist) {
+      return;
+    }
+
+    if (pathname !== "/providers") {
+      return;
+    }
+
+    if (hasProviders) {
+      openMutelistModal();
+    }
+
+    resetMutelistModalRequest();
+  }, [
+    hasProviders,
+    openMutelistModal,
+    pathname,
+    resetMutelistModalRequest,
+    shouldAutoOpenMutelist,
+  ]);
 
   const handleOpenModal = () => {
     if (hasProviders) {

--- a/ui/components/ui/sidebar/menu.tsx
+++ b/ui/components/ui/sidebar/menu.tsx
@@ -69,11 +69,13 @@ const hideMenuItems = (menuGroups: GroupProps[], labelsToHide: string[]) => {
 export const Menu = ({ isOpen }: { isOpen: boolean }) => {
   const pathname = usePathname();
   const { permissions } = useAuth();
-  const { hasProviders, openMutelistModal } = useUIStore();
+  const { hasProviders, openMutelistModal, requestMutelistModalOpen } =
+    useUIStore();
   const menuList = getMenuList({
     pathname,
     hasProviders,
     openMutelistModal,
+    requestMutelistModalOpen,
   });
 
   const labelsToHide = MENU_HIDE_RULES.filter((rule) =>

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -18,6 +18,7 @@ import {
   VolumeX,
   Warehouse,
 } from "lucide-react";
+import type { MouseEvent } from "react";
 
 import { ProwlerShort } from "@/components/icons";
 import {
@@ -39,12 +40,14 @@ interface MenuListOptions {
   pathname: string;
   hasProviders?: boolean;
   openMutelistModal?: () => void;
+  requestMutelistModalOpen?: () => void;
 }
 
 export const getMenuList = ({
   pathname,
   hasProviders,
   openMutelistModal,
+  requestMutelistModalOpen,
 }: MenuListOptions): GroupProps[] => {
   return [
     {
@@ -164,12 +167,28 @@ export const getMenuList = ({
           submenus: [
             { href: "/providers", label: "Cloud Providers", icon: CloudCog },
             {
-              // Use trailing slash to prevent both menu items from being active at /providers
-              href: "/providers/",
+              href: "/providers",
               label: "Mutelist",
               icon: VolumeX,
               disabled: hasProviders === false,
-              onClick: openMutelistModal,
+              active: false,
+              onClick: (event: MouseEvent<HTMLAnchorElement>) => {
+                if (hasProviders === false) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  return;
+                }
+
+                requestMutelistModalOpen?.();
+
+                if (pathname !== "/providers") {
+                  return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+                openMutelistModal?.();
+              },
             },
             { href: "/manage-groups", label: "Provider Groups", icon: Group },
             { href: "/scans", label: "Scan Jobs", icon: Timer },

--- a/ui/store/ui/store.ts
+++ b/ui/store/ui/store.ts
@@ -5,12 +5,15 @@ interface UIStoreState {
   isSideMenuOpen: boolean;
   isMutelistModalOpen: boolean;
   hasProviders: boolean;
+  shouldAutoOpenMutelist: boolean;
 
   openSideMenu: () => void;
   closeSideMenu: () => void;
   openMutelistModal: () => void;
   closeMutelistModal: () => void;
   setHasProviders: (value: boolean) => void;
+  requestMutelistModalOpen: () => void;
+  resetMutelistModalRequest: () => void;
 }
 
 export const useUIStore = create<UIStoreState>()(
@@ -19,11 +22,18 @@ export const useUIStore = create<UIStoreState>()(
       isSideMenuOpen: false,
       isMutelistModalOpen: false,
       hasProviders: false,
+      shouldAutoOpenMutelist: false,
       openSideMenu: () => set({ isSideMenuOpen: true }),
       closeSideMenu: () => set({ isSideMenuOpen: false }),
-      openMutelistModal: () => set({ isMutelistModalOpen: true }),
+      openMutelistModal: () =>
+        set({
+          isMutelistModalOpen: true,
+          shouldAutoOpenMutelist: false,
+        }),
       closeMutelistModal: () => set({ isMutelistModalOpen: false }),
       setHasProviders: (value: boolean) => set({ hasProviders: value }),
+      requestMutelistModalOpen: () => set({ shouldAutoOpenMutelist: true }),
+      resetMutelistModalRequest: () => set({ shouldAutoOpenMutelist: false }),
     }),
     {
       name: "ui-store",

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -1,5 +1,5 @@
 import { LucideIcon } from "lucide-react";
-import { SVGProps } from "react";
+import { MouseEvent, SVGProps } from "react";
 
 import { ProviderCredentialFields } from "@/lib/provider-credentials/provider-credential-fields";
 
@@ -21,7 +21,7 @@ export type SubmenuProps = {
   active?: boolean;
   icon: IconComponent;
   disabled?: boolean;
-  onClick?: () => void;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
 };
 
 export type MenuProps = {


### PR DESCRIPTION
### Context
- Mutelist sidebar entry briefly opened two modals because the `/providers` page mounted the action bar inside both the Suspense fallback and the resolved view.
- This change removes the flicker without altering mutelist functionality. (Fix N/A)

### Description
- Lifted the shared action bar (including `MutedFindingsConfigButton`) above the Suspense boundary in `app/(prowler)/providers/page.tsx` so it renders only once.
- Kept a lightweight table-only fallback to preserve the loading skeleton with no new dependencies.

### Steps to review
1. `npm run lint:check`
2. `npm run typecheck`
3. Navigate to Configuration → Mutelist in the sidebar and confirm the modal opens a single time without flicker.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [X] Review if backport is needed.
- [X] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [X] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
