### PR TITLE
chore: update changelog without "Fix"

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to the **Prowler API** are documented in this file.
 ## [1.15.1] (Prowler v5.14.1)
 
 ### Fixed
-- Fix typo in PDF reporting [(#9322)](https://github.com/prowler-cloud/prowler/pull/9322)
-- Fix IaC provider initialization failure when mutelist processor is configured [(#9331)](https://github.com/prowler-cloud/prowler/pull/9331)
+- Typo in PDF reporting [(#9322)](https://github.com/prowler-cloud/prowler/pull/9322)
+- IaC provider initialization failure when mutelist processor is configured [(#9331)](https://github.com/prowler-cloud/prowler/pull/9331)
 - Match logic for ThreatScore when counting findings [(#9348)](https://github.com/prowler-cloud/prowler/pull/9348)
 
 ---


### PR DESCRIPTION
### Context

The section already indicates these are fixes

### Description

- Delete `Fix` prefix from Fixed section

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
