### PR TITLE
chore(github): rename jobs to know which component they belong

### DIFF
--- a/.github/workflows/api-codeql.yml
+++ b/.github/workflows/api-codeql.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze:
+  api-analyze:
     name: CodeQL Security Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/ui-codeql.yml
+++ b/.github/workflows/ui-codeql.yml
@@ -27,7 +27,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  analyze:
+  ui-analyze:
+    if: github.repository == 'prowler-cloud/prowler'
     name: CodeQL Security Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
### Context

Same job names can be problematic if we want to know which belongs to which.

### Description

- Rename jobs

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
