### PR TITLE
feat(gcp): new check dns_policy_logging_enabled to ensure DNS logging

### DIFF
--- a/prowler/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled.metadata.json
+++ b/prowler/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled.metadata.json
@@ -1,28 +1,29 @@
 {
   "Provider": "gcp",
   "CheckID": "dns_policy_logging_enabled",
-  "CheckTitle": "Ensure that Cloud DNS logging is enabled for all VPC networks",
-  "CheckType": [
-    "Logging"
-  ],
+  "CheckTitle": "VPC network has Cloud DNS logging enabled",
+  "CheckType": [],
   "ServiceName": "dns",
   "SubServiceName": "",
-  "ResourceIdTemplate": "projects/{project}/locations/global/networks/{network_name}",
+  "ResourceIdTemplate": "",
   "Severity": "low",
-  "ResourceType": "GcpVpcNetwork",
-  "Description": "This check ensures that Cloud DNS logging is enabled for all VPC networks.",
-  "Risk": "Lack of DNS logging limits visibility into DNS queries, hindering detection of malicious domains or C2 communication.",
-  "RelatedUrl": "https://cloud.google.com/dns/docs/monitoring",
+  "ResourceType": "compute.googleapis.com/Network",
+  "Description": "Cloud DNS logging records the queries from the name servers within a VPC to Cloud Logging. This control evaluates whether a VPC network is associated with a Cloud DNS policy that has logging enabled. Enabling this feature provides visibility into DNS queries originating from the network resources.",
+  "Risk": "Without **Cloud DNS logging**, there is limited visibility into DNS queries originating from the VPC. This lack of traceability hinders the ability to detect malicious activities, such as communication with known **command and control (C2)** servers, data exfiltration via DNS tunneling, or resolving malicious domains.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://cloud.google.com/dns/docs/monitoring"
+  ],
   "Remediation": {
     "Code": {
       "CLI": "gcloud dns policies update <policy_name> --enable-logging",
       "NativeIaC": "",
       "Other": "",
-      "Terraform": ""
+      "Terraform": "```hcl\nresource \"google_dns_policy\" \"example_resource\" {\n  name           = \"example-policy\"\n  enable_logging = true\n\n  networks {\n    network_url = google_compute_network.example_resource.id\n  }\n}\n```"
     },
     "Recommendation": {
-      "Text": "Create or update a DNS policy to enable logging and associate it with your VPC networks.",
-      "Url": "https://cloud.google.com/dns/docs/monitoring#enable-logging"
+      "Text": "Configure **Cloud DNS policies** to enable logging and associate them with all active VPC networks. This ensures continuous monitoring and traceability of DNS resolution activities for security analysis.",
+      "Url": "https://hub.prowler.com/check/dns_policy_logging_enabled"
     }
   },
   "Categories": [
@@ -30,5 +31,5 @@
   ],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": "Checks if VPCs are attached to a DNS policy with logging on."
+  "Notes": ""
 }

--- a/prowler/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled.metadata.json
+++ b/prowler/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "gcp",
+  "CheckID": "dns_policy_logging_enabled",
+  "CheckTitle": "Ensure that Cloud DNS logging is enabled for all VPC networks",
+  "CheckType": [
+    "Logging"
+  ],
+  "ServiceName": "dns",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "projects/{project}/locations/global/networks/{network_name}",
+  "Severity": "low",
+  "ResourceType": "GcpVpcNetwork",
+  "Description": "This check ensures that Cloud DNS logging is enabled for all VPC networks.",
+  "Risk": "Lack of DNS logging limits visibility into DNS queries, hindering detection of malicious domains or C2 communication.",
+  "RelatedUrl": "https://cloud.google.com/dns/docs/monitoring",
+  "Remediation": {
+    "Code": {
+      "CLI": "gcloud dns policies update <policy_name> --enable-logging",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Create or update a DNS policy to enable logging and associate it with your VPC networks.",
+      "Url": "https://cloud.google.com/dns/docs/monitoring#enable-logging"
+    }
+  },
+  "Categories": [
+    "logging"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "Checks if VPCs are attached to a DNS policy with logging on."
+}

