### PR TITLE
fix(gcp): set unknown for resource name under metric resources

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Added
 - GitHub provider check `organization_default_repository_permission_strict` [(#8785)](https://github.com/prowler-cloud/prowler/pull/8785)
 
+---
+
+## [v5.13.1] (Prowler UNRELEASED)
+
+### Fixed
+- Add `resource_name` for checks under `logging` for the GCP provider [(#9023)](https://github.com/prowler-cloud/prowler/pull/9023)
+
+
+---
+
 ## [v5.13.0] (Prowler v5.13.0)
 
 ### Added

--- a/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled.py
+++ b/prowler/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled/logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled.py
@@ -14,35 +14,37 @@ class logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled(
                 'resource.type="gcs_bucket" AND protoPayload.methodName="storage.setIamPermissions"'
                 in metric.filter
             ):
+                metric_name = getattr(metric, "name", None) or "unknown"
                 report = Check_Report_GCP(
                     metadata=self.metadata(),
                     resource=metric,
+                    resource_id=metric_name,
+                    project_id=metric.project_id,
                     location=logging_client.region,
-                    resource_name=metric.name if metric.name else "Log Metric Filter",
+                    resource_name=(
+                        metric_name if metric_name != "unknown" else "Log Metric Filter"
+                    ),
                 )
                 projects_with_metric.add(metric.project_id)
                 report.status = "FAIL"
-                report.status_extended = f"Log metric filter {metric.name} found but no alerts associated in project {metric.project_id}."
+                report.status_extended = f"Log metric filter {metric_name} found but no alerts associated in project {metric.project_id}."
                 for alert_policy in monitoring_client.alert_policies:
                     for filter in alert_policy.filters:
-                        if metric.name in filter:
+                        if metric_name in filter:
                             report.status = "PASS"
-                            report.status_extended = f"Log metric filter {metric.name} found with alert policy {alert_policy.display_name} associated in project {metric.project_id}."
+                            report.status_extended = f"Log metric filter {metric_name} found with alert policy {alert_policy.display_name} associated in project {metric.project_id}."
                             break
                 findings.append(report)
 
         for project in logging_client.project_ids:
             if project not in projects_with_metric:
+                project_obj = logging_client.projects.get(project)
                 report = Check_Report_GCP(
                     metadata=self.metadata(),
-                    resource=logging_client.projects[project],
+                    resource=project_obj,
                     project_id=project,
                     location=logging_client.region,
-                    resource_name=(
-                        logging_client.projects[project].name
-                        if logging_client.projects[project].name
-                        else "GCP Project"
-                    ),
+                    resource_name=(getattr(project_obj, "name", None) or "GCP Project"),
                 )
                 report.status = "FAIL"
                 report.status_extended = f"There are no log metric filters or alerts associated in project {project}."

--- a/tests/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled_test.py
+++ b/tests/providers/gcp/services/logging/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled/logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled_test.py
@@ -259,3 +259,136 @@ class Test_logging_log_metric_filter_and_alert_for_project_ownership_changes_ena
             assert result[0].resource_name == "metric_name"
             assert result[0].project_id == GCP_PROJECT_ID
             assert result[0].location == GCP_EU1_LOCATION
+
+    def test_log_metric_filters_with_none_name(self):
+        """Test that metric with None name uses fallback 'Log Metric Filter'"""
+        logging_client = MagicMock()
+        monitoring_client = MagicMock()
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_gcp_provider(),
+            ),
+            patch(
+                "prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_client",
+                new=logging_client,
+            ),
+            patch(
+                "prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.monitoring_client",
+                new=monitoring_client,
+            ),
+        ):
+            from prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled import (
+                logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled,
+            )
+
+            # Create a MagicMock metric object with name=None
+            metric = MagicMock()
+            metric.name = None
+            metric.filter = '(protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership OR projectOwnerInvitee) OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner") OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")'
+            metric.project_id = GCP_PROJECT_ID
+
+            logging_client.metrics = [metric]
+            logging_client.project_ids = [GCP_PROJECT_ID]
+            logging_client.region = GCP_EU1_LOCATION
+
+            monitoring_client.alert_policies = []
+
+            check = (
+                logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled()
+            )
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_name == "Log Metric Filter"
+            assert result[0].resource_id == "unknown"
+            assert result[0].project_id == GCP_PROJECT_ID
+            assert result[0].location == GCP_EU1_LOCATION
+            assert "unknown" in result[0].status_extended
+
+    def test_log_metric_filters_with_missing_name_attribute(self):
+        """Test that metric without name attribute uses fallback 'Log Metric Filter'"""
+        logging_client = MagicMock()
+        monitoring_client = MagicMock()
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_gcp_provider(),
+            ),
+            patch(
+                "prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_client",
+                new=logging_client,
+            ),
+            patch(
+                "prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.monitoring_client",
+                new=monitoring_client,
+            ),
+        ):
+            from prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled import (
+                logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled,
+            )
+
+            # Create a MagicMock metric object without name attribute
+            metric = MagicMock(spec=["filter", "project_id"])
+            metric.filter = '(protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership OR projectOwnerInvitee) OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="REMOVE" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner") OR (protoPayload.serviceData.policyDelta.bindingDeltas.action="ADD" AND protoPayload.serviceData.policyDelta.bindingDeltas.role="roles/owner")'
+            metric.project_id = GCP_PROJECT_ID
+
+            logging_client.metrics = [metric]
+            logging_client.project_ids = [GCP_PROJECT_ID]
+            logging_client.region = GCP_EU1_LOCATION
+
+            monitoring_client.alert_policies = []
+
+            check = (
+                logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled()
+            )
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_name == "Log Metric Filter"
+            assert result[0].resource_id == "unknown"
+            assert result[0].project_id == GCP_PROJECT_ID
+            assert result[0].location == GCP_EU1_LOCATION
+
+    def test_project_not_in_projects_dict(self):
+        """Test that project not in projects dict uses None and fallback name"""
+        logging_client = MagicMock()
+        monitoring_client = MagicMock()
+
+        with (
+            patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_gcp_provider(),
+            ),
+            patch(
+                "prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_client",
+                new=logging_client,
+            ),
+            patch(
+                "prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.monitoring_client",
+                new=monitoring_client,
+            ),
+        ):
+            from prowler.providers.gcp.services.logging.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled.logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled import (
+                logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled,
+            )
+
+            logging_client.metrics = []
+            logging_client.project_ids = [GCP_PROJECT_ID]
+            logging_client.region = GCP_EU1_LOCATION
+            # Project is in project_ids but NOT in projects dict
+            logging_client.projects = {}
+
+            monitoring_client.alert_policies = []
+
+            check = (
+                logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled()
+            )
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert result[0].resource_name == "GCP Project"
+            assert result[0].project_id == GCP_PROJECT_ID
+            assert result[0].location == GCP_EU1_LOCATION


