### PR TITLE
fix(s3): support threatscore upload

### DIFF
--- a/api/src/backend/tasks/jobs/export.py
+++ b/api/src/backend/tasks/jobs/export.py
@@ -220,13 +220,12 @@ def _upload_to_s3(tenant_id: str, zip_path: str, scan_id: str) -> str | None:
 
         # Upload the compliance directory to the S3 bucket
         compliance_dir = os.path.join(os.path.dirname(zip_path), "compliance")
-        if os.path.exists(compliance_dir) and os.path.isdir(compliance_dir):
-            for filename in os.listdir(compliance_dir):
-                local_path = os.path.join(compliance_dir, filename)
-                if not os.path.isfile(local_path):
-                    continue
-                file_key = f"{tenant_id}/{scan_id}/compliance/{filename}"
-                s3.upload_file(Filename=local_path, Bucket=bucket, Key=file_key)
+        for filename in os.listdir(compliance_dir):
+            local_path = os.path.join(compliance_dir, filename)
+            if not os.path.isfile(local_path):
+                continue
+            file_key = f"{tenant_id}/{scan_id}/compliance/{filename}"
+            s3.upload_file(Filename=local_path, Bucket=bucket, Key=file_key)
 
         return f"s3://{base.DJANGO_OUTPUT_S3_AWS_OUTPUT_BUCKET}/{zip_key}"
     except (ClientError, NoCredentialsError, ParamValidationError, ValueError) as e:

--- a/api/src/backend/tasks/jobs/export.py
+++ b/api/src/backend/tasks/jobs/export.py
@@ -206,7 +206,12 @@ def _upload_to_s3(tenant_id: str, zip_path: str, scan_id: str) -> str | None:
         s3 = get_s3_client()
 
         # Upload the ZIP file (outputs) to the S3 bucket
-        zip_key = f"{tenant_id}/{scan_id}/{os.path.basename(zip_path)}"
+        # Preserve directory structure for threatscore and compliance subdirectories
+        zip_dir = os.path.basename(os.path.dirname(zip_path))
+        if zip_dir in ("threatscore", "compliance"):
+            zip_key = f"{tenant_id}/{scan_id}/{zip_dir}/{os.path.basename(zip_path)}"
+        else:
+            zip_key = f"{tenant_id}/{scan_id}/{os.path.basename(zip_path)}"
         s3.upload_file(
             Filename=zip_path,
             Bucket=bucket,

--- a/api/src/backend/tasks/jobs/export.py
+++ b/api/src/backend/tasks/jobs/export.py
@@ -20,10 +20,10 @@ from prowler.lib.outputs.asff.asff import ASFF
 from prowler.lib.outputs.compliance.aws_well_architected.aws_well_architected import (
     AWSWellArchitected,
 )
+from prowler.lib.outputs.compliance.c5.c5_aws import AWSC5
 from prowler.lib.outputs.compliance.ccc.ccc_aws import CCC_AWS
 from prowler.lib.outputs.compliance.ccc.ccc_azure import CCC_Azure
 from prowler.lib.outputs.compliance.ccc.ccc_gcp import CCC_GCP
-from prowler.lib.outputs.compliance.c5.c5_aws import AWSC5
 from prowler.lib.outputs.compliance.cis.cis_aws import AWSCIS
 from prowler.lib.outputs.compliance.cis.cis_azure import AzureCIS
 from prowler.lib.outputs.compliance.cis.cis_gcp import GCPCIS
@@ -215,12 +215,13 @@ def _upload_to_s3(tenant_id: str, zip_path: str, scan_id: str) -> str | None:
 
         # Upload the compliance directory to the S3 bucket
         compliance_dir = os.path.join(os.path.dirname(zip_path), "compliance")
-        for filename in os.listdir(compliance_dir):
-            local_path = os.path.join(compliance_dir, filename)
-            if not os.path.isfile(local_path):
-                continue
-            file_key = f"{tenant_id}/{scan_id}/compliance/{filename}"
-            s3.upload_file(Filename=local_path, Bucket=bucket, Key=file_key)
+        if os.path.exists(compliance_dir) and os.path.isdir(compliance_dir):
+            for filename in os.listdir(compliance_dir):
+                local_path = os.path.join(compliance_dir, filename)
+                if not os.path.isfile(local_path):
+                    continue
+                file_key = f"{tenant_id}/{scan_id}/compliance/{filename}"
+                s3.upload_file(Filename=local_path, Bucket=bucket, Key=file_key)
 
         return f"s3://{base.DJANGO_OUTPUT_S3_AWS_OUTPUT_BUCKET}/{zip_key}"
     except (ClientError, NoCredentialsError, ParamValidationError, ValueError) as e:


### PR DESCRIPTION
### Description

This pull request makes minor improvements to the `api/src/backend/tasks/jobs/export.py` file, focusing on import statement organization and adding a safety check before uploading compliance files to S3.

* **Robustness in file upload:** Added a check to ensure that the `compliance` directory exists and is a directory before attempting to upload its contents to S3, preventing potential errors if the directory is missing.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
