### PR TITLE
fix(lighthouse): show all models in selector even without default model

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.15.0] (Unreleased)
+## [1.15.0] (Prowler Unreleased)
 
 ### 🚀 Added
 
@@ -12,9 +12,15 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Threat Map component to Overview Page [(#9324)](https://github.com/prowler-cloud/prowler/pull/9324)
 - MongoDB Atlas provider support [(#9253)](https://github.com/prowler-cloud/prowler/pull/9253)
 
+---
+
+## [1.14.2] (Prowler v5.14.2)
+
 ### 🐞 Fixed
 
 - Models list in Lighthouse selector when default model is not set for provider [(9402)](https://github.com/prowler-cloud/prowler/pull/9402)
+
+---
 
 ## [1.14.0] (Prowler v5.14.0)
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Threat Map component to Overview Page [(#9324)](https://github.com/prowler-cloud/prowler/pull/9324)
 - MongoDB Atlas provider support [(#9253)](https://github.com/prowler-cloud/prowler/pull/9253)
 
+### 🐞 Fixed
+
+- Models list in Lighthouse selector when default model is not set for provider [(9402)](https://github.com/prowler-cloud/prowler/pull/9402)
+
 ## [1.14.0] (Prowler v5.14.0)
 
 ### 🚀 Added


### PR DESCRIPTION
### Context

When a user configures LLM credentials but doesn't select a default model for that provider, in the chat selector user will not be able to see any models.

<img width="3336" height="1970" alt="image" src="https://github.com/user-attachments/assets/43a21091-5bec-49e1-80e2-b315453ea230" />

### Description

This fix loads the models even if default model is not set

### Steps to review


https://github.com/user-attachments/assets/d4ee0f0c-4f95-4787-9654-a6a34ca35c21



### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
