### PR TITLE
fix(aws): `firehose_stream_encrypted_at_rest` description and logic

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Fix `ec2_instance_with_outdated_ami` check to handle None AMIs [(#9046)](https://github.com/prowler-cloud/prowler/pull/9046)
 - Handle timestamp when transforming compliance findings in CCC [(#9042)](https://github.com/prowler-cloud/prowler/pull/9042)
 - Update `resource_id` for admincenter service and avoid unnecessary msgraph requests [(#9019)](https://github.com/prowler-cloud/prowler/pull/9019)
+- Fix `firehose_stream_encrypted_at_rest` description and findings clarity [(#9142)](https://github.com/prowler-cloud/prowler/pull/9142)
 
 ---
 

--- a/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.metadata.json
+++ b/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.metadata.json
@@ -13,7 +13,7 @@
   "ResourceIdTemplate": "",
   "Severity": "medium",
   "ResourceType": "AwsKinesisStream",
-  "Description": "**Amazon Data Firehose** delivery streams use **server-side encryption at rest** with AWS KMS. For `DirectPut` or database sources, the stream must have KMS encryption enabled. When the source is **Kinesis Data Streams**, the source's encryption is considered. For **MSK** sources, encryption at rest is always applied by AWS.",
+  "Description": "**Amazon Data Firehose** delivery streams must enable **server-side encryption at rest** with AWS KMS regardless of the source type. Encryption of upstream sources such as **Kinesis Data Streams** or **MSK** does not replace the need to protect the delivery stream itself.",
   "Risk": "Unencrypted Firehose data at rest can be read if storage or backups are accessed, harming **confidentiality** and **integrity**. Disk-level access, snapshots, or misconfigured destinations enable data exfiltration or tampering. Lacking KMS-backed controls also reduces key rotation, segregation of duties, and auditability.",
   "RelatedUrl": "",
   "AdditionalURLs": [

--- a/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py
+++ b/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py
@@ -26,23 +26,23 @@ class firehose_stream_encrypted_at_rest(Check):
         for stream in firehose_client.delivery_streams.values():
             report = Check_Report_AWS(metadata=self.metadata(), resource=stream)
             report.status = "FAIL"
-            report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled or the source stream is not encrypted."
+            report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled."
 
-            # Encrypted Kinesis Stream source
             if stream.delivery_stream_type == "KinesisStreamAsSource":
-                source_stream = kinesis_client.streams.get(
-                    stream.source.kinesis_stream.kinesis_stream_arn
-                )
+                source_stream_arn = stream.source.kinesis_stream.kinesis_stream_arn
+                source_stream = kinesis_client.streams.get(source_stream_arn, None)
                 if source_stream:
-                    if source_stream.encrypted_at_rest != EncryptionType.NONE:
-                        report.status = "PASS"
-                        report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled but the source stream {source_stream.name} has at rest encryption enabled."
+                    if source_stream.encrypted_at_rest == EncryptionType.KMS:
+                        report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled even though source stream {source_stream.name} has at rest encryption enabled."
+                    else:
+                        report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled and the source stream {source_stream.name} is not encrypted at rest."
+                else:
+                    report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled and the referenced source stream could not be found."
 
-            # MSK source - check if the MSK cluster has encryption at rest with CMK
             elif stream.delivery_stream_type == "MSKAsSource":
                 msk_cluster_arn = stream.source.msk.msk_cluster_arn
+                msk_cluster = None
                 if msk_cluster_arn:
-                    msk_cluster = None
                     for cluster in kafka_client.clusters.values():
                         if cluster.arn == msk_cluster_arn:
                             msk_cluster = cluster
@@ -59,7 +59,6 @@ class firehose_stream_encrypted_at_rest(Check):
                     else:
                         report.status_extended = f"Firehose Stream {stream.name} uses MSK source which always has encryption at rest enabled by AWS."
 
-            # Check if the stream has encryption enabled directly (DirectPut or DatabaseAsSource cases)
             elif stream.kms_encryption == EncryptionStatus.ENABLED:
                 report.status = "PASS"
                 report.status_extended = f"Firehose Stream {stream.name} does have at rest encryption enabled."

--- a/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py
+++ b/prowler/providers/aws/services/firehose/firehose_stream_encrypted_at_rest/firehose_stream_encrypted_at_rest.py
@@ -28,7 +28,11 @@ class firehose_stream_encrypted_at_rest(Check):
             report.status = "FAIL"
             report.status_extended = f"Firehose Stream {stream.name} does not have at rest encryption enabled."
 
-            if stream.delivery_stream_type == "KinesisStreamAsSource":
+            if stream.kms_encryption == EncryptionStatus.ENABLED:
+                report.status = "PASS"
+                report.status_extended = f"Firehose Stream {stream.name} does have at rest encryption enabled."
+
+            elif stream.delivery_stream_type == "KinesisStreamAsSource":
                 source_stream_arn = stream.source.kinesis_stream.kinesis_stream_arn
                 source_stream = kinesis_client.streams.get(source_stream_arn, None)
                 if source_stream:
@@ -58,10 +62,6 @@ class firehose_stream_encrypted_at_rest(Check):
                             report.status_extended = f"Firehose Stream {stream.name} uses MSK provisioned source which always has encryption at rest enabled by AWS (either with AWS managed keys or CMK)."
                     else:
                         report.status_extended = f"Firehose Stream {stream.name} uses MSK source which always has encryption at rest enabled by AWS."
-
-            elif stream.kms_encryption == EncryptionStatus.ENABLED:
-                report.status = "PASS"
-                report.status_extended = f"Firehose Stream {stream.name} does have at rest encryption enabled."
 
             findings.append(report)
 


### PR DESCRIPTION
### Context

An user reported false positives in `firehose_stream_encrypted_at_rest` check.

Fix #9124

### Description

- The description has been updated to clarify that the stream must always be encrypted, regardless of whether the source is encrypted or not.
- `status_extended` has been enhanced to provide the user with more information about the state of the source and the stream itself.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
