### PR TITLE
fix(ui): improve pre commit

### DIFF
--- a/ui/.husky/pre-commit
+++ b/ui/.husky/pre-commit
@@ -54,10 +54,12 @@ if [ "$CODE_REVIEW_ENABLED" = "true" ]; then
     echo -e "${BLUE}📤 Sending to Claude Code for validation...${NC}"
     echo ""
 
-    # Build prompt with git diff of changes
+    # Build prompt with git diff of changes AND full context
     VALIDATION_PROMPT=$(
       cat <<'PROMPT_EOF'
-You are a code reviewer for the Prowler UI project. Analyze the code changes (git diff) below and validate they comply with AGENTS.md standards.
+You are a code reviewer for the Prowler UI project. Analyze the code changes (git diff with full context) below and validate they comply with AGENTS.md standards.
+
+**CRITICAL: You MUST check BOTH the changed lines AND the surrounding context for violations.**
 
 **RULES TO CHECK:**
 1. React Imports: NO `import * as React` or `import React, {` → Use `import { useState }`
@@ -70,35 +72,41 @@ You are a code reviewer for the Prowler UI project. Analyze the code changes (gi
 8. Directives: Server Actions need "use server", clients need "use client"
 9. Implement DRY, KISS principles. (example: reusable components, avoid repetition)
 10. Layout must work for all the responsive breakpoints (mobile, tablet, desktop)
-11. ANY types cannot be used
+11. ANY types cannot be used - CRITICAL: Check for `: any` in all visible lines
 12. Use the components inside components/shadcn if possible
 13. Check Accessibility best practices (like alt tags in images, semantic HTML, Aria labels, etc.)
 
-=== GIT DIFF OF CHANGES ===
+=== GIT DIFF WITH CONTEXT ===
 PROMPT_EOF
     )
 
-    # Add git diff to prompt (shows only actual changes)
+    # Add git diff to prompt with more context (U5 = 5 lines before/after)
     VALIDATION_PROMPT="$VALIDATION_PROMPT
-$(git diff --cached -U0)"
+$(git diff --cached -U5)"
 
     VALIDATION_PROMPT="$VALIDATION_PROMPT
 
 === END DIFF ===
 
-**RESPOND WITH:**
-STATUS: [PASSED | FAILED]
-[If FAILED: list violations with File, Rule, Issue, and line reference]
-[If PASSED: confirm all changes comply with AGENTS.md standards]"
+**IMPORTANT: Your response MUST start with exactly one of these lines:**
+STATUS: PASSED
+STATUS: FAILED
+
+**If FAILED:** List each violation with File, Line Number, Rule Number, and Issue.
+**If PASSED:** Confirm all visible code (including context) complies with AGENTS.md standards.
+
+**Start your response now with STATUS:**"
 
     # Send to Claude Code
     if VALIDATION_OUTPUT=$(echo "$VALIDATION_PROMPT" | claude 2>&1); then
       echo "$VALIDATION_OUTPUT"
       echo ""
 
-      # Check result
+      # Check result - STRICT MODE: fail if status unclear
       if echo "$VALIDATION_OUTPUT" | grep -q "^STATUS: PASSED"; then
+        echo ""
         echo -e "${GREEN}✅ VALIDATION PASSED${NC}"
+        echo ""
       elif echo "$VALIDATION_OUTPUT" | grep -q "^STATUS: FAILED"; then
         echo ""
         echo -e "${RED}❌ VALIDATION FAILED${NC}"
@@ -106,8 +114,14 @@ STATUS: [PASSED | FAILED]
         echo ""
         exit 1
       else
-        echo -e "${YELLOW}⚠️  Could not determine validation status${NC}"
-        echo "Continuing (validation inconclusive)"
+        echo ""
+        echo -e "${RED}❌ VALIDATION ERROR${NC}"
+        echo -e "${RED}Could not determine validation status from Claude Code response${NC}"
+        echo -e "${YELLOW}Response must start with 'STATUS: PASSED' or 'STATUS: FAILED'${NC}"
+        echo ""
+        echo -e "${YELLOW}To bypass validation temporarily, set CODE_REVIEW_ENABLED=false in .env${NC}"
+        echo ""
+        exit 1
       fi
     else
       echo -e "${YELLOW}⚠️  Claude Code not available${NC}"

--- a/ui/README.md
+++ b/ui/README.md
@@ -87,6 +87,12 @@ You can use one of them `npm`, `yarn`, `pnpm`, `bun`, Example using `npm`:
 npm install
 ```
 
+**Note:** The `npm install` command will automatically configure Git hooks for code quality checks. If you experience issues, you can manually configure them:
+
+```bash
+git config core.hooksPath "ui/.husky"
+```
+
 #### Run the development server
 
 ```bash
@@ -112,3 +118,48 @@ After modifying the `.npmrc` file, you need to run `pnpm install` again to ensur
 - [TypeScript](https://www.typescriptlang.org/)
 - [Framer Motion](https://www.framer.com/motion/)
 - [next-themes](https://github.com/pacocoursey/next-themes)
+
+## Git Hooks & Code Review
+
+This project uses Git hooks to maintain code quality. When you commit changes to TypeScript/JavaScript files, the pre-commit hook can optionally validate them against our coding standards using Claude Code.
+
+### Enabling Code Review
+
+To enable automatic code review on commits, add this to your `.env` file in the project root:
+
+```bash
+CODE_REVIEW_ENABLED=true
+```
+
+When enabled, the hook will:
+- ✅ Validate your staged changes against `AGENTS.md` standards
+- ✅ Check for common issues (any types, incorrect imports, styling violations, etc.)
+- ✅ Block commits that don't comply with the standards
+- ✅ Provide helpful feedback on how to fix issues
+
+### Disabling Code Review
+
+To disable code review (faster commits, useful for quick iterations):
+
+```bash
+CODE_REVIEW_ENABLED=false
+```
+
+Or remove the variable from your `.env` file.
+
+### Requirements
+
+- [Claude Code CLI](https://github.com/anthropics/claude-code) installed and authenticated
+- `.env` file in the project root with `CODE_REVIEW_ENABLED` set
+
+### Troubleshooting
+
+If hooks aren't running after commits:
+
+```bash
+# Verify hooks are configured
+git config --get core.hooksPath  # Should output: ui/.husky
+
+# Reconfigure if needed
+git config core.hooksPath "ui/.husky"
+```

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "start": "next start",
     "start:standalone": "node .next/standalone/server.js",
     "deps:log": "node scripts/update-dependency-log.js",
-    "postinstall": "node -e \"const fs=require('fs'); if(fs.existsSync('scripts/update-dependency-log.js')) require('./scripts/update-dependency-log.js'); else console.log('skip deps:log (script missing)');\"",
+    "postinstall": "node -e \"const fs=require('fs'); if(fs.existsSync('scripts/update-dependency-log.js')) require('./scripts/update-dependency-log.js'); else console.log('skip deps:log (script missing)');\" && node scripts/setup-git-hooks.js",
     "typecheck": "tsc",
     "healthcheck": "npm run typecheck && npm run lint:check",
     "lint:check": "eslint . --ext .ts,.tsx -c .eslintrc.cjs",

--- a/ui/scripts/setup-git-hooks.js
+++ b/ui/scripts/setup-git-hooks.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/**
+ * Setup Git Hooks for Prowler UI
+ *
+ * This script configures Git to use Husky hooks located in ui/.husky
+ * It runs automatically after npm install via the postinstall script.
+ */
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+try {
+  // Get the git root directory
+  const gitRoot = execSync('git rev-parse --show-toplevel', {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe']
+  }).trim();
+
+  // Check if we're in a git repository
+  if (!gitRoot) {
+    console.log('⚠️  Not in a git repository. Skipping git hooks setup.');
+    process.exit(0);
+  }
+
+  // Get current hooks path
+  let currentHooksPath;
+  try {
+    currentHooksPath = execSync('git config --get core.hooksPath', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+  } catch {
+    // core.hooksPath not set yet
+    currentHooksPath = null;
+  }
+
+  const expectedHooksPath = 'ui/.husky';
+
+  // Only configure if not already set correctly
+  if (currentHooksPath !== expectedHooksPath) {
+    execSync(`git config core.hooksPath "${expectedHooksPath}"`, {
+      stdio: 'inherit'
+    });
+    console.log('✅ Git hooks configured: core.hooksPath = ui/.husky');
+  } else {
+    console.log('✅ Git hooks already configured correctly');
+  }
+
+} catch (error) {
+  // Don't fail the installation if git hooks setup fails
+  console.warn('⚠️  Could not setup git hooks:', error.message);
+  console.warn('   You may need to run manually: git config core.hooksPath "ui/.husky"');
+}


### PR DESCRIPTION
### Context

  Pre-commit hook was not executing for team members committing from VS Code or other Git clients.
  Additionally, the hook was not detecting violations in surrounding code context (e.g., existing `any`
   types).

  ### Description

  **Improvements to Pre-commit Hook:**
  - Enhanced validation to check full context (5 lines before/after changes) instead of just changed
  lines
  - Made hook fail-safe: blocks commits if Claude Code response format is unclear
  - Improved prompt to emphasize detection of `any` types and other violations in visible context
  - Added stricter response format requirements for Claude Code validation

  **Automatic Setup for Team:**
  - Created `scripts/setup-git-hooks.js` that runs on `npm install` (postinstall)
  - Automatically configures `git config core.hooksPath "ui/.husky"` for all team members
  - No manual configuration needed - works across all Git clients (VS Code, terminal, etc.)

  **Documentation:**
  - Updated README.md with Git Hooks section
  - Documented `CODE_REVIEW_ENABLED` flag usage
  - Added troubleshooting steps for hooks configuration

  ### Steps to review

  1. **Verify automatic setup works:**
     ```bash
     # Simulate fresh install
     rm -rf node_modules
     npm install
     # Should see: ✅ Git hooks configured: core.hooksPath = ui/.husky

     # Verify config
     git config --get core.hooksPath  # Should output: ui/.husky

  2. Test hook detects violations:
  # Create test file with 'any' type
  echo "const test: any = 1;" > test.ts
  git add test.ts
  git commit -m "test"
  # Should FAIL with violation message about 'any' type

  # Clean up
  git restore --staged test.ts && rm test.ts
  3. Test hook passes valid code:
  # Create valid test file
  echo "const test: number = 1;" > test.ts
  git add test.ts
  git commit -m "test"
  # Should PASS validation

  # Clean up
  git reset HEAD~1 && rm test.ts
  4. Verify CODE_REVIEW_ENABLED flag works:
    - Set CODE_REVIEW_ENABLED=false in root .env
    - Commit should skip validation with message: "Code review disabled"
    - Set CODE_REVIEW_ENABLED=true in root .env
    - Commit should run validation
  5. Review code changes:
    - Check .husky/pre-commit for improved prompt and stricter validation logic
    - Check scripts/setup-git-hooks.js for automatic configuration logic
    - Check package.json postinstall script integration
    - Review README.md documentation additions

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
