### PR TITLE
fix(github): hardcode list of prowler-cloud organization members

### DIFF
--- a/.github/workflows/labeler-community.yml
+++ b/.github/workflows/labeler-community.yml
@@ -20,12 +20,39 @@ jobs:
       - name: Check if author is org member
         id: check_membership
         env:
-          GH_TOKEN: ${{ github.token }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
-          ORG: ${{ github.repository_owner }}
         run: |
-          echo "Checking if $AUTHOR is a member of $ORG"
-          if gh api --method GET "orgs/$ORG/members/$AUTHOR" >/dev/null 2>&1; then
+          # Hardcoded list of prowler-cloud organization members
+          # This list includes members who have set their organization membership as private
+          ORG_MEMBERS=(
+            "AdriiiPRodri"
+            "Alan-TheGentleman"
+            "alejandrobailo"
+            "amitsharm"
+            "andoniaf"
+            "cesararroba"
+            "Chan9390"
+            "danibarranqueroo"
+            "HugoPBrito"
+            "jfagoagas"
+            "josemazo"
+            "lydiavilchez"
+            "mmuller88"
+            "MrCloudSec"
+            "pedrooot"
+            "prowler-bot"
+            "puchy22"
+            "rakan-pro"
+            "RosaRivasProwler"
+            "StylusFrost"
+            "toniblyx"
+            "vicferpoy"
+          )
+
+          echo "Checking if $AUTHOR is a member of prowler-cloud organization"
+
+          # Check if author is in the org members list
+          if printf '%s\n' "${ORG_MEMBERS[@]}" | grep -q "^${AUTHOR}$"; then
             echo "is_member=true" >> $GITHUB_OUTPUT
             echo "$AUTHOR is an organization member"
           else


### PR DESCRIPTION
### Context
Permissions by default are not enough to access the members of the org that decided to put visibility to "private".

Hardcoding the list generated in local with `gh api orgs/prowler-cloud/members --paginate --jq '.[].login' | sort` avoids having to add a new token with `read:org` scope.

### Description
Add hardcoded list of members to avoid false positives in the labeler.

### Steps to review
Verify pipeline syntax.


### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
