### PR TITLE
fix(scan): implement temporary workaround to skip findings with UID exceeding 300 characters

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to the **Prowler API** are documented in this file.
 ### Changed
 - Optimized database write queries for scan related tasks [(#9190)](https://github.com/prowler-cloud/prowler/pull/9190)
 
+### Fixed
+- Scans no longer fail when findings have UIDs exceeding 300 characters; such findings are now skipped with detailed logging [(#9246)](https://github.com/prowler-cloud/prowler/pull/9246)
+
 ### Security
 - Django updated to the latest 5.1 security release, 5.1.14, due to problems with potential [SQL injection](https://github.com/prowler-cloud/prowler/security/dependabot/113) and [denial-of-service vulnerability](https://github.com/prowler-cloud/prowler/security/dependabot/114) [(#9176)](https://github.com/prowler-cloud/prowler/pull/9176)
 

--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -383,9 +383,13 @@ def _process_finding_micro_batch(
     mappings_to_create = []
     dirty_resources = {}
     resource_denormalized_data = []  # (finding_instance, resource_instance) pairs
+    skipped_findings_count = 0  # Track findings skipped due to UID length
 
     # Prefetch last statuses for all findings in this batch
-    finding_uids = [f.uid for f in findings_batch if f is not None]
+    # TEMPORARY WORKAROUND: Filter out UIDs > 300 chars to avoid query errors
+    finding_uids = [
+        f.uid for f in findings_batch if f is not None and len(f.uid) <= 300
+    ]
     with rls_transaction(tenant_id, using=READ_REPLICA_ALIAS):
         last_statuses = {
             item["uid"]: (item["status"], item["first_seen_at"])
@@ -485,6 +489,21 @@ def _process_finding_micro_batch(
 
         # Prepare finding data
         finding_uid = finding.uid
+
+        # TEMPORARY WORKAROUND: Skip findings with UID > 300 chars
+        # TODO: Remove this after implementing text field migration for finding.uid
+        # See: https://github.com/prowler-cloud/prowler/issues/XXXXX
+        if len(finding_uid) > 300:
+            skipped_findings_count += 1
+            logger.warning(
+                f"Skipping finding with UID exceeding 300 characters. "
+                f"Length: {len(finding_uid)}, "
+                f"Check: {finding.check_id}, "
+                f"Resource: {finding.resource_name[:100]}, "
+                f"UID prefix: {finding_uid[:100]}..."
+            )
+            continue
+
         last_status, last_first_seen_at = last_status_cache.get(
             finding_uid, (None, None)
         )
@@ -604,6 +623,13 @@ def _process_finding_micro_batch(
             objects=list(dirty_resources.values()),
             fields=["metadata", "details", "partition", "region", "service", "type"],
             batch_size=1000,
+        )
+
+    # Log skipped findings summary
+    if skipped_findings_count > 0:
+        logger.warning(
+            f"Scan {scan_instance.id}: Skipped {skipped_findings_count} finding(s) "
+            f"due to UID length exceeding 300 characters in this micro-batch."
         )
 
 

--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -492,15 +492,14 @@ def _process_finding_micro_batch(
 
         # TEMPORARY WORKAROUND: Skip findings with UID > 300 chars
         # TODO: Remove this after implementing text field migration for finding.uid
-        # See: https://github.com/prowler-cloud/prowler/issues/XXXXX
         if len(finding_uid) > 300:
             skipped_findings_count += 1
             logger.warning(
                 f"Skipping finding with UID exceeding 300 characters. "
                 f"Length: {len(finding_uid)}, "
                 f"Check: {finding.check_id}, "
-                f"Resource: {finding.resource_name[:100]}, "
-                f"UID prefix: {finding_uid[:100]}..."
+                f"Resource: {finding.resource_name}, "
+                f"UID: {finding_uid}"
             )
             continue
 


### PR DESCRIPTION
### Context

Scans were failing when findings had UIDs longer than 300 characters due to database field constraints. This is a temporary workaround to prevent complete scan failures while we work on the permanent solution (migrating the `uid` field from `varchar(300)` to `text`).

### Description

This PR implements a temporary workaround that prevents scans from failing when findings have UIDs exceeding 300 characters. Instead of failing the entire scan, the system now:

- Skips findings with UID > 300 characters
- Logs detailed warnings for each skipped finding (length, check ID, resource, UID prefix)
- Provides summary metrics per micro-batch showing total skipped findings
- Allows the scan to complete successfully with the remaining valid findings

**Changes:**
- Modified `_process_finding_micro_batch()` in `api/src/backend/tasks/jobs/scan.py`:
  - Added validation to skip findings with UID > 300 chars
  - Added counter to track skipped findings per micro-batch
  - Filter out long UIDs in prefetch query to avoid DB errors
  - Added comprehensive logging for monitoring
- Added test `test_process_finding_micro_batch_skips_long_uid` to verify the behavior

**Note:** This is a temporary solution. The permanent fix will involve:
1. Creating a new `finding.new_uid` column with `text` type
2. Migrating data using model properties
3. Eventually deprecating the old `uid` column

### Steps to review

1. **Review the code changes:**
   - Check `api/src/backend/tasks/jobs/scan.py` lines 386-502, 625-630
   - Verify the validation logic is correct and won't cause performance issues
   - Confirm logging provides enough detail for debugging

2. **Review the test:**
   - Check `api/src/backend/tasks/tests/test_scan.py` lines 1546-1638
   - Verify test covers both scenarios (long UID skipped, normal UID processed)
   - Confirm logging assertions are correct

3. **Test the behavior (optional):**
   - Temporarily change the limit from 300 to 5 (lines 391, 495)
   - Run a scan and observe logs showing skipped findings
   - Verify scan completes successfully despite skipped findings
   - Revert the limit back to 300

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
