### PR TITLE
chore(oraclecloud): enhance metadata for `audit` service

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update AWS CodeArtifact service metadata to new format [(#8850)](https://github.com/prowler-cloud/prowler/pull/8850)
 - Rename OCI provider to oraclecloud with oci alias [(#9126)](https://github.com/prowler-cloud/prowler/pull/9126)
 - Remove unnecessary tests for M365_PowerShell module [(#9204)](https://github.com/prowler-cloud/prowler/pull/9204)
+- Update oraclecloud audit service metadata to new format [(#9221)](https://github.com/prowler-cloud/prowler/pull/9221)
+
 
 ---
 

--- a/prowler/providers/oraclecloud/services/audit/audit_log_retention_period_365_days/audit_log_retention_period_365_days.metadata.json
+++ b/prowler/providers/oraclecloud/services/audit/audit_log_retention_period_365_days/audit_log_retention_period_365_days.metadata.json
@@ -1,35 +1,39 @@
 {
   "Provider": "oraclecloud",
   "CheckID": "audit_log_retention_period_365_days",
-  "CheckTitle": "Ensure audit log retention period is set to 365 days or greater",
-  "CheckType": [
-    "Software and Configuration Checks",
-    "Industry and Regulatory Standards",
-    "CIS OCI Foundations Benchmark"
-  ],
+  "CheckTitle": "Tenancy audit log retention period is 365 days or greater",
+  "CheckType": [],
   "ServiceName": "audit",
   "SubServiceName": "",
-  "ResourceIdTemplate": "oci:audit:configuration",
+  "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "OciAudit",
-  "Description": "Ensure audit log retention period is set to 365 days or greater",
-  "Risk": "Inadequate audit logging increases risk of undetected security incidents.",
-  "RelatedUrl": "https://docs.oracle.com/en-us/iaas/Content/Audit/Tasks/settingretentionperiod.htm",
+  "ResourceType": "Compartment",
+  "Description": "**OCI Audit configuration** defines tenancy-wide log retention for audit events. The finding evaluates whether the retention period (days) is `>= 365` and that an audit configuration exists, *applying across all regions and compartments*.",
+  "Risk": "**Insufficient audit retention** or missing configuration shrinks the **detection window** and breaks **accountability**.\n\nEvidence for older actions may be unavailable, enabling attackers to evade detection, mask **data exfiltration**, and impede **forensic reconstruction** and compliance reporting.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "http://man.hubwiz.com/docset/Terraform.docset/Contents/Resources/Documents/docs/providers/oci/r/audit_configuration.html",
+    "https://www.pulumi.com/registry/packages/oci/api-docs/audit/configuration/",
+    "https://docs.oracle.com/en-us/iaas/Content/Audit/Tasks/settingretentionperiod.htm",
+    "https://manualzz.com/doc/46527286/oracle-cloud-infrastructure-user-guide",
+    "https://docs.oracle.com/en-us/iaas/tools/terraform-provider-oci/4.88.1/docs/r/audit_configuration.html",
+    "https://stackoverflow.com/questions/65393643/terraform-oci-oci-audit-configuration-timing-out"
+  ],
   "Remediation": {
     "Code": {
       "CLI": "oci audit configuration update --compartment-id <tenancy-ocid> --retention-period-days 365",
       "NativeIaC": "",
-      "Other": "1. Navigate to Governance > Audit\n2. Click Configuration\n3. Set retention period to 365 days or greater\n4. Save changes",
-      "Terraform": "resource \"oci_audit_configuration\" \"example\" {\n  compartment_id = var.tenancy_ocid\n  retention_period_days = 365\n}"
+      "Other": "1. Open the OCI Console and go to Governance & Administration > Audit\n2. Click Configuration\n3. Set Retention period (days) to 365\n4. Click Save",
+      "Terraform": "```hcl\nresource \"oci_audit_configuration\" \"<example_resource_name>\" {\n  compartment_id        = var.tenancy_ocid\n  retention_period_days = 365 # Critical: sets audit log retention to 365 days to pass the check\n}\n```"
     },
     "Recommendation": {
-      "Text": "Ensure audit log retention period is set to 365 days or greater",
-      "Url": "https://hub.prowler.com/check/oci/audit_log_retention_period_365_days"
+      "Text": "Set audit retention to `>= 365` days at the tenancy level and protect the setting with **least privilege** and **separation of duties**.\n\nAdopt **defense in depth**: export audit logs to centralized, immutable storage or a SIEM for extended retention, integrity, and continuous monitoring.",
+      "Url": "https://hub.prowler.com/check/audit_log_retention_period_365_days"
     }
   },
   "Categories": [
     "logging",
-    "security-configuration"
+    "forensics-ready"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/oraclecloud/services/audit/audit_log_retention_period_365_days/audit_log_retention_period_365_days.metadata.json
+++ b/prowler/providers/oraclecloud/services/audit/audit_log_retention_period_365_days/audit_log_retention_period_365_days.metadata.json
@@ -12,12 +12,8 @@
   "Risk": "**Insufficient audit retention** or missing configuration shrinks the **detection window** and breaks **accountability**.\n\nEvidence for older actions may be unavailable, enabling attackers to evade detection, mask **data exfiltration**, and impede **forensic reconstruction** and compliance reporting.",
   "RelatedUrl": "",
   "AdditionalURLs": [
-    "http://man.hubwiz.com/docset/Terraform.docset/Contents/Resources/Documents/docs/providers/oci/r/audit_configuration.html",
-    "https://www.pulumi.com/registry/packages/oci/api-docs/audit/configuration/",
     "https://docs.oracle.com/en-us/iaas/Content/Audit/Tasks/settingretentionperiod.htm",
-    "https://manualzz.com/doc/46527286/oracle-cloud-infrastructure-user-guide",
-    "https://docs.oracle.com/en-us/iaas/tools/terraform-provider-oci/4.88.1/docs/r/audit_configuration.html",
-    "https://stackoverflow.com/questions/65393643/terraform-oci-oci-audit-configuration-timing-out"
+    "https://docs.oracle.com/en-us/iaas/tools/terraform-provider-oci/4.88.1/docs/r/audit_configuration.html"
   ],
   "Remediation": {
     "Code": {


### PR DESCRIPTION
### Context

Updating oraclecloud audit service metadata to conform with the new standardized metadata format used across Prowler checks, defined in #8411.

### Description

This PR updates all metadata files for oraclecloud audit checks to adapt to the new metadata format. The changes ensure consistency with the metadata structure being adopted across all Prowler services. The modified checks are:

- `audit_log_retention_period_365_days`


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.