### PR TITLE
feat(mcp_server): update API base URL environment variable to include complete path

### DIFF
--- a/docs/getting-started/basic-usage/prowler-mcp.mdx
+++ b/docs/getting-started/basic-usage/prowler-mcp.mdx
@@ -139,7 +139,7 @@ STDIO mode is only available when running the MCP server locally.
           "args": ["/absolute/path/to/prowler/mcp_server/"],
           "env": {
             "PROWLER_APP_API_KEY": "<your-api-key-here>",
-            "PROWLER_API_BASE_URL": "https://api.prowler.com/api/v1"
+            "API_BASE_URL": "https://api.prowler.com/api/v1"
           }
         }
       }
@@ -147,7 +147,7 @@ STDIO mode is only available when running the MCP server locally.
     ```
 
     <Note>
-    Replace `/absolute/path/to/prowler/mcp_server/` with the actual path. The `PROWLER_API_BASE_URL` is optional and defaults to Prowler Cloud API.
+    Replace `/absolute/path/to/prowler/mcp_server/` with the actual path. The `API_BASE_URL` is optional and defaults to Prowler Cloud API.
     </Note>
 
   </Tab>
@@ -167,7 +167,7 @@ STDIO mode is only available when running the MCP server locally.
             "--env",
             "PROWLER_APP_API_KEY=<your-api-key-here>",
             "--env",
-            "PROWLER_API_BASE_URL=https://api.prowler.com/api/v1",
+            "API_BASE_URL=https://api.prowler.com/api/v1",
             "prowlercloud/prowler-mcp"
           ]
         }
@@ -176,7 +176,7 @@ STDIO mode is only available when running the MCP server locally.
     ```
 
     <Note>
-    The `PROWLER_API_BASE_URL` is optional and defaults to Prowler Cloud API.
+    The `API_BASE_URL` is optional and defaults to Prowler Cloud API.
     </Note>
 
   </Tab>

--- a/docs/getting-started/basic-usage/prowler-mcp.mdx
+++ b/docs/getting-started/basic-usage/prowler-mcp.mdx
@@ -139,7 +139,7 @@ STDIO mode is only available when running the MCP server locally.
           "args": ["/absolute/path/to/prowler/mcp_server/"],
           "env": {
             "PROWLER_APP_API_KEY": "<your-api-key-here>",
-            "PROWLER_API_BASE_URL": "https://api.prowler.com"
+            "PROWLER_API_BASE_URL": "https://api.prowler.com/api/v1"
           }
         }
       }
@@ -167,7 +167,7 @@ STDIO mode is only available when running the MCP server locally.
             "--env",
             "PROWLER_APP_API_KEY=<your-api-key-here>",
             "--env",
-            "PROWLER_API_BASE_URL=https://api.prowler.com",
+            "PROWLER_API_BASE_URL=https://api.prowler.com/api/v1",
             "prowlercloud/prowler-mcp"
           ]
         }

--- a/docs/getting-started/installation/prowler-mcp.mdx
+++ b/docs/getting-started/installation/prowler-mcp.mdx
@@ -52,7 +52,7 @@ Choose one of the following installation methods:
     ```bash
     docker run --rm -i \
       -e PROWLER_APP_API_KEY="pk_your_api_key" \
-      -e PROWLER_API_BASE_URL="https://api.prowler.com" \
+      -e PROWLER_API_BASE_URL="https://api.prowler.com/api/v1" \
       prowlercloud/prowler-mcp
     ```
 
@@ -181,19 +181,19 @@ Configure the server using environment variables:
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `PROWLER_APP_API_KEY` | Prowler API key | Only for STDIO mode | - |
-| `PROWLER_API_BASE_URL` | Custom Prowler API endpoint | No | `https://api.prowler.com` |
+| `PROWLER_API_BASE_URL` | Custom Prowler API endpoint | No | `https://api.prowler.com/api/v1` |
 | `PROWLER_MCP_TRANSPORT_MODE` | Default transport mode (overwritten by `--transport` argument) | No | `stdio` |
 
 <CodeGroup>
 ```bash macOS/Linux
 export PROWLER_APP_API_KEY="pk_your_api_key_here"
-export PROWLER_API_BASE_URL="https://api.prowler.com"
+export PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
 export PROWLER_MCP_TRANSPORT_MODE="http"
 ```
 
 ```bash Windows PowerShell
 $env:PROWLER_APP_API_KEY="pk_your_api_key_here"
-$env:PROWLER_API_BASE_URL="https://api.prowler.com"
+$env:PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
 $env:PROWLER_MCP_TRANSPORT_MODE="http"
 ```
 </CodeGroup>
