### PR TITLE
fix(github): user previous command to set labels

### DIFF
--- a/.github/workflows/labeler-community.yml
+++ b/.github/workflows/labeler-community.yml
@@ -40,4 +40,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "Adding 'community' label to PR #$PR_NUMBER"
-          gh pr edit "$PR_NUMBER" --add-label community
+          gh api /repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
+            -X POST \
+            -f labels[]='community'


### PR DESCRIPTION
### Description
Use command from [previous action](https://github.com/prowler-cloud/prowler/blob/3dc702ddc42f439010773483b6d4c3d811d15beb/.github/workflows/labeler-community.yml) that was able to label PRs.

Current version is not being able to label.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
