### PR TITLE
fix(ui): extend Risk Plot gradient to cover full chart area

### DIFF
--- a/ui/components/graphs/scatter-plot.tsx
+++ b/ui/components/graphs/scatter-plot.tsx
@@ -277,16 +277,12 @@ export function ScatterPlot<T extends ScatterDataPoint = ScatterDataPoint>({
 
   const providers = Object.keys(dataByProvider);
 
-  // Calculate domain for ReferenceArea
-  // For X axis: get max value from data (using the correct dataKey)
-  // For Y axis: use domain if provided, otherwise calculate from data
-  const xDataValues = data.length > 0 ? data.map((d) => d[xAxis.dataKey]) : [0];
-  const yDataValues = data.length > 0 ? data.map((d) => d[yAxis.dataKey]) : [0];
-
+  // ReferenceArea bounds - use very large values and let ifOverflow="hidden" clip to chart area
+  // This ensures the gradient always covers exactly the visible chart area regardless of data
   const minX = xAxis.domain?.[0] ?? 0;
-  const maxX = xAxis.domain?.[1] ?? Math.max(...xDataValues) * 1.031;
+  const maxX = xAxis.domain?.[1] ?? Number.MAX_SAFE_INTEGER;
   const minY = yAxis.domain?.[0] ?? 0;
-  const maxY = yAxis.domain?.[1] ?? Math.max(...yDataValues) * 1.031;
+  const maxY = yAxis.domain?.[1] ?? Number.MAX_SAFE_INTEGER;
 
   const handleSelectPoint = (point: T) => {
     if (onSelectPoint) {
@@ -342,7 +338,7 @@ export function ScatterPlot<T extends ScatterDataPoint = ScatterDataPoint>({
                 y1={minY}
                 y2={maxY}
                 fill={`url(#${gradientId})`}
-                ifOverflow="extendDomain"
+                ifOverflow="hidden"
               />
             )}
             <CartesianGrid


### PR DESCRIPTION
### Context

<img width="3876" height="1040" alt="image" src="https://github.com/user-attachments/assets/842b4a6a-e7a5-4b45-9102-29cd663f2e3c" />

The Risk Plot gradient background was being cut off before reaching the edge of the chart when data points didn't extend to the full axis range.

### Description

The `ReferenceArea` gradient was calculated based on data values, which caused the gradient to stop wherever the data ended rather than at the chart boundary.

Changed the approach to use `Number.MAX_SAFE_INTEGER` for the gradient bounds combined with `ifOverflow="hidden"`, which lets Recharts clip the gradient exactly to the visible chart area. This makes the gradient completely independent of data values.

### Steps to review

1. Navigate to Overview > Risk Plot tab
2. Verify the red gradient extends exactly to the chart boundaries (matching the axis lines)
3. Test with different data sets - the gradient should always fill the exact chart area regardless of data values

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.