### PR TITLE
chore(ui): rename OCI provider to oraclecloud

### DIFF
--- a/ui/app/(prowler)/new-overview/components/accounts-selector.tsx
+++ b/ui/app/(prowler)/new-overview/components/accounts-selector.tsx
@@ -30,7 +30,7 @@ const PROVIDER_ICON: Record<ProviderType, ReactNode> = {
   m365: <M365ProviderBadge width={18} height={18} />,
   github: <GitHubProviderBadge width={18} height={18} />,
   iac: <IacProviderBadge width={18} height={18} />,
-  oci: <OracleCloudProviderBadge width={18} height={18} />,
+  oraclecloud: <OracleCloudProviderBadge width={18} height={18} />,
 };
 
 interface AccountsSelectorProps {

--- a/ui/app/(prowler)/new-overview/components/provider-type-selector.tsx
+++ b/ui/app/(prowler)/new-overview/components/provider-type-selector.tsx
@@ -91,7 +91,7 @@ const PROVIDER_DATA: Record<
     label: "Infrastructure as Code",
     icon: IacProviderBadge,
   },
-  oci: {
+  oraclecloud: {
     label: "Oracle Cloud Infrastructure",
     icon: OracleCloudProviderBadge,
   },

--- a/ui/components/filters/custom-select-provider.tsx
+++ b/ui/components/filters/custom-select-provider.tsx
@@ -49,7 +49,7 @@ const providerDisplayData: Record<
     label: "Infrastructure as Code",
     component: <CustomProviderInputIac />,
   },
