### PR TITLE
chore(github): increase sdk tests timeout to 120m

### DIFF
--- a/.github/workflows/sdk-pull-request.yml
+++ b/.github/workflows/sdk-pull-request.yml
@@ -141,7 +141,7 @@ jobs:
   tests:
     if: github.repository == 'prowler-cloud/prowler'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
### Context

SDK tests are timing out with 60m, we need to increase them

### Description

- Increase tests timeout to 120m

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