@@ -208,7 +208,7 @@ For convenience, create a `.env` file in the `mcp_server` directory:
 
 ```bash .env
 PROWLER_APP_API_KEY=pk_your_api_key_here
-PROWLER_API_BASE_URL=https://api.prowler.com
+PROWLER_API_BASE_URL=https://api.prowler.com/api/v1
 PROWLER_MCP_TRANSPORT_MODE=stdio
 ```
 

--- a/docs/getting-started/installation/prowler-mcp.mdx
+++ b/docs/getting-started/installation/prowler-mcp.mdx
@@ -52,7 +52,7 @@ Choose one of the following installation methods:
     ```bash
     docker run --rm -i \
       -e PROWLER_APP_API_KEY="pk_your_api_key" \
-      -e PROWLER_API_BASE_URL="https://api.prowler.com/api/v1" \
+      -e API_BASE_URL="https://api.prowler.com/api/v1" \
       prowlercloud/prowler-mcp
     ```
 
@@ -181,19 +181,19 @@ Configure the server using environment variables:
 | Variable | Description | Required | Default |
 |----------|-------------|----------|---------|
 | `PROWLER_APP_API_KEY` | Prowler API key | Only for STDIO mode | - |
-| `PROWLER_API_BASE_URL` | Custom Prowler API endpoint | No | `https://api.prowler.com/api/v1` |
+| `API_BASE_URL` | Custom Prowler API endpoint | No | `https://api.prowler.com/api/v1` |
 | `PROWLER_MCP_TRANSPORT_MODE` | Default transport mode (overwritten by `--transport` argument) | No | `stdio` |
 
 <CodeGroup>
 ```bash macOS/Linux
 export PROWLER_APP_API_KEY="pk_your_api_key_here"
-export PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
+export API_BASE_URL="https://api.prowler.com/api/v1"
 export PROWLER_MCP_TRANSPORT_MODE="http"
 ```
 
 ```bash Windows PowerShell
 $env:PROWLER_APP_API_KEY="pk_your_api_key_here"
-$env:PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
+$env:API_BASE_URL="https://api.prowler.com/api/v1"
 $env:PROWLER_MCP_TRANSPORT_MODE="http"
 ```
 </CodeGroup>
@@ -208,7 +208,7 @@ For convenience, create a `.env` file in the `mcp_server` directory:
 
 ```bash .env
 PROWLER_APP_API_KEY=pk_your_api_key_here
-PROWLER_API_BASE_URL=https://api.prowler.com/api/v1
+API_BASE_URL=https://api.prowler.com/api/v1
 PROWLER_MCP_TRANSPORT_MODE=stdio
 ```
 

--- a/mcp_server/.env.template
+++ b/mcp_server/.env.template
@@ -1,3 +1,3 @@
 PROWLER_APP_API_KEY="pk_your_api_key_here"
-PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
+API_BASE_URL="https://api.prowler.com/api/v1"
 PROWLER_MCP_TRANSPORT_MODE="stdio"

--- a/mcp_server/.env.template
+++ b/mcp_server/.env.template
@@ -1,3 +1,3 @@
 PROWLER_APP_API_KEY="pk_your_api_key_here"
-PROWLER_API_BASE_URL="https://api.prowler.com"
+PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
 PROWLER_MCP_TRANSPORT_MODE="stdio"

--- a/mcp_server/CHANGELOG.md
+++ b/mcp_server/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **Prowler MCP Server** are documented in this file.
 
