### PR TITLE
chore(github): check and scan arm builds

### DIFF
--- a/.github/actions/trivy-scan/action.yml
+++ b/.github/actions/trivy-scan/action.yml
@@ -87,7 +87,7 @@ runs:
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: always()
       with:
-        name: trivy-scan-report-${{ inputs.image-name }}
+        name: trivy-scan-report-${{ inputs.image-name }}-${{ inputs.image-tag }}
         path: trivy-report.json
         retention-days: ${{ inputs.artifact-retention-days }}
 

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - 'api/**'
       - 'prowler/**'
-      - '.github/workflows/api-build-lint-push-containers.yml'
+      - '.github/workflows/api-container-build-push.yml'
   release:
     types:
       - 'published'

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -43,7 +43,16 @@ jobs:
           ignore: DL3013
 
   api-container-build-and-scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     timeout-minutes: 30
     permissions:
       contents: read
@@ -68,22 +77,23 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build container
+      - name: Build container for ${{ matrix.arch }}
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.API_WORKING_DIR }}
           push: false
           load: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
-      - name: Scan container with Trivy
+      - name: Scan container with Trivy for ${{ matrix.arch }}
         if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          image-tag: ${{ github.sha }}
+          image-tag: ${{ github.sha }}-${{ matrix.arch }}
           fail-on-critical: 'false'
           severity: 'CRITICAL'

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -74,9 +74,11 @@ jobs:
             api/CHANGELOG.md
 
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build container for ${{ matrix.arch }}
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.API_WORKING_DIR }}
@@ -88,7 +90,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler'
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -74,11 +74,9 @@ jobs:
             api/CHANGELOG.md
 
       - name: Set up Docker Buildx
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build container for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.API_WORKING_DIR }}
@@ -90,7 +88,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
+        if: github.repository == 'prowler-cloud/prowler'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -42,7 +42,16 @@ jobs:
           dockerfile: mcp_server/Dockerfile
 
   mcp-container-build-and-scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     timeout-minutes: 30
     permissions:
       contents: read
@@ -66,22 +75,23 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build MCP container
+      - name: Build MCP container for ${{ matrix.arch }}
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.MCP_WORKING_DIR }}
           push: false
           load: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
-      - name: Scan MCP container with Trivy
+      - name: Scan MCP container with Trivy for ${{ matrix.arch }}
         if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          image-tag: ${{ github.sha }}
+          image-tag: ${{ github.sha }}-${{ matrix.arch }}
           fail-on-critical: 'false'
           severity: 'CRITICAL'

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -72,9 +72,11 @@ jobs:
             mcp_server/CHANGELOG.md
 
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build MCP container for ${{ matrix.arch }}
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.MCP_WORKING_DIR }}
@@ -86,7 +88,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan MCP container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler'
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -72,11 +72,9 @@ jobs:
             mcp_server/CHANGELOG.md
 
       - name: Set up Docker Buildx
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build MCP container for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.MCP_WORKING_DIR }}
@@ -88,7 +86,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan MCP container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
+        if: github.repository == 'prowler-cloud/prowler'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -44,7 +44,16 @@ jobs:
 
   sdk-container-build-and-scan:
     if: github.repository == 'prowler-cloud/prowler'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     timeout-minutes: 30
     permissions:
       contents: read
@@ -82,22 +91,23 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build SDK container
+      - name: Build SDK container for ${{ matrix.arch }}
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           push: false
           load: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
-      - name: Scan SDK container with Trivy
+      - name: Scan SDK container with Trivy for ${{ matrix.arch }}
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          image-tag: ${{ github.sha }}
+          image-tag: ${{ github.sha }}-${{ matrix.arch }}
           fail-on-critical: 'false'
           severity: 'CRITICAL'

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -88,9 +88,11 @@ jobs:
             contrib/**
 
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build SDK container for ${{ matrix.arch }}
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
@@ -102,7 +104,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan SDK container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler'
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -88,11 +88,9 @@ jobs:
             contrib/**
 
       - name: Set up Docker Buildx
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build SDK container for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
@@ -104,7 +102,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan SDK container with Trivy for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
+        if: github.repository == 'prowler-cloud/prowler'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -73,11 +73,9 @@ jobs:
             ui/README.md
 
       - name: Set up Docker Buildx
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build UI container for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.UI_WORKING_DIR }}
@@ -92,7 +90,7 @@ jobs:
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LwpXXXX
 
       - name: Scan UI container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
+        if: github.repository == 'prowler-cloud/prowler'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -43,7 +43,16 @@ jobs:
           ignore: DL3018
 
   ui-container-build-and-scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     timeout-minutes: 30
     permissions:
       contents: read
@@ -67,7 +76,7 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      - name: Build UI container
+      - name: Build UI container for ${{ matrix.arch }}
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
@@ -75,17 +84,18 @@ jobs:
           target: prod
           push: false
           load: true
-          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}-${{ matrix.arch }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
           build-args: |
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LwpXXXX
 
-      - name: Scan UI container with Trivy
+      - name: Scan UI container with Trivy for ${{ matrix.arch }}
         if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}
-          image-tag: ${{ github.sha }}
+          image-tag: ${{ github.sha }}-${{ matrix.arch }}
           fail-on-critical: 'false'
           severity: 'CRITICAL'

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -73,9 +73,11 @@ jobs:
             ui/README.md
 
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build UI container for ${{ matrix.arch }}
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.UI_WORKING_DIR }}
@@ -90,7 +92,7 @@ jobs:
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LwpXXXX
 
       - name: Scan UI container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler'
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
### Context

We are now building images for both platforms, `linux/amd64` and `linux/arm64`, so we need to ensure both build correctly and do a trivy scan.

### Description

- Include build and trivy scan for both platforms

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
