### PR TITLE
feat(ui): add SSO and API Key link cards to Integrations page

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🚀 Added
 
+- SSO and API Key link cards to Integrations page for better discoverability [(#9570)](https://github.com/prowler-cloud/prowler/pull/9570)
 - Risk Radar component with category-based severity breakdown to Overview page [(#9532)](https://github.com/prowler-cloud/prowler/pull/9532)
 - More extensive resource details (partition, details and metadata) within Findings detail and Resources detail view [(#9515)](https://github.com/prowler-cloud/prowler/pull/9515)
 

--- a/ui/app/(prowler)/integrations/page.tsx
+++ b/ui/app/(prowler)/integrations/page.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-
 import {
+  ApiKeyLinkCard,
   JiraIntegrationCard,
   S3IntegrationCard,
   SecurityHubIntegrationCard,
+  SsoLinkCard,
 } from "@/components/integrations";
 import { ContentLayout } from "@/components/ui";
 
@@ -27,6 +27,12 @@ export default async function Integrations() {
 
           {/* Jira Integration */}
           <JiraIntegrationCard />
+
+          {/* SSO Configuration - redirects to Profile */}
+          <SsoLinkCard />
+
+          {/* API Keys - redirects to Profile */}
+          <ApiKeyLinkCard />
         </div>
       </div>
     </ContentLayout>

--- a/ui/components/integrations/api-key/api-key-link-card.tsx
+++ b/ui/components/integrations/api-key/api-key-link-card.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { KeyRoundIcon } from "lucide-react";
+
+import { LinkCard } from "../shared/link-card";
+
+export const ApiKeyLinkCard = () => {
+  return (
+    <LinkCard
+      icon={KeyRoundIcon}
+      title="API Keys"
+      description="Manage API keys for programmatic access."
+      learnMoreUrl="https://docs.prowler.com/user-guide/providers/prowler-app-api-keys"
+      learnMoreAriaLabel="Learn more about API Keys"
+      bodyText="API Key management is available in your User Profile. Create and manage API keys to authenticate with the Prowler API for automation and integrations."
+      linkHref="/profile"
+      linkText="Go to Profile"
+    />
+  );
+};

--- a/ui/components/integrations/index.ts
+++ b/ui/components/integrations/index.ts
@@ -1,4 +1,5 @@
 export * from "../providers/enhanced-provider-selector";
+export * from "./api-key/api-key-link-card";
 export * from "./jira/jira-integration-card";
 export * from "./jira/jira-integration-form";
 export * from "./jira/jira-integrations-manager";
@@ -11,3 +12,4 @@ export * from "./security-hub/security-hub-integration-card";
 export * from "./security-hub/security-hub-integration-form";
 export * from "./security-hub/security-hub-integrations-manager";
 export * from "./shared";
+export * from "./sso/sso-link-card";

--- a/ui/components/integrations/shared/index.ts
+++ b/ui/components/integrations/shared/index.ts
@@ -1,3 +1,4 @@
 export { IntegrationActionButtons } from "./integration-action-buttons";
 export { IntegrationCardHeader } from "./integration-card-header";
 export { IntegrationSkeleton } from "./integration-skeleton";
+export { LinkCard } from "./link-card";

--- a/ui/components/integrations/shared/link-card.tsx
+++ b/ui/components/integrations/shared/link-card.tsx
@@ -34,11 +34,8 @@ export const LinkCard = ({
       <CardHeader>
         <div className="flex w-full flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
-            <div className="bg-prowler-stone-900/10 dark:bg-prowler-stone-100/10 flex h-10 w-10 items-center justify-center rounded-lg">
-              <Icon
-                size={24}
-                className="text-prowler-stone-900 dark:text-prowler-stone-100"
-              />
+            <div className="dark:bg-prowler-blue-800 flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100">
+              <Icon size={24} className="text-gray-700 dark:text-gray-200" />
             </div>
             <div className="flex flex-col gap-1">
               <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">

--- a/ui/components/integrations/shared/link-card.tsx
+++ b/ui/components/integrations/shared/link-card.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { ExternalLinkIcon, LucideIcon } from "lucide-react";
+import Link from "next/link";
+
+import { Button } from "@/components/shadcn";
+import { CustomLink } from "@/components/ui/custom/custom-link";
+
+import { Card, CardContent, CardHeader } from "../../shadcn";
+
+interface LinkCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  learnMoreUrl: string;
+  learnMoreAriaLabel: string;
+  bodyText: string;
+  linkHref: string;
+  linkText: string;
+}
+
+export const LinkCard = ({
+  icon: Icon,
+  title,
+  description,
+  learnMoreUrl,
+  learnMoreAriaLabel,
+  bodyText,
+  linkHref,
+  linkText,
+}: LinkCardProps) => {
+  return (
+    <Card variant="base" padding="lg">
+      <CardHeader>
+        <div className="flex w-full flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="bg-prowler-stone-900/10 dark:bg-prowler-stone-100/10 flex h-10 w-10 items-center justify-center rounded-lg">
+              <Icon
+                size={24}
+                className="text-prowler-stone-900 dark:text-prowler-stone-100"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+                {title}
+              </h4>
+              <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+                <p className="text-xs text-nowrap text-gray-500 dark:text-gray-300">
+                  {description}
+                </p>
+                <CustomLink
+                  href={learnMoreUrl}
+                  aria-label={learnMoreAriaLabel}
+                  size="xs"
+                >
+                  Learn more
+                </CustomLink>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 self-end sm:self-center">
+            <Button asChild size="sm">
+              <Link href={linkHref}>
+                <ExternalLinkIcon size={14} />
+                {linkText}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-gray-600 dark:text-gray-300">{bodyText}</p>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/components/integrations/sso/sso-link-card.tsx
+++ b/ui/components/integrations/sso/sso-link-card.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ShieldCheckIcon } from "lucide-react";
+
+import { LinkCard } from "../shared/link-card";
+
+export const SsoLinkCard = () => {
+  return (
+    <LinkCard
+      icon={ShieldCheckIcon}
+      title="SSO Configuration"
+      description="Configure SAML Single Sign-On for your organization."
+      learnMoreUrl="https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app-sso/"
+      learnMoreAriaLabel="Learn more about SSO configuration"
+      bodyText="SSO configuration is available in your User Profile. Enable SAML Single Sign-On to allow users to authenticate using your organization's identity provider."
+      linkHref="/profile"
+      linkText="Go to Profile"
+    />
+  );
+};


### PR DESCRIPTION
### Context
<img width="3008" height="1626" alt="Screenshot 2025-12-16 at 13 07 23" src="https://github.com/user-attachments/assets/e639f0e2-62d1-4542-8067-da700c393054" />


https://github.com/user-attachments/assets/300aefcb-f39c-4a25-af49-f368c12a3da8


Fix #PROWLER-505

Users frequently ask where to find SSO configuration and API Key management because these features are not easily discoverable in the current navigation. Both are only accessible through User Profile, but users expect to find them under Integrations as well.

### Description

Add two new link cards to the Integrations page that redirect users to User Profile where SSO and API Key management are located:

- **SSO Configuration card** - Links to `/profile` where SAML SSO configuration is available
- **API Keys card** - Links to `/profile` where API key management is available

Both cards follow the same design pattern as existing integration cards (S3, Security Hub, Jira) and include:
- Icon representation
- Title and short description
- "Learn more" link to documentation
- Action button to navigate to Profile
- Detailed body text explaining where the feature lives

**Technical implementation:**
- Created a reusable `LinkCard` component in `components/integrations/shared/` to avoid code duplication
- `SsoLinkCard` and `ApiKeyLinkCard` are thin wrappers around `LinkCard` with specific props

### Steps to review

1. Navigate to `/integrations`
2. Verify the SSO Configuration and API Keys cards appear at the bottom of the page
3. Click "Go to Profile" on each card and verify it navigates to `/profile`
4. Verify the "Learn more" links open the correct documentation pages
5. Check responsive behavior on mobile/tablet/desktop

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.