### PR TITLE
fix(gcp): store Cloud Storage bucket regions as lowercase

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 - Fix typo `trustboundaries` category to `trust-boundaries` [(#9536)](https://github.com/prowler-cloud/prowler/pull/9536)
 - Store MongoDB Atlas provider regions as lowercase [(#9554)](https://github.com/prowler-cloud/prowler/pull/9554)
+- Store GCP Cloud Storage bucket regions as lowercase [(#9567)](https://github.com/prowler-cloud/prowler/pull/9567)
 
 ---
 

--- a/prowler/providers/gcp/services/cloudstorage/cloudstorage_service.py
+++ b/prowler/providers/gcp/services/cloudstorage/cloudstorage_service.py
@@ -77,7 +77,7 @@ class CloudStorage(GCPService):
                             Bucket(
                                 name=bucket["name"],
                                 id=bucket["id"],
-                                region=bucket["location"],
+                                region=bucket["location"].lower(),
                                 uniform_bucket_level_access=bucket["iamConfiguration"][
                                     "uniformBucketLevelAccess"
                                 ]["enabled"],

--- a/tests/providers/gcp/services/cloudstorage/cloudstorage_service_test.py
+++ b/tests/providers/gcp/services/cloudstorage/cloudstorage_service_test.py
@@ -35,7 +35,7 @@ class TestCloudStorageService:
             assert len(cloudstorage_client.buckets) == 2
             assert cloudstorage_client.buckets[0].name == "bucket1"
             assert cloudstorage_client.buckets[0].id.__class__.__name__ == "str"
-            assert cloudstorage_client.buckets[0].region == "US"
+            assert cloudstorage_client.buckets[0].region == "us"
             assert cloudstorage_client.buckets[0].uniform_bucket_level_access
             assert cloudstorage_client.buckets[0].public
 
@@ -53,7 +53,7 @@ class TestCloudStorageService:
 
             assert cloudstorage_client.buckets[1].name == "bucket2"
             assert cloudstorage_client.buckets[1].id.__class__.__name__ == "str"
-            assert cloudstorage_client.buckets[1].region == "EU"
+            assert cloudstorage_client.buckets[1].region == "eu"
             assert not cloudstorage_client.buckets[1].uniform_bucket_level_access
             assert not cloudstorage_client.buckets[1].public
             assert cloudstorage_client.buckets[1].retention_policy is None


### PR DESCRIPTION
### Context
Cloud Storage checks are returning the bucket region/location in uppercase (e.g., `US-CENTRAL1`) instead of lowercase (e.g., `us-central1`). This inconsistency is caused by the GCP Cloud Storage API returning the `location` field in uppercase by default.

This should be normalized to lowercase for consistency with other GCP services and Prowler conventions.


### Description

This PR normalizes the `location` field in Cloud Storage buckets to lowercase.

#### Changes:

**Cloud Storage Service (`cloudstorage_service.py`):**
- Added `.lower()` to the `location` field when creating `Bucket` objects
- Ensures consistency with other GCP services that use lowercase region names

### Steps to review

Review the change in `cloudstorage_service.py`

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
