### PR TITLE
chore(github): check containers workflow only for prowler

### DIFF
--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -43,7 +43,8 @@ jobs:
           ignore: DL3013
 
   api-container-build-and-scan:
-    runs-on: ${{ matrix.arch == 'arm64' && github.repository == 'prowler-cloud/prowler' && 'ubuntu-24.04-arm' || matrix.runner }}
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
@@ -51,7 +52,7 @@ jobs:
             runner: ubuntu-latest
             arch: amd64
           - platform: linux/arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
             arch: arm64
     timeout-minutes: 30
     permissions:
@@ -72,12 +73,6 @@ jobs:
             api/docs/**
             api/README.md
             api/CHANGELOG.md
-
-      - name: Set up QEMU
-        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -42,7 +42,8 @@ jobs:
           dockerfile: mcp_server/Dockerfile
 
   mcp-container-build-and-scan:
-    runs-on: ${{ matrix.arch == 'arm64' && github.repository == 'prowler-cloud/prowler' && 'ubuntu-24.04-arm' || matrix.runner }}
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
@@ -50,7 +51,7 @@ jobs:
             runner: ubuntu-latest
             arch: amd64
           - platform: linux/arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
             arch: arm64
     timeout-minutes: 30
     permissions:
@@ -70,12 +71,6 @@ jobs:
           files_ignore: |
             mcp_server/README.md
             mcp_server/CHANGELOG.md
-
-      - name: Set up QEMU
-        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -43,7 +43,8 @@ jobs:
           ignore: DL3018
 
   ui-container-build-and-scan:
-    runs-on: ${{ matrix.arch == 'arm64' && github.repository == 'prowler-cloud/prowler' && 'ubuntu-24.04-arm' || matrix.runner }}
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         include:
@@ -51,7 +52,7 @@ jobs:
             runner: ubuntu-latest
             arch: amd64
           - platform: linux/arm64
-            runner: ubuntu-latest
+            runner: ubuntu-24.04-arm
             arch: arm64
     timeout-minutes: 30
     permissions:
@@ -71,12 +72,6 @@ jobs:
           files_ignore: |
             ui/CHANGELOG.md
             ui/README.md
-
-      - name: Set up QEMU
-        if: steps.check-changes.outputs.any_changed == 'true' && matrix.arch == 'arm64' && github.repository != 'prowler-cloud/prowler'
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         if: steps.check-changes.outputs.any_changed == 'true'


### PR DESCRIPTION
### Context

QEMU is not working good for ARM, we will use these workflows only for `prowler` repository.

### Description

Only check containers if repository is `prowler`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
