### PR TITLE
fix: clear core.hooksPath before installing pre-commit hooks

### DIFF
--- a/scripts/setup-git-hooks.sh
+++ b/scripts/setup-git-hooks.sh
@@ -18,13 +18,13 @@ echo "━━━━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 
 # Check if we're in a git repository
-if ! git rev-parse --git-dir > /dev/null 2>&1; then
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
   echo -e "${RED}❌ Not in a git repository${NC}"
   exit 1
 fi
 
 # Check if Poetry is installed
-if ! command -v poetry &> /dev/null; then
+if ! command -v poetry &>/dev/null; then
   echo -e "${RED}❌ Poetry is not installed${NC}"
   echo -e "${YELLOW}   Install Poetry: https://python-poetry.org/docs/#installation${NC}"
   exit 1
@@ -46,6 +46,12 @@ else
 fi
 
 echo ""
+# Clear any existing core.hooksPath to avoid pre-commit conflicts
+if git config --get core.hooksPath >/dev/null 2>&1; then
+  echo -e "${YELLOW}🧹 Clearing existing core.hooksPath configuration...${NC}"
+  git config --unset-all core.hooksPath
+fi
+
 echo -e "${YELLOW}🔗 Installing pre-commit hooks...${NC}"
 poetry run pre-commit install
 


### PR DESCRIPTION
### Context

When `core.hooksPath` is configured in git, pre-commit hooks may not work correctly because git uses the custom hooks path instead of the standard `.git/hooks` directory.

### Description

This fix clears any existing `core.hooksPath` configuration before installing pre-commit hooks to avoid conflicts.

Changes:
- Add check and unset for `core.hooksPath` before running `pre-commit install`
- Minor formatting fixes (spacing in redirects)

### Steps to review

1. Run `git config core.hooksPath /some/path` to simulate the issue
2. Run `./scripts/setup-git-hooks.sh`
3. Verify that `core.hooksPath` is cleared and pre-commit hooks work correctly

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.