### PR TITLE
chore: updated gitignore file to be more robust for VSCode development environments and AI coding assistants.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,21 +45,86 @@ pytest_*.xml
 .coverage
 htmlcov/
 
-# VSCode files
+# VSCode files and settings
 .vscode/
+*.code-workspace
+.vscode-test/
 
-# Cursor files
+# VSCode extension settings and workspaces
+.history/
+.ionide/
+
+# MCP Server Settings (various locations)
+**/cline_mcp_settings.json
+**/mcp_settings.json
+**/mcp-config.json
+**/mcpServers.json
+.mcp/
+
+# AI Coding Assistants - Cursor
 .cursorignore
 .cursor/
+.cursorrules
 
-# RooCode files
+# AI Coding Assistants - RooCode
 .roo/
 .rooignore
 .roomodes
 
-# Cline files
+# AI Coding Assistants - Cline (formerly Claude Dev)
 .cline/
 .clineignore
+.clinerules
+
+# AI Coding Assistants - Continue
+.continue/
+continue.json
+.continuerc
+.continuerc.json
+
+# AI Coding Assistants - GitHub Copilot
+.copilot/
+.github/copilot/
+
+# AI Coding Assistants - Amazon Q Developer (formerly CodeWhisperer)
+.aws/
+.codewhisperer/
+.amazonq/
+.aws-toolkit/
+
+# AI Coding Assistants - Tabnine
+.tabnine/
+tabnine_config.json
+
+# AI Coding Assistants - Kiro
+.kiro/
+.kiroignore
+kiro.config.json
+
+# AI Coding Assistants - Aider
+.aider/
+.aider.chat.history.md
+.aider.input.history
+.aider.tags.cache.v3/
+
+# AI Coding Assistants - Windsurf
+.windsurf/
+.windsurfignore
+
+# AI Coding Assistants - Replit Agent
+.replit
+.replitignore
+
+# AI Coding Assistants - Supermaven
+.supermaven/
+
+# AI Coding Assistants - Sourcegraph Cody
+.cody/
+
+# AI Coding Assistants - General
+.ai/
+.aiconfig
+ai-config.json
 
 # Terraform
 .terraform*


### PR DESCRIPTION
### Context

I am a lazy coder, and I got tired of having to create exceptions for all my VS Code tooling. I expanded my list to the common dev and genAI extensions config files, like their MCP servers and such. 

### Description

I've updated the .gitignore file to be more robust for VSCode development environments and AI coding assistants. The additions include:

__VSCode Development Environment:__

- Enhanced VSCode settings coverage (*.code-workspace, .vscode-test/)
- VSCode extension settings (.history/, .ionide/)

__MCP Server Settings:__

- Multiple common naming patterns (**/cline_mcp_settings.json, **/mcp_settings.json, **/mcp-config.json, **/mcpServers.json)
- Generic .mcp/ directory

__AI Coding Assistants:__

- Cursor (.cursor/, .cursorrules, .cursorignore)
- Cline/Claude Dev (.cline/, .clinerules, .clineignore)
- Continue (.continue/, continue.json, .continuerc files)
- GitHub Copilot (.copilot/, .github/copilot/)
- Amazon Q Developer (.aws/, .codewhisperer/, .amazonq/, .aws-toolkit/)
- Tabnine (.tabnine/, tabnine_config.json)
- Kiro (.kiro/, .kiroignore, kiro.config.json)
- Aider (.aider/, history and cache files)
- Windsurf (.windsurf/, .windsurfignore)
- Replit Agent (.replit, .replitignore)
- Supermaven (.supermaven/)
- Sourcegraph Cody (.cody/)
- Generic AI config patterns (.ai/, .aiconfig, ai-config.json)

The .gitignore file now provides comprehensive coverage for common custom configurations used in modern VSCode development environments with AI coding assistants.


### Steps to review

Update your .gitignore file, install cline, add an mcp server, confirm it isn't picked up in your git change history, get a coffee, and enjoy.

### Checklist

It's the gitignore file, so I didn't do the usual robust testing and checklist. 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
