### PR TITLE
fix(test-ui): update authentication method selection in ProvidersPage for AWS Add Provider e2e test

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: process.env.AUTH_URL ? process.env.AUTH_URL : "http://localhost:3000",
     trace: "off",
     screenshot: "off",
     video: "off",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: process.env.AUTH_URL ? process.env.AUTH_URL : "http://localhost:3000",
+    baseURL: process.env.AUTH_URL
+      ? process.env.AUTH_URL
+      : "http://localhost:3000",
     trace: "off",
     screenshot: "off",
     video: "off",

--- a/ui/tests/providers/providers-page.ts
+++ b/ui/tests/providers/providers-page.ts
@@ -689,4 +689,23 @@ export class ProvidersPage extends BasePage {
     await this.goto();
     await expect(this.providersTable).toBeVisible({ timeout: 10000 });
   }
+
+  async selectAuthenticationMethod(method: AWSCredentialType): Promise<void> {
+    // Select the authentication method
+
+     // Search botton that contains text AWS SDK Default or Prowler Cloud will assume or Access & Secret Key
+     const button = this.page.locator('button').filter({ hasText: /AWS SDK Default|Prowler Cloud will assume|Access & Secret Key/i });
+     await button.click();
+
+    if (method === AWS_CREDENTIAL_OPTIONS.AWS_ROLE_ARN) {
+     
+      const modal = this.page.locator('[role="dialog"], .modal, [data-testid*="modal"]').first();
+      await expect(modal).toBeVisible({ timeout: 10000 });
+
+      // Select the role credentials
+      this.page.getByRole('option', { name: 'Access & Secret Key' }).click({ force: true });
+    } else {
+      throw new Error(`Invalid authentication method: ${method}`);
+    }
+  }
 }

--- a/ui/tests/providers/providers.spec.ts
+++ b/ui/tests/providers/providers.spec.ts
@@ -164,14 +164,14 @@ test.describe("Add Provider", () => {
         );
         await providersPage.verifyCredentialsPageLoaded();
 
-        // Fill role credentials
-        await providersPage.fillRoleCredentials(roleCredentials);
-        await providersPage.clickNext();
-
         // Select Authentication Method
         await providersPage.selectAuthenticationMethod(
           AWS_CREDENTIAL_OPTIONS.AWS_ROLE_ARN,
         );
+
+        // Fill role credentials
+        await providersPage.fillRoleCredentials(roleCredentials);
+        await providersPage.clickNext();
 
         // Launch scan
         await providersPage.verifyLaunchScanPageLoaded();

--- a/ui/tests/providers/providers.spec.ts
+++ b/ui/tests/providers/providers.spec.ts
@@ -168,6 +168,11 @@ test.describe("Add Provider", () => {
         await providersPage.fillRoleCredentials(roleCredentials);
         await providersPage.clickNext();
 
+        // Select Authentication Method
+        await providersPage.selectAuthenticationMethod(
+          AWS_CREDENTIAL_OPTIONS.AWS_ROLE_ARN,
+        );
+
         // Launch scan
         await providersPage.verifyLaunchScanPageLoaded();
         await providersPage.clickNext();


### PR DESCRIPTION

### Context

Default value for Authentication Method into Add Provider AWS flow not always has to be the same

### Description

You must select the authentication method before filling in the input box with your credential information.

### Steps to review

```
cd ui
npx playwright test --grep @aws
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
