### PR TITLE
feat(exception): Add decorator for deleted providers during scans

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### Added
 - New endpoint to retrieve an overview of the attack surfaces [(#9309)](https://github.com/prowler-cloud/prowler/pull/9309)
+- Exception handler for provider deletions during scans [(#9414)](https://github.com/prowler-cloud/prowler/pull/9414)
 
 ### Changed
 - Restore the compliance overview endpoint's mandatory filters [(#9330)](https://github.com/prowler-cloud/prowler/pull/9330)

--- a/api/src/backend/api/exceptions.py
+++ b/api/src/backend/api/exceptions.py
@@ -66,6 +66,10 @@ class ProviderConnectionError(Exception):
     """Base exception for provider connection errors."""
 
 
+class ProviderDeletedException(Exception):
+    """Raised when a provider has been deleted during scan/task execution."""
+
+
 def custom_exception_handler(exc, context):
     if isinstance(exc, django_validation_error):
         if hasattr(exc, "error_dict"):

--- a/api/src/backend/api/tests/test_decorators.py
+++ b/api/src/backend/api/tests/test_decorators.py
@@ -2,9 +2,12 @@ import uuid
 from unittest.mock import call, patch
 
 import pytest
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import IntegrityError
 
 from api.db_utils import POSTGRES_TENANT_VAR, SET_CONFIG_QUERY
-from api.decorators import set_tenant
+from api.decorators import handle_provider_deletion, set_tenant
+from api.exceptions import ProviderDeletedException
 
 
 @pytest.mark.django_db
@@ -34,3 +37,142 @@ class TestSetTenantDecorator:
 
         with pytest.raises(KeyError):
             random_func("test_arg")
+
+
+@pytest.mark.django_db
+class TestHandleProviderDeletionDecorator:
+    def test_success_no_exception(self, tenants_fixture, providers_fixture):
+        """Decorated function runs normally when no exception is raised."""
+        tenant = tenants_fixture[0]
+        provider = providers_fixture[0]
+
+        @handle_provider_deletion
+        def task_func(**kwargs):
+            return "success"
+
+        result = task_func(
+            tenant_id=str(tenant.id),
+            provider_id=str(provider.id),
+        )
+        assert result == "success"
+
+    @patch("api.decorators.rls_transaction")
+    @patch("api.decorators.Provider.objects.filter")
+    def test_provider_deleted_with_provider_id(
+        self, mock_filter, mock_rls, tenants_fixture
+    ):
+        """Raises ProviderDeletedException when provider_id provided and provider deleted."""
+        tenant = tenants_fixture[0]
+        deleted_provider_id = str(uuid.uuid4())
+
+        mock_rls.return_value.__enter__ = lambda s: None
+        mock_rls.return_value.__exit__ = lambda s, *args: None
+        mock_filter.return_value.exists.return_value = False
+
+        @handle_provider_deletion
+        def task_func(**kwargs):
+            raise ObjectDoesNotExist("Some object not found")
+
+        with pytest.raises(ProviderDeletedException) as exc_info:
+            task_func(tenant_id=str(tenant.id), provider_id=deleted_provider_id)
+
+        assert deleted_provider_id in str(exc_info.value)
+
+    @patch("api.decorators.rls_transaction")
+    @patch("api.decorators.Provider.objects.filter")
+    @patch("api.decorators.Scan.objects.filter")
+    def test_provider_deleted_with_scan_id(
+        self, mock_scan_filter, mock_provider_filter, mock_rls, tenants_fixture
+    ):
+        """Raises ProviderDeletedException when scan exists but provider deleted."""
+        tenant = tenants_fixture[0]
+        scan_id = str(uuid.uuid4())
+        provider_id = str(uuid.uuid4())
+
+        mock_rls.return_value.__enter__ = lambda s: None
+        mock_rls.return_value.__exit__ = lambda s, *args: None
+
+        mock_scan = type("MockScan", (), {"provider_id": provider_id})()
+        mock_scan_filter.return_value.first.return_value = mock_scan
+        mock_provider_filter.return_value.exists.return_value = False
+
+        @handle_provider_deletion
+        def task_func(**kwargs):
+            raise ObjectDoesNotExist("Some object not found")
+
+        with pytest.raises(ProviderDeletedException) as exc_info:
+            task_func(tenant_id=str(tenant.id), scan_id=scan_id)
+
+        assert provider_id in str(exc_info.value)
+
+    @patch("api.decorators.rls_transaction")
+    @patch("api.decorators.Scan.objects.filter")
+    def test_scan_deleted_cascade(self, mock_scan_filter, mock_rls, tenants_fixture):
+        """Raises ProviderDeletedException when scan was deleted (CASCADE from provider)."""
+        tenant = tenants_fixture[0]
+        scan_id = str(uuid.uuid4())
+
+        mock_rls.return_value.__enter__ = lambda s: None
+        mock_rls.return_value.__exit__ = lambda s, *args: None
+        mock_scan_filter.return_value.first.return_value = None
+
+        @handle_provider_deletion
+        def task_func(**kwargs):
+            raise ObjectDoesNotExist("Some object not found")
+
+        with pytest.raises(ProviderDeletedException) as exc_info:
+            task_func(tenant_id=str(tenant.id), scan_id=scan_id)
+
+        assert scan_id in str(exc_info.value)
+
+    @patch("api.decorators.rls_transaction")
+    @patch("api.decorators.Provider.objects.filter")
+    def test_provider_exists_reraises_original(
+        self, mock_filter, mock_rls, tenants_fixture, providers_fixture
+    ):
+        """Re-raises original exception when provider still exists."""
+        tenant = tenants_fixture[0]
+        provider = providers_fixture[0]
+
+        mock_rls.return_value.__enter__ = lambda s: None
+        mock_rls.return_value.__exit__ = lambda s, *args: None
+        mock_filter.return_value.exists.return_value = True
+
+        @handle_provider_deletion
+        def task_func(**kwargs):
+            raise ObjectDoesNotExist("Actual object missing")
+
+        with pytest.raises(ObjectDoesNotExist):
+            task_func(tenant_id=str(tenant.id), provider_id=str(provider.id))
+
+    @patch("api.decorators.rls_transaction")
+    @patch("api.decorators.Provider.objects.filter")
+    def test_integrity_error_provider_deleted(
+        self, mock_filter, mock_rls, tenants_fixture
+    ):
+        """Raises ProviderDeletedException on IntegrityError when provider deleted."""
+        tenant = tenants_fixture[0]
+        deleted_provider_id = str(uuid.uuid4())
+
+        mock_rls.return_value.__enter__ = lambda s: None
+        mock_rls.return_value.__exit__ = lambda s, *args: None
+        mock_filter.return_value.exists.return_value = False
+
+        @handle_provider_deletion
+        def task_func(**kwargs):
+            raise IntegrityError("FK constraint violation")
+
+        with pytest.raises(ProviderDeletedException):
+            task_func(tenant_id=str(tenant.id), provider_id=deleted_provider_id)
+
+    def test_missing_provider_and_scan_raises_assertion(self, tenants_fixture):
+        """Raises AssertionError when neither provider_id nor scan_id in kwargs."""
+
+        @handle_provider_deletion
+        def task_func(**kwargs):
+            raise ObjectDoesNotExist("Some object not found")
+
+        with pytest.raises(AssertionError) as exc_info:
+            task_func(tenant_id=str(tenants_fixture[0].id))
+
+        assert "provider or scan" in str(exc_info.value)

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -5,6 +5,8 @@ IGNORED_EXCEPTIONS = [
     # Provider is not connected due to credentials errors
     "is not connected",
     "ProviderConnectionError",
+    # Provider was deleted during a scan
+    "ProviderDeletedException",
     # Authentication Errors from AWS
     "InvalidToken",
     "AccessDeniedException",


### PR DESCRIPTION
### Context

If a user deletes a provider during a scan, an unhandled exception was raised and Sentry would create new alerts.

### Description

This kind of situations have been wrapped under `ProviderDeletedException` and Sentry will ignore them.

> [!NOTE]
> These results can be reviewed using the `GET /tasks` endpoint.

```json
    {
      "type": "tasks",
      "id": "1059ab5d-1f54-42f7-9217-6ba857413d8b",
      "attributes": {
        "inserted_at": "2025-12-02T16:23:47.725504Z",
        "completed_at": "2025-12-02T16:23:48.100021Z",
        "name": "provider-deletion",
        "state": "completed",
        "result": {
          "api.ResourceFindingMapping": 22,
          "api.Finding": 22,
          "api.Resource": 19,
          "api.Scan": 1,
          "api.ProviderSecret": 1,
          "api.Provider": 1
        },
        "task_args": {
          "provider_id": "7cee1ddd-2691-406a-bb6a-9308c7069d5a"
        },
        "metadata": {}
      }
    },
    {
      "type": "tasks",
      "id": "ee742947-6c3e-4bf1-8b19-ac763d91e6bc",
      "attributes": {
        "inserted_at": "2025-12-02T16:23:35.356230Z",
        "completed_at": "2025-12-02T16:23:48.850397Z",
        "name": "scan-perform",
        "state": "failed",
        "result": {
          "exc_type": "ProviderDeletedException",
          "exc_message": [
            "Provider '7cee1ddd-2691-406a-bb6a-9308c7069d5a' was deleted during the scan"
          ],
          "exc_module": "api.exceptions"
        },
        "task_args": {
          "scan_id": "019adfe0-6055-73d4-aca8-d89ca0dc018f",
          "provider_id": "7cee1ddd-2691-406a-bb6a-9308c7069d5a"
        },
        "metadata": {}
      }
    },
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
