### PR TITLE
fix(api): unlimited limit-request-line

### DIFF
--- a/api/src/backend/config/guniconf.py
+++ b/api/src/backend/config/guniconf.py
@@ -20,7 +20,7 @@ PORT = env("DJANGO_PORT", default=8000)
 # Server settings
 bind = f"{BIND_ADDRESS}:{PORT}"
 # TODO: Remove after the category filter is implemented
-limit-request-line = 0
+limit_request_line = 0
 
 workers = env.int("DJANGO_WORKERS", default=multiprocessing.cpu_count() * 2 + 1)
 reload = DEBUG

--- a/api/src/backend/config/guniconf.py
+++ b/api/src/backend/config/guniconf.py
@@ -19,6 +19,8 @@ PORT = env("DJANGO_PORT", default=8000)
 
 # Server settings
 bind = f"{BIND_ADDRESS}:{PORT}"
+# TODO: Remove after the category filter is implemented
+limit-request-line = 0
 
 workers = env.int("DJANGO_WORKERS", default=multiprocessing.cpu_count() * 2 + 1)
 reload = DEBUG


### PR DESCRIPTION
### Context

The new attack surface overview creates a link with the `check_ids`. For internet-exposed the API server URI limit is reached.

https://docs.gunicorn.org/en/stable/settings.html#limit-request-line

### Description

Set `limit-request-line` in `guniconf.py` to 0.

### Steps to review

