### PR TITLE
fix(migrations): wrong fk definition

### DIFF
--- a/api/src/backend/api/migrations/0063_scan_category_summary.py
+++ b/api/src/backend/api/migrations/0063_scan_category_summary.py
@@ -26,8 +26,11 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
-                    "tenant_id",
-                    models.UUIDField(db_index=True, editable=False),
+                    "tenant",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="api.tenant",
+                    ),
                 ),
                 (
                     "inserted_at",
@@ -82,6 +85,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 "db_table": "scan_category_summaries",
+                "abstract": False,
             },
         ),
         migrations.AddIndex(


### PR DESCRIPTION
### Context

`tenant_id` was defined as a UUID field in the migration even though it is a foreign key.

### Description

This change fixes it, following the model definition.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
