### PR TITLE
fix(migrations): missing help text and constraint

### DIFF
--- a/api/src/backend/api/migrations/0063_scan_category_summary.py
+++ b/api/src/backend/api/migrations/0063_scan_category_summary.py
@@ -59,7 +59,6 @@ class Migration(migrations.Migration):
                             ("low", "Low"),
                             ("informational", "Informational"),
                         ],
-                        max_length=50,
                     ),
                 ),
                 (

--- a/api/src/backend/api/migrations/0064_finding_categories.py
+++ b/api/src/backend/api/migrations/0064_finding_categories.py
@@ -16,6 +16,7 @@ class Migration(migrations.Migration):
                 blank=True,
                 null=True,
                 size=None,
+                help_text="Categories from check metadata for efficient filtering",
             ),
         ),
     ]


### PR DESCRIPTION
### Context

Help text and a constraint change was not detected up until now.

### Description

It doesn't affect to the current code, but it generated an unnecessary migration file. Now it does not:

```
prowler@prowler-api:~/backend$ python manage.py makemigrations
No changes detected
prowler@prowler-api:~/backend$ 
```

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
