### PR TITLE
chore(ec2): prevent test from calling live AWS endpoint

### DIFF
--- a/tests/providers/aws/services/ec2/ec2_instance_uses_single_eni/ec2_instance_uses_single_eni_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_uses_single_eni/ec2_instance_uses_single_eni_test.py
@@ -189,6 +189,7 @@ class Test_ec2_instance_uses_single_eni:
 
             assert len(result) == 0
 
+    @mock_aws
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call_v2)
     def test_ec2_instance_no_eni(self):
 
@@ -222,6 +223,7 @@ class Test_ec2_instance_uses_single_eni:
                 == "EC2 Instance i-0123456789abcdef0 has no network interfaces attached."
             )
 
+    @mock_aws
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call)
     def test_instance_multiple_enis(self):
 
@@ -295,6 +297,7 @@ class Test_ec2_instance_uses_single_eni:
                 == f"EC2 Instance {instance.id} uses only one ENI: ( Interfaces: ['{network_interface.id}'] )."
             )
 
+    @mock_aws
     @mock.patch("botocore.client.BaseClient._make_api_call", new=mock_make_api_call_v3)
     def test_instance_one_efa_multiple_trunks(self):
 


### PR DESCRIPTION
### Context

When running the test suite locally I found this test calling out to the live AWS endpoint.

### Steps to review

You can run a proxy or firewall locally and observe the outbound traffic from the test process.

My firewall reported:

```
On Nov 12, 2025, Ghostty via python3.12 tried to establish a connection to ec2.us-east-1.amazonaws.com
```

while executing:

```
pytest -vv tests/providers/aws/services/ec2/ec2_instance_uses_single_eni/ec2_instance_uses_single_eni_test.py
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
