### PR TITLE
fix(compliance): handle timestamp when transforming CCC findings

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Add `resource_name` for checks under `logging` for the GCP provider [(#9023)](https://github.com/prowler-cloud/prowler/pull/9023)
-
+- Handle timestamp when transforming compliance findings in CCC [(#9042)](https://github.com/prowler-cloud/prowler/pull/9042)
 
 ---
 

--- a/prowler/lib/outputs/compliance/ccc/ccc_aws.py
+++ b/prowler/lib/outputs/compliance/ccc/ccc_aws.py
@@ -1,3 +1,4 @@
+from prowler.config.config import timestamp
 from prowler.lib.check.compliance_models import Compliance
 from prowler.lib.outputs.compliance.ccc.models import CCC_AWSModel
 from prowler.lib.outputs.compliance.compliance_output import ComplianceOutput
@@ -44,7 +45,7 @@ class CCC_AWS(ComplianceOutput):
                             Description=compliance.Description,
                             AccountId=finding.account_uid,
                             Region=finding.region,
-                            AssessmentDate=str(finding.timestamp),
+                            AssessmentDate=str(timestamp),
                             Requirements_Id=requirement.Id,
                             Requirements_Description=requirement.Description,
                             Requirements_Attributes_FamilyName=attribute.FamilyName,
@@ -73,7 +74,7 @@ class CCC_AWS(ComplianceOutput):
                         Description=compliance.Description,
                         AccountId="",
                         Region="",
-                        AssessmentDate=str(finding.timestamp),
+                        AssessmentDate=str(timestamp),
                         Requirements_Id=requirement.Id,
                         Requirements_Description=requirement.Description,
                         Requirements_Attributes_FamilyName=attribute.FamilyName,

--- a/prowler/lib/outputs/compliance/ccc/ccc_azure.py
+++ b/prowler/lib/outputs/compliance/ccc/ccc_azure.py
@@ -1,3 +1,4 @@
+from prowler.config.config import timestamp
 from prowler.lib.check.compliance_models import Compliance
 from prowler.lib.outputs.compliance.ccc.models import CCC_AzureModel
 from prowler.lib.outputs.compliance.compliance_output import ComplianceOutput
@@ -44,7 +45,7 @@ class CCC_Azure(ComplianceOutput):
                             Description=compliance.Description,
                             SubscriptionId=finding.account_uid,
                             Location=finding.region,
-                            AssessmentDate=str(finding.timestamp),
+                            AssessmentDate=str(timestamp),
                             Requirements_Id=requirement.Id,
                             Requirements_Description=requirement.Description,
                             Requirements_Attributes_FamilyName=attribute.FamilyName,
@@ -73,7 +74,7 @@ class CCC_Azure(ComplianceOutput):
                         Description=compliance.Description,
                         SubscriptionId="",
                         Location="",
-                        AssessmentDate=str(finding.timestamp),
+                        AssessmentDate=str(timestamp),
                         Requirements_Id=requirement.Id,
                         Requirements_Description=requirement.Description,
                         Requirements_Attributes_FamilyName=attribute.FamilyName,

--- a/prowler/lib/outputs/compliance/ccc/ccc_gcp.py
+++ b/prowler/lib/outputs/compliance/ccc/ccc_gcp.py
@@ -1,3 +1,4 @@
+from prowler.config.config import timestamp
 from prowler.lib.check.compliance_models import Compliance
 from prowler.lib.outputs.compliance.ccc.models import CCC_GCPModel
 from prowler.lib.outputs.compliance.compliance_output import ComplianceOutput
@@ -44,7 +45,7 @@ class CCC_GCP(ComplianceOutput):
                             Description=compliance.Description,
                             ProjectId=finding.account_uid,
                             Location=finding.region,
-                            AssessmentDate=str(finding.timestamp),
+                            AssessmentDate=str(timestamp),
                             Requirements_Id=requirement.Id,
                             Requirements_Description=requirement.Description,
                             Requirements_Attributes_FamilyName=attribute.FamilyName,
@@ -73,7 +74,7 @@ class CCC_GCP(ComplianceOutput):
                         Description=compliance.Description,
                         ProjectId="",
                         Location="",
-                        AssessmentDate=str(finding.timestamp),
+                        AssessmentDate=str(timestamp),
                         Requirements_Id=requirement.Id,
                         Requirements_Description=requirement.Description,
                         Requirements_Attributes_FamilyName=attribute.FamilyName,


### PR DESCRIPTION
### Description

This pull request standardizes the way assessment dates are handled in the CCC compliance output modules for AWS, Azure, and GCP. Previously, the assessment date was set individually for each finding using its own timestamp. Now, all assessment dates use a global `timestamp` imported from `prowler.config.config`, ensuring consistency across all compliance reports.

Updates to assessment date handling:

* AWS CCC compliance output (`prowler/lib/outputs/compliance/ccc/ccc_aws.py`): Changed assessment date from `finding.timestamp` to the global `timestamp` in both the main and fallback cases. [[1]](diffhunk://#diff-e87459bb550ab7b293c5dac788961f70da3806eab29d1746ee24fdfbea4f0521R1) [[2]](diffhunk://#diff-e87459bb550ab7b293c5dac788961f70da3806eab29d1746ee24fdfbea4f0521L47-R48) [[3]](diffhunk://#diff-e87459bb550ab7b293c5dac788961f70da3806eab29d1746ee24fdfbea4f0521L76-R77)
* Azure CCC compliance output (`prowler/lib/outputs/compliance/ccc/ccc_azure.py`): Changed assessment date from `finding.timestamp` to the global `timestamp` in both the main and fallback cases. [[1]](diffhunk://#diff-9a11189c08990aacbc616aebd35a075c2e4a6fcd7ae5886624acfe95154c2570R1) [[2]](diffhunk://#diff-9a11189c08990aacbc616aebd35a075c2e4a6fcd7ae5886624acfe95154c2570L47-R48) [[3]](diffhunk://#diff-9a11189c08990aacbc616aebd35a075c2e4a6fcd7ae5886624acfe95154c2570L76-R77)
* GCP CCC compliance output (`prowler/lib/outputs/compliance/ccc/ccc_gcp.py`): Changed assessment date from `finding.timestamp` to the global `timestamp` in both the main and fallback cases. [[1]](diffhunk://#diff-c37a23a72eac60013e29b60c6a3ddd3937f7e03d8f99438e9d432d86cfa4d8edR1) [[2]](diffhunk://#diff-c37a23a72eac60013e29b60c6a3ddd3937f7e03d8f99438e9d432d86cfa4d8edL47-R48) [[3]](diffhunk://#diff-c37a23a72eac60013e29b60c6a3ddd3937f7e03d8f99438e9d432d86cfa4d8edL76-R77)

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
