### PR TITLE
chore(api): upgrade api version to 1.15.2

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -44,7 +44,7 @@ name = "prowler-api"
 package-mode = false
 # Needed for the SDK compatibility
 requires-python = ">=3.11,<3.13"
-version = "1.15.1"
+version = "1.15.2"
 
 [project.scripts]
 celery = "src.backend.config.settings.celery"

--- a/api/src/backend/api/specs/v1.yaml
+++ b/api/src/backend/api/specs/v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Prowler API
-  version: 1.15.1
+  version: 1.15.2
   description: |-
     Prowler API specification.
 

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -350,7 +350,7 @@ class SchemaView(SpectacularAPIView):
 
     def get(self, request, *args, **kwargs):
         spectacular_settings.TITLE = "Prowler API"
-        spectacular_settings.VERSION = "1.15.1"
+        spectacular_settings.VERSION = "1.15.2"
         spectacular_settings.DESCRIPTION = (
             "Prowler API specification.\n\nThis file is auto-generated."
         )


### PR DESCRIPTION
### Context

Upgrade API version to 1.15.2 for release 5.14.2

### Description

- Upgrade version on `api/pyproject.toml`
- Upgrade version on `api/src/backend/api/specs/v1.yaml`
- Upgrade version on `api/src/backend/api/v1/views.py`
- Lock updated by pre-commit

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
