### PR TITLE
chore(github): update message when contaienr is pushed

### DIFF
--- a/.github/scripts/slack-messages/container-release-completed.json
+++ b/.github/scripts/slack-messages/container-release-completed.json
@@ -1,5 +1,6 @@
 {
   "channel": "${{ env.SLACK_CHANNEL_ID }}",
+  "ts": "${{ env.MESSAGE_TS }}",
   "attachments": [
     {
       "color": "${{ env.STATUS_COLOR }}",

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -79,6 +79,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Notify container push started
+        id: slack-notification-started
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/slack-notification
         env:
@@ -110,6 +111,7 @@ jobs:
         uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          MESSAGE_TS: ${{ steps.slack-notification-started.outputs.ts }}
           COMPONENT: API
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
@@ -119,6 +121,7 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
           step-outcome: ${{ steps.container-push.outcome }}
+          update-ts: ${{ steps.slack-notification-started.outputs.ts }}
 
   # Create and push multi-architecture manifest
   create-manifest:

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -77,6 +77,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Notify container push started
+        id: slack-notification-started
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/slack-notification
         env:
@@ -116,6 +117,7 @@ jobs:
         uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          MESSAGE_TS: ${{ steps.slack-notification-started.outputs.ts }}
           COMPONENT: MCP
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
@@ -125,6 +127,7 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
           step-outcome: ${{ steps.container-push.outcome }}
+          update-ts: ${{ steps.slack-notification-started.outputs.ts }}
 
   # Create and push multi-architecture manifest
   create-manifest:

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -148,6 +148,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Notify container push started
+        id: slack-notification-started
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/slack-notification
         env:
@@ -180,6 +181,7 @@ jobs:
         uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          MESSAGE_TS: ${{ steps.slack-notification-started.outputs.ts }}
           COMPONENT: SDK
           RELEASE_TAG: ${{ env.PROWLER_VERSION }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
@@ -189,6 +191,7 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
           step-outcome: ${{ steps.container-push.outcome }}
+          update-ts: ${{ steps.slack-notification-started.outputs.ts }}
 
   # Create and push multi-architecture manifest
   create-manifest:

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -81,6 +81,7 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Notify container push started
+        id: slack-notification-started
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: ./.github/actions/slack-notification
         env:
@@ -115,6 +116,7 @@ jobs:
         uses: ./.github/actions/slack-notification
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_PLATFORM_DEPLOYMENTS }}
+          MESSAGE_TS: ${{ steps.slack-notification-started.outputs.ts }}
           COMPONENT: UI
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
           GITHUB_SERVER_URL: ${{ github.server_url }}
@@ -124,6 +126,7 @@ jobs:
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
           step-outcome: ${{ steps.container-push.outcome }}
+          update-ts: ${{ steps.slack-notification-started.outputs.ts }}
 
   # Create and push multi-architecture manifest
   create-manifest:


### PR DESCRIPTION
### Context

We are receiving different messages when releasing new containers, one when starts and other when completes. We want to update the start message once completed.

### Description

- Fix message update once push is completed

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
