### PR TITLE
chore(github): improve trivy scan time

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -45,22 +45,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Run Trivy vulnerability scan (SARIF)
-      if: inputs.upload-sarif == 'true'
-      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+    - name: Cache Trivy vulnerability database
+      uses: actions/cache@f0a67a2ed41fa8c0d21ab1521da3a46b0c9ae5e4 # v4.3.1
       with:
-        image-ref: ${{ inputs.image-name }}:${{ inputs.image-tag }}
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        severity: 'CRITICAL,HIGH'
-        exit-code: '0'
-
-    - name: Upload Trivy results to GitHub Security tab
-      if: inputs.upload-sarif == 'true'
-      uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
-      with:
-        sarif_file: 'trivy-results.sarif'
-        category: 'trivy-container'
+        path: ~/.cache/trivy
+        key: trivy-db-${{ runner.os }}-${{ github.run_id }}
+        restore-keys: |
+          trivy-db-${{ runner.os }}-
 
     - name: Run Trivy vulnerability scan (JSON)
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
@@ -70,6 +61,27 @@ runs:
         output: 'trivy-report.json'
         severity: ${{ inputs.severity }}
         exit-code: '0'
+        scanners: 'vuln'
+        timeout: '5m'
+
+    - name: Run Trivy vulnerability scan (SARIF)
+      if: inputs.upload-sarif == 'true' && github.event_name == 'push'
+      uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+      with:
+        image-ref: ${{ inputs.image-name }}:${{ inputs.image-tag }}
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        severity: 'CRITICAL,HIGH'
+        exit-code: '0'
+        scanners: 'vuln'
+        timeout: '5m'
+
+    - name: Upload Trivy results to GitHub Security tab
+      if: inputs.upload-sarif == 'true' && github.event_name == 'push'
+      uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+      with:
+        sarif_file: 'trivy-results.sarif'
+        category: 'trivy-container'
 
     - name: Upload Trivy report artifact
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -109,20 +121,20 @@ runs:
       with:
         script: |
           const comment = require('./.github/scripts/trivy-pr-comment.js');
-          
+
           // Unique identifier to find our comment
           const marker = '<!-- trivy-scan-comment:${{ inputs.image-name }} -->';
           const body = marker + '\n' + comment;
-          
+
           // Find existing comment
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
           });
-          
+
           const existingComment = comments.find(c => c.body?.includes(marker));
-          
+
           if (existingComment) {
             // Update existing comment
             await github.rest.issues.updateComment({


### PR DESCRIPTION
### Context

Trivy scan is taking too much time

### Description

- Scan only for vulnerabilities
- Use cache

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
