### PR TITLE
chore(security-hub): handle SecurityHubNoEnabledRegionsError

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
-## [1.18.0] (Prowler UUNRELEASED)
+## [1.18.0] (Prowler UNRELEASED)
 
 ### Added
 - Support AlibabaCloud provider [(#9485)](https://github.com/prowler-cloud/prowler/pull/9485)
+
+---
+
+## [1.17.1] (Prowler v5.16.1)
+
+### Changed
+- Security Hub integration error when no regions [(#9635)](https://github.com/prowler-cloud/prowler/pull/9635)
 
 ---
 

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -411,7 +411,9 @@ def upload_security_hub_integration(
                                 f"Failed to archive previous findings: {str(archive_error)}"
                             )
             except SecurityHubNoEnabledRegionsError:
-                continue
+                logger.warning(
+                    f"Security Hub integration {integration.id} has no enabled regions"
+                )
             except Exception as e:
                 logger.error(
                     f"Security Hub integration {integration.id} failed: {str(e)}"

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -19,7 +19,9 @@ from prowler.providers.aws.aws_provider import AwsProvider
 from prowler.providers.aws.lib.s3.s3 import S3
 from prowler.providers.aws.lib.security_hub.security_hub import SecurityHub
 from prowler.providers.common.models import Connection
-from prowler.providers.aws.lib.security_hub.exceptions.exceptions import SecurityHubNoEnabledRegionsError
+from prowler.providers.aws.lib.security_hub.exceptions.exceptions import (
+    SecurityHubNoEnabledRegionsError,
+)
 
 logger = get_task_logger(__name__)
 

--- a/api/src/backend/tasks/jobs/integrations.py
+++ b/api/src/backend/tasks/jobs/integrations.py
@@ -19,6 +19,7 @@ from prowler.providers.aws.aws_provider import AwsProvider
 from prowler.providers.aws.lib.s3.s3 import S3
 from prowler.providers.aws.lib.security_hub.security_hub import SecurityHub
 from prowler.providers.common.models import Connection
+from prowler.providers.aws.lib.security_hub.exceptions.exceptions import SecurityHubNoEnabledRegionsError
 
 logger = get_task_logger(__name__)
 
@@ -409,7 +410,8 @@ def upload_security_hub_integration(
                             logger.warning(
                                 f"Failed to archive previous findings: {str(archive_error)}"
                             )
-
+            except SecurityHubNoEnabledRegionsError:
+                continue
             except Exception as e:
                 logger.error(
                     f"Security Hub integration {integration.id} failed: {str(e)}"

--- a/api/src/backend/tasks/tests/test_integrations.py
+++ b/api/src/backend/tasks/tests/test_integrations.py
@@ -1199,9 +1199,6 @@ class TestSecurityHubIntegrationUploads:
                     )
 
         assert result is False
-        # Integration should be marked as disconnected
-        integration.save.assert_called_once()
-        assert integration.connected is False
 
     @patch("tasks.jobs.integrations.ASFF")
     @patch("tasks.jobs.integrations.FindingOutput")


### PR DESCRIPTION
### Description

Handle `SecurityHubNoEnabledRegionsError` and continue checking integrations.

### Steps to review

1. Create a SH integration with configured regions
2. Assign it to an AWS account
3. Remove SH credentials or remove integrations in all regions
4. Launch an AWS scan and see the warning logger

```
security_hub_integration_task.apply_async(kwargs={"tenant_id": "06454126-2088-4954-b25d-f02b4aa745dd", "provider_id": "9c4e4092-5b91-4349-b502-16d27cab929c", "scan_id": "019b4672-7dba-7d32-af8f-ad7c7173daac"})

worker-dev-1  | [2025-12-22 15:21:54,722: INFO/MainProcess] Task integration-security-hub[a939ff8e-734f-45e3-8141-df02bcd4c38a] received
worker-dev-1  | [2025-12-22 15:21:54,807: INFO/ForkPoolWorker-11] integration-security-hub[a939ff8e-734f-45e3-8141-df02bcd4c38a]: Processing Security Hub integrations for provider 9c4e4092-5b91-4349-b502-16d27cab929c
worker-dev-1  | [2025-12-22 15:21:54,886: INFO/ForkPoolWorker-11] Initializing AWS provider ...
worker-dev-1  | [2025-12-22 15:21:54,886: INFO/ForkPoolWorker-11] Generating original session ...
worker-dev-1  | [2025-12-22 15:21:54,891: INFO/ForkPoolWorker-11] Validating credentials ...
worker-dev-1  | [2025-12-22 15:21:55,438: INFO/ForkPoolWorker-11] Credentials validated
worker-dev-1  | [2025-12-22 15:21:55,440: INFO/ForkPoolWorker-11] Original AWS Caller Identity UserId: test
worker-dev-1  | [2025-12-22 15:21:55,440: INFO/ForkPoolWorker-11] Original AWS Caller Identity ARN: arn='arn:aws:sts::111111111111:assumed-role/test' partition='aws' service='sts' region=None account_id='111111111111' resource='test' resource_type='assumed-role'
worker-dev-1  | [2025-12-22 15:21:55,440: INFO/ForkPoolWorker-11] Getting AWS Organizations metadata for account 111111111111
worker-dev-1  | [2025-12-22 15:21:56,339: INFO/ForkPoolWorker-11] AWS Organizations metadata retrieved for account 111111111111
worker-dev-1  | [2025-12-22 15:21:59,094: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-southeast-6 region.
worker-dev-1  | [2025-12-22 15:21:59,095: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-northeast-3 region.
worker-dev-1  | [2025-12-22 15:21:59,096: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the us-west-1 region.
worker-dev-1  | [2025-12-22 15:21:59,098: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the me-central-1 region.
worker-dev-1  | [2025-12-22 15:21:59,105: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-northeast-1 region.
worker-dev-1  | [2025-12-22 15:21:59,107: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-south-2 region.
worker-dev-1  | [2025-12-22 15:21:59,108: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-southeast-7 region.
worker-dev-1  | [2025-12-22 15:21:59,109: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-south-1 region.
worker-dev-1  | [2025-12-22 15:21:59,110: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-northeast-2 region.
worker-dev-1  | [2025-12-22 15:21:59,112: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-southeast-1 region.
worker-dev-1  | [2025-12-22 15:21:59,112: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the us-east-1 region.
worker-dev-1  | [2025-12-22 15:21:59,113: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the mx-central-1 region.
worker-dev-1  | [2025-12-22 15:21:59,115: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-southeast-4 region.
worker-dev-1  | [2025-12-22 15:21:59,117: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-southeast-3 region.
worker-dev-1  | [2025-12-22 15:21:59,119: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-west-2 region.
worker-dev-1  | [2025-12-22 15:21:59,120: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the sa-east-1 region.
worker-dev-1  | [2025-12-22 15:21:59,132: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the il-central-1 region.
worker-dev-1  | [2025-12-22 15:21:59,145: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the us-east-2 region.
worker-dev-1  | [2025-12-22 15:21:59,158: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the me-south-1 region.
worker-dev-1  | [2025-12-22 15:21:59,179: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the us-west-2 region.
worker-dev-1  | [2025-12-22 15:21:59,813: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:21:59,822: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eusc-de-east-1 region.
worker-dev-1  | [2025-12-22 15:22:00,066: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,083: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-southeast-2 region.
worker-dev-1  | [2025-12-22 15:22:00,126: WARNING/ForkPoolWorker-11] Security Hub is enabled in eu-west-2 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:00,132: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-southeast-5 region.
worker-dev-1  | [2025-12-22 15:22:00,312: WARNING/ForkPoolWorker-11] Security Hub is enabled in us-east-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:00,314: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-east-2 region.
worker-dev-1  | [2025-12-22 15:22:00,470: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,481: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the af-south-1 region.
worker-dev-1  | [2025-12-22 15:22:00,555: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,557: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,575: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-east-1 region.
worker-dev-1  | [2025-12-22 15:22:00,597: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-south-1 region.
worker-dev-1  | [2025-12-22 15:22:00,673: WARNING/ForkPoolWorker-11] Security Hub is enabled in us-east-2 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:00,674: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-west-1 region.
worker-dev-1  | [2025-12-22 15:22:00,757: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,766: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ca-west-1 region.
worker-dev-1  | [2025-12-22 15:22:00,815: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,822: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-central-1 region.
worker-dev-1  | [2025-12-22 15:22:00,973: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,978: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,984: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:00,989: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ca-central-1 region.
worker-dev-1  | [2025-12-22 15:22:01,001: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-north-1 region.
worker-dev-1  | [2025-12-22 15:22:01,005: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,015: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the ap-south-2 region.
worker-dev-1  | [2025-12-22 15:22:01,023: WARNING/ForkPoolWorker-11] Security Hub is enabled in us-west-2 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,024: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-central-2 region.
worker-dev-1  | [2025-12-22 15:22:01,034: INFO/ForkPoolWorker-11] Checking if the prowler/prowler is enabled in the eu-west-3 region.
worker-dev-1  | [2025-12-22 15:22:01,038: WARNING/ForkPoolWorker-11] Security Hub is enabled in eu-west-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,047: WARNING/ForkPoolWorker-11] Security Hub is enabled in us-west-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,090: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,109: WARNING/ForkPoolWorker-11] Security Hub is enabled in eu-central-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,170: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,191: WARNING/ForkPoolWorker-11] Security Hub is enabled in ap-south-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,204: WARNING/ForkPoolWorker-11] Security Hub is enabled in ap-southeast-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,218: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,221: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,241: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,286: WARNING/ForkPoolWorker-11] Security Hub is enabled in ap-northeast-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,316: WARNING/ForkPoolWorker-11] Security Hub is enabled in sa-east-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,336: WARNING/ForkPoolWorker-11] Security Hub is enabled in ap-northeast-3 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,351: WARNING/ForkPoolWorker-11] Security Hub is enabled in eu-west-3 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,366: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,391: WARNING/ForkPoolWorker-11] Security Hub is enabled in ap-northeast-2 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,432: WARNING/ForkPoolWorker-11] Security Hub is enabled in eu-north-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,548: WARNING/ForkPoolWorker-11] Security Hub is enabled in ap-southeast-2 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,591: ERROR/ForkPoolWorker-11] ClientError -- [251]: An error occurred (UnrecognizedClientException) when calling the DescribeHub operation: The security token included in the request is invalid
worker-dev-1  | [2025-12-22 15:22:01,594: WARNING/ForkPoolWorker-11] Security Hub is enabled in ca-central-1 but Prowler integration does not accept findings. More info: https://docs.prowler.com/user-guide/providers/aws/securityhub#aws-security-hub-integration-with-prowler
worker-dev-1  | [2025-12-22 15:22:01,617: WARNING/ForkPoolWorker-11] No regions found with the Security Hub integration enabled.
worker-dev-1  | [2025-12-22 15:22:01,635: WARNING/ForkPoolWorker-11] integration-security-hub[a939ff8e-734f-45e3-8141-df02bcd4c38a]: Security Hub integration 63b327dd-1c0c-439e-b8c7-84331a377f7f has no enabled regions
```

### Checklist

- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
