### PR TITLE
Improve reporting message for s3_bucket_server_access_logging_enabled

### DIFF
--- a/prowler/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.py
+++ b/prowler/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.py
@@ -1,5 +1,5 @@
-from prowler.lib.check.models import Check, Check_Report_AWS
-from prowler.providers.aws.services.s3.s3_client import s3_client
+nano prowler/providers/aws/services/s3/s3_bucket_server_access_logging_enabled/s3_bucket_server_access_logging_enabled.pyfrom prowler.lib.check.models import Check, Check_Report_AWS from 
+prowler.providers.aws.services.s3.s3_client import s3_client
 
 
 class s3_bucket_server_access_logging_enabled(Check):
@@ -16,6 +16,7 @@ class s3_bucket_server_access_logging_enabled(Check):
                 report.status = "FAIL"
                 report.status_extended = (
                     f"S3 Bucket {bucket.name} has server access logging disabled."
+                    "Without access logs, object-level access activity cannot be audited."
                 )
             findings.append(report)
 


### PR DESCRIPTION
### Context
The current failure message does not clearly explain the security impact of disabled S3 access logging.

### Description
Improved the `status_extended` message to provide clearer security context when server access logging is not enabled.

### Testing
- Verified `prowler-cli.py -h` runs successfully
- Logic-only change; no functional behavior modified

### Checklist
- [x] No new checks added
- [x] No logic behavior changes
- [x] Improves reporting clarity
