### PR TITLE
fix: improve API startup process manage.py detection

### DIFF
--- a/api/src/backend/api/apps.py
+++ b/api/src/backend/api/apps.py
@@ -35,10 +35,12 @@ class ApiConfig(AppConfig):
         from api.compliance import load_prowler_compliance
 
         # Generate required cryptographic keys if not present, but only if:
-        #   `"manage.py" not in sys.argv`: If an external server (e.g., Gunicorn) is running the app
+        #   `"manage.py" not in sys.argv[1]`: If an external server (e.g., Gunicorn) is running the app
         #   `os.environ.get("RUN_MAIN")`: If it's not a Django command or using `runserver`,
         #                                 only the main process will do it
-        if "manage.py" not in sys.argv or os.environ.get("RUN_MAIN"):
+        if (len(sys.argv) >= 1 and "manage.py" not in sys.argv[0]) or os.environ.get(
+            "RUN_MAIN"
+        ):
             self._ensure_crypto_keys()
 
         # Commands that don't need Neo4j
@@ -51,9 +53,10 @@ class ApiConfig(AppConfig):
             "check_and_fix_socialaccount_sites_migration",
         ]
 
+        # Skip Neo4j initialization during tests or specific Django commands
         if getattr(settings, "TESTING", False) or (
-            "manage.py" in sys.argv
-            and len(sys.argv) > 1
+            len(sys.argv) > 1
+            and "manage.py" in sys.argv[0]
             and sys.argv[1] in SKIP_NEO4J_DJANGO_COMMANDS
         ):
             logger.info(

--- a/api/src/backend/api/apps.py
+++ b/api/src/backend/api/apps.py
@@ -35,7 +35,7 @@ class ApiConfig(AppConfig):
         from api.compliance import load_prowler_compliance
 
         # Generate required cryptographic keys if not present, but only if:
-        #   `"manage.py" not in sys.argv[1]`: If an external server (e.g., Gunicorn) is running the app
+        #   `"manage.py" not in sys.argv[0]`: If an external server (e.g., Gunicorn) is running the app
         #   `os.environ.get("RUN_MAIN")`: If it's not a Django command or using `runserver`,
         #                                 only the main process will do it
         if (len(sys.argv) >= 1 and "manage.py" not in sys.argv[0]) or os.environ.get(


### PR DESCRIPTION
### Description

The API startup process couldn't behave as expected if called as `python src/backend/manage.py` instead of the expected `python manage.py`.

### Steps to review

Just pass the tests and startup the application in local.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [s] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
