### PR TITLE
chore(github): fix container build pipelines

### DIFF
--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -120,7 +120,7 @@ jobs:
   # Create and push multi-architecture manifest
   create-manifest:
     needs: [setup, container-build-push]
-    if: github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: always() && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -198,8 +198,8 @@ jobs:
           update-ts: ${{ needs.notify-release-started.outputs.message-ts }}
 
   trigger-deployment:
-    if: github.event_name == 'push'
     needs: [setup, container-build-push]
+    if: always() && github.event_name == 'push' && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -126,7 +126,7 @@ jobs:
   # Create and push multi-architecture manifest
   create-manifest:
     needs: [setup, container-build-push]
-    if: github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: always() && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -204,8 +204,8 @@ jobs:
           update-ts: ${{ needs.notify-release-started.outputs.message-ts }}
 
   trigger-deployment:
-    if: github.event_name == 'push'
     needs: [setup, container-build-push]
+    if: always() && github.event_name == 'push' && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -125,7 +125,7 @@ jobs:
   # Create and push multi-architecture manifest
   create-manifest:
     needs: [setup, container-build-push]
-    if: github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: always() && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -203,8 +203,8 @@ jobs:
           update-ts: ${{ needs.notify-release-started.outputs.message-ts }}
 
   trigger-deployment:
-    if: github.event_name == 'push'
     needs: [setup, container-build-push]
+    if: always() && github.event_name == 'push' && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
### Context

When there is a skipped job in the dependency chain (`notify-release-started` is skipped in pushes), GitHub Actions propagates that skip to descendant jobs even if they do not directly depend on it.

### Description

The solution is to add `always()` and explicitly verify that previous jobs were successful

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
