### PR TITLE
fix(ens): solve division by zero at reporting

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### Fixed
 - Unique constraint violation during compliance overviews task [(#9436)](https://github.com/prowler-cloud/prowler/pull/9436)
+- Division by zero error in ENS PDF report when all requirements are manual [(#9443)](https://github.com/prowler-cloud/prowler/pull/9443)
 
 ---
 

--- a/api/src/backend/tasks/jobs/report.py
+++ b/api/src/backend/tasks/jobs/report.py
@@ -2238,12 +2238,20 @@ def generate_ens_report(
             [
                 "CUMPLE",
                 str(passed_requirements),
-                f"{(passed_requirements / total_requirements * 100):.1f}%",
+                (
+                    f"{(passed_requirements / total_requirements * 100):.1f}%"
+                    if total_requirements > 0
+                    else "0.0%"
+                ),
             ],
             [
                 "NO CUMPLE",
                 str(failed_requirements),
-                f"{(failed_requirements / total_requirements * 100):.1f}%",
+                (
+                    f"{(failed_requirements / total_requirements * 100):.1f}%"
+                    if total_requirements > 0
+                    else "0.0%"
+                ),
             ],
             ["TOTAL", str(total_requirements), "100%"],
         ]


### PR DESCRIPTION
### Description

This pull request makes a small but important fix to the percentage calculation in the `generate_ens_report` function. The change ensures that when `total_requirements` is zero, the percentage values for both "CUMPLE" and "NO CUMPLE" are displayed as "0.0%" instead of causing a division by zero error.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
