### PR TITLE
docs: add audit scope column to supported providers table

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -23,19 +23,19 @@
 
 The supported providers right now are:
 
-| Provider                                                                         | Support    | Interface    |
-| -------------------------------------------------------------------------------- | ---------- | ------------ |
-| [AWS](/user-guide/providers/aws/getting-started-aws)                             | Official   | UI, API, CLI |
-| [Azure](/user-guide/providers/azure/getting-started-azure)                       | Official   | UI, API, CLI |
-| [Google Cloud](/user-guide/providers/gcp/getting-started-gcp)                    | Official   | UI, API, CLI |
-| [Kubernetes](/user-guide/providers/kubernetes/getting-started-k8s)               | Official   | UI, API, CLI |
-| [M365](/user-guide/providers/microsoft365/getting-started-m365)                  | Official   | UI, API, CLI |
-| [Github](/user-guide/providers/github/getting-started-github)                    | Official   | UI, API, CLI |
-| [Oracle Cloud](/user-guide/providers/oci/getting-started-oci)                    | Official   | UI, API, CLI |
-| [Infra as Code](/user-guide/providers/iac/getting-started-iac)                   | Official   | UI, API, CLI |
-| [MongoDB Atlas](/user-guide/providers/mongodbatlas/getting-started-mongodbatlas) | Official   | UI, API, CLI |
-| [LLM](/user-guide/providers/llm/getting-started-llm)                             | Official   | CLI          |
-| **NHN**                                                                          | Unofficial | CLI          |
+| Provider                                                                         | Support    | Audit Scope/Entities         | Interface    |
+| -------------------------------------------------------------------------------- | ---------- | ---------------------------- | ------------ |
+| [AWS](/user-guide/providers/aws/getting-started-aws)                             | Official   | Accounts                     | UI, API, CLI |
+| [Azure](/user-guide/providers/azure/getting-started-azure)                       | Official   | Subscriptions                | UI, API, CLI |
+| [Google Cloud](/user-guide/providers/gcp/getting-started-gcp)                    | Official   | Projects                     | UI, API, CLI |
+| [Kubernetes](/user-guide/providers/kubernetes/getting-started-k8s)               | Official   | Clusters                     | UI, API, CLI |
+| [M365](/user-guide/providers/microsoft365/getting-started-m365)                  | Official   | Tenants                      | UI, API, CLI |
+| [Github](/user-guide/providers/github/getting-started-github)                    | Official   | Organizations / Repositories | UI, API, CLI |
+| [Oracle Cloud](/user-guide/providers/oci/getting-started-oci)                    | Official   | Tenancies / Compartments     | UI, API, CLI |
+| [Infra as Code](/user-guide/providers/iac/getting-started-iac)                   | Official   | Repositories                 | UI, API, CLI |
+| [MongoDB Atlas](/user-guide/providers/mongodbatlas/getting-started-mongodbatlas) | Official   | Organizations                | UI, API, CLI |
+| [LLM](/user-guide/providers/llm/getting-started-llm)                             | Official   | Models                       | CLI          |
+| **NHN**                                                                          | Unofficial | Tenants                      | CLI          |
 
 For more information about the checks and compliance of each provider visit [Prowler Hub](https://hub.prowler.com).
 


### PR DESCRIPTION
### Context

This PR improves the documentation by adding clarity about what entity/scope each cloud provider audits.

### Description

Added a new "Audit Scope/Entities" column to the supported providers table in the introduction documentation. This helps users quickly understand what organizational unit or resource scope each provider targets:

- **AWS**: Accounts
- **Azure**: Subscriptions
- **Google Cloud**: Projects
- **Kubernetes**: Clusters
- **M365**: Tenants
- **Github**: Organizations / Repositories
- **Oracle Cloud**: Tenancies / Compartments
- **Infra as Code**: Repositories
- **MongoDB Atlas**: Organizations
- **LLM**: Models
- **NHN**: Tenants

### Steps to review

1. Navigate to the [introduction documentation](docs/introduction.mdx)
2. Verify the table renders correctly with the new column
3. Confirm the audit scope values are accurate for each provider

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.