--- a/prowler/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled.py
+++ b/prowler/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled.py
@@ -1,0 +1,44 @@
+from prowler.lib.check.models import Check, Check_Report
+from prowler.providers.gcp.services.dns.dns_client import dns_client
+from prowler.providers.gcp.services.compute.compute_client import compute_client
+
+class dns_policy_logging_enabled(Check):
+    def execute(self):
+        findings = []
+
+        # 1. Iterate through all VPC Networks
+        for network in compute_client.networks:
+            report = Check_Report(self.metadata(), network)
+            
+            # Manually fill report details
+            report.project_id = compute_client.project_ids[0]
+            report.resource_id = network.name
+            report.resource_name = network.name  # FIX: Added this line
+            report.resource_arn = str(network.id)
+            report.location = "global"
+
+            report.status = "FAIL"
+            report.status_extended = f"VPC Network {network.name} does NOT have Cloud DNS logging enabled."
+
+            # 2. Check against all DNS Policies
+            for policy in dns_client.policies:
+                if policy.networks:
+                    for policy_network_url in policy.networks:
+                        # Check if the network name is inside the policy network URL
+                        if f"/networks/{network.name}" in policy_network_url or network.name == policy_network_url:
+                            
+                            # We found the policy attached to this VPC. Now check logging.
+                            if policy.logging:
+                                report.status = "PASS"
+                                report.status_extended = f"VPC Network {network.name} has Cloud DNS logging enabled via policy {policy.name}."
+                            
+                            # Found the specific policy for this VPC, stop checking other policies
+                            break 
+                
+                # If we passed, stop checking other policies
+                if report.status == "PASS":
+                    break
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled_test.py
+++ b/tests/providers/gcp/services/dns/dns_policy_logging_enabled/dns_policy_logging_enabled_test.py
@@ -1,0 +1,94 @@
+from unittest import mock
+
+# Mock the global provider BEFORE importing the check to prevent the 'session' AttributeError
+mock_provider = mock.MagicMock()
+mock_provider.session = mock.MagicMock()
+
+with mock.patch("prowler.providers.common.provider.Provider.get_global_provider", return_value=mock_provider):
+    from prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled import (
+        dns_policy_logging_enabled,
+    )
+
+class Test_dns_policy_logging_enabled:
+    
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.compute_client")
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.dns_client")
+    def test_no_networks(self, dns_client_mock, compute_client_mock):
+        compute_client_mock.project_ids = ["test-project"]
+        compute_client_mock.networks = []
+        dns_client_mock.policies = []
+
+        check = dns_policy_logging_enabled()
+        result = check.execute()
+        
+        assert len(result) == 0
+
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.compute_client")
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.dns_client")
+    def test_network_without_policy(self, dns_client_mock, compute_client_mock):
+        compute_client_mock.project_ids = ["test-project"]
+        
+        network_mock = mock.MagicMock()
+        network_mock.name = "test-vpc-bad"
+        network_mock.id = "123456"
+        compute_client_mock.networks = [network_mock]
+
+        dns_client_mock.policies = []
+
+        check = dns_policy_logging_enabled()
+        result = check.execute()
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert result[0].resource_id == "test-vpc-bad"
+        assert result[0].resource_name == "test-vpc-bad"
+        assert result[0].project_id == "test-project"
+        assert result[0].status_extended == "VPC Network test-vpc-bad does NOT have Cloud DNS logging enabled."
+
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.compute_client")
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.dns_client")
+    def test_network_with_policy_logging_disabled(self, dns_client_mock, compute_client_mock):
+        compute_client_mock.project_ids = ["test-project"]
+        
+        network_mock = mock.MagicMock()
+        network_mock.name = "test-vpc-bad"
+        network_mock.id = "123456"
+        compute_client_mock.networks = [network_mock]
+
+        policy_mock = mock.MagicMock()
+        policy_mock.name = "bad-policy"
+        policy_mock.networks = ["/networks/test-vpc-bad"]
+        policy_mock.logging = False
+        dns_client_mock.policies = [policy_mock]
+
+        check = dns_policy_logging_enabled()
+        result = check.execute()
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert result[0].resource_id == "test-vpc-bad"
+        assert result[0].status_extended == "VPC Network test-vpc-bad does NOT have Cloud DNS logging enabled."
+
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.compute_client")
+    @mock.patch("prowler.providers.gcp.services.dns.dns_policy_logging_enabled.dns_policy_logging_enabled.dns_client")
+    def test_network_with_policy_logging_enabled(self, dns_client_mock, compute_client_mock):
+        compute_client_mock.project_ids = ["test-project"]
+        
+        network_mock = mock.MagicMock()
+        network_mock.name = "test-vpc-good"
+        network_mock.id = "654321"
+        compute_client_mock.networks = [network_mock]
+
+        policy_mock = mock.MagicMock()
+        policy_mock.name = "good-policy"
+        policy_mock.networks = ["/networks/test-vpc-good"]
+        policy_mock.logging = True
+        dns_client_mock.policies = [policy_mock]
+
+        check = dns_policy_logging_enabled()
+        result = check.execute()
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert result[0].resource_id == "test-vpc-good"
+        assert result[0].status_extended == "VPC Network test-vpc-good has Cloud DNS logging enabled via policy good-policy."


### PR DESCRIPTION
### Context

Cloud DNS logging is critical for security auditing, as it records queries from name servers within VPCs to Cloud Logging. This visibility helps detect malicious domains or C2 communication. Currently, Prowler does not verify if this logging is enabled for VPC networks. This PR adds a check to ensure all VPC networks have Cloud DNS logging enabled.

Fix #7287

### Description

I have added a new check: `dns_policy_logging_enabled`.

**Logic implemented:**
1. Iterates through all **VPC Networks** in the project (using the Compute API).
2. Iterates through all **Cloud DNS Policies** (using the DNS API).
3. Checks if a VPC is associated with any DNS policy.
4. If an association is found, verifies if `logging` is enabled on that policy.
5. Returns **PASS** if the VPC is attached to a policy with logging enabled.
6. Returns **FAIL** if the VPC is not attached to any policy, or if the attached policy has logging disabled.

**Dependencies:**
- Uses standard `compute_client.networks` and `dns_client.policies`. No new external dependencies.

### Steps to review

To verify this check manually:

1. **Create a "Bad" VPC (No Policy):**
   ```bash
   gcloud compute networks create prowler-test-vpc-bad --subnet-mode=auto
   ```

2. **Create a "Good" VPC and Policy:**
   ```bash
   # Create VPC
   gcloud compute networks create prowler-test-vpc-good --subnet-mode=auto
   
   # Create Policy with Logging Enabled
   gcloud dns policies create prowler-logging-policy \
       --description="Policy for Prowler Test" \
       --networks=prowler-test-vpc-good \
       --enable-logging
   ```

3. **Run the check:**
   ```bash
   python prowler-cli.py gcp --check dns_policy_logging_enabled
   ```

4. **Verify Output:**
   - `prowler-test-vpc-bad` should **FAIL**.
   - `prowler-test-vpc-good` should **PASS**.

### Checklist

- Are there new checks included in this PR? **Yes**
    - If so, do we need to update permissions for the provider? **No** (Standard ReadOnly permissions for Compute and DNS cover this).
- [x] Review if the code is being covered by tests. (Verified manually via CLI execution).
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.