### PR TITLE
chore(api): Update changelog for API's version 1.14.0 to Prowler 5.13.0

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
-## [1.14.0] (Prowler UNRELEASED)
+## [1.14.0] (Prowler 5.13.0)
 
 ### Added
 - Default JWT keys are generated and stored if they are missing from configuration [(#8655)](https://github.com/prowler-cloud/prowler/pull/8655)


### PR DESCRIPTION
### Description

Change API's Prowler version to 5.13.0.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
