### PR TITLE
chore(github): fix trivy action

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -46,7 +46,7 @@ runs:
   using: 'composite'
   steps:
     - name: Cache Trivy vulnerability database
-      uses: actions/cache@f0a67a2ed41fa8c0d21ab1521da3a46b0c9ae5e4 # v4.3.1
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/trivy
         key: trivy-db-${{ runner.os }}-${{ github.run_id }}


### PR DESCRIPTION
### Context

Fix trivy action

### Description

- Fix trivi action step, cache action was using a wrong version

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
