### PR TITLE
fix(iac): ignore mutelist in IaC scans

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### Fixed
 - Fix typo in PDF reporting [(#9322)](https://github.com/prowler-cloud/prowler/pull/9322)
+- Fix IaC provider initialization failure when mutelist processor is configured [(#9331)](https://github.com/prowler-cloud/prowler/pull/9331)
 
 ---
 

--- a/api/src/backend/api/utils.py
+++ b/api/src/backend/api/utils.py
@@ -158,7 +158,8 @@ def get_prowler_provider_kwargs(
 
     if mutelist_processor:
         mutelist_content = mutelist_processor.configuration.get("Mutelist", {})
-        if mutelist_content:
+        # IaC provider doesn't support mutelist (uses Trivy's built-in logic)
+        if mutelist_content and provider.provider != Provider.ProviderChoices.IAC.value:
             prowler_provider_kwargs["mutelist_content"] = mutelist_content
 
     return prowler_provider_kwargs


### PR DESCRIPTION
### Context

When running IaC scans in Prowler App with a mutelist processor configured, the scan fails with the error:
```
Provider iac is not connected: IacProvider.__init__() got an unexpected keyword argument 'mutelist_content'
```

### Description

The IaC provider uses Trivy's built-in mutelist logic instead of Prowler's standard mutelist mechanism. However, the `get_prowler_provider_kwargs` function in `api/src/backend/api/utils.py` was adding the `mutelist_content` parameter to all providers indiscriminately, causing the IaC provider initialization to fail.

This PR adds a condition to exclude the IaC provider from receiving the `mutelist_content` parameter, consistent with the existing comment in `iac_provider.py` that states: "Mutelist (not needed for IAC since Trivy has its own mutelist logic)".

**Changes:**
- Modified `get_prowler_provider_kwargs()` to exclude IaC provider from receiving `mutelist_content`
- Added comprehensive unit tests for IaC provider kwargs handling
- Added CHANGELOG entry

### Steps to review

1. Review the fix in `api/src/backend/api/utils.py` - the condition now excludes IaC provider from receiving `mutelist_content`
2. Review the new tests in `api/src/backend/api/tests/test_utils.py`:
   - `test_get_prowler_provider_kwargs_iac_provider` - Tests IaC with access token
   - `test_get_prowler_provider_kwargs_iac_provider_without_token` - Tests IaC without token (public repos)
   - `test_get_prowler_provider_kwargs_iac_provider_ignores_mutelist` - Tests that mutelist is NOT passed to IaC

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) - Not needed
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. - Not applicable (SDK unchanged)

#### API
- [x] Verify if API specs need to be regenerated. - Not needed (no API contract changes)
- [x] Check if version updates are required (e.g., specs, Poetry, etc.). - Not needed
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. - Done

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[DEVREL-121]: https://prowlerpro.atlassian.net/browse/DEVREL-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