- `cURL` request:
```
curl --location --globoff 'http://0.0.0.0:8080/api/v1/findings/latest?filter[check_id__in]=documentdb_cluster_public_snapshot%2Ccloudtrail_logs_s3_bucket_is_not_publicly_accessible%2Cec2_instance_port_elasticsearch_kibana_exposed_to_internet%2Cnetwork_security_list_ingress_from_internet_to_ssh_port%2Cs3_bucket_policy_public_write_access%2Ceks_cluster_private_nodes_enabled%2Cec2_securitygroup_allow_wide_open_public_ipv4%2Cfms_policy_compliant%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22%2Cawslambda_function_url_public%2Cs3_bucket_public_list_acl%2Cses_identity_not_publicly_accessible%2Cec2_ami_public%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211%2Csecretsmanager_not_publicly_accessible%2Cs3_bucket_public_access%2Ceventbridge_bus_exposed%2Cdms_instance_no_public_access%2Ccloudstorage_uses_vpc_service_controls%2Cec2_instance_port_redis_exposed_to_internet%2Cec2_networkacl_allow_ingress_tcp_port_22%2Ccodebuild_project_not_publicly_accessible%2Ccompute_firewall_ssh_access_from_the_internet_allowed%2Cec2_elastic_ip_shodan%2Ccloudfront_distributions_using_waf%2Ccloudsql_instance_public_ip%2Ccloudfront_distributions_https_enabled%2Cec2_instance_port_mongodb_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483%2Cec2_instance_internet_facing_with_instance_profile%2Cec2_networkacl_allow_ingress_tcp_port_3389%2Cglacier_vaults_policy_public_access%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432%2Ckms_key_not_publicly_accessible%2Cglue_data_catalogs_not_publicly_accessible%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389%2Clightsail_instance_public%2Cawslambda_function_url_cors_policy%2Capigateway_restapi_public_with_authorizer%2Copensearch_service_domains_not_publicly_accessible%2Cec2_instance_port_oracle_exposed_to_internet%2Cobjectstorage_bucket_not_publicly_accessible%2Celasticache_cluster_uses_public_subnet%2Cec2_ebs_public_snapshot%2Cec2_instance_port_ftp_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306%2Cec2_instance_port_cassandra_exposed_to_internet%2Cec2_ebs_snapshot_account_block_public_access%2Crds_snapshots_public_access%2Cneptune_cluster_public_snapshot%2Cec2_instance_port_postgresql_exposed_to_internet%2Cneptune_cluster_uses_public_subnet%2Csqs_queues_not_publicly_accessible%2Cec2_instance_port_cifs_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports%2Csns_topics_not_publicly_accessible%2Cec2_instance_port_kafka_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092%2Canalytics_instance_access_restricted%2Cec2_instance_port_telnet_exposed_to_internet%2Clightsail_database_public%2Cec2_networkacl_unused%2Cecs_task_set_no_assign_public_ip%2Cs3_bucket_public_write_acl%2Ccloudstorage_bucket_public_access%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mongodb_27017_27018%2Cec2_instance_port_kerberos_exposed_to_internet%2Cec2_instance_public_ip%2Cecr_repositories_not_publicly_accessible%2Cemr_cluster_master_nodes_no_public_ip%2Cemr_cluster_account_public_block_enabled%2Cmq_broker_not_publicly_accessible%2Capigateway_restapi_public%2Ccompute_public_address_shodan%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23%2Cec2_instance_port_ldap_exposed_to_internet%2Cec2_networkacl_allow_ingress_any_port%2Csagemaker_notebook_instance_without_direct_internet_access_configured%2Ccompute_firewall_rdp_access_from_the_internet_allowed%2Cec2_instance_port_ssh_exposed_to_internet%2Cefs_mount_target_not_publicly_accessible%2Ccloudsql_instance_public_access%2Cec2_instance_port_rdp_exposed_to_internet%2Cec2_instance_port_sqlserver_exposed_to_internet%2Cssm_documents_set_as_public%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888%2Celbv2_internet_facing%2Cawslambda_function_not_publicly_accessible%2Celb_internet_facing%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_ftp_20_21%2Ckafka_cluster_is_public%2Crds_instance_no_public_access%2Cnetwork_security_group_ingress_from_internet_to_ssh_port%2Credshift_cluster_public_access%2Cecs_service_no_assign_public_ip%2Caccessanalyzer_enabled_without_findings%2Cprojects_network_access_list_exposed_to_internet%2Cautoscaling_group_launch_configuration_no_public_ip%2Ceks_cluster_not_publicly_accessible%2Cec2_instance_port_memcached_exposed_to_internet%2Cappstream_fleet_default_internet_access_disabled%2Cec2_instance_port_mysql_exposed_to_internet%2Cemr_cluster_publicly_accesible%2Cec2_instance_account_imdsv2_enabled%2Ccloudwatch_log_group_not_publicly_accessible%2Cec2_securitygroup_allow_ingress_from_internet_to_any_port%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434%2Cec2_securitygroup_allow_ingress_from_internet_to_all_ports%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379%2Ccloudfront_distributions_geo_restrictions_enabled%0A' \
--header 'Accept: application/vnd.api+json' \
--header 'Authorization: Bearer XXXXXX'

{"links":{"first":"http://0.0.0.0:8080/api/v1/findings/latest?filter%5Bcheck_id__in%5D=documentdb_cluster_public_snapshot%2Ccloudtrail_logs_s3_bucket_is_not_publicly_accessible%2Cec2_instance_port_elasticsearch_kibana_exposed_to_internet%2Cnetwork_security_list_ingress_from_internet_to_ssh_port%2Cs3_bucket_policy_public_write_access%2Ceks_cluster_private_nodes_enabled%2Cec2_securitygroup_allow_wide_open_public_ipv4%2Cfms_policy_compliant%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22%2Cawslambda_function_url_public%2Cs3_bucket_public_list_acl%2Cses_identity_not_publicly_accessible%2Cec2_ami_public%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211%2Csecretsmanager_not_publicly_accessible%2Cs3_bucket_public_access%2Ceventbridge_bus_exposed%2Cdms_instance_no_public_access%2Ccloudstorage_uses_vpc_service_controls%2Cec2_instance_port_redis_exposed_to_internet%2Cec2_networkacl_allow_ingress_tcp_port_22%2Ccodebuild_project_not_publicly_accessible%2Ccompute_firewall_ssh_access_from_the_internet_allowed%2Cec2_elastic_ip_shodan%2Ccloudfront_distributions_using_waf%2Ccloudsql_instance_public_ip%2Ccloudfront_distributions_https_enabled%2Cec2_instance_port_mongodb_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483%2Cec2_instance_internet_facing_with_instance_profile%2Cec2_networkacl_allow_ingress_tcp_port_3389%2Cglacier_vaults_policy_public_access%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432%2Ckms_key_not_publicly_accessible%2Cglue_data_catalogs_not_publicly_accessible%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389%2Clightsail_instance_public%2Cawslambda_function_url_cors_policy%2Capigateway_restapi_public_with_authorizer%2Copensearch_service_domains_not_publicly_accessible%2Cec2_instance_port_oracle_exposed_to_internet%2Cobjectstorage_bucket_not_publicly_accessible%2Celasticache_cluster_uses_public_subnet%2Cec2_ebs_public_snapshot%2Cec2_instance_port_ftp_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306%2Cec2_instance_port_cassandra_exposed_to_internet%2Cec2_ebs_snapshot_account_block_public_access%2Crds_snapshots_public_access%2Cneptune_cluster_public_snapshot%2Cec2_instance_port_postgresql_exposed_to_internet%2Cneptune_cluster_uses_public_subnet%2Csqs_queues_not_publicly_accessible%2Cec2_instance_port_cifs_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports%2Csns_topics_not_publicly_accessible%2Cec2_instance_port_kafka_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092%2Canalytics_instance_access_restricted%2Cec2_instance_port_telnet_exposed_to_internet%2Clightsail_database_public%2Cec2_networkacl_unused%2Cecs_task_set_no_assign_public_ip%2Cs3_bucket_public_write_acl%2Ccloudstorage_bucket_public_access%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mongodb_27017_27018%2Cec2_instance_port_kerberos_exposed_to_internet%2Cec2_instance_public_ip%2Cecr_repositories_not_publicly_accessible%2Cemr_cluster_master_nodes_no_public_ip%2Cemr_cluster_account_public_block_enabled%2Cmq_broker_not_publicly_accessible%2Capigateway_restapi_public%2Ccompute_public_address_shodan%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23%2Cec2_instance_port_ldap_exposed_to_internet%2Cec2_networkacl_allow_ingress_any_port%2Csagemaker_notebook_instance_without_direct_internet_access_configured%2Ccompute_firewall_rdp_access_from_the_internet_allowed%2Cec2_instance_port_ssh_exposed_to_internet%2Cefs_mount_target_not_publicly_accessible%2Ccloudsql_instance_public_access%2Cec2_instance_port_rdp_exposed_to_internet%2Cec2_instance_port_sqlserver_exposed_to_internet%2Cssm_documents_set_as_public%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888%2Celbv2_internet_facing%2Cawslambda_function_not_publicly_accessible%2Celb_internet_facing%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_ftp_20_21%2Ckafka_cluster_is_public%2Crds_instance_no_public_access%2Cnetwork_security_group_ingress_from_internet_to_ssh_port%2Credshift_cluster_public_access%2Cecs_service_no_assign_public_ip%2Caccessanalyzer_enabled_without_findings%2Cprojects_network_access_list_exposed_to_internet%2Cautoscaling_group_launch_configuration_no_public_ip%2Ceks_cluster_not_publicly_accessible%2Cec2_instance_port_memcached_exposed_to_internet%2Cappstream_fleet_default_internet_access_disabled%2Cec2_instance_port_mysql_exposed_to_internet%2Cemr_cluster_publicly_accesible%2Cec2_instance_account_imdsv2_enabled%2Ccloudwatch_log_group_not_publicly_accessible%2Cec2_securitygroup_allow_ingress_from_internet_to_any_port%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434%2Cec2_securitygroup_allow_ingress_from_internet_to_all_ports%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379%2Ccloudfront_distributions_geo_restrictions_enabled%0A&page%5Bnumber%5D=1","last":"http://0.0.0.0:8080/api/v1/findings/latest?filter%5Bcheck_id__in%5D=documentdb_cluster_public_snapshot%2Ccloudtrail_logs_s3_bucket_is_not_publicly_accessible%2Cec2_instance_port_elasticsearch_kibana_exposed_to_internet%2Cnetwork_security_list_ingress_from_internet_to_ssh_port%2Cs3_bucket_policy_public_write_access%2Ceks_cluster_private_nodes_enabled%2Cec2_securitygroup_allow_wide_open_public_ipv4%2Cfms_policy_compliant%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_22%2Cawslambda_function_url_public%2Cs3_bucket_public_list_acl%2Cses_identity_not_publicly_accessible%2Cec2_ami_public%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_memcached_11211%2Csecretsmanager_not_publicly_accessible%2Cs3_bucket_public_access%2Ceventbridge_bus_exposed%2Cdms_instance_no_public_access%2Ccloudstorage_uses_vpc_service_controls%2Cec2_instance_port_redis_exposed_to_internet%2Cec2_networkacl_allow_ingress_tcp_port_22%2Ccodebuild_project_not_publicly_accessible%2Ccompute_firewall_ssh_access_from_the_internet_allowed%2Cec2_elastic_ip_shodan%2Ccloudfront_distributions_using_waf%2Ccloudsql_instance_public_ip%2Ccloudfront_distributions_https_enabled%2Cec2_instance_port_mongodb_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_oracle_1521_2483%2Cec2_instance_internet_facing_with_instance_profile%2Cec2_networkacl_allow_ingress_tcp_port_3389%2Cglacier_vaults_policy_public_access%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_postgres_5432%2Ckms_key_not_publicly_accessible%2Cglue_data_catalogs_not_publicly_accessible%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_3389%2Clightsail_instance_public%2Cawslambda_function_url_cors_policy%2Capigateway_restapi_public_with_authorizer%2Copensearch_service_domains_not_publicly_accessible%2Cec2_instance_port_oracle_exposed_to_internet%2Cobjectstorage_bucket_not_publicly_accessible%2Celasticache_cluster_uses_public_subnet%2Cec2_ebs_public_snapshot%2Cec2_instance_port_ftp_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mysql_3306%2Cec2_instance_port_cassandra_exposed_to_internet%2Cec2_ebs_snapshot_account_block_public_access%2Crds_snapshots_public_access%2Cneptune_cluster_public_snapshot%2Cec2_instance_port_postgresql_exposed_to_internet%2Cneptune_cluster_uses_public_subnet%2Csqs_queues_not_publicly_accessible%2Cec2_instance_port_cifs_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_high_risk_tcp_ports%2Csns_topics_not_publicly_accessible%2Cec2_instance_port_kafka_exposed_to_internet%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_kafka_9092%2Canalytics_instance_access_restricted%2Cec2_instance_port_telnet_exposed_to_internet%2Clightsail_database_public%2Cec2_networkacl_unused%2Cecs_task_set_no_assign_public_ip%2Cs3_bucket_public_write_acl%2Ccloudstorage_bucket_public_access%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_mongodb_27017_27018%2Cec2_instance_port_kerberos_exposed_to_internet%2Cec2_instance_public_ip%2Cecr_repositories_not_publicly_accessible%2Cemr_cluster_master_nodes_no_public_ip%2Cemr_cluster_account_public_block_enabled%2Cmq_broker_not_publicly_accessible%2Capigateway_restapi_public%2Ccompute_public_address_shodan%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_telnet_23%2Cec2_instance_port_ldap_exposed_to_internet%2Cec2_networkacl_allow_ingress_any_port%2Csagemaker_notebook_instance_without_direct_internet_access_configured%2Ccompute_firewall_rdp_access_from_the_internet_allowed%2Cec2_instance_port_ssh_exposed_to_internet%2Cefs_mount_target_not_publicly_accessible%2Ccloudsql_instance_public_access%2Cec2_instance_port_rdp_exposed_to_internet%2Cec2_instance_port_sqlserver_exposed_to_internet%2Cssm_documents_set_as_public%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_cassandra_7199_9160_8888%2Celbv2_internet_facing%2Cawslambda_function_not_publicly_accessible%2Celb_internet_facing%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_ftp_20_21%2Ckafka_cluster_is_public%2Crds_instance_no_public_access%2Cnetwork_security_group_ingress_from_internet_to_ssh_port%2Credshift_cluster_public_access%2Cecs_service_no_assign_public_ip%2Caccessanalyzer_enabled_without_findings%2Cprojects_network_access_list_exposed_to_internet%2Cautoscaling_group_launch_configuration_no_public_ip%2Ceks_cluster_not_publicly_accessible%2Cec2_instance_port_memcached_exposed_to_internet%2Cappstream_fleet_default_internet_access_disabled%2Cec2_instance_port_mysql_exposed_to_internet%2Cemr_cluster_publicly_accesible%2Cec2_instance_account_imdsv2_enabled%2Ccloudwatch_log_group_not_publicly_accessible%2Cec2_securitygroup_allow_ingress_from_internet_to_any_port%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_sql_server_1433_1434%2Cec2_securitygroup_allow_ingress_from_internet_to_all_ports%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_elasticsearch_kibana_9200_9300_5601%2Cec2_securitygroup_allow_ingress_from_internet_to_tcp_port_redis_6379%2Ccloudfront_distributions_geo_restrictions_enabled%0A&page%5Bnumber%5D=1","next":null,"prev":null},"data":[],"meta":{"pagination":{"page":1,"pages":1,"count":0},"version":"v1"}}
```

Previously:
```
<html>

<head>
    <title>Bad Request</title>
</head>

<body>
    <h1>
        <p>Bad Request</p>
    </h1>
    Request Line is too large (4853 &gt; 4094)
</body>

</html>
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
