### PR TITLE
chore(github): fix sdk container build pipeline

### DIFF
--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -188,7 +188,7 @@ jobs:
   # Create and push multi-architecture manifest
   create-manifest:
     needs: [setup, container-build-push]
-    if: github.event_name == 'push' || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    if: always() && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
 
     steps:
@@ -280,8 +280,8 @@ jobs:
           update-ts: ${{ needs.notify-release-started.outputs.message-ts }}
 
   dispatch-v3-deployment:
-    if: needs.setup.outputs.prowler_version_major == '3'
     needs: [setup, container-build-push]
+    if: always() && needs.setup.outputs.prowler_version_major == '3' && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
### Context

When there is a skipped job in the dependency chain (`notify-release-started` is skipped in pushes), GitHub Actions propagates that skip to descendant jobs even if they do not directly depend on it.

### Description

The solution is to add `always()` and explicitly verify that previous jobs were successful

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
