### PR TITLE
chore(attack-paths): adding stability to Neo4j driver and session

### DIFF
--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -42,7 +42,12 @@ def init_driver() -> neo4j.Driver:
             config = settings.DATABASES["neo4j"]
 
             _driver = neo4j.GraphDatabase.driver(
-                uri, auth=(config["USER"], config["PASSWORD"])
+                uri,
+                auth=(config["USER"], config["PASSWORD"]),
+                keep_alive=True,
+                max_connection_lifetime=7200,
+                connection_acquisition_timeout=120,
+                max_connection_pool_size=50,
             )
             _driver.verify_connectivity()
 

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -76,7 +76,6 @@ def get_session(database: str | None = None) -> Iterator[RetryableSession]:
     try:
         session_wrapper = RetryableSession(
             session_factory=lambda: get_driver().session(database=database),
-            close_driver=close_driver,  # Just to avoid circular imports
             max_retries=SERVICE_UNAVAILABLE_MAX_RETRIES,
         )
         yield session_wrapper

--- a/api/src/backend/api/attack_paths/retryable_session.py
+++ b/api/src/backend/api/attack_paths/retryable_session.py
@@ -58,7 +58,7 @@ class RetryableSession:
 
     def _call_with_retry(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
         attempt = 0
-        last_exc: neo4j.exceptions.ServiceUnavailable | None = None
+        last_exc: Exception | None = None
 
         while attempt <= self._max_retries:
             try:
@@ -66,7 +66,8 @@ class RetryableSession:
                 return method(*args, **kwargs)
 
             except (
-                neo4j.exceptions.ServiceUnavailable
+                neo4j.exceptions.ServiceUnavailable,
+                ConnectionResetError,
             ) as exc:  # pragma: no cover - depends on infra
                 last_exc = exc
                 attempt += 1
@@ -75,7 +76,7 @@ class RetryableSession:
                     raise
 
                 logger.warning(
-                    f"Neo4j session {method_name} failed with ServiceUnavailable ({attempt}/{self._max_retries} attempts). Retrying..."
+                    f"Neo4j session {method_name} failed with {type(exc).__name__} ({attempt}/{self._max_retries} attempts). Retrying..."
                 )
                 self._refresh_session()
 
@@ -83,7 +84,10 @@ class RetryableSession:
 
     def _refresh_session(self) -> None:
         if self._session is not None:
-            self._session.close()
+            try:
+                self._session.close()
+            except Exception:
+                # Best-effort close; failures just mean we open a new session below
+                pass
 
-        self._close_driver()
         self._session = self._session_factory()

--- a/api/src/backend/api/attack_paths/retryable_session.py
+++ b/api/src/backend/api/attack_paths/retryable_session.py
@@ -17,11 +17,9 @@ class RetryableSession:
     def __init__(
         self,
         session_factory: Callable[[], neo4j.Session],
-        close_driver: Callable[[], None],  # Just to avoid circular imports
         max_retries: int,
     ) -> None:
         self._session_factory = session_factory
-        self._close_driver = close_driver
         self._max_retries = max(0, max_retries)
         self._session = self._session_factory()
 


### PR DESCRIPTION
### Description

Modifying our Neo4j retryable session with connection options and closing the session instead of the driver when an error occurrs.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
