### PR TITLE
feat(iac): set only misconfig and secret as default scanners

### DIFF
--- a/docs/user-guide/providers/iac/getting-started-iac.mdx
+++ b/docs/user-guide/providers/iac/getting-started-iac.mdx
@@ -5,18 +5,26 @@ import { VersionBadge } from "/snippets/version-badge.mdx"
 
 Prowler's Infrastructure as Code (IaC) provider enables scanning of local or remote infrastructure code for security and compliance issues using [Trivy](https://trivy.dev/). This provider supports a wide range of IaC frameworks, allowing assessment of code before deployment.
 
-## Supported Scanners
+## Supported IaC Formats
 
-The IaC provider leverages [Trivy](https://trivy.dev/latest/docs/scanner/vulnerability/) to support multiple scanners, including:
+Prowler IaC provider scans the following Infrastructure as Code configurations for misconfigurations and secrets:
 
-- Vulnerability
-- Misconfiguration
-- Secret
-- License
+| Configuration Type | File Patterns                                |
+|--------------------|----------------------------------------------|
+| Kubernetes         | `*.yml`, `*.yaml`, `*.json`                  |
+| Docker             | `Dockerfile`, `Containerfile`                |
+| Terraform          | `*.tf`, `*.tf.json`, `*.tfvars`              |
+| Terraform Plan     | `tfplan`, `*.tfplan`, `*.json`               |
+| CloudFormation     | `*.yml`, `*.yaml`, `*.json`                  |
+| Azure ARM Template | `*.json`                                     |
+| Helm               | `*.yml`, `*.yaml`, `*.tpl`, `*.tar.gz`, etc. |
+| YAML               | `*.yaml`, `*.yml`                            |
+| JSON               | `*.json`                                     |
+| Ansible            | `*.yml`, `*.yaml`, `*.json`, `*.ini`, without extension |
 
 ## How It Works
 
-- The IaC provider scans local directories (or specified paths) for supported IaC files, or scans remote repositories.
+- Prowler App leverages [Trivy](https://trivy.dev/docs/latest/guide/coverage/iac/#scanner) to scan local directories (or specified paths) for supported IaC files, or scans remote repositories.
 - No cloud credentials or authentication are required for local scans.
 - For remote repository scans, authentication can be provided via [git URL](https://git-scm.com/docs/git-clone#_git_urls), CLI flags or environment variables.
   - Check the [IaC Authentication](/user-guide/providers/iac/authentication) page for more details.
@@ -26,6 +34,10 @@ The IaC provider leverages [Trivy](https://trivy.dev/latest/docs/scanner/vulnera
 ## Prowler App
 
 <VersionBadge version="5.14.0" />
+
+### Supported Scanners
+
+Scanner selection is not configurable in Prowler App. Default scanners, misconfig and secret, run automatically during each scan.
 
 ### Step 1: Access Prowler Cloud/App
 
@@ -62,6 +74,17 @@ The IaC provider leverages [Trivy](https://trivy.dev/latest/docs/scanner/vulnera
 ## Prowler CLI
 
 <VersionBadge version="5.8.0" />
+
+### Supported Scanners
+
+Prowler CLI supports the following scanners:
+
+- [Vulnerability](https://trivy.dev/docs/latest/guide/scanner/vulnerability/)
+- [Misconfiguration](https://trivy.dev/docs/latest/guide/scanner/misconfiguration/)
+- [Secret](https://trivy.dev/docs/latest/guide/scanner/secret/)
+- [License](https://trivy.dev/docs/latest/guide/scanner/license/)
+
+By default, only misconfiguration and secret scanners run during a scan. To specify which scanners to use, refer to the [Specify Scanners](#specify-scanners) section below.
 
 ### Usage
 
@@ -103,7 +126,7 @@ Authentication for private repositories can be provided using one of the followi
 
 #### Specify Scanners
 
-Scan only vulnerability and misconfiguration scanners:
+To run only specific scanners, use the `--scanners` flag. For example, to scan only for vulnerabilities and misconfigurations:
 
 ```sh
 prowler iac --scan-path ./my-iac-directory --scanners vuln misconfig

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Added
 
 - `privilege-escalation` and `ec2-imdsv1` categories for AWS checks [(#9536)](https://github.com/prowler-cloud/prowler/pull/9536)
+- Supported IaC formats and scanner documentation for the IaC provider [(#9553)](https://github.com/prowler-cloud/prowler/pull/9553)
 
 ## [5.15.1] (Prowler UNRELEASED)
 

--- a/prowler/providers/iac/lib/arguments/arguments.py
+++ b/prowler/providers/iac/lib/arguments/arguments.py
@@ -35,9 +35,9 @@ def init_parser(self):
         "--scanner",
         dest="scanners",
         nargs="+",
-        default=["vuln", "misconfig", "secret"],
+        default=["misconfig", "secret"],
         choices=SCANNERS_CHOICES,
-        help="Comma-separated list of scanners to scan. Default: vuln, misconfig, secret",
+        help="Comma-separated list of scanners to scan. Default: misconfig, secret",
     )
     iac_scan_subparser.add_argument(
         "--exclude-path",


### PR DESCRIPTION
### Description
- Update default scanner to IaC-only related scanners (misconfig and secret).
- Clarify docs to explain support scanners in both Cloud/App and CLI and supported IaC file formats.

### Steps to review
- Review generated docs.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