-  oci: {
+  oraclecloud: {
     label: "Oracle Cloud Infrastructure",
     component: <CustomProviderInputOracleCloud />,
   },

--- a/ui/components/overview/provider-overview/provider-overview.tsx
+++ b/ui/components/overview/provider-overview/provider-overview.tsx
@@ -41,7 +41,7 @@ export const ProvidersOverview = ({
         return <GitHubProviderBadge width={30} height={30} />;
       case "iac":
         return <IacProviderBadge width={30} height={30} />;
-      case "oci":
+      case "oraclecloud":
         return <OracleCloudProviderBadge width={30} height={30} />;
       default:
         return null;
@@ -56,7 +56,7 @@ export const ProvidersOverview = ({
     kubernetes: "Kubernetes",
     github: "GitHub",
     iac: "IaC",
-    oci: "OCI",
+    oraclecloud: "OCI",
   };
 
   const providers = PROVIDER_TYPES.map((providerType) => ({

--- a/ui/components/providers/enhanced-provider-selector.tsx
+++ b/ui/components/providers/enhanced-provider-selector.tsx
@@ -18,7 +18,7 @@ const providerTypeLabels: Record<ProviderType, string> = {
   kubernetes: "Kubernetes",
   github: "GitHub",
   iac: "Infrastructure as Code",
-  oci: "Oracle Cloud Infrastructure",
+  oraclecloud: "Oracle Cloud Infrastructure",
 };
 
 interface EnhancedProviderSelectorProps {

--- a/ui/components/providers/radio-group-provider.tsx
+++ b/ui/components/providers/radio-group-provider.tsx
@@ -88,7 +88,7 @@ export const RadioGroupProvider: React.FC<RadioGroupProviderProps> = ({
               </CustomRadio>
               <CustomRadio
                 description="Oracle Cloud Infrastructure"
-                value="oci"
+                value="oraclecloud"
               >
                 <div className="flex items-center">
                   <OracleCloudProviderBadge size={26} />

--- a/ui/components/providers/workflow/forms/base-credentials-form.tsx
+++ b/ui/components/providers/workflow/forms/base-credentials-form.tsx
@@ -167,7 +167,7 @@ export const BaseCredentialsForm = ({
             control={form.control as unknown as Control<IacCredentials>}
           />
         )}
-        {providerType === "oci" && (
+        {providerType === "oraclecloud" && (
           <OracleCloudCredentialsForm
             control={form.control as unknown as Control<OCICredentials>}
           />

--- a/ui/components/providers/workflow/forms/connect-account-form.tsx
+++ b/ui/components/providers/workflow/forms/connect-account-form.tsx
@@ -56,7 +56,7 @@ const getProviderFieldDetails = (providerType?: ProviderType) => {
         label: "Repository URL",
         placeholder: "e.g. https://github.com/user/repo",
       };
-    case "oci":
+    case "oraclecloud":
       return {
         label: "Tenancy OCID",
         placeholder: "e.g. ocid1.tenancy.oc1..aaaaaaa...",

--- a/ui/components/ui/entities/get-provider-logo.tsx
+++ b/ui/components/ui/entities/get-provider-logo.tsx
@@ -28,7 +28,7 @@ export const getProviderLogo = (provider: ProviderType) => {
       return <GitHubProviderBadge width={35} height={35} />;
     case "iac":
       return <IacProviderBadge width={35} height={35} />;
-    case "oci":
+    case "oraclecloud":
       return <OracleCloudProviderBadge width={35} height={35} />;
     default:
       return null;
@@ -51,7 +51,7 @@ export const getProviderName = (provider: ProviderType): string => {
       return "GitHub";
     case "iac":
       return "Infrastructure as Code";
-    case "oci":
+    case "oraclecloud":
       return "Oracle Cloud Infrastructure";
     default:
       return "Unknown Provider";

--- a/ui/hooks/use-credentials-form.ts
+++ b/ui/hooks/use-credentials-form.ts
@@ -157,7 +157,7 @@ export const useCredentialsForm = ({
           };
         }
         return baseDefaults;
-      case "oci":
+      case "oraclecloud":
         return {
           ...baseDefaults,
           [ProviderCredentialFields.OCI_USER]: "",

--- a/ui/lib/external-urls.ts
+++ b/ui/lib/external-urls.ts
@@ -37,10 +37,10 @@ export const getProviderHelpText = (provider: string) => {
         text: "Need help scanning your Infrastructure as Code repository?",
         link: "https://goto.prowler.com/provider-iac",
       };
-    case "oci":
+    case "oraclecloud":
       return {
         text: "Need help connecting your Oracle Cloud account?",
-        link: "https://goto.prowler.com/provider-oci",
+        link: "https://goto.prowler.com/provider-oraclecloud",
       };
     default:
       return {

--- a/ui/lib/provider-credentials/build-crendentials.ts
+++ b/ui/lib/provider-credentials/build-crendentials.ts
@@ -304,7 +304,7 @@ export const buildSecretConfig = (
       secretType: "static",
       secret: buildIacSecret(formData),
     }),
-    oci: () => ({
+    oraclecloud: () => ({
       secretType: "static",
       secret: buildOracleCloudSecret(formData, providerUid),
     }),

--- a/ui/types/formSchemas.ts
+++ b/ui/types/formSchemas.ts
@@ -116,7 +116,7 @@ export const addProviderFormSchema = z
         providerUid: z.string(),
       }),
       z.object({
-        providerType: z.literal("oci"),
+        providerType: z.literal("oraclecloud"),
         [ProviderCredentialFields.PROVIDER_ALIAS]: z.string(),
         providerUid: z.string(),
       }),
@@ -210,7 +210,7 @@ export const addCredentialsFormSchema = (
                           .string()
                           .optional(),
                       }
-                    : providerType === "oci"
+                    : providerType === "oraclecloud"
                       ? {
                           [ProviderCredentialFields.OCI_USER]: z
                             .string()

--- a/ui/types/providers.ts
+++ b/ui/types/providers.ts
@@ -6,7 +6,7 @@ export const PROVIDER_TYPES = [
   "m365",
   "github",
   "iac",
-  "oci",
+  "oraclecloud",
 ] as const;
 
 export type ProviderType = (typeof PROVIDER_TYPES)[number];


### PR DESCRIPTION
### Context

Renames the OCI provider to "oraclecloud" in the UI to align with the core library naming convention. Maintains "OCI" as the display name for brevity.

Related to PROWLER-313.

### Description

- Updated provider type from `"oci"` to `"oraclecloud"` in `ui/types/providers.ts`
- Display name remains "OCI" for user-facing labels
- All components, forms, and schemas updated to use `"oraclecloud"`
- No breaking changes - backend and UI now use consistent identifier

### Steps to review

1. Review changes in `ui/types/providers.ts` - provider type updated to `"oraclecloud"`
2. Verify all UI components reference `"oraclecloud"`:
   - Provider selectors
   - Credential forms
   - Provider badges and icons
3. Test Oracle Cloud provider creation flow in UI

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