### PR DESCRIPTION
### Description

This pull request improves the robustness and consistency of GCP logging checks by standardizing how resource names and IDs are handled, especially when attributes are missing or set to `None`. It also adds comprehensive unit tests to cover these edge cases, ensuring the checks behave predictably and produce clear, non-null output.

🔧 Changes applied to each check:

For metric/sink-type resources:
	1.	✅ Extract the name using getattr(resource, "name", None) or "unknown"
	2.	✅ Pass resource_id explicitly (never None)
	3.	✅ Pass project_id explicitly
	4.	✅ Use the extracted name for resource_name with an appropriate fallback

For projects without a resource:
	1.	✅ Use .get(project) instead of [project] to avoid KeyError
	2.	✅ Pass resource_id=project explicitly
	3.	✅ Pass project_id=project explicitly
	4.	✅ Use getattr(project_obj, "name", None) or "GCP Project" for resource_name

### Improvements to resource identification and reporting

* All checks now use `getattr` to safely retrieve resource and metric names, defaulting to `"unknown"` when the name is missing or `None`, and fallback names like `"Log Metric Filter"` or `"GCP Project"` for display purposes. This prevents issues with missing attributes and ensures consistent reporting. [[1]](diffhunk://#diff-531a6cd960cd2544f24c52330e0bd5ec808ca7e3c1c982ea6b8e6a168c6aa109R17-R47) [[2]](diffhunk://#diff-1f4344b1f835500e6dcc1e8ef7df39b07e70b8188cd15cce4922892f13c9ff7bR17-R48) [[3]](diffhunk://#diff-922eee077e8dbd354a45f40b907e02b416e3c31b3fe5a41214bd8c26bf682c70R15-R41)
* The `resource_id` field is now always set, never left as `None`, using the same fallback logic for missing names or IDs. [[1]](diffhunk://#diff-531a6cd960cd2544f24c52330e0bd5ec808ca7e3c1c982ea6b8e6a168c6aa109R17-R47) [[2]](diffhunk://#diff-1f4344b1f835500e6dcc1e8ef7df39b07e70b8188cd15cce4922892f13c9ff7bR17-R48) [[3]](diffhunk://#diff-922eee077e8dbd354a45f40b907e02b416e3c31b3fe5a41214bd8c26bf682c70R15-R41)

### Enhanced unit testing for edge cases

* Added new tests to `logging_log_metric_filter_and_alert_for_bucket_permission_changes_enabled_test.py` and `logging_log_metric_filter_and_alert_for_project_ownership_changes_enabled_test.py` to verify correct fallback behavior when metric or project names are missing or `None`, and when a project is not present in the projects dictionary. [[1]](diffhunk://#diff-c4b33f1152401af377e2d79074a201b89e2bcaf79a576de98e8fb2a8e97bf997R262-R399) [[2]](diffhunk://#diff-dd69f542e394400747108f66c87927b6aa138176722b335e07e77475adf9c7b2R262-R394)
* Tests confirm that `resource_name` and `resource_id` are never `None` and always use the appropriate fallback values, improving reliability and clarity of check results. [[1]](diffhunk://#diff-c4b33f1152401af377e2d79074a201b89e2bcaf79a576de98e8fb2a8e97bf997R262-R399) [[2]](diffhunk://#diff-dd69f542e394400747108f66c87927b6aa138176722b335e07e77475adf9c7b2R262-R394)

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
