### PR TITLE
ci(mcp): add GitHub Actions workflow for PyPI release

### DIFF
--- a/.github/workflows/mcp-pypi-release.yml
+++ b/.github/workflows/mcp-pypi-release.yml
@@ -1,0 +1,81 @@
+name: "MCP: PyPI Release"
+
+on:
+  release:
+    types:
+      - "published"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ github.event.release.tag_name }}
+  PYTHON_VERSION: "3.12"
+  WORKING_DIRECTORY: ./mcp_server
+
+jobs:
+  validate-release:
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      prowler_version: ${{ steps.parse-version.outputs.version }}
+      major_version: ${{ steps.parse-version.outputs.major }}
+
+    steps:
+      - name: Parse and validate version
+        id: parse-version
+        run: |
+          PROWLER_VERSION="${{ env.RELEASE_TAG }}"
+          echo "version=${PROWLER_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          # Extract major version
+          MAJOR_VERSION="${PROWLER_VERSION%%.*}"
+          echo "major=${MAJOR_VERSION}" >> "${GITHUB_OUTPUT}"
+
+          # Validate major version (only Prowler 3, 4, 5 supported)
+          case ${MAJOR_VERSION} in
+            3|4|5)
+              echo "✓ Releasing Prowler MCP for tag ${PROWLER_VERSION}"
+              ;;
+            *)
+              echo "::error::Unsupported Prowler major version: ${MAJOR_VERSION}"
+              exit 1
+              ;;
+          esac
+
+  publish-prowler-mcp:
+    needs: validate-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi-prowler-mcp
+      url: https://pypi.org/project/prowler-mcp/
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Build prowler-mcp package
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: uv build
+
+      - name: Publish prowler-mcp package to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          packages-dir: ${{ env.WORKING_DIRECTORY }}/dist/
+          print-hash: true

--- a/mcp_server/prowler_mcp_server/__init__.py
+++ b/mcp_server/prowler_mcp_server/__init__.py
@@ -5,8 +5,8 @@ This package provides MCP tools for accessing:
 - Prowler Hub: All security artifacts (detections, remediations and frameworks) supported by Prowler
 """
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"
 __author__ = "Prowler Team"
 __email__ = "engineering@prowler.com"
 
-__all__ = ["__version__", "prowler_mcp_server"]
+__all__ = ["__version__", "__author__", "__email__"]

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -14,7 +14,6 @@ requires-python = ">=3.12"
 version = "0.3.0"
 
 [project.scripts]
-generate-prowler-app-mcp-server = "prowler_mcp_server.prowler_app.utils.server_generator:generate_server_file"
 prowler-mcp = "prowler_mcp_server.main:main"
 
 [tool.uv]


### PR DESCRIPTION
### Context

This PR adds a GitHub Actions workflow to automatically publish the prowler-mcp package to PyPI when a new release is published.

### Description

This PR introduces a new GitHub Actions workflow (`.github/workflows/mcp-pypi-release.yml`) that automates the publishing of the `prowler-mcp` package to PyPI. The workflow:

- **Triggers on release publication events**: Automatically runs when a new release is published on GitHub
- **Validates release tag version**: Ensures the release tag corresponds to a supported Prowler major version (3, 4, or 5)
- **Uses concurrency control**: Prevents duplicate runs for the same release tag
- **Builds with uv**: Uses the `uv` tool for fast and reliable package building
- **Publishes via trusted publishing (OIDC)**: Uses PyPA's official action with OpenID Connect for secure authentication, no API tokens required
- **Targets the pypi-prowler-mcp environment**: Links to the PyPI project page

### Steps to review

1. Review the workflow file at `.github/workflows/mcp-pypi-release.yml`
2. Verify the workflow configuration matches the existing SDK PyPI release workflow pattern
3. Ensure the environment name `pypi-prowler-mcp` matches the configured GitHub environment for trusted publishing
4. Confirm the working directory `./mcp_server` is correct for the MCP package

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests. (N/A - CI workflow)
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings (N/A - YAML workflow)
- [x] Review if backport is needed. (No backport needed)
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) (No changes needed)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. (N/A - CI workflow)

#### UI
N/A - This is a CI workflow change only.

#### API
N/A - This is a CI workflow change only.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.