### PR TITLE
chore(github): improve trufflehog action

### DIFF
--- a/.github/workflows/find-secrets.yml
+++ b/.github/workflows/find-secrets.yml
@@ -30,7 +30,4 @@ jobs:
       - name: Scan for secrets with TruffleHog
         uses: trufflesecurity/trufflehog@ad6fc8fb446b8fafbf7ea8193d2d6bfd42f45690 # v3.90.11
         with:
-          path: './'
-          base: ${{ github.event.repository.default_branch }}
-          head: 'HEAD'
           extra_args: '--results=verified,unknown'

--- a/.github/workflows/find-secrets.yml
+++ b/.github/workflows/find-secrets.yml
@@ -33,4 +33,4 @@ jobs:
           path: './'
           base: ${{ github.event.repository.default_branch }}
           head: 'HEAD'
-          extra_args: '--results=verified,unknown --fail'
+          extra_args: '--results=verified,unknown'

--- a/.github/workflows/find-secrets.yml
+++ b/.github/workflows/find-secrets.yml
@@ -1,19 +1,36 @@
-name: Prowler - Find secrets
+name: 'Tools: TruffleHog'
 
-on: pull_request
+on:
+  push:
+    branches:
+      - 'master'
+      - 'v5.*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'v5.*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  trufflehog:
+  scan-secrets:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@466da5b0bb161144f6afca9afe5d57975828c410 # v3.90.8
+
+      - name: Scan for secrets with TruffleHog
+        uses: trufflesecurity/trufflehog@ad6fc8fb446b8fafbf7ea8193d2d6bfd42f45690 # v3.90.11
         with:
-          path: ./
+          path: './'
           base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          extra_args: --only-verified
+          head: 'HEAD'
+          extra_args: '--results=verified,unknown --fail'


### PR DESCRIPTION
### Context

Improve Trufflehog action

### Description

- Replace `--only-verified` by `--results=verified,unknown` (official TruffleHog recommendation)
- Remove `path`, `base`and `head`:
  - On PRs: Automatically scans the PR commits (difference between base and head of the PR)
  - On pushes: Scans the commits included in the push event

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
