### PR TITLE
fix(attack-paths): demo neo4j connection

### DIFF
--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -42,6 +42,7 @@ def init_driver() -> neo4j.Driver:
                 uri,
                 auth=(config["USER"], config["PASSWORD"]),
                 max_connection_lifetime=604800,  # 7 days
+                keep_alive=True,
             )
             _driver.verify_connectivity()
 

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -41,7 +41,7 @@ def init_driver() -> neo4j.Driver:
             _driver = neo4j.GraphDatabase.driver(
                 uri,
                 auth=(config["USER"], config["PASSWORD"]),
-                max_connection_lifetime=3600,
+                max_connection_lifetime=604800,  # 7 days
             )
             _driver.verify_connectivity()
 
@@ -65,9 +65,6 @@ def close_driver() -> None:  # TODO: Use it
 
 @contextmanager
 def get_session(database: str | None = None) -> Iterator[neo4j.Session]:
-    # Let's close the driver on this thread/process, any new session will re-open it, just in case it's closed from the database
-    close_driver()
-
     try:
         with get_driver().session(database=database) as session:
             yield session

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -39,7 +39,9 @@ def init_driver() -> neo4j.Driver:
             config = settings.DATABASES["neo4j"]
 
             _driver = neo4j.GraphDatabase.driver(
-                uri, auth=(config["USER"], config["PASSWORD"])
+                uri,
+                auth=(config["USER"], config["PASSWORD"]),
+                max_connection_lifetime=3600,
             )
             _driver.verify_connectivity()
 

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -65,6 +65,9 @@ def close_driver() -> None:  # TODO: Use it
 
 @contextmanager
 def get_session(database: str | None = None) -> Iterator[neo4j.Session]:
+    # Let's close the driver on this thread/process, any new session will re-open it, just in case it's closed from the database
+    close_driver()
+
     try:
         with get_driver().session(database=database) as session:
             yield session

--- a/api/src/backend/api/attack_paths/retryable_session.py
+++ b/api/src/backend/api/attack_paths/retryable_session.py
@@ -1,0 +1,87 @@
+import logging
+from collections.abc import Callable
+from typing import Any
+
+import neo4j
+import neo4j.exceptions
+
+logger = logging.getLogger(__name__)
+
+
+class RetryableSession:
+    """
+    Wrapper around `neo4j.Session` that retries `neo4j.exceptions.ServiceUnavailable` errors.
+    """
+
+    def __init__(
+        self,
+        session_factory: Callable[[], neo4j.Session],
+        close_driver: Callable[[], None],  # Just to avoid circular imports
+        max_retries: int,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._close_driver = close_driver
+        self._max_retries = max(0, max_retries)
+        self._session = self._session_factory()
+
+    def close(self) -> None:
+        if self._session is not None:
+            self._session.close()
+            self._session = None
+
+    def __enter__(self) -> "RetryableSession":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, exc_tb: Any) -> None:
+        self.close()
+
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        return self._call_with_retry("run", *args, **kwargs)
+
+    def write_transaction(self, *args: Any, **kwargs: Any) -> Any:
+        return self._call_with_retry("write_transaction", *args, **kwargs)
+
+    def read_transaction(self, *args: Any, **kwargs: Any) -> Any:
+        return self._call_with_retry("read_transaction", *args, **kwargs)
+
+    def execute_write(self, *args: Any, **kwargs: Any) -> Any:
+        return self._call_with_retry("execute_write", *args, **kwargs)
+
+    def execute_read(self, *args: Any, **kwargs: Any) -> Any:
+        return self._call_with_retry("execute_read", *args, **kwargs)
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._session, item)
+
+    def _call_with_retry(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        attempt = 0
+        last_exc: neo4j.exceptions.ServiceUnavailable | None = None
+
+        while attempt <= self._max_retries:
+            try:
+                method = getattr(self._session, method_name)
+                return method(*args, **kwargs)
+
+            except (
+                neo4j.exceptions.ServiceUnavailable
+            ) as exc:  # pragma: no cover - depends on infra
+                last_exc = exc
+                attempt += 1
+
+                if attempt > self._max_retries:
+                    raise
+
+                logger.warning(
+                    f"Neo4j session {method_name} failed with ServiceUnavailable ({attempt}/{self._max_retries} attempts). Retrying..."
+                )
+                self._refresh_session()
+
+        raise last_exc if last_exc else RuntimeError("Unexpected retry loop exit")
+
+    def _refresh_session(self) -> None:
+        if self._session is not None:
+            self._session.close()
+
+        self._close_driver()
+        self._session = self._session_factory()

--- a/api/src/backend/tasks/jobs/attack_paths/scan.py
+++ b/api/src/backend/tasks/jobs/attack_paths/scan.py
@@ -74,6 +74,8 @@ def run(tenant_id: str, scan_id: str, task_id: str) -> dict[str, Any]:
             f"Creating Neo4j database {cartography_config.neo4j_database} for tenant {prowler_api_provider.tenant_id}"
         )
 
+        # Let's close the driver on this thread/process, any new session will re-open it, just in case is closed from the database
+        graph_database.close_driver()
         graph_database.create_database(cartography_config.neo4j_database)
         db_utils.update_attack_paths_scan_progress(attack_paths_scan, 1)
 

--- a/api/src/backend/tasks/jobs/attack_paths/scan.py
+++ b/api/src/backend/tasks/jobs/attack_paths/scan.py
@@ -74,8 +74,6 @@ def run(tenant_id: str, scan_id: str, task_id: str) -> dict[str, Any]:
             f"Creating Neo4j database {cartography_config.neo4j_database} for tenant {prowler_api_provider.tenant_id}"
         )
 
-        # Let's close the driver on this thread/process, any new session will re-open it, just in case is closed from the database
-        graph_database.close_driver()
         graph_database.create_database(cartography_config.neo4j_database)
         db_utils.update_attack_paths_scan_progress(attack_paths_scan, 1)
 


### PR DESCRIPTION
### Description

As there is a probably a network configuration problem a Neo4j retryable session has been created, that when one of `run`, `write_transaction`, `read_transaction`, `execute_write`, `execute_read` fails with a `neo4j.exceptions.ServiceUnavailable` it closes the current session and driver, and creates a new driver and new a session with the same database parameter as the last one and retry the method.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
