### PR TITLE
fix(ui): UI improvements - buttons, form validations, and chart alignment

### DIFF
--- a/ui/components/auth/oss/sign-in-form.tsx
+++ b/ui/components/auth/oss/sign-in-form.tsx
@@ -156,7 +156,6 @@ export const SignInForm = ({
             type="email"
             label="Email"
             placeholder="Enter your email"
-            showFormMessage
           />
           {!isSamlMode && (
             <CustomInput control={form.control} name="password" password />

--- a/ui/components/auth/oss/sign-up-form.tsx
+++ b/ui/components/auth/oss/sign-up-form.tsx
@@ -155,7 +155,6 @@ export const SignUpForm = ({
             type="email"
             label="Email"
             placeholder="Enter your email"
-            showFormMessage
           />
           <CustomInput control={form.control} name="password" password />
           <PasswordRequirementsMessage password={passwordValue || ""} />

--- a/ui/components/compliance/compliance-charts/top-failed-sections-card.tsx
+++ b/ui/components/compliance/compliance-charts/top-failed-sections-card.tsx
@@ -31,7 +31,7 @@ export function TopFailedSectionsCard({
         <CardTitle>Top Failed Sections</CardTitle>
       </CardHeader>
       <CardContent className="flex flex-1 items-center justify-start">
-        <HorizontalBarChart data={barData} labelWidth="w-60" />
+        <HorizontalBarChart data={barData} />
       </CardContent>
     </Card>
   );

--- a/ui/components/compliance/compliance-download-button.tsx
+++ b/ui/components/compliance/compliance-download-button.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Button } from "@heroui/button";
 import { DownloadIcon } from "lucide-react";
 import { useState } from "react";
 
+import { Button } from "@/components/shadcn/button/button";
 import { toast } from "@/components/ui";
 import {
   COMPLIANCE_REPORT_BUTTON_LABELS,
@@ -37,18 +37,15 @@ export const ComplianceDownloadButton = ({
 
   return (
     <Button
-      color="success"
-      variant="solid"
-      startContent={
-        <DownloadIcon
-          className={isDownloading ? "animate-download-icon" : ""}
-          size={16}
-        />
-      }
-      onPress={handleDownload}
-      isLoading={isDownloading}
+      variant="default"
       size="sm"
+      onClick={handleDownload}
+      disabled={isDownloading}
     >
+      <DownloadIcon
+        className={isDownloading ? "animate-download-icon" : ""}
+        size={16}
+      />
       {label || defaultLabel}
     </Button>
   );

--- a/ui/components/graphs/horizontal-bar-chart.tsx
+++ b/ui/components/graphs/horizontal-bar-chart.tsx
@@ -11,14 +11,12 @@ interface HorizontalBarChartProps {
   data: BarDataPoint[];
   height?: number;
   title?: string;
-  labelWidth?: string;
   onBarClick?: (dataPoint: BarDataPoint, index: number) => void;
 }
 
 export function HorizontalBarChart({
   data,
   title,
-  labelWidth = "w-20",
   onBarClick,
 }: HorizontalBarChartProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);

--- a/ui/components/graphs/horizontal-bar-chart.tsx
+++ b/ui/components/graphs/horizontal-bar-chart.tsx
@@ -64,7 +64,7 @@ export function HorizontalBarChart({
           return (
             <div
               key={item.name}
-              className="flex items-center gap-10"
+              className="flex items-center gap-6"
               style={{ cursor: isClickable ? "pointer" : "default" }}
               role={isClickable ? "button" : undefined}
               tabIndex={isClickable ? 0 : undefined}
@@ -89,7 +89,7 @@ export function HorizontalBarChart({
               }}
             >
               {/* Label */}
-              <div className={`w-20 md:${labelWidth} shrink-0`}>
+              <div className="w-20 shrink-0">
                 <span
                   className="text-text-neutral-secondary block truncate text-sm font-medium"
                   style={{

--- a/ui/components/icons/providers-badge/m365-provider-badge.tsx
+++ b/ui/components/icons/providers-badge/m365-provider-badge.tsx
@@ -31,7 +31,7 @@ export const M365ProviderBadge: FC<IconSvgProps> = ({
     >
       <g>
         <rect width="256" height="256" rx="60" fill="#f4f2ed" />
-        <g transform="scale(3.5) translate(2 2)">
+        <g transform="scale(3.1) translate(2 2)">
           <g clipPath={`url(#${clipId0})`}>
             <g clipPath={`url(#${clipId1})`}>
               <path

--- a/ui/components/ui/custom/custom-input.tsx
+++ b/ui/components/ui/custom/custom-input.tsx
@@ -2,7 +2,7 @@
 
 import { Input } from "@heroui/input";
 import { Icon } from "@iconify/react";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Control, FieldPath, FieldValues } from "react-hook-form";
 
 import { FormControl, FormField, FormMessage } from "@/components/ui/form";
@@ -92,7 +92,7 @@ export const CustomInput = <T extends FieldValues>({
     <FormField
       control={control}
       name={name}
-      render={({ field }) => (
+      render={({ field, fieldState }) => (
         <>
           <FormControl>
             <Input
@@ -113,6 +113,8 @@ export const CustomInput = <T extends FieldValues>({
               endContent={endContent}
               isDisabled={isDisabled}
               isReadOnly={isReadOnly}
+              isInvalid={!!fieldState.error}
+              errorMessage={fieldState.error?.message}
               {...field}
               value={field.value ?? ""}
             />

--- a/ui/components/ui/custom/custom-input.tsx
+++ b/ui/components/ui/custom/custom-input.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@iconify/react";
 import { useState } from "react";
 import { Control, FieldPath, FieldValues } from "react-hook-form";
 
-import { FormControl, FormField, FormMessage } from "@/components/ui/form";
+import { FormControl, FormField } from "@/components/ui/form";
 
 interface CustomInputProps<T extends FieldValues> {
   control: Control<T>;
@@ -22,7 +22,6 @@ interface CustomInputProps<T extends FieldValues> {
   isReadOnly?: boolean;
   isRequired?: boolean;
   isDisabled?: boolean;
-  showFormMessage?: boolean;
 }
 
 export const CustomInput = <T extends FieldValues>({
@@ -40,7 +39,6 @@ export const CustomInput = <T extends FieldValues>({
   isReadOnly = false,
   isRequired = true,
   isDisabled = false,
-  showFormMessage = true,
 }: CustomInputProps<T>) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
@@ -119,9 +117,6 @@ export const CustomInput = <T extends FieldValues>({
               value={field.value ?? ""}
             />
           </FormControl>
-          {showFormMessage && (
-            <FormMessage className="text-text-error max-w-full text-xs" />
-          )}
         </>
       )}
     />

--- a/ui/components/ui/custom/custom-table-link.tsx
+++ b/ui/components/ui/custom/custom-table-link.tsx
@@ -13,9 +13,9 @@ interface TableLinkProps {
 export const TableLink = ({ href, label, isDisabled }: TableLinkProps) => {
   if (isDisabled) {
     return (
-      <Button variant="link" size="sm" disabled className="text-xs">
+      <span className="text-text-neutral-tertiary inline-flex h-9 cursor-not-allowed items-center justify-center px-3 text-xs font-medium opacity-60">
         {label}
-      </Button>
+      </span>
     );
   }
 


### PR DESCRIPTION
### Context

Multiple UI improvements to enhance user experience and visual consistency across the application.

### Description

This PR addresses several UI issues:

1. **PDF ENS Report button styling** - Updated to use shadcn button component with green style matching Launch Scan button
2. **Form validation visual feedback** - Added red border styling to form inputs on validation errors
3. **Risk Severity chart alignment** - Fixed horizontal bar chart alignment issues
4. **TableLink disabled state** - Improved visual distinction for disabled table links with proper gray styling
5. **Duplicate error messages** - Removed duplicate error messages in sign-in and sign-up forms

### Steps to review

1. **PDF Button**: Navigate to compliance ENS page and verify the "PDF ENS Report" button has green styling matching "Launch Scan"
2. **Form Validation**: Go to sign-in/sign-up pages, submit with invalid data, and verify:
   - Red borders appear on invalid fields
   - Only one error message displays per field (below the input)
3. **Chart Alignment**: Check Risk Severity chart on overview page - all bars should be properly aligned
4. **Disabled Links**: In scans table, verify disabled "See Findings"/"See Compliance" links appear grayed out with reduced opacity

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.