### PR TITLE
fix(aws): correct bedrock-agent regional availability

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### Fixed
 - Fix typo `trustboundaries` category to `trust-boundaries` [(#9536)](https://github.com/prowler-cloud/prowler/pull/9536)
+- Fix incorrect `bedrock-agent` regional availability, now using official AWS docs instead of copying from `bedrock`
 - Store MongoDB Atlas provider regions as lowercase [(#9554)](https://github.com/prowler-cloud/prowler/pull/9554)
 - Store GCP Cloud Storage bucket regions as lowercase [(#9567)](https://github.com/prowler-cloud/prowler/pull/9567)
 

--- a/prowler/providers/aws/aws_regions_by_service.json
+++ b/prowler/providers/aws/aws_regions_by_service.json
@@ -1426,42 +1426,23 @@
     "bedrock-agent": {
       "regions": {
         "aws": [
-          "af-south-1",
-          "ap-east-2",
           "ap-northeast-1",
           "ap-northeast-2",
-          "ap-northeast-3",
           "ap-south-1",
-          "ap-south-2",
           "ap-southeast-1",
           "ap-southeast-2",
-          "ap-southeast-3",
-          "ap-southeast-4",
-          "ap-southeast-5",
-          "ap-southeast-7",
           "ca-central-1",
-          "ca-west-1",
           "eu-central-1",
           "eu-central-2",
-          "eu-north-1",
-          "eu-south-1",
-          "eu-south-2",
           "eu-west-1",
           "eu-west-2",
           "eu-west-3",
-          "il-central-1",
-          "me-central-1",
-          "me-south-1",
-          "mx-central-1",
           "sa-east-1",
           "us-east-1",
-          "us-east-2",
-          "us-west-1",
           "us-west-2"
         ],
         "aws-cn": [],
         "aws-us-gov": [
-          "us-gov-east-1",
           "us-gov-west-1"
         ]
       }

--- a/util/update_aws_services_regions.py
+++ b/util/update_aws_services_regions.py
@@ -48,10 +48,32 @@ for page in get_parameters_by_path_paginator.paginate(
 logging.info("Updating subservices and the services not present in the original matrix")
 # macie2 --> macie
 regions_by_service["services"]["macie2"] = regions_by_service["services"]["macie"]
-# bedrock-agent --> bedrock
-regions_by_service["services"]["bedrock-agent"] = regions_by_service["services"][
-    "bedrock"
-]
+# bedrock-agent is not in SSM, and has different availability than bedrock
+# See: https://docs.aws.amazon.com/bedrock/latest/userguide/agents-supported.html
+regions_by_service["services"]["bedrock-agent"] = {
+    "regions": {
+        "aws": [
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ca-central-1",
+            "eu-central-1",
+            "eu-central-2",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "sa-east-1",
+            "us-east-1",
+            "us-west-2",
+        ],
+        "aws-cn": [],
+        "aws-us-gov": [
+            "us-gov-west-1",
+        ],
+    }
+}
 # cognito --> cognito-idp
 regions_by_service["services"]["cognito"] = regions_by_service["services"][
     "cognito-idp"


### PR DESCRIPTION
### Context
Solves #9562

### Description
Updated util/update_aws_services_regions.py: Explicitly defines the 15 regions (14 commercial + 1 GovCloud) from AWS [docs](https://docs.aws.amazon.com/bedrock/latest/userguide/agents-supported.html) instead of copying from bedrock

### Steps to review
- Review changes in `util/update_aws_services_regions.py`
- See [comment](https://github.com/prowler-cloud/prowler/pull/9562#issuecomment-3661652812) in #9562 for more context

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
