### PR TITLE
perf(ui): optimize CI cache for pnpm and Next.js builds

### DIFF
--- a/.github/workflows/ui-e2e-tests.yml
+++ b/.github/workflows/ui-e2e-tests.yml
@@ -125,16 +125,20 @@ jobs:
       - name: Get pnpm store directory
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-      - name: Setup pnpm cache
+      - name: Setup pnpm and Next.js cache
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('ui/pnpm-lock.yaml') }}
+          path: |
+            ${{ env.STORE_PATH }}
+            ./ui/node_modules
+            ./ui/.next/cache
+          key: ${{ runner.os }}-pnpm-nextjs-${{ hashFiles('ui/pnpm-lock.yaml') }}-${{ hashFiles('ui/**/*.ts', 'ui/**/*.tsx', 'ui/**/*.js', 'ui/**/*.jsx') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-nextjs-${{ hashFiles('ui/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-pnpm-nextjs-
       - name: Install UI dependencies
         working-directory: ./ui
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
       - name: Build UI application
         working-directory: ./ui
         run: pnpm run build

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -62,18 +62,22 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - name: Setup pnpm cache
+      - name: Setup pnpm and Next.js cache
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('ui/pnpm-lock.yaml') }}
+          path: |
+            ${{ env.STORE_PATH }}
+            ${{ env.UI_WORKING_DIR }}/node_modules
+            ${{ env.UI_WORKING_DIR }}/.next/cache
+          key: ${{ runner.os }}-pnpm-nextjs-${{ hashFiles('ui/pnpm-lock.yaml') }}-${{ hashFiles('ui/**/*.ts', 'ui/**/*.tsx', 'ui/**/*.js', 'ui/**/*.jsx') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-nextjs-${{ hashFiles('ui/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-pnpm-nextjs-
 
       - name: Install dependencies
         if: steps.check-changes.outputs.any_changed == 'true'
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Run healthcheck
         if: steps.check-changes.outputs.any_changed == 'true'


### PR DESCRIPTION
## Summary

Optimizes UI CI workflows by improving cache strategy for faster builds.

## Changes

- Cache `node_modules` alongside pnpm store to skip install on cache hit
- Cache `.next/cache` for incremental Next.js builds  
- Add `--prefer-offline` flag to use cached packages first
- Improve cache key to include source file hashes for smarter invalidation

## Expected Impact

| Step | Before | After (cache hit) |
|------|--------|-------------------|
| `pnpm install` | ~60-90s | ~5-15s |
| `pnpm build` | ~60-120s | ~15-30s |

## Workflows Updated

- `ui-tests.yml`
- `ui-e2e-tests.yml`