### PR TITLE
fix(ui): filter Risk Pipeline chart by selected providers and show zero-data legends

### DIFF
--- a/ui/actions/overview/sankey.adapter.ts
+++ b/ui/actions/overview/sankey.adapter.ts
@@ -29,7 +29,6 @@ export interface SankeyData {
 
 export interface SankeyFilters {
   providerTypes?: string[];
-  hasActiveFilter?: boolean;
 }
 
 interface AggregatedProvider {
@@ -97,8 +96,7 @@ export function adaptProvidersOverviewToSankey(
 
   // Filter providers based on selection:
   // - If providerTypes filter is set: show only those provider types
-  // - If hasActiveFilter is true (e.g., account filter): only show providers with actual data
-  // - If no filters: show all providers from the API response
+  // - Otherwise: show all providers from the API response
   const hasProviderTypeFilter =
     filters?.providerTypes && filters.providerTypes.length > 0;
 
@@ -108,14 +106,9 @@ export function adaptProvidersOverviewToSankey(
     providersToShow = aggregatedProviders.filter((p) =>
       filters.providerTypes!.includes(p.id.toLowerCase()),
     );
-  } else if (filters?.hasActiveFilter) {
-    // Account filter is active - only show providers that have actual findings data
-    // (not just pass=0, fail=0 which means no scans for that provider type)
-    providersToShow = aggregatedProviders.filter(
-      (p) => p.pass > 0 || p.fail > 0,
-    );
   } else {
-    // No filters - show all providers but only those with data
+    // No provider type filter - show all providers from the API response
+    // Providers with no findings (pass=0, fail=0) will appear in the legend
     providersToShow = aggregatedProviders;
   }
 

--- a/ui/app/(prowler)/_new-overview/components/graphs-tabs/risk-pipeline-view/risk-pipeline-view.ssr.tsx
+++ b/ui/app/(prowler)/_new-overview/components/graphs-tabs/risk-pipeline-view/risk-pipeline-view.ssr.tsx
@@ -2,7 +2,9 @@ import {
   adaptProvidersOverviewToSankey,
   getFindingsBySeverity,
   getProvidersOverview,
+  SankeyFilters,
 } from "@/actions/overview";
+import { getProviders } from "@/actions/providers";
 import { SankeyChart } from "@/components/graphs/sankey-chart";
 import { SearchParamsProps } from "@/types";
 
@@ -15,30 +17,99 @@ export async function RiskPipelineViewSSR({
 }) {
   const filters = pickFilterParams(searchParams);
 
-  // Fetch both endpoints in parallel
-  const [providersResponse, severityResponse] = await Promise.all([
-    getProvidersOverview({ filters }),
-    getFindingsBySeverity({ filters }),
-  ]);
+  // Check if any provider/account filter is active
+  const providerTypeFilter = filters["filter[provider_type__in]"];
+  const providerIdFilter = filters["filter[provider_id__in]"];
+  const hasActiveFilter = !!(providerTypeFilter || providerIdFilter);
+
+  // Fetch data in parallel
+  const [providersResponse, severityResponse, providersListResponse] =
+    await Promise.all([
+      getProvidersOverview({ filters }),
+      getFindingsBySeverity({ filters }),
+      // Only fetch providers list if we need to look up account IDs
+      providerIdFilter && !providerTypeFilter
+        ? getProviders({ pageSize: 200 })
+        : Promise.resolve(null),
+    ]);
+
+  // Determine provider types to show
+  let providerTypesToShow: string[] | undefined;
+
+  if (providerTypeFilter) {
+    // Provider type filter is set - use it directly
+    providerTypesToShow = String(providerTypeFilter)
+      .split(",")
+      .map((t) => t.trim().toLowerCase());
+  } else if (providerIdFilter && providersListResponse?.data) {
+    // Account filter is set - look up provider types from account IDs
+    const selectedAccountIds = String(providerIdFilter)
+      .split(",")
+      .map((id) => id.trim());
+
+    const providerTypesSet = new Set<string>();
+    for (const accountId of selectedAccountIds) {
+      const provider = providersListResponse.data.find(
+        (p) => p.id === accountId,
+      );
+      if (provider) {
+        providerTypesSet.add(provider.attributes.provider.toLowerCase());
+      }
+    }
+    providerTypesToShow = Array.from(providerTypesSet);
+  }
+
+  // Build sankey filters
+  const sankeyFilters: SankeyFilters = {
+    hasActiveFilter,
+    providerTypes: providerTypesToShow,
+  };
 
   const sankeyData = adaptProvidersOverviewToSankey(
     providersResponse,
     severityResponse,
+    sankeyFilters,
   );
 
-  if (sankeyData.nodes.length === 0) {
+  // If no chart data and no zero-data providers, show empty state message
+  if (
+    sankeyData.nodes.length === 0 &&
+    sankeyData.zeroDataProviders.length === 0
+  ) {
     return (
       <div className="flex h-[460px] w-full items-center justify-center">
         <p className="text-text-neutral-tertiary text-sm">
-          No provider data available
+          No findings data available for the selected filters
         </p>
+      </div>
+    );
+  }
+
+  // If no chart data but there are zero-data providers, show only the legend
+  if (sankeyData.nodes.length === 0) {
+    return (
+      <div className="flex h-[460px] w-full items-center justify-center">
+        <div className="text-center">
+          <p className="text-text-neutral-tertiary mb-4 text-sm">
+            No failed findings for the selected accounts
+          </p>
+          <SankeyChart
+            data={sankeyData}
+            zeroDataProviders={sankeyData.zeroDataProviders}
+            height={100}
+          />
+        </div>
       </div>
     );
   }
 
   return (
     <div className="w-full flex-1 overflow-visible">
-      <SankeyChart data={sankeyData} height={460} />
+      <SankeyChart
+        data={sankeyData}
+        zeroDataProviders={sankeyData.zeroDataProviders}
+        height={460}
+      />
     </div>
   );
 }

--- a/ui/app/(prowler)/_new-overview/components/graphs-tabs/risk-pipeline-view/risk-pipeline-view.ssr.tsx
+++ b/ui/app/(prowler)/_new-overview/components/graphs-tabs/risk-pipeline-view/risk-pipeline-view.ssr.tsx
@@ -20,7 +20,6 @@ export async function RiskPipelineViewSSR({
   // Check if any provider/account filter is active
   const providerTypeFilter = filters["filter[provider_type__in]"];
   const providerIdFilter = filters["filter[provider_id__in]"];
-  const hasActiveFilter = !!(providerTypeFilter || providerIdFilter);
 
   // Fetch data in parallel
   const [providersResponse, severityResponse, providersListResponse] =
@@ -61,7 +60,6 @@ export async function RiskPipelineViewSSR({
 
   // Build sankey filters
   const sankeyFilters: SankeyFilters = {
-    hasActiveFilter,
     providerTypes: providerTypesToShow,
   };
 

--- a/ui/app/(prowler)/_new-overview/components/graphs-tabs/risk-pipeline-view/risk-pipeline-view.ssr.tsx
+++ b/ui/app/(prowler)/_new-overview/components/graphs-tabs/risk-pipeline-view/risk-pipeline-view.ssr.tsx
@@ -61,6 +61,7 @@ export async function RiskPipelineViewSSR({
   // Build sankey filters
   const sankeyFilters: SankeyFilters = {
     providerTypes: providerTypesToShow,
+    allSelectedProviderTypes: providerTypesToShow,
   };
 
   const sankeyData = adaptProvidersOverviewToSankey(

--- a/ui/app/(prowler)/compliance/page.tsx
+++ b/ui/app/(prowler)/compliance/page.tsx
@@ -61,7 +61,8 @@ export default async function Compliance({
 
       // Find the provider data in the included array
       const providerData = scansData.included?.find(
-        (item: any) => item.type === "providers" && item.id === providerId,
+        (item: { type: string; id: string }) =>
+          item.type === "providers" && item.id === providerId,
       );
 
       if (!providerData) {

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -148,9 +148,12 @@ const SSRDataTableScans = async ({
     include: "provider",
   });
 
-  // Process scans with provider information from included data
+  const scans = scansData?.data;
+  const included = scansData?.included;
+  const meta = scansData && "meta" in scansData ? scansData.meta : undefined;
+
   const expandedScansData =
-    scansData?.data?.map((scan: any) => {
+    scans?.map((scan: ScanProps) => {
       const providerId = scan.relationships?.provider?.data?.id;
 
       if (!providerId) {
@@ -158,8 +161,9 @@ const SSRDataTableScans = async ({
       }
 
       // Find the provider data in the included array
-      const providerData = scansData.included?.find(
-        (item: any) => item.type === "providers" && item.id === providerId,
+      const providerData = included?.find(
+        (item: { type: string; id: string }) =>
+          item.type === "providers" && item.id === providerId,
       );
 
       if (!providerData) {
@@ -181,7 +185,7 @@ const SSRDataTableScans = async ({
       key={`scans-${Date.now()}`}
       columns={ColumnGetScans}
       data={expandedScansData || []}
-      metadata={scansData?.meta}
+      metadata={meta}
     />
   );
 };

--- a/ui/components/graphs/sankey-chart.tsx
+++ b/ui/components/graphs/sankey-chart.tsx
@@ -592,7 +592,7 @@ export function SankeyChart({
       {zeroDataProviders.length > 0 && (
         <div className="border-divider-primary mt-4 border-t pt-4">
           <p className="text-text-neutral-tertiary mb-3 text-xs font-medium tracking-wide uppercase">
-            Providers with no findings
+            Providers with no failed findings
           </p>
           <div className="flex flex-wrap gap-4">
             {zeroDataProviders.map((provider) => {

--- a/ui/components/graphs/sankey-chart.tsx
+++ b/ui/components/graphs/sankey-chart.tsx
@@ -35,11 +35,17 @@ interface SankeyLink {
   value: number;
 }
 
+interface ZeroDataProvider {
+  id: string;
+  displayName: string;
+}
+
 interface SankeyChartProps {
   data: {
     nodes: SankeyNode[];
     links: SankeyLink[];
   };
+  zeroDataProviders?: ZeroDataProvider[];
   height?: number;
 }
 
@@ -382,7 +388,11 @@ const CustomLink = ({
   );
 };
 
-export function SankeyChart({ data, height = 400 }: SankeyChartProps) {
+export function SankeyChart({
+  data,
+  zeroDataProviders = [],
+  height = 400,
+}: SankeyChartProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [hoveredLink, setHoveredLink] = useState<number | null>(null);
@@ -577,6 +587,29 @@ export function SankeyChart({ data, height = 400 }: SankeyChartProps) {
               },
             ]}
           />
+        </div>
+      )}
+      {zeroDataProviders.length > 0 && (
+        <div className="border-divider-primary mt-4 border-t pt-4">
+          <p className="text-text-neutral-tertiary mb-3 text-xs font-medium tracking-wide uppercase">
+            Providers with no findings
+          </p>
+          <div className="flex flex-wrap gap-4">
+            {zeroDataProviders.map((provider) => {
+              const IconComponent = PROVIDER_ICONS[provider.displayName];
+              return (
+                <div
+                  key={provider.id}
+                  className="flex items-center gap-2 text-sm"
+                >
+                  {IconComponent && <IconComponent width={20} height={20} />}
+                  <span className="text-text-neutral-secondary">
+                    {provider.displayName}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
### Context

When filtering by provider types or accounts in the Overview page, the Risk Pipeline chart should only display the selected providers and show providers with no failed findings in a legend below the chart.

### Description

- Add provider filtering to the Risk Pipeline chart based on selected provider types or account IDs
- When filtering by accounts, look up the provider types from the account IDs to filter the chart
- Show providers with no failed findings (fail=0) in a legend below the chart
- Show providers that are selected but have no data at all in the API response in the legend
- Fix TypeScript implicit `any` errors in compliance and scans pages

### Steps to review

1. Go to the Overview page
2. Select one or more provider types (e.g., AWS, Kubernetes)
3. Verify the Risk Pipeline chart only shows selected providers
4. If a selected provider has no failed findings, verify it appears in the legend below the chart titled "Providers with no failed findings"
5. Select accounts instead of provider types and verify the same behavior

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.