### PR TITLE
fix(ec2): AttributeError in `ec2_instance_with_outdated_ami` check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -18,7 +18,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add `resource_name` for checks under `logging` for the GCP provider [(#9023)](https://github.com/prowler-cloud/prowler/pull/9023)
 - Fix `ec2_instance_with_outdated_ami` check to handle None AMIs [(#9046)](https://github.com/prowler-cloud/prowler/pull/9046)
 
-
 ---
 
 ## [v5.13.0] (Prowler v5.13.0)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Add `resource_name` for checks under `logging` for the GCP provider [(#9023)](https://github.com/prowler-cloud/prowler/pull/9023)
+- Fix `ec2_instance_with_outdated_ami` check to handle None AMIs [(#9046)](https://github.com/prowler-cloud/prowler/pull/9046)
 
 
 ---

--- a/prowler/providers/aws/services/ec2/ec2_instance_with_outdated_ami/ec2_instance_with_outdated_ami.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_with_outdated_ami/ec2_instance_with_outdated_ami.py
@@ -31,7 +31,7 @@ class ec2_instance_with_outdated_ami(Check):
                 (image for image in ec2_client.images if image.id == instance.image_id),
                 None,
             )
-            if ami.owner == "amazon":
+            if ami and ami.owner == "amazon":
                 report = Check_Report_AWS(metadata=self.metadata(), resource=instance)
                 report.status = "PASS"
                 report.status_extended = (


### PR DESCRIPTION
### Context

This PR fixes the AttributeError reported when scanning instances that reference AMIs unavailable in the prefetched image list. In order to solve this we need to guard the EC2 outdated AMI check against missing AMI metadata.

Fix #9038 

### Description

Modified `ec2_instance_with_outdated_ami` check and added unit test for this scenario.

### Steps to review

Review the code and run the check with real infra if needed.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
