### PR TITLE
chore(github): use `gh` instead of github-script to lable community

### DIFF
--- a/.github/workflows/labeler-community.yml
+++ b/.github/workflows/labeler-community.yml
@@ -12,26 +12,23 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            // Get the author association from the event
-            const association = context.payload.pull_request?.author_association ||
-                              context.payload.issue?.author_association;
+      - name: Label community contributors
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch fresh PR data to get current author_association
+          ASSOCIATION=$(gh api /repos/${{ github.repository }}/pulls/${{ github.event.number }} --jq '.author_association')
+          AUTHOR=$(gh api /repos/${{ github.repository }}/pulls/${{ github.event.number }} --jq '.user.login')
 
-            // Members have associations like: OWNER, MEMBER, COLLABORATOR
-            // Non-members have: CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE
-            const memberAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+          echo "Author: $AUTHOR, Association: $ASSOCIATION"
 
-            if (!memberAssociations.includes(association)) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels: ['community']
-              });
-
-              console.log(`Added 'community' label for ${association} contributor`);
-            } else {
-              console.log(`Skipped labeling for ${association}`);
-            }
+          # Members have associations like: OWNER, MEMBER, COLLABORATOR
+          # Non-members have: CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, FIRST_TIMER, NONE
+          if [[ "$ASSOCIATION" != "OWNER" && "$ASSOCIATION" != "MEMBER" && "$ASSOCIATION" != "COLLABORATOR" ]]; then
+            gh api /repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
+              -X POST \
+              -f labels[]='community'
+            echo "Added 'community' label for $ASSOCIATION contributor"
+          else
+            echo "Skipped labeling for $ASSOCIATION"
+          fi


### PR DESCRIPTION
### Description
PRs are not being labeled properly, github-script is returning `CONTRIBUTOR` while `gh api` in local returns `MEMBER`.

Let's try using `gh` in the action too.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
