### PR TITLE
fix(api): standardize JSON:API resource types for Lighthouse endpoints

### DIFF
--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -2104,7 +2104,7 @@ class LighthouseTenantConfiguration(RowLevelSecurityProtectedModel):
         ]
 
     class JSONAPIMeta:
-        resource_name = "lighthouse-config"
+        resource_name = "lighthouse-configuration"
 
 
 class LighthouseProviderModels(RowLevelSecurityProtectedModel):
@@ -2153,3 +2153,6 @@ class LighthouseProviderModels(RowLevelSecurityProtectedModel):
                 name="lh_prov_models_cfg_idx",
             ),
         ]
+
+    class JSONAPIMeta:
+        resource_name = "lighthouse-models"

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -2104,7 +2104,7 @@ class LighthouseTenantConfiguration(RowLevelSecurityProtectedModel):
         ]
 
     class JSONAPIMeta:
-        resource_name = "lighthouse-configuration"
+        resource_name = "lighthouse-configurations"
 
 
 class LighthouseProviderModels(RowLevelSecurityProtectedModel):

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -8923,7 +8923,7 @@ class TestLighthouseTenantConfigViewSet:
         """Test creating a tenant config successfully via PATCH (upsert)"""
         payload = {
             "data": {
-                "type": "lighthouse-config",
+                "type": "lighthouse-configuration",
                 "attributes": {
                     "business_context": "Test business context for security analysis",
                     "default_provider": "",
@@ -8932,7 +8932,7 @@ class TestLighthouseTenantConfigViewSet:
             }
         }
         response = authenticated_client.patch(
-            reverse("lighthouse-config"),
+            reverse("lighthouse-configuration"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -8949,7 +8949,7 @@ class TestLighthouseTenantConfigViewSet:
         """Test that PATCH creates config if not exists and updates if exists (upsert)"""
         payload = {
             "data": {
-                "type": "lighthouse-config",
+                "type": "lighthouse-configuration",
                 "attributes": {
                     "business_context": "First config",
                 },
@@ -8958,7 +8958,7 @@ class TestLighthouseTenantConfigViewSet:
 
         # First PATCH creates the config
         response = authenticated_client.patch(
-            reverse("lighthouse-config"),
+            reverse("lighthouse-configuration"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -8969,7 +8969,7 @@ class TestLighthouseTenantConfigViewSet:
         # Second PATCH updates the same config (not creating a duplicate)
         payload["data"]["attributes"]["business_context"] = "Updated config"
         response = authenticated_client.patch(
-            reverse("lighthouse-config"),
+            reverse("lighthouse-configuration"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -9025,7 +9025,7 @@ class TestLighthouseTenantConfigViewSet:
         )
 
         # Retrieve and verify the configuration
-        response = authenticated_client.get(reverse("lighthouse-config"))
+        response = authenticated_client.get(reverse("lighthouse-configuration"))
         assert response.status_code == status.HTTP_200_OK
         data = response.json()["data"]
         assert data["id"] == str(config.id)
@@ -9035,7 +9035,7 @@ class TestLighthouseTenantConfigViewSet:
 
     def test_lighthouse_tenant_config_retrieve_not_found(self, authenticated_client):
         """Test GET when config doesn't exist returns 404"""
-        response = authenticated_client.get(reverse("lighthouse-config"))
+        response = authenticated_client.get(reverse("lighthouse-configuration"))
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "not found" in response.json()["errors"][0]["detail"].lower()
 
@@ -9056,14 +9056,14 @@ class TestLighthouseTenantConfigViewSet:
         # Update it
         payload = {
             "data": {
-                "type": "lighthouse-config",
+                "type": "lighthouse-configuration",
                 "attributes": {
                     "business_context": "Updated context for cloud security",
                 },
             }
         }
         response = authenticated_client.patch(
-            reverse("lighthouse-config"),
+            reverse("lighthouse-configuration"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -9088,14 +9088,14 @@ class TestLighthouseTenantConfigViewSet:
         # Try to set invalid provider
         payload = {
             "data": {
-                "type": "lighthouse-config",
+                "type": "lighthouse-configuration",
                 "attributes": {
                     "default_provider": "nonexistent-provider",
                 },
             }
         }
         response = authenticated_client.patch(
-            reverse("lighthouse-config"),
+            reverse("lighthouse-configuration"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -9116,7 +9116,7 @@ class TestLighthouseTenantConfigViewSet:
 
         # Send invalid JSON
         response = authenticated_client.patch(
-            reverse("lighthouse-config"),
+            reverse("lighthouse-configuration"),
             data="invalid json",
             content_type=API_JSON_CONTENT_TYPE,
         )

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -8923,7 +8923,7 @@ class TestLighthouseTenantConfigViewSet:
         """Test creating a tenant config successfully via PATCH (upsert)"""
         payload = {
             "data": {
-                "type": "lighthouse-configuration",
+                "type": "lighthouse-configurations",
                 "attributes": {
                     "business_context": "Test business context for security analysis",
                     "default_provider": "",
@@ -8932,7 +8932,7 @@ class TestLighthouseTenantConfigViewSet:
             }
         }
         response = authenticated_client.patch(
-            reverse("lighthouse-configuration"),
+            reverse("lighthouse-configurations"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -8949,7 +8949,7 @@ class TestLighthouseTenantConfigViewSet:
         """Test that PATCH creates config if not exists and updates if exists (upsert)"""
         payload = {
             "data": {
-                "type": "lighthouse-configuration",
+                "type": "lighthouse-configurations",
                 "attributes": {
                     "business_context": "First config",
                 },
@@ -8958,7 +8958,7 @@ class TestLighthouseTenantConfigViewSet:
 
         # First PATCH creates the config
         response = authenticated_client.patch(
-            reverse("lighthouse-configuration"),
+            reverse("lighthouse-configurations"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -8969,7 +8969,7 @@ class TestLighthouseTenantConfigViewSet:
         # Second PATCH updates the same config (not creating a duplicate)
         payload["data"]["attributes"]["business_context"] = "Updated config"
         response = authenticated_client.patch(
-            reverse("lighthouse-configuration"),
+            reverse("lighthouse-configurations"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -9025,7 +9025,7 @@ class TestLighthouseTenantConfigViewSet:
         )
 
         # Retrieve and verify the configuration
-        response = authenticated_client.get(reverse("lighthouse-configuration"))
+        response = authenticated_client.get(reverse("lighthouse-configurations"))
         assert response.status_code == status.HTTP_200_OK
         data = response.json()["data"]
         assert data["id"] == str(config.id)
@@ -9035,7 +9035,7 @@ class TestLighthouseTenantConfigViewSet:
 
     def test_lighthouse_tenant_config_retrieve_not_found(self, authenticated_client):
         """Test GET when config doesn't exist returns 404"""
-        response = authenticated_client.get(reverse("lighthouse-configuration"))
+        response = authenticated_client.get(reverse("lighthouse-configurations"))
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "not found" in response.json()["errors"][0]["detail"].lower()
 
@@ -9056,14 +9056,14 @@ class TestLighthouseTenantConfigViewSet:
         # Update it
         payload = {
             "data": {
-                "type": "lighthouse-configuration",
+                "type": "lighthouse-configurations",
                 "attributes": {
                     "business_context": "Updated context for cloud security",
                 },
             }
         }
         response = authenticated_client.patch(
-            reverse("lighthouse-configuration"),
+            reverse("lighthouse-configurations"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -9088,14 +9088,14 @@ class TestLighthouseTenantConfigViewSet:
         # Try to set invalid provider
         payload = {
             "data": {
-                "type": "lighthouse-configuration",
+                "type": "lighthouse-configurations",
                 "attributes": {
                     "default_provider": "nonexistent-provider",
                 },
             }
         }
         response = authenticated_client.patch(
-            reverse("lighthouse-configuration"),
+            reverse("lighthouse-configurations"),
             data=payload,
             content_type=API_JSON_CONTENT_TYPE,
         )
@@ -9116,7 +9116,7 @@ class TestLighthouseTenantConfigViewSet:
 
         # Send invalid JSON
         response = authenticated_client.patch(
-            reverse("lighthouse-configuration"),
+            reverse("lighthouse-configurations"),
             data="invalid json",
             content_type=API_JSON_CONTENT_TYPE,
         )

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -3197,7 +3197,7 @@ class LighthouseTenantConfigSerializer(RLSSerializer):
 
     def get_url(self, obj):
         request = self.context.get("request")
-        return reverse("lighthouse-config", request=request)
+        return reverse("lighthouse-configuration", request=request)
 
     class Meta:
         model = LighthouseTenantConfiguration

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -3197,7 +3197,7 @@ class LighthouseTenantConfigSerializer(RLSSerializer):
 
     def get_url(self, obj):
         request = self.context.get("request")
-        return reverse("lighthouse-configuration", request=request)
+        return reverse("lighthouse-configurations", request=request)
 
     class Meta:
         model = LighthouseTenantConfiguration

--- a/api/src/backend/api/v1/urls.py
+++ b/api/src/backend/api/v1/urls.py
@@ -156,7 +156,7 @@ urlpatterns = [
         LighthouseTenantConfigViewSet.as_view(
             {"get": "list", "patch": "partial_update"}
         ),
-        name="lighthouse-configuration",
+        name="lighthouse-configurations",
     ),
     # API endpoint to start SAML SSO flow
     path(

--- a/api/src/backend/api/v1/urls.py
+++ b/api/src/backend/api/v1/urls.py
@@ -156,7 +156,7 @@ urlpatterns = [
         LighthouseTenantConfigViewSet.as_view(
             {"get": "list", "patch": "partial_update"}
         ),
-        name="lighthouse-config",
+        name="lighthouse-configuration",
     ),
     # API endpoint to start SAML SSO flow
     path(


### PR DESCRIPTION
### Context

Lighthouse endpoints have inconsistent JSON:API type.

<img width="585" height="858" alt="image" src="https://github.com/user-attachments/assets/1ea9e70e-0f77-40af-9e18-369b43d04cc7" />

<img width="611" height="778" alt="image" src="https://github.com/user-attachments/assets/c5bc7cf8-d8e6-4acd-8b28-0e3cb0a7525b" />

### Description

This PR fixes it by having consistent type names:
1. `lighthouse-config` -> `lighthouse-configuration` (Note: `lighthouse-configurations` resource name is taken by older model that will be deprecated. Also, this new endpoint is singleton. Hence, lighthouse-configuration)
2. LighthouseProviderModels -> `lighthouse-models`

### Steps to review

The PR tests must pass. Documentation must reflect the new JSON:API types.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
