### PR TITLE
docs: remove AMD-only docker images warning

### DIFF
--- a/docs/getting-started/installation/prowler-app.mdx
+++ b/docs/getting-started/installation/prowler-app.mdx
@@ -26,8 +26,6 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
     curl -sLO "https://raw.githubusercontent.com/prowler-cloud/prowler/refs/tags/${VERSION}/.env"
     docker compose up -d
     ```
-
-    > Containers are built for `linux/amd64`. If your workstation's architecture is different, please set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in your environment or use the `--platform linux/amd64` flag in the docker command.
   </Tab>
   <Tab title="GitHub">
     _Requirements_:

--- a/docs/getting-started/installation/prowler-app.mdx
+++ b/docs/getting-started/installation/prowler-app.mdx
@@ -4,12 +4,12 @@ title: "Installation"
 
 ### Installation
 
-Prowler App supports multiple installation methods based on your environment.
+Prowler App offers flexible installation methods tailored to various environments.
 
 Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detailed usage instructions.
 
 <Warning>
-  Prowler configuration is based in `.env` files. Every version of Prowler can have differences on that file, so, please, use the file that corresponds with that version or repository branch or tag.
+  Prowler configuration is based on `.env` files. Every version of Prowler can have differences on that file, so, please, use the file that corresponds with that version or repository branch or tag.
 </Warning>
 
 <Tabs>
@@ -104,11 +104,13 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
   </Tab>
 </Tabs>
 
-### Update Prowler App
+### Updating Prowler App
 
 Upgrade Prowler App installation using one of two options:
 
-#### Option 1: Update Environment File
+#### Option 1: Updating the Environment File
+
+To update the environment file:
 
 Edit the `.env` file and change version values:
 
@@ -117,7 +119,7 @@ PROWLER_UI_VERSION="5.9.0"
 PROWLER_API_VERSION="5.9.0"
 ```
 
-#### Option 2: Use Docker Compose Pull
+#### Option 2: Using Docker Compose Pull
 
 ```bash
 docker compose pull --policy always
@@ -131,7 +133,7 @@ The `--policy always` flag ensures that Docker pulls the latest images even if t
   Everything is preserved, nothing will be deleted after the update.
 </Note>
 
-### Troubleshooting
+### Troubleshooting Installation Issues
 
 If containers don't start, check logs for errors:
 
@@ -143,16 +145,16 @@ docker compose logs
 docker images | grep prowler
 ```
 
-If you encounter issues, you can rollback to the previous version by changing the `.env` file back to your previous version and running:
+If issues are encountered, rollback to the previous version by changing the `.env` file back to the previous version and running:
 
 ```bash
 docker compose pull
 docker compose up -d
 ```
 
-### Container versions
+### Container Versions
 
-The available versions of Prowler CLI are the following:
+The available versions of Prowler App are the following:
 
 - `latest`: in sync with `master` branch (please note that it is not a stable version)
 - `v4-latest`: in sync with `v4` branch (please note that it is not a stable version)

--- a/docs/getting-started/installation/prowler-cli.mdx
+++ b/docs/getting-started/installation/prowler-cli.mdx
@@ -4,7 +4,7 @@ title: 'Installation'
 
 ## Installation
 
-Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). Install it as a Python package with `Python >= 3.9, <= 3.12`:
+To install Prowler as a Python package, use `Python >= 3.9, <= 3.12`. Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/):
 
 <Tabs>
   <Tab title="pipx">
@@ -41,7 +41,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). 
     prowler -v
     ```
 
-    Upgrade Prowler to the latest version:
+    To upgrade Prowler to the latest version:
 
     ``` bash
     pip install --upgrade prowler
@@ -73,7 +73,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). 
 
     _Commands_:
 
-    ```
+    ```bash
     git clone https://github.com/prowler-cloud/prowler
     cd prowler
     poetry install
@@ -92,7 +92,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). 
 
     _Commands_:
 
-    ```
+    ```bash
     python3 -m pip install --user pipx
     python3 -m pipx ensurepath
     pipx install prowler
@@ -102,7 +102,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). 
   <Tab title="Ubuntu">
     _Requirements_:
 
-    * `Ubuntu 23.04` or above, if you are using an older version of Ubuntu check [pipx installation](https://docs.prowler.com/projects/prowler-open-source/en/latest/#__tabbed_1_1) and ensure you have `Python >= 3.9, <= 3.12`.
+    * `Ubuntu 23.04` or above. For older Ubuntu versions, check [pipx installation](https://docs.prowler.com/projects/prowler-open-source/en/latest/#__tabbed_1_1) and ensure `Python >= 3.9, <= 3.12` is installed.
     * `Python >= 3.9, <= 3.12`
     * AWS, GCP, Azure and/or Kubernetes credentials
 
@@ -119,7 +119,7 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). 
   <Tab title="Brew">
     _Requirements_:
 
-    * `Brew` installed in your Mac or Linux
+    * `Brew` installed on Mac or Linux
     * AWS, GCP, Azure and/or Kubernetes credentials
 
     _Commands_:
@@ -169,7 +169,8 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). 
     ```
   </Tab>
 </Tabs>
-## Container versions
+
+## Container Versions
 
 The available versions of Prowler CLI are the following:
 

--- a/docs/getting-started/installation/prowler-cli.mdx
+++ b/docs/getting-started/installation/prowler-cli.mdx
@@ -54,8 +54,6 @@ Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/). 
     * In the command below, change `-v` to your local directory path in order to access the reports.
     * AWS, GCP, Azure and/or Kubernetes credentials
 
-    > Containers are built for `linux/amd64`. If your workstation's architecture is different, please set `DOCKER_DEFAULT_PLATFORM=linux/amd64` in your environment or use the `--platform linux/amd64` flag in the docker command.
-
     _Commands_:
 
     ``` bash


### PR DESCRIPTION
### Context
With version v5.14 we added support for ARM builds #8773, so we no longer need the warning.

### Description
- Remove docker `amd` images warning.
- Review pages against docs guidelines.

### Steps to review
Review changes in Mintlify.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
