### PR TITLE
fix(ui): use Sentry namespace for browserTracingIntegration

### DIFF
--- a/ui/app/instrumentation.client.ts
+++ b/ui/app/instrumentation.client.ts
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * Client-side Sentry instrumentation
  *
@@ -12,8 +14,8 @@ import * as Sentry from "@sentry/nextjs";
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-// Only initialize Sentry if DSN is configured
-if (SENTRY_DSN) {
+// Only initialize Sentry in the browser (not during SSR)
+if (typeof window !== "undefined" && SENTRY_DSN) {
   const isDevelopment = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "local";
 
   /**
@@ -42,7 +44,7 @@ if (SENTRY_DSN) {
     tracesSampleRate: isDevelopment ? 1.0 : 0.5,
     profilesSampleRate: isDevelopment ? 1.0 : 0.5,
 
-    // 🔌 Integrations
+    // 🔌 Integrations - browserTracingIntegration is client-only
     integrations: [
       // 📊 Performance Monitoring: Core Web Vitals + RUM
       // Tracks LCP, FID, CLS, INP

--- a/ui/app/instrumentation.client.ts
+++ b/ui/app/instrumentation.client.ts
@@ -9,7 +9,6 @@
  */
 
 import * as Sentry from "@sentry/nextjs";
-import { browserTracingIntegration } from "@sentry/nextjs";
 
 const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
@@ -48,7 +47,7 @@ if (SENTRY_DSN) {
       // 📊 Performance Monitoring: Core Web Vitals + RUM
       // Tracks LCP, FID, CLS, INP
       // Real User Monitoring captures actual user experience, not synthetic tests
-      browserTracingIntegration({
+      Sentry.browserTracingIntegration({
         enableLongTask: true, // Detect tasks that block UI (>50ms)
         enableInp: true, // Interaction to Next Paint (Core Web Vital)
       }),


### PR DESCRIPTION
### Context

Fixes runtime error `TypeError: (0 , e.browserTracingIntegration) is not a function` occurring in production on the sign-in page.

<img width="3001" height="1617" alt="image" src="https://github.com/user-attachments/assets/cece9787-e531-4b61-9a74-ab4db39116c5" />


### Description

In Sentry v10+, `browserTracingIntegration` should be accessed from the Sentry namespace rather than as a named import. The bundler was not properly resolving the named export, causing the function to be undefined at runtime.

**Before:**
```typescript
import { browserTracingIntegration } from "@sentry/nextjs";
// ...
browserTracingIntegration({...})
```

**After:**
```typescript
import * as Sentry from "@sentry/nextjs";
// ...
Sentry.browserTracingIntegration({...})
```

### Steps to review

1. Review the change in `ui/app/instrumentation.client.ts`
2. Verify the build passes (pre-commit hook runs build)
3. Deploy to dev and confirm no more `browserTracingIntegration is not a function` errors in Sentry

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- N/A - No visual changes, instrumentation fix only
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- N/A - No API changes

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.