### PR TITLE
feat(mongodbatlas): add provider_id verification

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Added validation for invalid checks, services, and categories in `load_checks_to_execute` function [(#8971)](https://github.com/prowler-cloud/prowler/pull/8971)
 - NIST CSF 2.0 compliance framework for the AWS provider [(#9185)](https://github.com/prowler-cloud/prowler/pull/9185)
 - Add FedRAMP 20x KSI Low for AWS, Azure and GCP [(#9198)](https://github.com/prowler-cloud/prowler/pull/9198)
+- Add verification for provider ID in MongoDB Atlas provider [(#9211)](https://github.com/prowler-cloud/prowler/pull/9211)
 
 ### Changed
 - Update AWS Direct Connect service metadata to new format [(#8855)](https://github.com/prowler-cloud/prowler/pull/8855)

--- a/prowler/providers/mongodbatlas/exceptions/exceptions.py
+++ b/prowler/providers/mongodbatlas/exceptions/exceptions.py
@@ -30,6 +30,10 @@ class MongoDBAtlasBaseException(ProwlerException):
             "message": "MongoDB Atlas API rate limit exceeded",
             "remediation": "Reduce the number of API requests or wait before making more requests.",
         },
+        (8006, "MongoDBAtlasInvalidOrganizationIdError"): {
+            "message": "The provided credentials do not have access to the organization with the provided ID",
+            "remediation": "Check the organization ID and ensure it is a valid organization ID and that the credentials have access to it.",
+        },
     }
 
     def __init__(self, code, file=None, original_exception=None, message=None):
@@ -112,6 +116,18 @@ class MongoDBAtlasRateLimitError(MongoDBAtlasBaseException):
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
             code=8005,
+            file=file,
+            original_exception=original_exception,
+            message=message,
+        )
+
+
+class MongoDBAtlasInvalidOrganizationIdError(MongoDBAtlasBaseException):
+    """Exception for MongoDB Atlas invalid organization ID errors"""
+
+    def __init__(self, file=None, original_exception=None, message=None):
+        super().__init__(
+            code=8006,
             file=file,
             original_exception=original_exception,
             message=message,


### PR DESCRIPTION
### Context

This PR added a verification during the `test_connection` of the `MongoDBAtlas` provider so we can check that the provided api keys belongs to the provided organization id.

### Description

Modified `mongodbatlas_provider.py` adding this new condition.

### Steps to review

Test that the exception is working and that the old behaviour continue working as expected.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
