### PR TITLE
chore(release): Upgrade Prowler API versions to 1.14.1 for releasing Prowler 5.13.1

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -43,7 +43,7 @@ name = "prowler-api"
 package-mode = false
 # Needed for the SDK compatibility
 requires-python = ">=3.11,<3.13"
-version = "1.14.0"
+version = "1.14.1"
 
 [project.scripts]
 celery = "src.backend.config.settings.celery"

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Prowler API
-  version: 1.14.0
+  version: 1.14.1
   description: |-
     Prowler API specification.
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -307,7 +307,7 @@ class SchemaView(SpectacularAPIView):
 
     def get(self, request, *args, **kwargs):
         spectacular_settings.TITLE = "Prowler API"
-        spectacular_settings.VERSION = "1.14.0"
+        spectacular_settings.VERSION = "1.14.1"
         spectacular_settings.DESCRIPTION = (
             "Prowler API specification.\n\nThis file is auto-generated."
         )


### PR DESCRIPTION
### Context

We are releasing Prowler 5.13.1, so we setting the API version to 1.14.1

### Description

We've modified `api/pyproject.toml` and the API views and its spec YAML file for setting the version to 1.14.1

### Checklist

- Are there new checks included in this PR? No.
- [✓] Review if the code is being covered by tests.
- [✓] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [✓] Review if backport is needed.
- [✓] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [✓] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [✓] Verify if API specs need to be regenerated.
- [✓] Check if version updates are required (e.g., specs, Poetry, etc.).
- [✓] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
