### PR TITLE
chore(github): send slack message on container release

### DIFF
--- a/.github/actions/slack-notification/README.md
+++ b/.github/actions/slack-notification/README.md
@@ -1,0 +1,198 @@
+# Slack Notification Action
+
+A generic and flexible GitHub composite action for sending Slack notifications using JSON template files. Supports both standalone messages and message updates, with automatic status detection.
+
+## Features
+
+- **Template-based**: All messages use JSON template files for consistency
+- **Automatic status detection**: Pass `step-outcome` to auto-calculate success/failure
+- **Message updates**: Supports updating existing messages (using `chat.update`)
+- **Simple API**: Clean and minimal interface
+- **Reusable**: Use across all workflows and scenarios
+- **Maintainable**: Centralized message templates
+
+## Use Cases
+
+1. **Container releases**: Track push start and completion with automatic status
+2. **Deployments**: Track deployment progress with rich Block Kit formatting
+3. **Custom notifications**: Any scenario where you need to notify Slack
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `slack-bot-token` | Slack bot token for authentication | Yes | - |
+| `payload-file-path` | Path to JSON file with the Slack message payload | Yes | - |
+| `update-ts` | Message timestamp to update (leave empty for new messages) | No | `''` |
+| `step-outcome` | Step outcome for automatic status detection (sets STATUS_EMOJI and STATUS_TEXT env vars) | No | `''` |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `ts` | Timestamp of the Slack message (use for updates) |
+
+## Usage Examples
+
+### Example 1: Container Release with Automatic Status Detection
+
+Using JSON template files with automatic status detection:
+
+```yaml
+# Send start notification
+- name: Notify container push started
+  if: github.event_name == 'release'
+  uses: ./.github/actions/slack-notification
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    COMPONENT: API
+    RELEASE_TAG: ${{ env.RELEASE_TAG }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+  with:
+    slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+    payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
+
+# Do the work
+- name: Build and push container
+  if: github.event_name == 'release'
+  id: container-push
+  uses: docker/build-push-action@...
+  with:
+    push: true
+    tags: ...
+
+# Send completion notification with automatic status detection
+- name: Notify container push completed
+  if: github.event_name == 'release' && always()
+  uses: ./.github/actions/slack-notification
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    COMPONENT: API
+    RELEASE_TAG: ${{ env.RELEASE_TAG }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+  with:
+    slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+    payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
+    step-outcome: ${{ steps.container-push.outcome }}
+```
+
+**Benefits:**
+- No status calculation needed in workflow
+- Reusable template files
+- Clean and concise
+- Automatic `STATUS_EMOJI` and `STATUS_TEXT` env vars set by action
+- Consistent message format across all workflows
+
+### Example 2: Deployment with Message Update Pattern
+
+```yaml
+# Send initial deployment message
+- name: Notify deployment started
+  id: slack-start
+  uses: ./.github/actions/slack-notification
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    COMPONENT: API
+    ENVIRONMENT: PRODUCTION
+    COMMIT_HASH: ${{ github.sha }}
+    VERSION_DEPLOYED: latest
+    GITHUB_ACTOR: ${{ github.actor }}
+    GITHUB_WORKFLOW: ${{ github.workflow }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+  with:
+    slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+    payload-file-path: "./.github/scripts/slack-messages/deployment-started.json"
+
+# Run deployment
+- name: Deploy
+  id: deploy
+  run: terraform apply -auto-approve
+
+# Determine additional status variables
+- name: Determine deployment status
+  if: always()
+  id: deploy-status
+  run: |
+    if [[ "${{ steps.deploy.outcome }}" == "success" ]]; then
+      echo "STATUS_COLOR=28a745" >> $GITHUB_ENV
+      echo "STATUS=Completed" >> $GITHUB_ENV
+    else
+      echo "STATUS_COLOR=fc3434" >> $GITHUB_ENV
+      echo "STATUS=Failed" >> $GITHUB_ENV
+    fi
+
+# Update the same message with final status
+- name: Update deployment notification
+  if: always()
+  uses: ./.github/actions/slack-notification
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    MESSAGE_TS: ${{ steps.slack-start.outputs.ts }}
+    COMPONENT: API
+    ENVIRONMENT: PRODUCTION
+    COMMIT_HASH: ${{ github.sha }}
+    VERSION_DEPLOYED: latest
+    GITHUB_ACTOR: ${{ github.actor }}
+    GITHUB_WORKFLOW: ${{ github.workflow }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+    STATUS: ${{ env.STATUS }}
+    STATUS_COLOR: ${{ env.STATUS_COLOR }}
+  with:
+    slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+    update-ts: ${{ steps.slack-start.outputs.ts }}
+    payload-file-path: "./.github/scripts/slack-messages/deployment-completed.json"
+    step-outcome: ${{ steps.deploy.outcome }}
+```
+
+## Automatic Status Detection
+
+When you provide `step-outcome` input, the action automatically sets these environment variables:
+
+| Outcome | STATUS_EMOJI | STATUS_TEXT |
+|---------|--------------|-------------|
+| success | `[✓]` | `completed successfully!` |
+| failure | `[✗]` | `failed` |
+
+These variables are then available in your payload template files.
+
+## Template File Format
+
+All template files must be valid JSON and support environment variable substitution. Example:
+
+```json
+{
+  "channel": "$SLACK_CHANNEL_ID",
+  "text": "$STATUS_EMOJI $COMPONENT container release $RELEASE_TAG push $STATUS_TEXT <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View run>"
+}
+```
+
+See available templates in [`.github/scripts/slack-messages/`](../../scripts/slack-messages/).
+
+## Requirements
+
+- Slack Bot Token with scopes: `chat:write`, `chat:write.public`
+- Slack Channel ID where messages will be posted
+- JSON template files for your messages
+
+## Benefits
+
+- **Consistency**: All notifications use standardized templates
+- **Automatic status handling**: No need to calculate success/failure in workflows
+- **Clean workflows**: Minimal boilerplate code
+- **Reusable templates**: One template for all components
+- **Easy to maintain**: Change template once, applies everywhere
+- **Version controlled**: All message formats in git
+
+## Related Resources
+
+- [Slack Block Kit Builder](https://app.slack.com/block-kit-builder)
+- [Slack API Method Documentation](https://docs.slack.dev/tools/slack-github-action/sending-techniques/sending-data-slack-api-method/)
+- [Message templates documentation](../../scripts/slack-messages/README.md)

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -1,0 +1,65 @@
+name: 'Slack Notification'
+description: 'Generic action to send Slack notifications with optional message updates and automatic status detection'
+inputs:
+  slack-bot-token:
+    description: 'Slack bot token for authentication'
+    required: true
+  payload-file-path:
+    description: 'Path to JSON file with the Slack message payload'
+    required: true
+  update-ts:
+    description: 'Message timestamp to update (only for updates, leave empty for new messages)'
+    required: false
+    default: ''
+  step-outcome:
+    description: 'Outcome of a step to determine status (success/failure) - automatically sets STATUS_EMOJI and STATUS_TEXT env vars'
+    required: false
+    default: ''
+outputs:
+  ts:
+    description: 'Timestamp of the Slack message'
+    value: ${{ steps.slack-notification.outputs.ts }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Determine status
+      if: inputs.step-outcome != ''
+      id: status
+      shell: bash
+      run: |
+        if [[ "${{ inputs.step-outcome }}" == "success" ]]; then
+          echo "STATUS_EMOJI=[✓]" >> $GITHUB_ENV
+          echo "STATUS_TEXT=completed successfully!" >> $GITHUB_ENV
+        else
+          echo "STATUS_EMOJI=[✗]" >> $GITHUB_ENV
+          echo "STATUS_TEXT=failed" >> $GITHUB_ENV
+        fi
+
+    - name: Send Slack notification (new message)
+      if: inputs.update-ts == ''
+      id: slack-notification-post
+      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+      with:
+        method: chat.postMessage
+        token: ${{ inputs.slack-bot-token }}
+        payload-file-path: ${{ inputs.payload-file-path }}
+
+    - name: Update Slack notification
+      if: inputs.update-ts != ''
+      id: slack-notification-update
+      uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+      with:
+        method: chat.update
+        token: ${{ inputs.slack-bot-token }}
+        payload-file-path: ${{ inputs.payload-file-path }}
+
+    - name: Set output
+      id: slack-notification
+      shell: bash
+      run: |
+        if [[ "${{ inputs.update-ts }}" == "" ]]; then
+          echo "ts=${{ steps.slack-notification-post.outputs.ts }}" >> $GITHUB_OUTPUT
+        else
+          echo "ts=${{ inputs.update-ts }}" >> $GITHUB_OUTPUT
+        fi
+

--- a/.github/scripts/slack-messages/README.md
+++ b/.github/scripts/slack-messages/README.md
@@ -1,0 +1,266 @@
+# Slack Message Templates
+
+This directory contains reusable message templates for Slack notifications sent from GitHub Actions workflows.
+
+## Usage
+
+These JSON templates are used with the `slackapi/slack-github-action` using the Slack API method (`chat.postMessage` and `chat.update`). All templates support rich Block Kit formatting and message updates.
+
+### Available Templates
+
+**Container Releases**
+- `container-release-started.json`: Simple one-line notification when container push starts
+- `container-release-completed.json`: Simple one-line notification when container release completes
+
+**Deployments**
+- `deployment-started.json`: Deployment start notification with Block Kit formatting
+- `deployment-completed.json`: Deployment completion notification (updates the start message)
+
+All templates use the Slack API method and require a Slack Bot Token.
+
+## Setup Requirements
+
+1. Create a Slack App (or use existing)
+2. Add Bot Token Scopes: `chat:write`, `chat:write.public`
+3. Install the app to your workspace
+4. Get the Bot Token from OAuth & Permissions page
+5. Add secrets:
+   - `SLACK_BOT_TOKEN`: Your bot token
+   - `SLACK_CHANNEL_ID`: The channel ID where messages will be posted
+
+Reference: [Sending data using a Slack API method](https://docs.slack.dev/tools/slack-github-action/sending-techniques/sending-data-slack-api-method/)
+
+## Environment Variables
+
+### Required Secrets (GitHub Secrets)
+- `SLACK_BOT_TOKEN`: Passed as `token` parameter to the action (not as env variable)
+- `SLACK_CHANNEL_ID`: Used in payload as env variable
+
+### Container Release Variables (configured as env)
+- `COMPONENT`: Component name (e.g., "API", "SDK", "UI", "MCP")
+- `RELEASE_TAG` / `PROWLER_VERSION`: The release tag or version being deployed
+- `GITHUB_SERVER_URL`: Provided by GitHub context
+- `GITHUB_REPOSITORY`: Provided by GitHub context
+- `GITHUB_RUN_ID`: Provided by GitHub context
+
+### Deployment Variables (configured as env)
+- `COMPONENT`: Component name (e.g., "API", "SDK", "UI", "MCP")
+- `ENVIRONMENT`: Environment name (e.g., "DEVELOPMENT", "PRODUCTION")
+- `COMMIT_HASH`: Commit hash being deployed
+- `VERSION_DEPLOYED`: Version being deployed
+- `GITHUB_ACTOR`: User who triggered the workflow
+- `GITHUB_WORKFLOW`: Workflow name
+- `GITHUB_SERVER_URL`: Provided by GitHub context
+- `GITHUB_REPOSITORY`: Provided by GitHub context
+- `GITHUB_RUN_ID`: Provided by GitHub context
+
+All other variables (MESSAGE_TS, STATUS, STATUS_COLOR, STATUS_EMOJI, etc.) are calculated internally within the workflow and should NOT be configured as environment variables.
+
+## Example Workflow Usage
+
+### Container Release Notification (Simple One-Line)
+
+Simple one-line notifications for container releases:
+
+```yaml
+# Step 1: Notify when push starts
+- name: Notify container push started
+  if: github.event_name == 'release'
+  uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    COMPONENT: API
+    RELEASE_TAG: ${{ env.RELEASE_TAG }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+  with:
+    method: chat.postMessage
+    token: ${{ secrets.SLACK_BOT_TOKEN }}
+    payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
+
+# Step 2: Build and push container
+- name: Build and push container
+  uses: docker/build-push-action@...
+  with:
+    push: true
+    tags: ...
+
+# Step 3: Notify when push completes
+- name: Notify container push completed
+  if: github.event_name == 'release'
+  uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    COMPONENT: API
+    RELEASE_TAG: ${{ env.RELEASE_TAG }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+  with:
+    method: chat.postMessage
+    token: ${{ secrets.SLACK_BOT_TOKEN }}
+    payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
+```
+
+### Deployment with Update Pattern
+
+For deployments that start with one message and update it with the final status:
+
+```yaml
+# Step 1: Send deployment start notification
+- name: Notify Deployment Start
+  id: slack-notification-start
+  uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    COMPONENT: API
+    ENVIRONMENT: PRODUCTION
+    COMMIT_HASH: ${{ github.sha }}
+    VERSION_DEPLOYED: latest
+    GITHUB_ACTOR: ${{ github.actor }}
+    GITHUB_WORKFLOW: ${{ github.workflow }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+  with:
+    method: chat.postMessage
+    token: ${{ secrets.SLACK_BOT_TOKEN }}
+    payload-file-path: "./.github/scripts/slack-messages/deployment-started.json"
+
+# Step 2: Run your deployment steps
+- name: Terraform Plan
+  id: terraform-plan
+  run: terraform plan
+
+- name: Terraform Apply
+  id: terraform-apply
+  run: terraform apply -auto-approve
+
+# Step 3: Determine status (calculated internally, not configured)
+- name: Determine Status
+  if: always()
+  id: determine-status
+  run: |
+    if [[ "${{ steps.terraform-apply.outcome }}" == "success" ]]; then
+      echo "status=Completed" >> $GITHUB_OUTPUT
+      echo "status-color=28a745" >> $GITHUB_OUTPUT
+      echo "status-emoji=[✓]" >> $GITHUB_OUTPUT
+      echo "plan-emoji=[✓]" >> $GITHUB_OUTPUT
+      echo "apply-emoji=[✓]" >> $GITHUB_OUTPUT
+    elif [[ "${{ steps.terraform-plan.outcome }}" == "failure" || "${{ steps.terraform-apply.outcome }}" == "failure" ]]; then
+      echo "status=Failed" >> $GITHUB_OUTPUT
+      echo "status-color=fc3434" >> $GITHUB_OUTPUT
+      echo "status-emoji=[✗]" >> $GITHUB_OUTPUT
+      if [[ "${{ steps.terraform-plan.outcome }}" == "failure" ]]; then
+        echo "plan-emoji=[✗]" >> $GITHUB_OUTPUT
+      else
+        echo "plan-emoji=[✓]" >> $GITHUB_OUTPUT
+      fi
+      if [[ "${{ steps.terraform-apply.outcome }}" == "failure" ]]; then
+        echo "apply-emoji=[✗]" >> $GITHUB_OUTPUT
+      else
+        echo "apply-emoji=[✓]" >> $GITHUB_OUTPUT
+      fi
+    else
+      echo "status=Failed" >> $GITHUB_OUTPUT
+      echo "status-color=fc3434" >> $GITHUB_OUTPUT
+      echo "status-emoji=[✗]" >> $GITHUB_OUTPUT
+      echo "plan-emoji=[?]" >> $GITHUB_OUTPUT
+      echo "apply-emoji=[?]" >> $GITHUB_OUTPUT
+    fi
+
+# Step 4: Update the same Slack message (using calculated values)
+- name: Notify Deployment Result
+  if: always()
+  uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+  env:
+    SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+    MESSAGE_TS: ${{ steps.slack-notification-start.outputs.ts }}
+    COMPONENT: API
+    ENVIRONMENT: PRODUCTION
+    COMMIT_HASH: ${{ github.sha }}
+    VERSION_DEPLOYED: latest
+    GITHUB_ACTOR: ${{ github.actor }}
+    GITHUB_WORKFLOW: ${{ github.workflow }}
+    GITHUB_SERVER_URL: ${{ github.server_url }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+    GITHUB_RUN_ID: ${{ github.run_id }}
+    STATUS: ${{ steps.determine-status.outputs.status }}
+    STATUS_COLOR: ${{ steps.determine-status.outputs.status-color }}
+    STATUS_EMOJI: ${{ steps.determine-status.outputs.status-emoji }}
+    PLAN_EMOJI: ${{ steps.determine-status.outputs.plan-emoji }}
+    APPLY_EMOJI: ${{ steps.determine-status.outputs.apply-emoji }}
+    TERRAFORM_PLAN_OUTCOME: ${{ steps.terraform-plan.outcome }}
+    TERRAFORM_APPLY_OUTCOME: ${{ steps.terraform-apply.outcome }}
+  with:
+    method: chat.update
+    token: ${{ secrets.SLACK_BOT_TOKEN }}
+    payload-file-path: "./.github/scripts/slack-messages/deployment-completed.json"
+```
+
+**Note**: Variables like `STATUS`, `STATUS_COLOR`, `STATUS_EMOJI`, `PLAN_EMOJI`, `APPLY_EMOJI` are calculated by the `determine-status` step based on the outcomes of previous steps. They should NOT be manually configured.
+
+## Key Features
+
+### Benefits of Using Slack API Method
+
+- **Rich Block Kit Formatting**: Full support for Slack's Block Kit including headers, sections, fields, colors, and attachments
+- **Message Updates**: Update the same message instead of posting multiple messages (using `chat.update` with `ts`)
+- **Consistent Experience**: Same look and feel as Prowler Cloud notifications
+- **Flexible**: Easy to customize message appearance by editing JSON templates
+
+### Differences from Webhook Method
+
+| Feature | webhook-trigger | Slack API (chat.postMessage) |
+|---------|-----------------|------------------------------|
+| Setup | Workflow Builder webhook | Slack Bot Token + Channel ID |
+| Formatting | Plain text/simple | Full Block Kit support |
+| Message Update | No | Yes (with chat.update) |
+| Authentication | Webhook URL | Bot Token |
+| Scopes Required | None | chat:write, chat:write.public |
+
+## Message Appearance
+
+### Container Release (Simple One-Line)
+
+**Start message:**
+```
+API container release 4.5.0 push started... View run
+```
+
+**Completion message:**
+```
+[✓] API container release 4.5.0 has been pushed successfully! View run
+```
+
+Both messages are simple one-liners with a clickable "View run" link.
+
+### Deployment Start
+- Header: Component and environment
+- Yellow bar (color: `dbab09`)
+- Status: In Progress
+- Details: Commit, version, actor, workflow
+- Link: Direct link to deployment run
+
+### Deployment Completion
+- Header: Component and environment
+- Green bar for success (color: `28a745`) / Red bar for failure (color: `fc3434`)
+- Status: [✓] Completed or [✗] Failed
+- Details: All deployment info plus terraform outcomes
+- Link: Direct link to deployment run
+
+## Adding New Templates
+
+1. Create a new JSON file with Block Kit structure
+2. Use environment variable placeholders (e.g., `$VAR_NAME`)
+3. Include `channel` and `text` fields (required)
+4. Add `blocks` or `attachments` for rich formatting
+5. For update templates, include `ts` field as `$MESSAGE_TS`
+6. Document the template in this README
+7. Reference it in your workflow using `payload-file-path`
+
+## Reference
+
+- [Slack Block Kit Builder](https://app.slack.com/block-kit-builder)
+- [Slack API Method Documentation](https://docs.slack.dev/tools/slack-github-action/sending-techniques/sending-data-slack-api-method/)

--- a/.github/scripts/slack-messages/container-release-completed.json
+++ b/.github/scripts/slack-messages/container-release-completed.json
@@ -1,0 +1,4 @@
+{
+  "channel": "$SLACK_CHANNEL_ID",
+  "text": "[✓] $COMPONENT container release $RELEASE_TAG has been pushed successfully! <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View run>"
+}

--- a/.github/scripts/slack-messages/container-release-completed.json
+++ b/.github/scripts/slack-messages/container-release-completed.json
@@ -1,4 +1,4 @@
 {
   "channel": "$SLACK_CHANNEL_ID",
-  "text": "[✓] $COMPONENT container release $RELEASE_TAG has been pushed successfully! <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View run>"
+  "text": "$STATUS_EMOJI $COMPONENT container release $RELEASE_TAG push $STATUS_TEXT <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View run>"
 }

--- a/.github/scripts/slack-messages/container-release-started.json
+++ b/.github/scripts/slack-messages/container-release-started.json
@@ -1,0 +1,4 @@
+{
+  "channel": "$SLACK_CHANNEL_ID",
+  "text": "$COMPONENT container release $RELEASE_TAG push started... <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|View run>"
+}

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -75,6 +75,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Notify container push started
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: API
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
+
       - name: Build and push API container (release)
         if: github.event_name == 'release'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -86,6 +101,21 @@ jobs:
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.STABLE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify container push completed
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: API
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
 
   trigger-deployment:
     if: github.event_name == 'push'

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Notify container push started
         if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: API
@@ -86,12 +86,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
 
       - name: Build and push API container (release)
         if: github.event_name == 'release'
+        id: container-push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.WORKING_DIRECTORY }}
@@ -103,8 +103,8 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify container push completed
-        if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: github.event_name == 'release' && always()
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: API
@@ -113,9 +113,9 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
+          step-outcome: ${{ steps.container-push.outcome }}
 
   trigger-deployment:
     if: github.event_name == 'push'

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -80,6 +80,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Notify container push started
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: MCP
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
+
       - name: Build and push MCP container (release)
         if: github.event_name == 'release'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -99,6 +114,21 @@ jobs:
             org.opencontainers.image.created=${{ github.event.release.published_at }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify container push completed
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: MCP
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
 
   trigger-deployment:
     if: github.event_name == 'push'

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Notify container push started
         if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: MCP
@@ -91,12 +91,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
 
       - name: Build and push MCP container (release)
         if: github.event_name == 'release'
+        id: container-push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.WORKING_DIRECTORY }}
@@ -116,8 +116,8 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify container push completed
-        if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: github.event_name == 'release' && always()
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: MCP
@@ -126,9 +126,9 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
+          step-outcome: ${{ steps.container-push.outcome }}
 
   trigger-deployment:
     if: github.event_name == 'push'

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -138,6 +138,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Notify container push started
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: SDK
+          RELEASE_TAG: ${{ env.PROWLER_VERSION }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
+
       - name: Build and push SDK container (release)
         if: github.event_name == 'release'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -154,6 +169,21 @@ jobs:
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.STABLE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify container push completed
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: SDK
+          RELEASE_TAG: ${{ env.PROWLER_VERSION }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
 
   dispatch-v3-deployment:
     if: needs.container-build-push.outputs.prowler_version_major == '3'

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Notify container push started
         if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: SDK
@@ -149,12 +149,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
 
       - name: Build and push SDK container (release)
         if: github.event_name == 'release'
+        id: container-push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
@@ -171,8 +171,8 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify container push completed
-        if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: github.event_name == 'release' && always()
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: SDK
@@ -181,9 +181,9 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
+          step-outcome: ${{ steps.container-push.outcome }}
 
   dispatch-v3-deployment:
     if: needs.container-build-push.outputs.prowler_version_major == '3'

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -80,6 +80,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Notify container push started
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: UI
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
+
       - name: Build and push UI container (release)
         if: github.event_name == 'release'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -94,6 +109,21 @@ jobs:
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${{ env.STABLE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify container push completed
+        if: github.event_name == 'release'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          COMPONENT: UI
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
 
   trigger-deployment:
     if: github.event_name == 'push'

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Notify container push started
         if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: UI
@@ -91,12 +91,12 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-started.json"
 
       - name: Build and push UI container (release)
         if: github.event_name == 'release'
+        id: container-push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.WORKING_DIRECTORY }}
@@ -111,8 +111,8 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Notify container push completed
-        if: github.event_name == 'release'
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        if: github.event_name == 'release' && always()
+        uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
           COMPONENT: UI
@@ -121,9 +121,9 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
+          step-outcome: ${{ steps.container-push.outcome }}
 
   trigger-deployment:
     if: github.event_name == 'push'


### PR DESCRIPTION
### Context

Send slack message when a container is pushed during a release process

### Description

- Create generic `slack-notification` action:
 - Send single message
 - Send start message, update with completed message
- Added container release messages templates on `scripts/slack-messages`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
