### PR TITLE
test(ui): add AWS provider E2E test for assume role using AWS SDK defaults

### DIFF
--- a/ui/tests/providers/providers-page.ts
+++ b/ui/tests/providers/providers-page.ts
@@ -41,7 +41,8 @@ export interface GitHubProviderData {
 // AWS credential options
 export const AWS_CREDENTIAL_OPTIONS = {
   AWS_ROLE_ARN: "role",
-  AWS_CREDENTIALS: "credentials"
+  AWS_CREDENTIALS: "credentials",
+  AWS_SDK_DEFAULT: "aws-sdk-default"
 } as const;
 
 // AWS credential type
@@ -53,6 +54,8 @@ export interface AWSProviderCredential {
   roleArn?: string;
   externalId?: string;
   accessKeyId?: string;
+  sdkAccessKeyId?: string;
+  sdkSecretAccessKey?: string;
   secretAccessKey?: string;
 }
 
@@ -1010,5 +1013,27 @@ export class ProvidersPage extends BasePage {
     // Wait for redirect to provider page
     const scansPage = new ScansPage(this.page);
     await scansPage.verifyPageLoaded();
+  }
+
+  async selectAuthenticationMethod(method: AWSCredentialType): Promise<void> {
+    // Select the authentication method
+
+    // Search botton that contains text AWS SDK Default or Prowler Cloud will assume or Access & Secret Key
+    const button = this.page.locator('button').filter({ hasText: /AWS SDK Default|Prowler Cloud will assume|Access & Secret Key/i });
+    await button.click();
+
+    if (method === AWS_CREDENTIAL_OPTIONS.AWS_ROLE_ARN) {
+
+      const modal = this.page.locator('[role="dialog"], .modal, [data-testid*="modal"]').first();
+      await expect(modal).toBeVisible({ timeout: 10000 });
+
+      // Select the role credentials
+      this.page.getByRole('option', { name: 'Access & Secret Key' }).click({ force: true });
+    } else if (method === AWS_CREDENTIAL_OPTIONS.AWS_SDK_DEFAULT) {
+      // Select the AWS SDK Default
+      this.page.getByRole('option', { name: 'AWS SDK Default' }).click({ force: true });
+    } else {
+      throw new Error(`Invalid authentication method: ${method}`);
+    }
   }
 }

--- a/ui/tests/providers/providers.md
+++ b/ui/tests/providers/providers.md
@@ -118,6 +118,65 @@
 
 ---
 
+## Test Case: `PROVIDER-E2E-011` - Add AWS Provider with Assume Role via AWS SDK Defaults
+
+**Priority:** `critical`
+
+**Tags:**
+
+- type → @e2e, @serial
+- feature → @providers
+- provider → @aws
+
+**Description/Objective:** Validates adding an AWS provider assuming a role while sourcing credentials from the AWS SDK default chain (e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) instead of manually entered keys.
+
+**Preconditions:**
+
+- Admin user authentication required (admin.auth.setup setup)
+- Environment variables configured: E2E_AWS_PROVIDER_ACCOUNT_ID, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, E2E_AWS_PROVIDER_ROLE_ARN
+- Remove any existing provider with the same Account ID before starting the test
+- This test must be run serially and never in parallel with other tests, as it requires the Account ID not to be already registered beforehand
+
+### Flow Steps:
+
+1. Navigate to providers page
+2. Click "Add Provider" button
+3. Select AWS provider type
+4. Fill provider details (account ID and alias)
+5. Select "role" authentication type
+6. Switch authentication method to "Use AWS SDK default credentials"
+7. Fill role ARN using AWS SDK credential inputs
+8. Launch initial scan
+9. Verify redirect to Scans page
+10. Verify scheduled scan status in Scans table (provider exists and scan name is "scheduled scan")
+
+### Expected Result:
+
+- AWS provider successfully added using AWS SDK default credentials to assume the role
+- Initial scan launched successfully
+- User redirected to Scans page
+- Scheduled scan appears in Scans table with correct provider and scan name
+
+### Key verification points:
+
+- Provider page loads correctly
+- Connect account page displays AWS option
+- Credentials form exposes AWS SDK default authentication method
+- Role ARN field accepts provided value when SDK method is selected
+- Launch scan page appears
+- Successful redirect to Scans page after scan launch
+- Provider exists in Scans table (verified by account ID)
+- Scan name field contains "scheduled scan"
+
+### Notes:
+
+- Test leverages AWS SDK default credential chain (environment-configured keys) for Access Key and Secret Key
+- Environment variable `E2E_AWS_PROVIDER_ROLE_ARN` must reference a valid assumable role
+- Provider cleanup performed before each test to ensure clean state
+- Requires valid AWS account with permissions to assume the target role
+
+---
+
 ## Test Case: `PROVIDER-E2E-003` - Add Azure Provider with Static Credentials
 
 **Priority:** `critical`


### PR DESCRIPTION
### Context

This PR implements the critical path of Add AWS provider for assume role using AWS SDK Default e2e test flow. PR DEPENDECY https://github.com/prowler-cloud/prowler/pull/9155

### Description
The implementation includes a comprehensive E2E test suite @PROVIDER-E2E-011 that validates the AWS provider with using AWS SDK defaults and assume role

@PROVIDER-E2E-011

1. Navigate to providers page
2. Click "Add Provider" button
3. Select AWS provider type
4. Fill provider details (account ID and alias)
5. Select "role" authentication type
6. Switch authentication method to "Use AWS SDK default credentials"
7. Fill role ARN using AWS SDK credential inputs
8. Launch initial scan
9. Verify redirect to Scans page
10. Verify scheduled scan status in Scans table (provider exists and scan name is "scheduled scan")

### Steps to review

```
cd ui
npx playwright test --grep @PROVIDER-E2E-011
```

### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
