### PR TITLE
fix(metadata): Remediation URL for s3_bucket_server_access_logging_enabled

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.metadata.json
+++ b/prowler/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.metadata.json
@@ -23,7 +23,7 @@
     },
     "Recommendation": {
       "Text": "Ensure that S3 buckets have Logging enabled. CloudTrail data events can be used in place of S3 bucket logging. If that is the case, this finding can be considered a false positive.",
-      "Url": "https://docs.aws.amazon.com/AmazonS3/latest/dev/security-best-practices.html"
+      "Url": "https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html"
     }
   },
   "Categories": [


### PR DESCRIPTION
### Context
The previous remediation URL pointed to a deprecated Amazon S3 documentation page.

### Description
Updated the remediation documentation link for the `s3_bucket_server_access_logging_enabled` check.

- New URL: https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html
- File: `prowler/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.metadata.json`

### Testing
- Validated metadata JSON using `python3 -m json.tool`
- Verified `prowler-cli.py -h` runs successfully

### Checklist
- [x] No new checks added
- [x] No code logic changes
- [x] Metadata-only update

