### PR TITLE
chore(github): separate mcp pr jobs in different actions

### DIFF
--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -1,4 +1,4 @@
-name: 'MCP: Pull Request'
+name: 'MCP: Container Checks'
 
 on:
   push:
@@ -6,15 +6,15 @@ on:
       - 'master'
       - 'v5.*'
     paths:
-      - '.github/workflows/mcp-pull-request.yml'
       - 'mcp_server/**'
+      - '.github/workflows/mcp-container-checks.yml'
   pull_request:
     branches:
       - 'master'
       - 'v5.*'
     paths:
-      - '.github/workflows/mcp-pull-request.yml'
       - 'mcp_server/**'
+      - '.github/workflows/mcp-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,36 +25,7 @@ env:
   IMAGE_NAME: prowler-mcp
 
 jobs:
-  check-changes:
-    if: github.repository == 'prowler-cloud/prowler'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      mcp-changed: ${{ steps.filter.outputs.mcp }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Check for MCP changes
-        id: filter
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
-        with:
-          files_ignore: |
-            mcp_server/README.md
-            mcp_server/CHANGELOG.md
-
-      - name: Set output
-        id: set-output
-        run: |
-          if [[ "${{ steps.filter.outputs.any_changed }}" == "true" ]]; then
-            echo "mcp=true" >> $GITHUB_OUTPUT
-          else
-            echo "mcp=false" >> $GITHUB_OUTPUT
-          fi
-
-  dockerfile-lint:
-    needs: check-changes
-    if: github.repository == 'prowler-cloud/prowler' && needs.check-changes.outputs.mcp-changed == 'true'
+  mcp-dockerfile-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -64,14 +35,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Check if Dockerfile changed
+        id: dockerfile-changed
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
+        with:
+          files: mcp_server/Dockerfile
+
       - name: Lint Dockerfile with Hadolint
+        if: steps.dockerfile-changed.outputs.any_changed == 'true'
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: mcp_server/Dockerfile
 
-  container-build-and-scan:
-    needs: check-changes
-    if: github.repository == 'prowler-cloud/prowler' && needs.check-changes.outputs.mcp-changed == 'true'
+  mcp-container-build-and-scan:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -83,10 +59,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Check for MCP changes
+        id: check-changes
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47.0.0
+        with:
+          files_ignore: |
+            mcp_server/README.md
+            mcp_server/CHANGELOG.md
+
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build MCP container
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.MCP_WORKING_DIR }}
@@ -97,6 +83,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan MCP container with Trivy
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
### Context

Separate jobs in different actions. This allows us to have more flexibility when it comes to required actions and to be able to handle the different types of controls we want to have.

### Description

New actions:
 - `mcp-container-checks.yml`
 - Compatibility with `prowler-cloud` repository

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
