### PR TITLE
chore(github): trigger only if repository is prowler

### DIFF
--- a/.github/workflows/api-pull-request.yml
+++ b/.github/workflows/api-pull-request.yml
@@ -42,6 +42,7 @@ env:
 
 jobs:
   code-quality:
+    if: github.repository == 'prowler-cloud/prowler'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -77,6 +78,7 @@ jobs:
         run: poetry run pylint --disable=W,C,R,E -j 0 -rn -sn src/
 
   security-scans:
+    if: github.repository == 'prowler-cloud/prowler'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -111,6 +113,7 @@ jobs:
         run: poetry run vulture --exclude "contrib,tests,conftest.py" --min-confidence 100 .
 
   tests:
+    if: github.repository == 'prowler-cloud/prowler'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -174,6 +177,7 @@ jobs:
           flags: api
 
   dockerfile-lint:
+    if: github.repository == 'prowler-cloud/prowler'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -190,6 +194,7 @@ jobs:
           ignore: DL3013
 
   container-build-and-scan:
+    if: github.repository == 'prowler-cloud/prowler'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
### Context

We want to trigger this action only for this repository

### Description

- Add conditional

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
