### PR TITLE
fix(pre-commit): update isort repo URL to pycqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
             "--remove-unused-variable",
           ]
 
-  - repo: https://github.com/timothycrosley/isort
+  - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
       - id: isort


### PR DESCRIPTION
### Context

The `isort` package repository has been moved from `timothycrosley/isort` to `pycqa/isort` on GitHub. The old repository URL redirects to the new location, but using the canonical URL is a best practice.

### Description

Updates the `isort` pre-commit hook repository URL from `https://github.com/timothycrosley/isort` to `https://github.com/pycqa/isort` in `.pre-commit-config.yaml`.

The `isort` project is now maintained under the PyCQA (Python Code Quality Authority) organization. Using the updated URL ensures:
- Proper attribution to the current maintainers
- Avoidance of potential future issues if the redirect is removed
- Consistency with official isort documentation

### Steps to review

1. Verify the pre-commit configuration is valid:
   ```bash
   pre-commit validate-config .pre-commit-config.yaml
   ```
2. Run pre-commit hooks to ensure isort still works correctly:
   ```bash
   pre-commit run isort --all-files
   ```

### Checklist

- [x] Review if the code is being covered by tests. *(N/A - configuration change only)*
- [x] Review if code is being documented following this specification *(N/A)*
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) *(Not needed)*
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. *(Not needed - minor maintenance change)*

#### SDK/CLI
- Are there new checks included in this PR? **No**

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
