### PR TITLE
docs: get latest version to install Prowler App

### DIFF
--- a/docs/getting-started/installation/prowler-app.mdx
+++ b/docs/getting-started/installation/prowler-app.mdx
@@ -22,8 +22,8 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
 
     ```bash
     VERSION=$(curl -s https://api.github.com/repos/prowler-cloud/prowler/releases/latest | jq -r .tag_name)
-    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/${VERSION}/docker-compose.yml
-    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/${VERSION}/.env
+    curl -sLO "https://raw.githubusercontent.com/prowler-cloud/prowler/refs/tags/${VERSION}/docker-compose.yml"
+    curl -sLO "https://raw.githubusercontent.com/prowler-cloud/prowler/refs/tags/${VERSION}/.env"
     docker compose up -d
     ```
 

--- a/docs/getting-started/installation/prowler-app.mdx
+++ b/docs/getting-started/installation/prowler-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Installation'
+title: "Installation"
 ---
 
 ### Installation
@@ -9,41 +9,40 @@ Prowler App supports multiple installation methods based on your environment.
 Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detailed usage instructions.
 
 <Warning>
-Prowler configuration is based in `.env` files. Every version of Prowler can have differences on that file, so, please, use the file that corresponds with that version or repository branch or tag.
-
+  Prowler configuration is based in `.env` files. Every version of Prowler can have differences on that file, so, please, use the file that corresponds with that version or repository branch or tag.
 </Warning>
+
 <Tabs>
   <Tab title="Docker Compose">
     _Requirements_:
 
-    * `Docker Compose` installed: https://docs.docker.com/compose/install/.
+    - `Docker Compose` installed: https://docs.docker.com/compose/install/.
 
     _Commands_:
 
-    ``` bash
-    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/docker-compose.yml
-    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/master/.env
+    ```bash
+    VERSION=$(curl -s https://api.github.com/repos/prowler-cloud/prowler/releases/latest | jq -r .tag_name)
+    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/${VERSION}/docker-compose.yml
+    curl -LO https://raw.githubusercontent.com/prowler-cloud/prowler/refs/heads/${VERSION}/.env
     docker compose up -d
     ```
 
     > Containers are built for `linux/amd64`. If your workstation's architecture is different, please set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in your environment or use the `--platform linux/amd64` flag in the docker command.
-
   </Tab>
   <Tab title="GitHub">
     _Requirements_:
 
-    * `git` installed.
-    * `poetry` installed: [poetry installation](https://python-poetry.org/docs/#installation).
-    * `npm` installed: [npm installation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
-    * `Docker Compose` installed: https://docs.docker.com/compose/install/.
+    - `git` installed.
+    - `poetry` installed: [poetry installation](https://python-poetry.org/docs/#installation).
+    - `npm` installed: [npm installation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+    - `Docker Compose` installed: https://docs.docker.com/compose/install/.
 
     <Warning>
-    Make sure to have `api/.env` and `ui/.env.local` files with the required environment variables. You can find the required environment variables in the [`api/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/api/.env.example) and [`ui/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/ui/.env.template) files.
+      Make sure to have `api/.env` and `ui/.env.local` files with the required environment variables. You can find the required environment variables in the [`api/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/api/.env.example) and [`ui/.env.template`](https://github.com/prowler-cloud/prowler/blob/master/ui/.env.template) files.
     </Warning>
-
     _Commands to run the API_:
 
-    ``` bash
+    ```bash
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/api \
     poetry install \
@@ -57,17 +56,15 @@ Prowler configuration is based in `.env` files. Every version of Prowler can hav
     ```
 
     <Warning>
-    Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
+      Starting from Poetry v2.0.0, `poetry shell` has been deprecated in favor of `poetry env activate`.
 
-    If your poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment.
-    In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
+      If your poetry version is below 2.0.0 you must keep using `poetry shell` to activate your environment. In case you have any doubts, consult the Poetry environment activation guide: https://python-poetry.org/docs/managing-environments/#activating-the-environment
     </Warning>
-
     > Now, you can access the API documentation at http://localhost:8080/api/v1/docs.
 
     _Commands to run the API Worker_:
 
-    ``` bash
+    ```bash
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/api \
     poetry install \
@@ -80,7 +77,7 @@ Prowler configuration is based in `.env` files. Every version of Prowler can hav
 
     _Commands to run the API Scheduler_:
 
-    ``` bash
+    ```bash
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/api \
     poetry install \
@@ -93,7 +90,7 @@ Prowler configuration is based in `.env` files. Every version of Prowler can hav
 
     _Commands to run the UI_:
 
-    ``` bash
+    ```bash
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/ui \
     npm install \
@@ -104,10 +101,11 @@ Prowler configuration is based in `.env` files. Every version of Prowler can hav
     > Enjoy Prowler App at http://localhost:3000 by signing up with your email and password.
 
     <Warning>
-    Google and GitHub authentication is only available in [Prowler Cloud](https://prowler.com).
+      Google and GitHub authentication is only available in [Prowler Cloud](https://prowler.com).
     </Warning>
   </Tab>
 </Tabs>
+
 ### Update Prowler App
 
 Upgrade Prowler App installation using one of two options:
@@ -129,13 +127,12 @@ docker compose pull --policy always
 
 The `--policy always` flag ensures that Docker pulls the latest images even if they already exist locally.
 
-
 <Note>
-**What Gets Preserved During Upgrade**
+  **What Gets Preserved During Upgrade**
 
-Everything is preserved, nothing will be deleted after the update.
-
+  Everything is preserved, nothing will be deleted after the update.
 </Note>
+
 ### Troubleshooting
 
 If containers don't start, check logs for errors:
@@ -155,7 +152,6 @@ docker compose pull
 docker compose up -d
 ```
 
-
 ### Container versions
 
 The available versions of Prowler CLI are the following:
@@ -171,6 +167,5 @@ The available versions of Prowler CLI are the following:
 The container images are available here:
 
 - Prowler App:
-
-    - [DockerHub - Prowler UI](https://hub.docker.com/r/prowlercloud/prowler-ui/tags)
-    - [DockerHub - Prowler API](https://hub.docker.com/r/prowlercloud/prowler-api/tags)
+  - [DockerHub - Prowler UI](https://hub.docker.com/r/prowlercloud/prowler-ui/tags)
+  - [DockerHub - Prowler API](https://hub.docker.com/r/prowlercloud/prowler-api/tags)


### PR DESCRIPTION
### Description

Get Prowler App latest version `docker-compose` and `.env`.

Alternatively, we can use
```
curl -s https://api.github.com/repos/prowler-cloud/prowler/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
```

The rest of changes comes from Mintlify formatter.