### PR TITLE
fix(m365_powershell): teams connection with `--sp-env-auth` and enhanced timeouts error logging 

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Check `check_name` has no `resource_name` error for GCP provider [(#9169)](https://github.com/prowler-cloud/prowler/pull/9169)
 - Depth Truncation and parsing error in PowerShell queries [(#9181)](https://github.com/prowler-cloud/prowler/pull/9181)
+- Fix M365 Teams `--sp-env-auth` connection error and enhanced timeout logging [(#9191)](https://github.com/prowler-cloud/prowler/pull/9191)
 
 ---
 

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -137,7 +137,7 @@ class M365PowerShell(PowerShellSession):
         """
         connect_timeout = 15
         result = self.execute(command, timeout=connect_timeout)
-        return result or "Timeout"
+        return result or "'execute_connect' command timeout reached"
 
     def test_credentials(self, credentials: M365Credentials) -> bool:
         """

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 from prowler.lib.logger import logger
 from prowler.lib.powershell.powershell import PowerShellSession
@@ -124,7 +123,7 @@ class M365PowerShell(PowerShellSession):
                 '$graphToken = Invoke-RestMethod -Uri "https://login.microsoftonline.com/$tenantID/oauth2/v2.0/token" -Method POST -Body $graphtokenBody | Select-Object -ExpandProperty Access_Token'
             )
 
-    def execute_connect(self, command: str, timeout: Optional[int] = None) -> str:
+    def execute_connect(self, command: str) -> str:
         """
         Execute a PowerShell connect command ensuring empty responses surface as timeouts.
 

--- a/prowler/providers/m365/lib/powershell/m365_powershell.py
+++ b/prowler/providers/m365/lib/powershell/m365_powershell.py
@@ -221,12 +221,12 @@ class M365PowerShell(PowerShellSession):
             result = self.execute(
                 '$teamsToken = Invoke-RestMethod -Uri "https://login.microsoftonline.com/$tenantID/oauth2/v2.0/token" -Method POST -Body $teamstokenBody | Select-Object -ExpandProperty Access_Token'
             )
-            result = self.execute_connect(
-                'Connect-MicrosoftTeams -AccessTokens @("$graphToken","$teamsToken")'
-            )
             if result != "":
                 logger.error(f"Microsoft Teams connection failed: {result}")
                 return False
+            self.execute_connect(
+                'Connect-MicrosoftTeams -AccessTokens @("$graphToken","$teamsToken")'
+            )
             return True
         except Exception as e:
             logger.error(

--- a/tests/providers/m365/lib/powershell/m365_powershell_test.py
+++ b/tests/providers/m365/lib/powershell/m365_powershell_test.py
@@ -547,8 +547,7 @@ class Testm365PowerShell:
         session.close()
 
     @patch("subprocess.Popen")
-    @patch("prowler.providers.m365.lib.powershell.m365_powershell.decode_jwt")
-    def test_test_teams_connection_success(self, mock_decode_jwt, mock_popen):
+    def test_test_teams_connection_success(self, mock_popen):
         """Test test_teams_connection when token is valid"""
         mock_process = MagicMock()
         mock_popen.return_value = mock_process
@@ -567,30 +566,20 @@ class Testm365PowerShell:
         )
         session = M365PowerShell(credentials, identity)
 
-        # Mock execute to return valid responses
-        def mock_execute(command, *args, **kwargs):
-            if "Write-Output $teamsToken" in command:
-                return "valid_teams_token"
-            return None
-
-        session.execute = MagicMock(side_effect=mock_execute)
-        # Mock JWT decode to return proper permissions
-        mock_decode_jwt.return_value = {"roles": ["application_access"]}
+        session.execute = MagicMock(return_value=None)
+        session.execute_connect = MagicMock(return_value="")
 
         result = session.test_teams_connection()
 
         assert result is True
-        # Verify all expected PowerShell commands were called
-        # 4 calls: teamstokenBody, teamsToken, Write-Output $teamsToken, Connect-MicrosoftTeams
-        assert session.execute.call_count == 4
-        mock_decode_jwt.assert_called_once_with("valid_teams_token")
+        assert session.execute.call_count == 2
+        session.execute_connect.assert_called_once_with(
+            'Connect-MicrosoftTeams -AccessTokens @("$graphToken","$teamsToken")'
+        )
         session.close()
 
     @patch("subprocess.Popen")
-    @patch("prowler.providers.m365.lib.powershell.m365_powershell.decode_jwt")
-    def test_test_teams_connection_missing_permissions(
-        self, mock_decode_jwt, mock_popen
-    ):
+    def test_test_teams_connection_missing_permissions(self, mock_popen):
         """Test test_teams_connection when token lacks required permissions"""
         mock_process = MagicMock()
         mock_popen.return_value = mock_process
@@ -609,22 +598,15 @@ class Testm365PowerShell:
         )
         session = M365PowerShell(credentials, identity)
 
-        # Mock execute to return valid token but decode returns no permissions
-        def mock_execute(command, *args, **kwargs):
-            if "Write-Output $teamsToken" in command:
-                return "valid_teams_token"
-            return None
-
-        session.execute = MagicMock(side_effect=mock_execute)
-        # Mock JWT decode to return missing required permission
-        mock_decode_jwt.return_value = {"roles": ["other_permission"]}
+        session.execute = MagicMock(return_value=None)
+        session.execute_connect = MagicMock(return_value="Permission denied")
 
         with patch("prowler.lib.logger.logger.error") as mock_error:
             result = session.test_teams_connection()
 
         assert result is False
         mock_error.assert_called_once_with(
-            "Microsoft Teams connection failed: Please check your permissions and try again."
+            "Microsoft Teams connection failed: Permission denied"
         )
         session.close()
 
@@ -688,15 +670,17 @@ class Testm365PowerShell:
             return None
 
         session.execute = MagicMock(side_effect=mock_execute)
+        session.execute_connect = MagicMock(return_value=None)
         # Mock MSAL token decode to return proper permissions
         mock_decode_msal_token.return_value = {"roles": ["Exchange.ManageAsApp"]}
 
         result = session.test_exchange_connection()
 
         assert result is True
-        # Verify all expected PowerShell commands were called
-        # 4 calls: SecureSecret, exchangeToken, Write-Output $exchangeToken, Connect-ExchangeOnline
-        assert session.execute.call_count == 4
+        assert session.execute.call_count == 3
+        session.execute_connect.assert_called_once_with(
+            'Connect-ExchangeOnline -AccessToken $exchangeToken.AccessToken -Organization "$tenantID"'
+        )
         mock_decode_msal_token.assert_called_once_with("valid_exchange_token")
         session.close()
 
@@ -730,6 +714,7 @@ class Testm365PowerShell:
             return None
 
         session.execute = MagicMock(side_effect=mock_execute)
+        session.execute_connect = MagicMock(return_value=None)
         # Mock MSAL token decode to return missing required permission
         mock_decode_msal_token.return_value = {"roles": ["other_permission"]}
 
@@ -737,6 +722,7 @@ class Testm365PowerShell:
             result = session.test_exchange_connection()
 
         assert result is False
+        session.execute_connect.assert_not_called()
         mock_error.assert_called_once_with(
             "Exchange Online connection failed: Please check your permissions and try again."
         )
@@ -781,7 +767,7 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         credentials = M365Credentials()
-        identity = M365IdentityInfo()
+        identity = M365IdentityInfo(identity_id="expected-id")
         session = M365PowerShell(credentials, identity)
 
         # Test with clean base64 content
@@ -924,20 +910,18 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         credentials = M365Credentials()
-        identity = M365IdentityInfo()
+        identity = M365IdentityInfo(identity_id="expected-id")
         session = M365PowerShell(credentials, identity)
 
-        # Mock successful Exchange connection
-        session.execute = MagicMock(
+        session.execute_connect = MagicMock(
             return_value="Connected successfully https://aka.ms/exov3-module"
         )
 
         result = session.test_exchange_certificate_connection()
         assert result is True
 
-        session.execute.assert_called_once_with(
-            "Connect-ExchangeOnline -Certificate $certificate -AppId $clientID -Organization $tenantDomain",
-            timeout=M365PowerShell.CONNECT_TIMEOUT,
+        session.execute_connect.assert_called_once_with(
+            "Connect-ExchangeOnline -Certificate $certificate -AppId $clientID -Organization $tenantDomain"
         )
 
         session.close()
@@ -949,20 +933,23 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         credentials = M365Credentials()
-        identity = M365IdentityInfo()
+        identity = M365IdentityInfo(identity_id="expected-id")
         session = M365PowerShell(credentials, identity)
 
-        # Mock failed Exchange connection
-        session.execute = MagicMock(
+        session.execute_connect = MagicMock(
             return_value="Connection failed: Authentication error"
         )
 
-        result = session.test_exchange_certificate_connection()
+        with patch("prowler.lib.logger.logger.error") as mock_error:
+            result = session.test_exchange_certificate_connection()
+
         assert result is False
 
-        session.execute.assert_called_once_with(
-            "Connect-ExchangeOnline -Certificate $certificate -AppId $clientID -Organization $tenantDomain",
-            timeout=M365PowerShell.CONNECT_TIMEOUT,
+        session.execute_connect.assert_called_once_with(
+            "Connect-ExchangeOnline -Certificate $certificate -AppId $clientID -Organization $tenantDomain"
+        )
+        mock_error.assert_called_once_with(
+            "Exchange Online Certificate connection failed: Connection failed: Authentication error"
         )
 
         session.close()
@@ -981,20 +968,15 @@ class Testm365PowerShell:
             session = M365PowerShell(credentials, identity)
 
         # Mock successful Teams connection - the method returns bool
-        def mock_execute_side_effect(command, *_, **__):
-            if "Connect-MicrosoftTeams" in command:
-                # Return result that contains the identity_id for success
-                return "Connected successfully test_identity_id"
-            return ""
-
-        session.execute = MagicMock(side_effect=mock_execute_side_effect)
+        session.execute_connect = MagicMock(
+            return_value="Connected successfully test_identity_id"
+        )
 
         result = session.test_teams_certificate_connection()
         assert result is True
 
-        session.execute.assert_called_once_with(
-            "Connect-MicrosoftTeams -Certificate $certificate -ApplicationId $clientID -TenantId $tenantID",
-            timeout=M365PowerShell.CONNECT_TIMEOUT,
+        session.execute_connect.assert_called_once_with(
+            "Connect-MicrosoftTeams -Certificate $certificate -ApplicationId $clientID -TenantId $tenantID"
         )
 
         session.close()
@@ -1006,22 +988,21 @@ class Testm365PowerShell:
         mock_popen.return_value = mock_process
 
         credentials = M365Credentials()
-        identity = M365IdentityInfo()
+        identity = M365IdentityInfo(identity_id="expected-id")
         session = M365PowerShell(credentials, identity)
 
-        # Mock failed Teams connection
-        def mock_execute_side_effect(command, **kwargs):
-            if "Connect-MicrosoftTeams" in command:
-                raise Exception("Connection failed: Authentication error")
-            return ""
+        session.execute_connect = MagicMock(return_value="Connection failed")
 
-        session.execute = MagicMock(side_effect=mock_execute_side_effect)
+        with patch("prowler.lib.logger.logger.error") as mock_error:
+            result = session.test_teams_certificate_connection()
 
-        # Should raise exception on connection failure
-        with pytest.raises(Exception) as exc_info:
-            session.test_teams_certificate_connection()
-
-        assert "Connection failed: Authentication error" in str(exc_info.value)
+        assert result is False
+        session.execute_connect.assert_called_once_with(
+            "Connect-MicrosoftTeams -Certificate $certificate -ApplicationId $clientID -TenantId $tenantID"
+        )
+        mock_error.assert_called_once_with(
+            "Microsoft Teams Certificate connection failed: Connection failed"
+        )
 
         session.close()
 

--- a/tests/providers/m365/lib/powershell/m365_powershell_test.py
+++ b/tests/providers/m365/lib/powershell/m365_powershell_test.py
@@ -566,7 +566,7 @@ class Testm365PowerShell:
         )
         session = M365PowerShell(credentials, identity)
 
-        session.execute = MagicMock(return_value=None)
+        session.execute = MagicMock(side_effect=[None, ""])
         session.execute_connect = MagicMock(return_value="")
 
         result = session.test_teams_connection()
@@ -598,8 +598,8 @@ class Testm365PowerShell:
         )
         session = M365PowerShell(credentials, identity)
 
-        session.execute = MagicMock(return_value=None)
-        session.execute_connect = MagicMock(return_value="Permission denied")
+        session.execute = MagicMock(side_effect=[None, "Permission denied"])
+        session.execute_connect = MagicMock()
 
         with patch("prowler.lib.logger.logger.error") as mock_error:
             result = session.test_teams_connection()
@@ -608,6 +608,7 @@ class Testm365PowerShell:
         mock_error.assert_called_once_with(
             "Microsoft Teams connection failed: Permission denied"
         )
+        session.execute_connect.assert_not_called()
         session.close()
 
     @patch("subprocess.Popen")


### PR DESCRIPTION
### Description

- **teams connection testing**: Restores the Teams connection flow: refactors `certificate-auth` testing to call Teams first and fall back to Exchange when needed, and updates the unit tests to match the new helper contract.
- **enhance timeout error log**: Improves observability by logging `"Timeout"` whenever a `Connect-* PowerShell` command returns empty output, making it obvious when a hang (not invalid credentials) caused the failure.
- **fix tests**: Cleans up the test suite to align with the refactored helpers: switches to unittest.mock, drops the unused moto dependency from fixtures, and mocks `_execute_connect_command` so `Teams`/`Exchange` tests assert the new timeout behavior.

### Steps to review

Force Errors to se new timeouts and execute teams with `--sp-env-auth` to see that it works fine now.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
