### PR TITLE
chore(gcp): enhance metadata for `gke` service

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update GCP Dataproc service metadata to new format [(#9642)](https://github.com/prowler-cloud/prowler/pull/9642)
 - Update GCP DNS service metadata to new format [(#9643)](https://github.com/prowler-cloud/prowler/pull/9643)
 - Update GCP GCR service metadata to new format [(#9644)](https://github.com/prowler-cloud/prowler/pull/9644)
+- Update GCP GKE service metadata to new format [(#9645)](https://github.com/prowler-cloud/prowler/pull/9645)
 
 ### 🔐 Security
 

--- a/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.metadata.json
+++ b/prowler/providers/gcp/services/gke/gke_cluster_no_default_service_account/gke_cluster_no_default_service_account.metadata.json
@@ -1,37 +1,35 @@
 {
   "Provider": "gcp",
   "CheckID": "gke_cluster_no_default_service_account",
-  "CheckTitle": "Ensure GKE clusters are not running using the Compute Engine default service account",
-  "CheckType": [
-    "Security",
-    "Configuration"
-  ],
+  "CheckTitle": "GKE cluster does not use the Compute Engine default service account",
+  "CheckType": [],
   "ServiceName": "gke",
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "Service",
-  "ResourceGroup": "container",
-  "Description": "Ensure GKE clusters are not running using the Compute Engine default service account. Create and use minimally privileged service accounts for GKE cluster nodes instead of using the Compute Engine default service account to minimize unnecessary permissions.",
-  "Risk": "Using the Compute Engine default service account for GKE cluster nodes may grant excessive permissions, increasing the risk of unauthorized access or compromise if a node is compromised.",
-  "RelatedUrl": "https://cloud.google.com/compute/docs/access/service-accounts#default_service_account",
-  "Remediation": {
-    "Code": {
-      "CLI": "gcloud container node-pools create [NODE_POOL] --service-account=[SA_NAME]@[PROJECT_ID].iam.gserviceaccount.com --cluster=[CLUSTER_NAME] --zone [COMPUTE_ZONE]",
-      "NativeIaC": "",
-      "Other": "",
-      "Terraform": "https://docs.prowler.com/checks/gcp/google-cloud-kubernetes-policies/ensure-gke-clusters-are-not-running-using-the-compute-engine-default-service-account#terraform"
-    },
-    "Recommendation": {
-      "Text": "Create and use minimally privileged service accounts for GKE cluster nodes instead of using the Compute Engine default service account.",
-      "Url": "https://cloud.google.com/compute/docs/access/service-accounts#default_service_account"
-    }
-  },
-  "Categories": [],
-  "DependsOn": [],
-  "RelatedTo": [],
-  "Notes": "By default, nodes use the Compute Engine default service account when you create a new cluster.",
+  "ResourceType": "container.googleapis.com/Cluster",
+  "Description": "**GKE clusters** are evaluated for use of the **Compute Engine default service account** (`default`) as the node identity. The expectation is that clusters and node pools run with dedicated, minimally privileged IAM service accounts instead of the project-wide default.",
+  "Risk": "**Default node service accounts** often have broad project access. If a node is compromised, its credentials can read secrets, modify resources, or delete infrastructure, enabling lateral movement and data exfiltration. This harms **confidentiality**, **integrity**, and **availability** across the environment.",
+  "RelatedUrl": "",
   "AdditionalURLs": [
     "https://www.trendmicro.com/trendaivisiononecloudriskmanagement/knowledge-base/gcp/GKE/ensure-service-account-is-not-the-default-compute-engine-service-account.html"
-  ]
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "gcloud container node-pools create <example_resource_name> --cluster=<example_resource_name> --location <example_resource_name> --service-account=<example_resource_name>@<example_resource_id>.iam.gserviceaccount.com",
+      "NativeIaC": "",
+      "Other": "1. In Google Cloud Console, go to Kubernetes Engine > Clusters and open your cluster\n2. Click Add node pool\n3. In Security > Service account, select your non-default service account and click Create\n4. In Nodes > Node Pools, delete the node pool(s) that show Service account = default",
+      "Terraform": "```hcl\nresource \"google_container_node_pool\" \"<example_resource_name>\" {\n  name     = \"<example_resource_name>\"\n  cluster  = \"<example_resource_name>\"\n  location = \"<example_resource_name>\"\n\n  node_config {\n    service_account = \"<example_resource_name>@<example_resource_id>.iam.gserviceaccount.com\" # critical: use a custom SA, not the Compute Engine default\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Assign a **custom, least-privileged IAM service account** to each node pool instead of `default`.\n- Grant only permissions required for node logging/monitoring and operations\n- Enforce **separation of duties** and restrict impersonation\n- Periodically review roles and audit usage for **defense in depth**",
+      "Url": "https://hub.prowler.com/check/gke_cluster_no_default_service_account"
+    }
+  },
+  "Categories": [
+    "identity-access"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "By default, nodes use the Compute Engine default service account when you create a new cluster."
 }


### PR DESCRIPTION
### Context

Updating gcp gke service metadata to conform with the new standardized metadata format used across Prowler checks, defined in #8411.

### Description

This PR updates all metadata files for GCP GKE checks to adapt to the new metadata format. The changes ensure consistency with the metadata structure being adopted across all Prowler services. The modified checks are:

- `gke_cluster_no_default_service_account`


### Checklist

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.