### PR TITLE
fix(github): use members endpoint to verify author

### DIFF
--- a/.github/workflows/labeler-community.yml
+++ b/.github/workflows/labeler-community.yml
@@ -11,16 +11,33 @@ permissions: {}
 jobs:
   label-if-community:
     name: Add 'community' label if the PR is from a community contributor
-    if: github.repository == 'prowler-cloud/prowler' && github.event.pull_request.author_association != 'MEMBER' && github.event.pull_request.author_association != 'OWNER'
+    if: github.repository == 'prowler-cloud/prowler'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write # to write the label
+      pull-requests: write
 
     steps:
-      - name: Add the 'community' label
+      - name: Check if author is org member
+        id: check_membership
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          echo "Checking if $AUTHOR is a member of $ORG"
+          if gh api --method GET "orgs/$ORG/members/$AUTHOR" >/dev/null 2>&1; then
+            echo "is_member=true" >> $GITHUB_OUTPUT
+            echo "$AUTHOR is an organization member"
+          else
+            echo "is_member=false" >> $GITHUB_OUTPUT
+            echo "$AUTHOR is not an organization member"
+          fi
+
+      - name: Add community label
+        if: steps.check_membership.outputs.is_member == 'false'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "Adding 'community' label to the PR"
+          echo "Adding 'community' label to PR #$PR_NUMBER"
           gh pr edit "$PR_NUMBER" --add-label community


### PR DESCRIPTION
### Context
There's an open issue with the `github.event.issue.author_association`: https://github.com/actions/github-script/issues/643#issuecomment-3253122356

This was causing the flaky labeling.

### Description
Use the `/org/<org>/members/<member>` endpoint to verify if user is MEMBER.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
