### PR TITLE
fix(attack-paths): read findings using replica DB and add more logs

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the **Prowler API** are documented in this file.
 - Improve API startup process by `manage.py` argument detection [(#9856)](https://github.com/prowler-cloud/prowler/pull/9856)
 - Deleting providers don't try to delete a `None` Neo4j database when an Attack Paths scan is scheduled [(#9858)](https://github.com/prowler-cloud/prowler/pull/9858)
 
+### Fixed
+
+- Use replica database for reading Findings to add them to the Attack Paths graph [(#9861)](https://github.com/prowler-cloud/prowler/pull/9861)
+
 ## [1.18.0] (Prowler v5.17.0)
 
 ### Added
@@ -21,6 +25,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Attack Paths: `/api/v1/attack-paths-scans` for AWS providers backed by Neo4j [(#9805)](https://github.com/prowler-cloud/prowler/pull/9805)
 
 ### Security
+
 - Django 5.1.15 (CVE-2025-64460, CVE-2025-13372), Werkzeug 3.1.4 (CVE-2025-66221), sqlparse 0.5.5 (PVE-2025-82038), fonttools 4.60.2 (CVE-2025-66034) [(#9730)](https://github.com/prowler-cloud/prowler/pull/9730)
 - `safety` to `3.7.0` and `filelock` to `3.20.3` due to [Safety vulnerability 82754 (CVE-2025-68146)](https://data.safetycli.com/v/82754/97c/) [(#9816)](https://github.com/prowler-cloud/prowler/pull/9816)
 - `pyasn1` to v0.6.2 to address [CVE-2026-23490](https://nvd.nist.gov/vuln/detail/CVE-2026-23490) [(#9818)](https://github.com/prowler-cloud/prowler/pull/9818)

--- a/api/src/backend/tasks/jobs/attack_paths/aws.py
+++ b/api/src/backend/tasks/jobs/attack_paths/aws.py
@@ -59,6 +59,7 @@ def start_aws_ingestion(
     )
 
     # Starting with sync functions
+    logger.info(f"Syncing organizations for AWS account {prowler_api_provider.uid}")
     cartography_aws.organizations.sync(
         neo4j_session,
         {prowler_api_provider.alias: prowler_api_provider.uid},
@@ -84,13 +85,22 @@ def start_aws_ingestion(
     )
 
     if "permission_relationships" in requested_syncs:
+        logger.info(
+            f"Syncing function permission_relationships for AWS account {prowler_api_provider.uid}"
+        )
         cartography_aws.RESOURCE_FUNCTIONS["permission_relationships"](**sync_args)
     db_utils.update_attack_paths_scan_progress(attack_paths_scan, 88)
 
     if "resourcegroupstaggingapi" in requested_syncs:
+        logger.info(
+            f"Syncing function resourcegroupstaggingapi for AWS account {prowler_api_provider.uid}"
+        )
         cartography_aws.RESOURCE_FUNCTIONS["resourcegroupstaggingapi"](**sync_args)
     db_utils.update_attack_paths_scan_progress(attack_paths_scan, 89)
 
+    logger.info(
+        f"Syncing ec2_iaminstanceprofile scoped analysis for AWS account {prowler_api_provider.uid}"
+    )
     cartography_aws.run_scoped_analysis_job(
         "aws_ec2_iaminstanceprofile.json",
         neo4j_session,
@@ -98,6 +108,9 @@ def start_aws_ingestion(
     )
     db_utils.update_attack_paths_scan_progress(attack_paths_scan, 90)
 
+    logger.info(
+        f"Syncing lambda_ecr analysis for AWS account {prowler_api_provider.uid}"
+    )
     cartography_aws.run_analysis_job(
         "aws_lambda_ecr.json",
         neo4j_session,
@@ -105,6 +118,7 @@ def start_aws_ingestion(
     )
     db_utils.update_attack_paths_scan_progress(attack_paths_scan, 91)
 
+    logger.info(f"Syncing metadata for AWS account {prowler_api_provider.uid}")
     cartography_aws.merge_module_sync_metadata(
         neo4j_session,
         group_type="AWSAccount",
@@ -118,6 +132,7 @@ def start_aws_ingestion(
     # Removing the added extra field
     del common_job_parameters["AWS_ID"]
 
+    logger.info(f"Syncing cleanup_job for AWS account {prowler_api_provider.uid}")
     cartography_aws.run_cleanup_job(
         "aws_post_ingestion_principals_cleanup.json",
         neo4j_session,
@@ -125,6 +140,7 @@ def start_aws_ingestion(
     )
     db_utils.update_attack_paths_scan_progress(attack_paths_scan, 93)
 
+    logger.info(f"Syncing analysis for AWS account {prowler_api_provider.uid}")
     cartography_aws._perform_aws_analysis(
         requested_syncs, neo4j_session, common_job_parameters
     )

--- a/api/src/backend/tasks/jobs/attack_paths/scan.py
+++ b/api/src/backend/tasks/jobs/attack_paths/scan.py
@@ -117,13 +117,22 @@ def run(tenant_id: str, scan_id: str, task_id: str) -> dict[str, Any]:
             )
 
             # Post-processing: Just keeping it to be more Cartography compliant
+            logger.info(
+                f"Syncing Cartography ontology for AWS account {prowler_api_provider.uid}"
+            )
             cartography_ontology.run(neo4j_session, cartography_config)
             db_utils.update_attack_paths_scan_progress(attack_paths_scan, 95)
 
+            logger.info(
+                f"Syncing Cartography analysis for AWS account {prowler_api_provider.uid}"
+            )
             cartography_analysis.run(neo4j_session, cartography_config)
             db_utils.update_attack_paths_scan_progress(attack_paths_scan, 96)
 
             # Adding Prowler nodes and relationships
+            logger.info(
+                f"Syncing Prowler analysis for AWS account {prowler_api_provider.uid}"
+            )
             prowler.analysis(
                 neo4j_session, prowler_api_provider, scan_id, cartography_config
             )

--- a/api/src/backend/tasks/tests/test_attack_paths_scan.py
+++ b/api/src/backend/tasks/tests/test_attack_paths_scan.py
@@ -402,6 +402,9 @@ class TestAttackPathsProwlerHelpers:
         with patch(
             "tasks.jobs.attack_paths.prowler.rls_transaction",
             new=lambda *args, **kwargs: nullcontext(),
+        ), patch(
+            "tasks.jobs.attack_paths.prowler.MainRouter.replica_db",
+            "default",
         ):
             findings_data = prowler_module.get_provider_last_scan_findings(
                 provider,


### PR DESCRIPTION
### Description

In the Attack Paths scans, when the Cartography run is done, we take all the Prowler Findings for the regular scan and add it the graph database. The reading of the Findings now is done using the replica database.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.