### PR TITLE
fix(ui): add default date_from filter for severity over time endpoint

### DIFF
--- a/ui/actions/overview/severity-trends/severity-trends.ts
+++ b/ui/actions/overview/severity-trends/severity-trends.ts
@@ -1,5 +1,9 @@
 "use server";
 
+import {
+  getDateFromForTimeRange,
+  type TimeRange,
+} from "@/app/(prowler)/_new-overview/severity-over-time/_constants/time-range.constants";
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
@@ -8,20 +12,6 @@ import {
   AdaptedSeverityTrendsResponse,
   FindingsSeverityOverTimeResponse,
 } from "./types";
-
-const TIME_RANGE_VALUES = {
-  FIVE_DAYS: "5D",
-  ONE_WEEK: "1W",
-  ONE_MONTH: "1M",
-} as const;
-
-type TimeRange = (typeof TIME_RANGE_VALUES)[keyof typeof TIME_RANGE_VALUES];
-
-const TIME_RANGE_DAYS: Record<TimeRange, number> = {
-  "5D": 5,
-  "1W": 7,
-  "1M": 30,
-};
 
 export type SeverityTrendsResult =
   | { status: "success"; data: AdaptedSeverityTrendsResponse }
@@ -76,21 +66,9 @@ export const getSeverityTrendsByTimeRange = async ({
   timeRange: TimeRange;
   filters?: Record<string, string | string[] | undefined>;
 }): Promise<SeverityTrendsResult> => {
-  const days = TIME_RANGE_DAYS[timeRange];
-
-  if (!days) {
-    console.error("Invalid time range provided");
-    return { status: "error" };
-  }
-
-  const endDate = new Date();
-  const startDate = new Date(endDate.getTime() - days * 24 * 60 * 60 * 1000);
-
-  const dateFrom = startDate.toISOString().split("T")[0];
-
   const dateFilters = {
     ...filters,
-    date_from: dateFrom,
+    "filter[date_from]": getDateFromForTimeRange(timeRange),
   };
 
   return getFindingsSeverityTrends({ filters: dateFilters });

--- a/ui/app/(prowler)/_new-overview/severity-over-time/_components/finding-severity-over-time.tsx
+++ b/ui/app/(prowler)/_new-overview/severity-over-time/_components/finding-severity-over-time.tsx
@@ -13,6 +13,7 @@ import {
   SeverityLevel,
 } from "@/types/severities";
 
+import { DEFAULT_TIME_RANGE } from "../_constants/time-range.constants";
 import { type TimeRange, TimeRangeSelector } from "./time-range-selector";
 
 interface FindingSeverityOverTimeProps {
@@ -24,7 +25,7 @@ export const FindingSeverityOverTime = ({
 }: FindingSeverityOverTimeProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [timeRange, setTimeRange] = useState<TimeRange>("5D");
+  const [timeRange, setTimeRange] = useState<TimeRange>(DEFAULT_TIME_RANGE);
   const [data, setData] = useState<LineDataPoint[]>(initialData);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/ui/app/(prowler)/_new-overview/severity-over-time/_components/time-range-selector.tsx
+++ b/ui/app/(prowler)/_new-overview/severity-over-time/_components/time-range-selector.tsx
@@ -2,14 +2,12 @@
 
 import { cn } from "@/lib/utils";
 
-const TIME_RANGE_OPTIONS = {
-  FIVE_DAYS: "5D",
-  ONE_WEEK: "1W",
-  ONE_MONTH: "1M",
-} as const;
+import {
+  TIME_RANGE_OPTIONS,
+  type TimeRange,
+} from "../_constants/time-range.constants";
 
-export type TimeRange =
-  (typeof TIME_RANGE_OPTIONS)[keyof typeof TIME_RANGE_OPTIONS];
+export type { TimeRange };
 
 interface TimeRangeSelectorProps {
   value: TimeRange;

--- a/ui/app/(prowler)/_new-overview/severity-over-time/_constants/index.ts
+++ b/ui/app/(prowler)/_new-overview/severity-over-time/_constants/index.ts
@@ -1,0 +1,1 @@
+export * from "./time-range.constants";

--- a/ui/app/(prowler)/_new-overview/severity-over-time/_constants/time-range.constants.ts
+++ b/ui/app/(prowler)/_new-overview/severity-over-time/_constants/time-range.constants.ts
@@ -1,0 +1,23 @@
+export const TIME_RANGE_OPTIONS = {
+  FIVE_DAYS: "5D",
+  ONE_WEEK: "1W",
+  ONE_MONTH: "1M",
+} as const;
+
+export type TimeRange =
+  (typeof TIME_RANGE_OPTIONS)[keyof typeof TIME_RANGE_OPTIONS];
+
+export const TIME_RANGE_DAYS: Record<TimeRange, number> = {
+  "5D": 5,
+  "1W": 7,
+  "1M": 30,
+};
+
+export const DEFAULT_TIME_RANGE: TimeRange = "5D";
+
+export const getDateFromForTimeRange = (timeRange: TimeRange): string => {
+  const days = TIME_RANGE_DAYS[timeRange];
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString().split("T")[0];
+};

--- a/ui/app/(prowler)/_new-overview/severity-over-time/finding-severity-over-time.ssr.tsx
+++ b/ui/app/(prowler)/_new-overview/severity-over-time/finding-severity-over-time.ssr.tsx
@@ -8,6 +8,14 @@ import { FindingSeverityOverTimeSkeleton } from "./_components/finding-severity-
 
 export { FindingSeverityOverTimeSkeleton };
 
+const DEFAULT_DAYS = 5;
+
+const getDefaultDateFrom = (): string => {
+  const date = new Date();
+  date.setDate(date.getDate() - DEFAULT_DAYS);
+  return date.toISOString().split("T")[0];
+};
+
 const EmptyState = ({ message }: { message: string }) => (
   <Card variant="base" className="flex h-full min-h-[405px] flex-1 flex-col">
     <CardHeader className="flex flex-col gap-4">
@@ -25,6 +33,12 @@ export const FindingSeverityOverTimeSSR = async ({
   searchParams,
 }: SSRComponentProps) => {
   const filters = pickFilterParams(searchParams);
+
+  // API requires filter[date_from], add default if not provided
+  if (!filters["filter[date_from]"]) {
+    filters["filter[date_from]"] = getDefaultDateFrom();
+  }
+
   const result = await getFindingsSeverityTrends({ filters });
 
   if (result.status === "error") {

--- a/ui/app/(prowler)/_new-overview/severity-over-time/finding-severity-over-time.ssr.tsx
+++ b/ui/app/(prowler)/_new-overview/severity-over-time/finding-severity-over-time.ssr.tsx
@@ -1,20 +1,13 @@
-import { getFindingsSeverityTrends } from "@/actions/overview/severity-trends";
+import { getSeverityTrendsByTimeRange } from "@/actions/overview/severity-trends";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/shadcn";
 
 import { pickFilterParams } from "../_lib/filter-params";
 import { SSRComponentProps } from "../_types";
 import { FindingSeverityOverTime } from "./_components/finding-severity-over-time";
 import { FindingSeverityOverTimeSkeleton } from "./_components/finding-severity-over-time.skeleton";
+import { DEFAULT_TIME_RANGE } from "./_constants/time-range.constants";
 
 export { FindingSeverityOverTimeSkeleton };
-
-const DEFAULT_DAYS = 5;
-
-const getDefaultDateFrom = (): string => {
-  const date = new Date();
-  date.setDate(date.getDate() - DEFAULT_DAYS);
-  return date.toISOString().split("T")[0];
-};
 
 const EmptyState = ({ message }: { message: string }) => (
   <Card variant="base" className="flex h-full min-h-[405px] flex-1 flex-col">
@@ -34,12 +27,10 @@ export const FindingSeverityOverTimeSSR = async ({
 }: SSRComponentProps) => {
   const filters = pickFilterParams(searchParams);
 
-  // API requires filter[date_from], add default if not provided
-  if (!filters["filter[date_from]"]) {
-    filters["filter[date_from]"] = getDefaultDateFrom();
-  }
-
-  const result = await getFindingsSeverityTrends({ filters });
+  const result = await getSeverityTrendsByTimeRange({
+    timeRange: DEFAULT_TIME_RANGE,
+    filters,
+  });
 
   if (result.status === "error") {
     return <EmptyState message="Failed to load severity trends data" />;


### PR DESCRIPTION
### Context

The new \`findings_severity/timeseries\` API endpoint (from PR #9363) requires the \`filter[date_from]\` parameter. Without a default value, the initial page load fails with a 400 error.

### Description

Adds a default \`filter[date_from]\` parameter (5 days ago) to the FindingSeverityOverTime SSR component to match the default TimeRange selector value ("5D").

Changes:
- Added \`getDefaultDateFrom()\` helper function that calculates 5 days ago
- SSR component now automatically adds the date filter if not present in search params

### Steps to review

1. Check the \`finding-severity-over-time.ssr.tsx\` file
2. Verify the \`DEFAULT_DAYS\` constant matches the client component's default TimeRange ("5D" = 5 days)
3. Confirm the filter is only added when not already present in URL params

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.