### PR TITLE
fix(attack-paths): neo4j.exceptions import

### DIFF
--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -6,10 +6,9 @@ from typing import Iterator
 from uuid import UUID
 
 import neo4j
+import neo4j.exceptions
 
 from django.conf import settings
-
-import neo4j.exceptions
 
 from api.attack_paths.retryable_session import RetryableSession
 

--- a/api/src/backend/api/attack_paths/retryable_session.py
+++ b/api/src/backend/api/attack_paths/retryable_session.py
@@ -1,4 +1,5 @@
 import logging
+
 from collections.abc import Callable
 from typing import Any
 
@@ -18,7 +19,6 @@ class RetryableSession:
         session_factory: Callable[[], neo4j.Session],
         close_driver: Callable[[], None],  # Just to avoid circular imports
         max_retries: int,
-        logger: logging.Logger | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._close_driver = close_driver


### PR DESCRIPTION
### Description

Just fix the order of the imports and remove an unused and useless parameter from the `RetryableSession` constructor.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
