### PR TITLE
chore(github): use QEMU to build ARM images if repository is not prowler

### DIFF
--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -43,7 +43,7 @@ jobs:
           ignore: DL3013
 
   api-container-build-and-scan:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.arch == 'arm64' && github.repository == 'prowler-cloud/prowler' && 'ubuntu-24.04-arm' || matrix.runner }}
     strategy:
       matrix:
         include:
@@ -51,7 +51,7 @@ jobs:
             runner: ubuntu-latest
             arch: amd64
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest
             arch: arm64
     timeout-minutes: 30
     permissions:
@@ -72,6 +72,12 @@ jobs:
             api/docs/**
             api/README.md
             api/CHANGELOG.md
+
+      - name: Set up QEMU
+        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -2,13 +2,13 @@ name: 'API: Container Checks'
 
 on:
   push:
-    branches:
-      - 'master'
-      - 'v5.*'
-  pull_request:
-    branches:
-      - 'master'
-      - 'v5.*'
+  #   branches:
+  #     - 'master'
+  #     - 'v5.*'
+  # pull_request:
+  #   branches:
+  #     - 'master'
+  #     - 'v5.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -2,13 +2,13 @@ name: 'API: Container Checks'
 
 on:
   push:
-  #   branches:
-  #     - 'master'
-  #     - 'v5.*'
-  # pull_request:
-  #   branches:
-  #     - 'master'
-  #     - 'v5.*'
+    branches:
+      - 'master'
+      - 'v5.*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'v5.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -74,15 +74,17 @@ jobs:
             api/CHANGELOG.md
 
       - name: Set up QEMU
-        if: matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build container for ${{ matrix.arch }}
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.API_WORKING_DIR }}
@@ -94,7 +96,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler'
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -74,17 +74,15 @@ jobs:
             api/CHANGELOG.md
 
       - name: Set up QEMU
-        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        if: matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build container for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.API_WORKING_DIR }}
@@ -96,7 +94,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
+        if: github.repository == 'prowler-cloud/prowler'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -72,17 +72,15 @@ jobs:
             mcp_server/CHANGELOG.md
 
       - name: Set up QEMU
-        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        if: matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build MCP container for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.MCP_WORKING_DIR }}
@@ -94,7 +92,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan MCP container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
+        if: github.repository == 'prowler-cloud/prowler'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -42,7 +42,7 @@ jobs:
           dockerfile: mcp_server/Dockerfile
 
   mcp-container-build-and-scan:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.arch == 'arm64' && github.repository == 'prowler-cloud/prowler' && 'ubuntu-24.04-arm' || matrix.runner }}
     strategy:
       matrix:
         include:
@@ -50,7 +50,7 @@ jobs:
             runner: ubuntu-latest
             arch: amd64
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest
             arch: arm64
     timeout-minutes: 30
     permissions:
@@ -70,6 +70,12 @@ jobs:
           files_ignore: |
             mcp_server/README.md
             mcp_server/CHANGELOG.md
+
+      - name: Set up QEMU
+        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -2,13 +2,13 @@ name: 'MCP: Container Checks'
 
 on:
   push:
-    branches:
-      - 'master'
-      - 'v5.*'
-  pull_request:
-    branches:
-      - 'master'
-      - 'v5.*'
+  #   branches:
+  #     - 'master'
+  #     - 'v5.*'
+  # pull_request:
+  #   branches:
+  #     - 'master'
+  #     - 'v5.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -2,13 +2,13 @@ name: 'MCP: Container Checks'
 
 on:
   push:
-  #   branches:
-  #     - 'master'
-  #     - 'v5.*'
-  # pull_request:
-  #   branches:
-  #     - 'master'
-  #     - 'v5.*'
+    branches:
+      - 'master'
+      - 'v5.*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'v5.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,15 +72,17 @@ jobs:
             mcp_server/CHANGELOG.md
 
       - name: Set up QEMU
-        if: matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build MCP container for ${{ matrix.arch }}
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.MCP_WORKING_DIR }}
@@ -92,7 +94,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
 
       - name: Scan MCP container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler'
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -43,7 +43,7 @@ jobs:
           ignore: DL3018
 
   ui-container-build-and-scan:
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.arch == 'arm64' && github.repository == 'prowler-cloud/prowler' && 'ubuntu-24.04-arm' || matrix.runner }}
     strategy:
       matrix:
         include:
@@ -51,7 +51,7 @@ jobs:
             runner: ubuntu-latest
             arch: amd64
           - platform: linux/arm64
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-latest
             arch: arm64
     timeout-minutes: 30
     permissions:
@@ -71,6 +71,12 @@ jobs:
           files_ignore: |
             ui/CHANGELOG.md
             ui/README.md
+
+      - name: Set up QEMU
+        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -2,13 +2,13 @@ name: 'UI: Container Checks'
 
 on:
   push:
-  #   branches:
-  #     - 'master'
-  #     - 'v5.*'
-  # pull_request:
-  #   branches:
-  #     - 'master'
-  #     - 'v5.*'
+    branches:
+      - 'master'
+      - 'v5.*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'v5.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -73,15 +73,17 @@ jobs:
             ui/README.md
 
       - name: Set up QEMU
-        if: matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build UI container for ${{ matrix.arch }}
+        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.UI_WORKING_DIR }}
@@ -96,7 +98,7 @@ jobs:
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LwpXXXX
 
       - name: Scan UI container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler'
+        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -73,7 +73,7 @@ jobs:
             ui/README.md
 
       - name: Set up QEMU
-        if: && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        if: matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -2,13 +2,13 @@ name: 'UI: Container Checks'
 
 on:
   push:
-    branches:
-      - 'master'
-      - 'v5.*'
-  pull_request:
-    branches:
-      - 'master'
-      - 'v5.*'
+  #   branches:
+  #     - 'master'
+  #     - 'v5.*'
+  # pull_request:
+  #   branches:
+  #     - 'master'
+  #     - 'v5.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -73,17 +73,15 @@ jobs:
             ui/README.md
 
       - name: Set up QEMU
-        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
+        if: && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Build UI container for ${{ matrix.arch }}
-        if: steps.check-changes.outputs.any_changed == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.UI_WORKING_DIR }}
@@ -98,7 +96,7 @@ jobs:
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LwpXXXX
 
       - name: Scan UI container with Trivy for ${{ matrix.arch }}
-        if: github.repository == 'prowler-cloud/prowler' && steps.check-changes.outputs.any_changed == 'true'
+        if: github.repository == 'prowler-cloud/prowler'
         uses: ./.github/actions/trivy-scan
         with:
           image-name: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
### Context

In private repositories ARM runners are not available, we need a workaround for it.

### Description

- Use QEMU to emulate ARM environment, only use it when repository is not `prowler`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
