### PR TITLE
docs(developer-guide): add missing compliance framework link

### DIFF
--- a/docs/developer-guide/introduction.mdx
+++ b/docs/developer-guide/introduction.mdx
@@ -32,6 +32,9 @@ Prowler is constantly evolving. Contributions to checks, services, or integratio
   <Card title="Adding New Providers" icon="cloud" href="/developer-guide/provider">
     If you would like to extend Prowler to work with a new cloud provider, this typically involves setting up new services and checks to ensure compatibility.
   </Card>
+  <Card title="Adding New Compliance Frameworks" icon="scale-balanced" href="/developer-guide/security-compliance-framework">
+    Need to ensure Prowler supports a specific compliance framework? Add new security compliance frameworks to map checks against regulatory or industry standards.
+  </Card>
   <Card title="Adding New Output Formats" icon="file" href="/developer-guide/outputs">
     Want to tailor how results are displayed or exported? You can add custom output formats.
   </Card>


### PR DESCRIPTION
### Context

The Developer Guide introduction page has an "Expand Prowler's Capabilities" section listing various contribution areas. However, the link to the "Adding new compliance" page (Security Compliance Framework) was missing.

### Description

Added a new card in the "Expand Prowler's Capabilities" section linking to the Security Compliance Framework documentation page (`/developer-guide/security-compliance-framework`).

The card was placed after "Adding New Providers" and before "Adding New Output Formats" to maintain logical grouping with related contribution types.

### Steps to review

1. Navigate to the Developer Guide introduction page
2. Verify the new "Adding New Compliance Frameworks" card appears in the "Expand Prowler's Capabilities" section
3. Confirm the link correctly navigates to `/developer-guide/security-compliance-framework`

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests. N/A (documentation only)
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings N/A
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) - Not needed
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. - Not applicable for minor docs fix

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.