### PR TITLE
chore: remove security template as it's already there

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,6 @@ contact_links:
   - name: 💬 GitHub Discussions
     url: https://github.com/prowler-cloud/prowler/discussions
     about: Ask questions and discuss with the community
-  - name: 🔒 Security Vulnerability
-    url: https://github.com/prowler-cloud/prowler/security/policy
-    about: Report security vulnerabilities privately
   - name: 🌟 Prowler Community
     url: https://goto.prowler.com/slack
     about: Join our community for support and updates


### PR DESCRIPTION
### Description

Remove security issue template as it's already there. Github adds it if you have a `SECURITY.md` file.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