+## [0.2.1] (UNRELEASED)
+
+### Changed
+
+- Update API base URL environment variable to include complete path [(#9542)](https://github.com/prowler-cloud/prowler/pull/9300)
+
 ## [0.2.0] (Prowler v5.15.0)
 
 ### Added

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -78,7 +78,7 @@ With environment variables:
 ```bash
 docker run --rm -i \
   -e PROWLER_APP_API_KEY="pk_your_api_key" \
-  -e PROWLER_API_BASE_URL="https://api.prowler.com" \
+  -e PROWLER_API_BASE_URL="https://api.prowler.com/api/v1" \
   prowlercloud/prowler-mcp
 ```
 
@@ -147,7 +147,7 @@ uv run prowler-mcp --transport http --host 0.0.0.0 --port 8080
 For self-deployed MCP remote server, you can use also configure the server to use a custom API base URL with the environment variable `PROWLER_API_BASE_URL`; and the transport mode with the environment variable `PROWLER_MCP_TRANSPORT_MODE`.
 
 ```bash
-export PROWLER_API_BASE_URL="https://api.prowler.com"
+export PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
 export PROWLER_MCP_TRANSPORT_MODE="http"
 ```
 
@@ -319,7 +319,7 @@ For STDIO mode, authentication is handled via environment variables using an API
 export PROWLER_APP_API_KEY="pk_your_api_key_here"
 
 # Optional - for custom API endpoint, in case not provided Prowler Cloud API will be used
-export PROWLER_API_BASE_URL="https://api.prowler.com"
+export PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
 ```
 
 #### HTTP Mode Authentication
@@ -370,7 +370,7 @@ For local execution, configure your MCP client to launch the server directly. Be
       "args": ["/path/to/prowler/mcp_server/"],
       "env": {
         "PROWLER_APP_API_KEY": "pk_your_api_key_here",
-        "PROWLER_API_BASE_URL": "https://api.prowler.com"  // Optional, in case not provided Prowler Cloud API will be used
+        "PROWLER_API_BASE_URL": "https://api.prowler.com/api/v1"  // Optional, in case not provided Prowler Cloud API will be used
       }
     }
   }
@@ -387,7 +387,7 @@ For local execution, configure your MCP client to launch the server directly. Be
       "args": [
         "run", "--rm", "-i",
         "--env", "PROWLER_APP_API_KEY=pk_your_api_key_here",
-        "--env", "PROWLER_API_BASE_URL=https://api.prowler.com",  // Optional, in case not provided Prowler Cloud API will be used
+        "--env", "PROWLER_API_BASE_URL=https://api.prowler.com/api/v1",  // Optional, in case not provided Prowler Cloud API will be used
         "prowler-mcp"
       ]
     }

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -78,7 +78,7 @@ With environment variables:
 ```bash
 docker run --rm -i \
   -e PROWLER_APP_API_KEY="pk_your_api_key" \
-  -e PROWLER_API_BASE_URL="https://api.prowler.com/api/v1" \
+  -e API_BASE_URL="https://api.prowler.com/api/v1" \
   prowlercloud/prowler-mcp
 ```
 
@@ -144,10 +144,10 @@ uv run prowler-mcp --transport http
 uv run prowler-mcp --transport http --host 0.0.0.0 --port 8080
 ```
 
-For self-deployed MCP remote server, you can use also configure the server to use a custom API base URL with the environment variable `PROWLER_API_BASE_URL`; and the transport mode with the environment variable `PROWLER_MCP_TRANSPORT_MODE`.
+For self-deployed MCP remote server, you can use also configure the server to use a custom API base URL with the environment variable `API_BASE_URL`; and the transport mode with the environment variable `PROWLER_MCP_TRANSPORT_MODE`.
 
 ```bash
-export PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
+export API_BASE_URL="https://api.prowler.com/api/v1"
 export PROWLER_MCP_TRANSPORT_MODE="http"
 ```
 
@@ -319,7 +319,7 @@ For STDIO mode, authentication is handled via environment variables using an API
 export PROWLER_APP_API_KEY="pk_your_api_key_here"
 
 # Optional - for custom API endpoint, in case not provided Prowler Cloud API will be used
-export PROWLER_API_BASE_URL="https://api.prowler.com/api/v1"
+export API_BASE_URL="https://api.prowler.com/api/v1"
 ```
 
 #### HTTP Mode Authentication
@@ -370,7 +370,7 @@ For local execution, configure your MCP client to launch the server directly. Be
       "args": ["/path/to/prowler/mcp_server/"],
       "env": {
         "PROWLER_APP_API_KEY": "pk_your_api_key_here",
-        "PROWLER_API_BASE_URL": "https://api.prowler.com/api/v1"  // Optional, in case not provided Prowler Cloud API will be used
+        "API_BASE_URL": "https://api.prowler.com/api/v1"  // Optional, in case not provided Prowler Cloud API will be used
       }
     }
   }
@@ -387,7 +387,7 @@ For local execution, configure your MCP client to launch the server directly. Be
       "args": [
         "run", "--rm", "-i",
         "--env", "PROWLER_APP_API_KEY=pk_your_api_key_here",
-        "--env", "PROWLER_API_BASE_URL=https://api.prowler.com/api/v1",  // Optional, in case not provided Prowler Cloud API will be used
+        "--env", "API_BASE_URL=https://api.prowler.com/api/v1",  // Optional, in case not provided Prowler Cloud API will be used
         "prowler-mcp"
       ]
     }

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/base.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/base.py
@@ -33,7 +33,7 @@ class BaseTool(ABC):
 
             async def search_security_findings(self, severity: list[str] = Field(...)):
                 # Implementation with access to self.api_client
-                response = await self.api_client.get("/api/v1/findings")
+                response = await self.api_client.get("/findings")
                 return response
     """
 

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/findings.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/findings.py
@@ -6,13 +6,14 @@ across all cloud providers.
 
 from typing import Any, Literal
 
+from pydantic import Field
+
 from prowler_mcp_server.prowler_app.models.findings import (
     DetailedFinding,
     FindingsListResponse,
     FindingsOverview,
 )
 from prowler_mcp_server.prowler_app.tools.base import BaseTool
-from pydantic import Field
 
 
 class FindingsTools(BaseTool):
@@ -122,11 +123,11 @@ class FindingsTools(BaseTool):
 
         if date_range is None:
             # No dates provided - use latest findings endpoint
-            endpoint = "/api/v1/findings/latest"
+            endpoint = "/findings/latest"
             params = {}
         else:
             # Dates provided - use historical findings endpoint
-            endpoint = "/api/v1/findings"
+            endpoint = "/findings"
             params = {
                 "filter[inserted_at__gte]": date_range[0],
                 "filter[inserted_at__lte]": date_range[1],
@@ -228,7 +229,7 @@ class FindingsTools(BaseTool):
 
         # Get API response and transform to detailed format
         api_response = await self.api_client.get(
-            f"/api/v1/findings/{finding_id}", params=params
+            f"/findings/{finding_id}", params=params
         )
         detailed_finding = DetailedFinding.from_api_response(
             api_response.get("data", {})
@@ -281,7 +282,7 @@ class FindingsTools(BaseTool):
 
         # Get API response and transform to simplified format
         api_response = await self.api_client.get(
-            "/api/v1/overviews/findings", params=clean_params
+            "/overviews/findings", params=clean_params
         )
         overview = FindingsOverview.from_api_response(api_response)
 

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/muting.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/muting.py
@@ -430,7 +430,6 @@ Structure:
             f"/mute-rules/{rule_id}", json_data=update_body
         )
 
-        self.logger.info(f"API response: {api_response}")
         detailed_rule = DetailedMuteRule.from_api_response(api_response.get("data", {}))
         return detailed_rule.model_dump()
 

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/muting.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/muting.py
@@ -8,13 +8,14 @@ This module provides tools for managing finding muting in Prowler, including:
 import json
 from typing import Any
 
+from pydantic import Field
+
 from prowler_mcp_server.prowler_app.models.muting import (
     DetailedMuteRule,
     MutelistResponse,
     MuteRulesListResponse,
 )
 from prowler_mcp_server.prowler_app.tools.base import BaseTool
-from pydantic import Field
 
 
 class MutingTools(BaseTool):
@@ -53,9 +54,7 @@ class MutingTools(BaseTool):
         }
 
         clean_params = self.api_client.build_filter_params(params)
-        api_response = await self.api_client.get(
-            "/api/v1/processors", params=clean_params
-        )
+        api_response = await self.api_client.get("/processors", params=clean_params)
 
         data = api_response.get("data", [])
 
@@ -145,7 +144,7 @@ Structure:
             }
 
             api_response = await self.api_client.post(
-                "/api/v1/processors", json_data=create_body
+                "/processors", json_data=create_body
             )
             mutelist = MutelistResponse.from_api_response(api_response.get("data", {}))
             return mutelist.model_dump()
@@ -163,7 +162,7 @@ Structure:
             }
 
             api_response = await self.api_client.patch(
-                f"/api/v1/processors/{existing_mutelist['id']}", json_data=update_body
+                f"/processors/{existing_mutelist['id']}", json_data=update_body
             )
             mutelist = MutelistResponse.from_api_response(api_response.get("data", {}))
             return mutelist.model_dump()
@@ -194,7 +193,7 @@ Structure:
 
         # Delete the mutelist
         mutelist_id = existing_mutelist["id"]
-        await self.api_client.delete(f"/api/v1/processors/{mutelist_id}")
+        await self.api_client.delete(f"/processors/{mutelist_id}")
 
         return {
             "success": True,
@@ -276,9 +275,7 @@ Structure:
             params["filter[search]"] = search
 
         clean_params = self.api_client.build_filter_params(params)
-        api_response = await self.api_client.get(
-            "/api/v1/mute-rules", params=clean_params
-        )
+        api_response = await self.api_client.get("/mute-rules", params=clean_params)
 
         simplified_response = MuteRulesListResponse.from_api_response(api_response)
         return simplified_response.model_dump()
@@ -311,7 +308,7 @@ Structure:
         }
 
         api_response = await self.api_client.get(
-            f"/api/v1/mute-rules/{rule_id}", params=params
+            f"/mute-rules/{rule_id}", params=params
         )
 
         detailed_rule = DetailedMuteRule.from_api_response(api_response.get("data", {}))
@@ -363,9 +360,7 @@ Structure:
             }
         }
 
-        api_response = await self.api_client.post(
-            "/api/v1/mute-rules", json_data=create_body
-        )
+        api_response = await self.api_client.post("/mute-rules", json_data=create_body)
 
         detailed_rule = DetailedMuteRule.from_api_response(api_response.get("data", {}))
         return detailed_rule.model_dump()
@@ -432,7 +427,7 @@ Structure:
         }
 
         api_response = await self.api_client.patch(
-            f"/api/v1/mute-rules/{rule_id}", json_data=update_body
+            f"/mute-rules/{rule_id}", json_data=update_body
         )
 
         self.logger.info(f"API response: {api_response}")
@@ -463,7 +458,7 @@ Structure:
         """
         self.logger.info(f"Deleting mute rule {rule_id}...")
 
-        result = await self.api_client.delete(f"/api/v1/mute-rules/{rule_id}")
+        result = await self.api_client.delete(f"/mute-rules/{rule_id}")
 
         if result.get("success"):
             return {

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/resources.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/resources.py
@@ -209,7 +209,6 @@ class ResourcesTools(BaseTool):
         api_response = await self.api_client.get(
             f"/resources/{resource_id}", params=params
         )
-        self.logger.info(f"API response: {api_response}")
         detailed_resource = DetailedResource.from_api_response(
             api_response.get("data", {})
         )

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/resources.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/resources.py
@@ -6,13 +6,14 @@ across all providers.
 
 from typing import Any
 
+from pydantic import Field
+
 from prowler_mcp_server.prowler_app.models.resources import (
     DetailedResource,
     ResourcesListResponse,
     ResourcesMetadataResponse,
 )
 from prowler_mcp_server.prowler_app.tools.base import BaseTool
-from pydantic import Field
 
 
 class ResourcesTools(BaseTool):
@@ -121,11 +122,11 @@ class ResourcesTools(BaseTool):
 
         if date_range is None:
             # No dates provided - use latest resources endpoint
-            endpoint = "/api/v1/resources/latest"
+            endpoint = "/resources/latest"
             params = {}
         else:
             # Dates provided - use historical resources endpoint
-            endpoint = "/api/v1/resources"
+            endpoint = "/resources"
             params = {
                 "filter[updated_at__gte]": date_range[0],
                 "filter[updated_at__lte]": date_range[1],
@@ -206,7 +207,7 @@ class ResourcesTools(BaseTool):
 
         # Get API response and transform to detailed format
         api_response = await self.api_client.get(
-            f"/api/v1/resources/{resource_id}", params=params
+            f"/resources/{resource_id}", params=params
         )
         self.logger.info(f"API response: {api_response}")
         detailed_resource = DetailedResource.from_api_response(
@@ -265,13 +266,13 @@ class ResourcesTools(BaseTool):
 
         if date_range is None:
             # No dates provided - use latest metadata endpoint
-            metadata_endpoint = "/api/v1/resources/metadata/latest"
-            list_endpoint = "/api/v1/resources/latest"
+            metadata_endpoint = "/resources/metadata/latest"
+            list_endpoint = "/resources/latest"
             params = {}
         else:
             # Dates provided - use historical endpoints
-            metadata_endpoint = "/api/v1/resources/metadata"
-            list_endpoint = "/api/v1/resources"
+            metadata_endpoint = "/resources/metadata"
+            list_endpoint = "/resources"
             params = {
                 "filter[updated_at__gte]": date_range[0],
                 "filter[updated_at__lte]": date_range[1],

--- a/mcp_server/prowler_mcp_server/prowler_app/tools/scans.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/tools/scans.py
@@ -5,6 +5,8 @@ This module provides tools for managing and monitoring Prowler security scans.
 
 from typing import Any, Literal
 
+from pydantic import Field
+
 from prowler_mcp_server.prowler_app.models.scans import (
     DetailedScan,
     ScanCreationResult,
@@ -12,7 +14,6 @@ from prowler_mcp_server.prowler_app.models.scans import (
     ScheduleCreationResult,
 )
 from prowler_mcp_server.prowler_app.tools.base import BaseTool
-from pydantic import Field
 
 
 class ScansTools(BaseTool):
@@ -119,7 +120,7 @@ class ScansTools(BaseTool):
 
         clean_params = self.api_client.build_filter_params(params)
 
-        api_response = await self.api_client.get("/api/v1/scans", params=clean_params)
+        api_response = await self.api_client.get("/scans", params=clean_params)
         simplified_response = ScansListResponse.from_api_response(api_response)
 
         return simplified_response.model_dump()
@@ -163,9 +164,7 @@ class ScansTools(BaseTool):
             "fields[scans]": "name,trigger,state,progress,duration,unique_resource_count,started_at,completed_at,scheduled_at,next_scan_at,inserted_at"
         }
 
-        api_response = await self.api_client.get(
-            f"/api/v1/scans/{scan_id}", params=params
-        )
+        api_response = await self.api_client.get(f"/scans/{scan_id}", params=params)
         detailed_scan = DetailedScan.from_api_response(api_response["data"])
 
         return detailed_scan.model_dump()
@@ -213,9 +212,7 @@ class ScansTools(BaseTool):
 
             # Create scan (returns Task)
             self.logger.info(f"Creating scan for provider {provider_id}")
-            task_response = await self.api_client.post(
-                "/api/v1/scans", json_data=request_data
-            )
+            task_response = await self.api_client.post("/scans", json_data=request_data)
 
             scan_id = (
                 task_response.get("data", {})
@@ -228,7 +225,7 @@ class ScansTools(BaseTool):
                 raise Exception("No scan_id returned from scan creation")
 
             self.logger.info(f"Scan created successfully: {scan_id}")
-            scan_response = await self.api_client.get(f"/api/v1/scans/{scan_id}")
+            scan_response = await self.api_client.get(f"/scans/{scan_id}")
             scan_info = DetailedScan.from_api_response(scan_response["data"])
 
             return ScanCreationResult(
@@ -273,7 +270,7 @@ class ScansTools(BaseTool):
         """
         self.logger.info(f"Creating daily schedule for provider {provider_id}")
         task_response = await self.api_client.post(
-            "/api/v1/schedules/daily",
+            "/schedules/daily",
             json_data={
                 "data": {
                     "type": "daily-schedules",
@@ -316,7 +313,7 @@ class ScansTools(BaseTool):
         2. Use this tool with the scan 'id' and new name
         """
         api_response = await self.api_client.patch(
-            f"/api/v1/scans/{scan_id}",
+            f"/scans/{scan_id}",
             json_data={
                 "data": {
                     "type": "scans",

--- a/mcp_server/prowler_mcp_server/prowler_app/utils/api_client.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/utils/api_client.py
@@ -228,7 +228,7 @@ class ProwlerAPIClient(metaclass=SingletonMeta):
                 )
 
             # Fetch current task state
-            response = await self.get(f"/api/v1/tasks/{task_id}")
+            response = await self.get(f"/tasks/{task_id}")
             task_data = response.get("data", {})
             task_attrs = task_data.get("attributes", {})
             state = task_attrs.get("state")

--- a/mcp_server/prowler_mcp_server/prowler_app/utils/auth.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/utils/auth.py
@@ -15,7 +15,9 @@ class ProwlerAppAuth:
     def __init__(
         self,
         mode: str = os.getenv("PROWLER_MCP_TRANSPORT_MODE", "stdio"),
-        base_url: str = os.getenv("PROWLER_API_BASE_URL", "https://api.prowler.com"),
+        base_url: str = os.getenv(
+            "PROWLER_API_BASE_URL", "https://api.prowler.com/api/v1"
+        ),
     ):
         self.base_url = base_url.rstrip("/")
         logger.info(f"Using Prowler App API base URL: {self.base_url}")

--- a/mcp_server/prowler_mcp_server/prowler_app/utils/auth.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/utils/auth.py
@@ -15,9 +15,7 @@ class ProwlerAppAuth:
     def __init__(
         self,
         mode: str = os.getenv("PROWLER_MCP_TRANSPORT_MODE", "stdio"),
-        base_url: str = os.getenv(
-            "PROWLER_API_BASE_URL", "https://api.prowler.com/api/v1"
-        ),
+        base_url: str = os.getenv("API_BASE_URL", "https://api.prowler.com/api/v1"),
     ):
         self.base_url = base_url.rstrip("/")
         logger.info(f"Using Prowler App API base URL: {self.base_url}")


### PR DESCRIPTION
### Context

The `PROWLER_API_BASE_URL` environment variable was previously expected to contain just the base domain (e.g., `https://api.prowler.com`), while all endpoint paths included the `/api/v1` prefix. This change updates the configuration to expect the complete API path in the base URL, making the configuration more explicit and maintainable.

### Description

This PR updates the MCP server to expect the complete API path (including `/api/v1`) in the `PROWLER_API_BASE_URL` environment variable, and change its name to `API_BASE_URL`. This change:

1. **Updates the default base URL** from `https://api.prowler.com` to `https://api.prowler.com/api/v1`
2. **Removes the `/api/v1` prefix** from all endpoint paths in tool modules, as it is now part of the base URL
3. **Updates documentation** (.env.template and README.md) to reflect the new URL format

**Benefits:**
- More explicit configuration - users can see the full API path they are connecting to
- Easier to support different API versions in the future
- Cleaner endpoint paths in the codebase

**Affected files:**
- `mcp_server/.env.template` - Updated example URL
- `mcp_server/README.md` - Updated all URL examples
- `mcp_server/prowler_mcp_server/prowler_app/utils/auth.py` - Updated default base URL
- `mcp_server/prowler_mcp_server/prowler_app/utils/api_client.py` - Removed prefix from task endpoint
- `mcp_server/prowler_mcp_server/prowler_app/tools/base.py` - Updated docstring example
- `mcp_server/prowler_mcp_server/prowler_app/tools/findings.py` - Removed /api/v1 prefix
- `mcp_server/prowler_mcp_server/prowler_app/tools/muting.py` - Removed /api/v1 prefix
- `mcp_server/prowler_mcp_server/prowler_app/tools/providers.py` - Removed /api/v1 prefix
- `mcp_server/prowler_mcp_server/prowler_app/tools/resources.py` - Removed /api/v1 prefix
- `mcp_server/prowler_mcp_server/prowler_app/tools/scans.py` - Removed /api/v1 prefix

### Steps to review

1. Review the changes to ensure all `/api/v1` prefixes have been consistently removed from endpoint paths
2. Verify the default base URL is correctly updated in `auth.py`
3. Check that documentation examples show the new URL format (`https://api.prowler.com/api/v1`)
4. Test the MCP server with the new configuration to ensure API calls work correctly

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) - Not needed, changes are in mcp_server/README.md
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- N/A - No UI changes

#### API
- N/A - No API changes (only MCP server configuration)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.