### PR TITLE
chore(github): replace `status/awaiting-response` label with `status/waiting-for-revision` if comment added

### DIFF
--- a/.github/workflows/comment-label-update.yml
+++ b/.github/workflows/comment-label-update.yml
@@ -20,11 +20,20 @@ jobs:
 
     steps:
       - name: Remove 'status/awaiting-response' label
-        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        with:
-          labels: status/awaiting-response
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          echo "Removing 'status/awaiting-response' label from #$ISSUE_NUMBER"
+          gh api /repos/${{ github.repository }}/issues/$ISSUE_NUMBER/labels/status%2Fawaiting-response \
+            -X DELETE
 
       - name: Add 'status/waiting-for-revision' label
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
-        with:
-          labels: status/waiting-for-revision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          echo "Adding 'status/waiting-for-revision' label to #$ISSUE_NUMBER"
+          gh api /repos/${{ github.repository }}/issues/$ISSUE_NUMBER/labels \
+            -X POST \
+            -f labels[]='status/waiting-for-revision'

--- a/.github/workflows/comment-label-update.yml
+++ b/.github/workflows/comment-label-update.yml
@@ -1,0 +1,30 @@
+name: 'Tools: Comment Label Update'
+
+on:
+  issue_comment:
+    types:
+      - 'created'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  update-labels:
+    if: contains(github.event.issue.labels.*.name, 'status/awaiting-response')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Remove 'status/awaiting-response' label
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
+        with:
+          labels: status/awaiting-response
+
+      - name: Add 'status/waiting-for-revision' label
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
+        with:
+          labels: status/waiting-for-revision


### PR DESCRIPTION
### Context
Some issues that were awaiting a response from the user lost visibility after we added the status/awaiting-response label. This PR aims to improve this by replacing the label once someone adds a comment.

### Description
- Adds a Github workflow to automatically replace `status/awaiting-response` label with `status/waiting-for-revision` if someone adds a comment to the issue/PR.

### Steps to review
- Adding a comment to a PR/issue with the `status/awaiting-response` label.
  - AFAIK, we need to merge into master first, but I've added some comments from a test in a private repo.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
