### PR TITLE
fix(ui): correct API keys documentation URL

### DIFF
--- a/ui/components/integrations/api-key/api-key-link-card.tsx
+++ b/ui/components/integrations/api-key/api-key-link-card.tsx
@@ -10,7 +10,7 @@ export const ApiKeyLinkCard = () => {
       icon={KeyRoundIcon}
       title="API Keys"
       description="Manage API keys for programmatic access."
-      learnMoreUrl="https://docs.prowler.com/user-guide/providers/prowler-app-api-keys"
+      learnMoreUrl="https://docs.prowler.com/user-guide/tutorials/prowler-app-api-keys"
       learnMoreAriaLabel="Learn more about API Keys"
       bodyText="API Key management is available in your User Profile. Create and manage API keys to authenticate with the Prowler API for automation and integrations."
       linkHref="/profile"

--- a/ui/components/users/profile/api-keys-card-client.tsx
+++ b/ui/components/users/profile/api-keys-card-client.tsx
@@ -77,7 +77,7 @@ export const ApiKeysCardClient = ({
             <CardTitle>API Keys</CardTitle>
             <p className="text-xs text-gray-500">
               Manage API keys for programmatic access.{" "}
-              <CustomLink href="https://docs.prowler.com/user-guide/providers/prowler-app-api-keys">
+              <CustomLink href="https://docs.prowler.com/user-guide/tutorials/prowler-app-api-keys">
                 Read the docs
               </CustomLink>
             </p>

--- a/ui/components/users/profile/create-api-key-modal.tsx
+++ b/ui/components/users/profile/create-api-key-modal.tsx
@@ -99,7 +99,7 @@ export const CreateApiKeyModal = ({
         >
           <p className="text-xs text-gray-500">
             Need help configuring API Keys?{" "}
-            <CustomLink href="https://docs.prowler.com/user-guide/providers/prowler-app-api-keys">
+            <CustomLink href="https://docs.prowler.com/user-guide/tutorials/prowler-app-api-keys">
               Read the docs
             </CustomLink>
           </p>


### PR DESCRIPTION
### Context

The API Keys documentation links were pointing to an incorrect URL path (`/user-guide/providers/`) instead of the correct tutorials section.

### Description

Fix incorrect documentation URL for API keys across 3 components:
- `components/integrations/api-key/api-key-link-card.tsx`
- `components/users/profile/api-keys-card-client.tsx`
- `components/users/profile/create-api-key-modal.tsx`

Changed from `/user-guide/providers/prowler-app-api-keys` to `/user-guide/tutorials/prowler-app-api-keys`

### Steps to review

1. Check that the 3 files only have the URL change
2. Verify the new URL is correct: https://docs.prowler.com/user-guide/tutorials/prowler-app-api-keys

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- N/A - No visual changes, only URL fix
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.