### PR TITLE
chore(lighthouse): change meta tools descriptions to be more accurate

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.16.1] (Prowler v5.17.1)
+
+### 🔄 Changed
+
+- Lighthouse AI meta tools descriptions updated for clarity with more representative examples [(#9632)](https://github.com/prowler-cloud/prowler/pull/9632)
+
+---
+
 ## [1.16.0] (Prowler v5.16.0)
 
 ### 🚀 Added

--- a/ui/lib/lighthouse/tools/meta-tool.ts
+++ b/ui/lib/lighthouse/tools/meta-tool.ts
@@ -89,23 +89,23 @@ export const describeTool = tool(
   },
   {
     name: "describe_tool",
-    description: `Get the full schema and parameter details for a specific Prowler Hub tool.
+    description: `Get the full schema and parameter details for a specific Prowler tool.
 
 Use this to understand what parameters a tool requires before executing it.
 Tool names are listed in your system prompt - use the exact name.
 
 You must always provide the toolName key in the JSON object.
-Example: describe_tool({ "toolName": "prowler_hub_list_providers" })
+Example: describe_tool({ "toolName": "prowler_app_search_security_findings" })
 
 Returns:
 - Full parameter schema with types and descriptions
 - Tool description
-- Required vs optional parameters`,
+- Required and optional parameters`,
     schema: z.object({
       toolName: z
         .string()
         .describe(
-          "Exact name of the tool to describe (e.g., 'prowler_hub_list_providers'). You must always provide the toolName key in the JSON object.",
+          "Exact name of the tool to describe (e.g., 'prowler_hub_list_compliances'). You must always provide the toolName key in the JSON object.",
         ),
     }),
   },
@@ -198,20 +198,20 @@ export const executeTool = tool(
   },
   {
     name: "execute_tool",
-    description: `Execute a Prowler Hub MCP tool with the specified parameters.
+    description: `Execute a Prowler MCP tool with the specified parameters.
 
 Provide the exact tool name and its input parameters as specified in the tool's schema.
 
 You must always provide the toolName and toolInput keys in the JSON object.
-Example: execute_tool({ "toolName": "prowler_hub_list_providers", "toolInput": {} })
+Example: execute_tool({ "toolName": "prowler_app_search_security_findings", "toolInput": {} })
 
 All input to the tool must be provided in the toolInput key as a JSON object.
-Example: execute_tool({ "toolName": "prowler_hub_list_providers", "toolInput": { "query": "value1", "page": 1, "pageSize": 10 } })
+Example: execute_tool({ "toolName": "prowler_hub_list_compliances", "toolInput": { "provider": ["aws"] } })
 
 Always describe the tool first to understand:
 1. What parameters it requires
 2. The expected input format
-3. Required vs optional parameters`,
+3. Which parameters are mandatory and which are optional`,
     schema: z.object({
       toolName: z
         .string()
@@ -222,7 +222,7 @@ Always describe the tool first to understand:
         .record(z.string(), z.unknown())
         .default({})
         .describe(
-          "Input parameters for the tool as a JSON object. Use empty object {} if tool requires no parameters.",
+          "Input parameters for the tool as a JSON object. Use empty object {} if tool requires no parameters or it has defined defaults or only optional parameters.",
         ),
     }),
   },


### PR DESCRIPTION
### Context

Improving the descriptions of the Lighthouse meta tools to provide clearer guidance for the AI assistant when using Prowler tools.

### Description

This PR updates the tool descriptions in `meta-tool.ts` to be more accurate and helpful:

- Changed "Prowler Hub tool" to "Prowler tool" for consistency
- Updated example tool names to use more representative examples (`prowler_app_search_security_findings`, `prowler_hub_list_compliances`)
- Improved wording from "Required vs optional parameters" to "Required and optional parameters" and "Which parameters are mandatory and which are optional"
- Added clarification about default values and optional parameters in the toolInput description

### Steps to review

1. Review the updated descriptions in `ui/lib/lighthouse/tools/meta-tool.ts`
2. Verify the new examples are more representative of common tool usage
3. Confirm the wording improvements make the tool descriptions clearer

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- N/A - No visual changes, only description text updates
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- N/A - No API changes

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.