### PR TITLE
fix(dashboard): typo and format errors

### DIFF
--- a/dashboard/pages/compliance.py
+++ b/dashboard/pages/compliance.py
@@ -125,7 +125,7 @@ if data is None:
     )
 else:
 
-    data["ASSESSMENTDATE"] = pd.to_datetime(data["ASSESSMENTDATE"])
+    data["ASSESSMENTDATE"] = pd.to_datetime(data["ASSESSMENTDATE"], format="mixed")
     data["ASSESSMENT_TIME"] = data["ASSESSMENTDATE"].dt.strftime("%Y-%m-%d %H:%M:%S")
 
     data_values = data["ASSESSMENT_TIME"].unique()

--- a/dashboard/pages/compliance.py
+++ b/dashboard/pages/compliance.py
@@ -76,8 +76,8 @@ def load_csv_files(csv_files):
                 result = result.replace("_AZURE", " - AZURE")
             if "KUBERNETES" in result:
                 result = result.replace("_KUBERNETES", " - KUBERNETES")
-            if "M65" in result:
-                result = result.replace("_M65", " - M65")
+            if "M365" in result:
+                result = result.replace("_M365", " - M365")
             results.append(result)
 
     unique_results = set(results)

--- a/dashboard/pages/compliance.py
+++ b/dashboard/pages/compliance.py
@@ -280,7 +280,7 @@ def display_data(
             ].apply(lambda x: x.split(" - ")[0])
     # Filter the chosen level of the CIS
     if is_level_1:
-        data = data[data["REQUIREMENTS_ATTRIBUTES_PROFILE"] == "Level 1"]
+        data = data[data["REQUIREMENTS_ATTRIBUTES_PROFILE"].str.contains("Level 1")]
 
     # Rename the column PROJECTID to ACCOUNTID for GCP
     if data.columns.str.contains("PROJECTID").any():


### PR DESCRIPTION
### Context

Fix for dashboard startup errors when loading compliance data with mixed datetime formats and a typo in results append.

### Description

**Fix 1**: DateTime parsing error in compliance dashboard

  The compliance dashboard failed to load when ASSESSMENTDATE column contained mixed datetime formats:
  - Some entries: `2025-11-17 14:00:01.123456` (with microseconds)
  - Other entries: `2025-11-17 14:00:01` (without microseconds)

  This caused a `ValueError`:
 `ValueError: time data "2025-11-17 14:00:01" doesn't match format "%Y-%m-%d %H:%M:%S.%f"`

  Solution: Added `format="mixed"` parameter to `pd.to_datetime()` to handle inconsistent formats.

  **Fix 2**: Replaced `M65` with `M365` provider in compliance page.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
