### PR TITLE
fix: remove incorrect `threat-detection` category from checks

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -23,7 +23,14 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ---
 
-## [v5.14.2] (Prowler UNRELEASED)
+## [v5.14.3] (Prowler UNRELEASED)
+
+### Fixed
+- Removed incorrect threat-detection category from checks metadata [(#9489)](https://github.com/prowler-cloud/prowler/pull/9489)
+
+---
+
+## [v5.14.2] (Prowler 5.14.2)
 
 ### Fixed
 - Custom check folder metadata validation [(#9335)](https://github.com/prowler-cloud/prowler/pull/9335)

--- a/prowler/providers/aws/services/apigateway/apigateway_restapi_waf_acl_attached/apigateway_restapi_waf_acl_attached.metadata.json
+++ b/prowler/providers/aws/services/apigateway/apigateway_restapi_waf_acl_attached/apigateway_restapi_waf_acl_attached.metadata.json
@@ -29,9 +29,7 @@
       "Url": "https://hub.prowler.com/check/apigateway_restapi_waf_acl_attached"
     }
   },
-  "Categories": [
-    "threat-detection"
-  ],
+  "Categories": [],
   "DependsOn": [],
   "RelatedTo": [],
   "Notes": "",

--- a/prowler/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist.metadata.json
+++ b/prowler/providers/aws/services/cloudtrail/cloudtrail_insights_exist/cloudtrail_insights_exist.metadata.json
@@ -33,7 +33,7 @@
     }
   },
   "Categories": [
-    "threat-detection"
+    "forensics-ready"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_acls_alarm_configured/cloudwatch_changes_to_network_acls_alarm_configured.metadata.json
@@ -34,8 +34,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_gateways_alarm_configured/cloudwatch_changes_to_network_gateways_alarm_configured.metadata.json
@@ -35,8 +35,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_network_route_tables_alarm_configured/cloudwatch_changes_to_network_route_tables_alarm_configured.metadata.json
@@ -32,8 +32,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_changes_to_vpcs_alarm_configured/cloudwatch_changes_to_vpcs_alarm_configured.metadata.json
@@ -29,8 +29,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_aws_config_configuration_changes_enabled.metadata.json
@@ -31,8 +31,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled/cloudwatch_log_metric_filter_and_alarm_for_cloudtrail_configuration_changes_enabled.metadata.json
@@ -33,8 +33,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_authentication_failures/cloudwatch_log_metric_filter_authentication_failures.metadata.json
@@ -36,8 +36,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_aws_organizations_changes/cloudwatch_log_metric_filter_aws_organizations_changes.metadata.json
@@ -34,8 +34,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes/cloudwatch_log_metric_filter_for_s3_bucket_policy_changes.metadata.json
@@ -32,8 +32,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_policy_changes/cloudwatch_log_metric_filter_policy_changes.metadata.json
@@ -32,8 +32,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_root_usage/cloudwatch_log_metric_filter_root_usage.metadata.json
@@ -38,8 +38,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_security_group_changes/cloudwatch_log_metric_filter_security_group_changes.metadata.json
@@ -33,8 +33,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_sign_in_without_mfa/cloudwatch_log_metric_filter_sign_in_without_mfa.metadata.json
@@ -37,8 +37,7 @@
     }
   },
   "Categories": [
-    "logging",
-    "threat-detection"
+    "logging"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls.metadata.json
+++ b/prowler/providers/aws/services/cloudwatch/cloudwatch_log_metric_filter_unauthorized_api_calls/cloudwatch_log_metric_filter_unauthorized_api_calls.metadata.json
@@ -36,7 +36,6 @@
     }
   },
   "Categories": [
-    "threat-detection",
     "logging"
   ],
   "DependsOn": [],

--- a/prowler/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc.metadata.json
+++ b/prowler/providers/aws/services/networkfirewall/networkfirewall_in_all_vpc/networkfirewall_in_all_vpc.metadata.json
@@ -32,8 +32,7 @@
     }
   },
   "Categories": [
-    "trust-boundaries",
-    "threat-detection"
+    "trust-boundaries"
   ],
   "DependsOn": [],
   "RelatedTo": [],


### PR DESCRIPTION
### Context

Due to a recent change in the metadata, an error occurred where the `threat-detection` category was added to checks that were not meant to have it, which affects Prowler’s behavior.

### Description

This PR fixes the issue by removing the category from checks where it was incorrectly applied.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
