### PR TITLE
fix(beat): Increase scheduled scans countdown to 5 seconds

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ---
 
+## [1.16.2] (Prowler v5.15.2)
+
+### Changed
+- Increased execution delay for the first scheduled scan tasks to 5 seconds[(#9558)](https://github.com/prowler-cloud/prowler/pull/9558)
+
+---
+
 ## [1.16.1] (Prowler v5.15.1)
 
 ### Fixed

--- a/api/src/backend/tasks/beat.py
+++ b/api/src/backend/tasks/beat.py
@@ -61,5 +61,5 @@ def schedule_provider_scan(provider_instance: Provider):
             "tenant_id": str(provider_instance.tenant_id),
             "provider_id": provider_id,
         },
-        countdown=1,  # Avoid race conditions between the worker and the database
+        countdown=5,  # Avoid race conditions between the worker and the database
     )

--- a/api/src/backend/tasks/tests/test_beat.py
+++ b/api/src/backend/tasks/tests/test_beat.py
@@ -28,7 +28,7 @@ class TestScheduleProviderScan:
                     "tenant_id": str(provider_instance.tenant_id),
                     "provider_id": str(provider_instance.id),
                 },
-                countdown=1,
+                countdown=5,
             )
 
             task_name = f"scan-perform-scheduled-{provider_instance.id}"


### PR DESCRIPTION
### Context

There are still race conditions regarding already deployed workers and newly added providers via UI (triggers `POST /schedules/daily`)

### Description

We are increasing the `countdown` to 5 seconds since we've observed delays of at least 2-3 seconds.

### Steps to review

The very first scheduled scan task after requesting to `POST /schedules/daily` will be delayed 5 seconds.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
