### PR TITLE
fix(neo4j): lazy load driver

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Deleting providers don't try to delete a `None` Neo4j database when an Attack Paths scan is scheduled [(#9858)](https://github.com/prowler-cloud/prowler/pull/9858)
 - Use replica database for reading Findings to add them to the Attack Paths graph [(#9861)](https://github.com/prowler-cloud/prowler/pull/9861)
 - Attack paths findings loading query to use streaming generator for O(batch_size) memory instead of O(total_findings) [(#9862)](https://github.com/prowler-cloud/prowler/pull/9862)
+- Lazy load Neo4j driver [(#9868)](https://github.com/prowler-cloud/prowler/pull/9868)
 
 ## [1.18.0] (Prowler v5.17.0)
 

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -112,9 +112,7 @@ def drop_subgraph(database: str, root_node_label: str, root_node_id: str) -> int
         YIELD node
         DETACH DELETE node
         RETURN COUNT(node) AS deleted_nodes_count
-    """.replace(
-        "__ROOT_NODE_LABEL__", root_node_label
-    )
+    """.replace("__ROOT_NODE_LABEL__", root_node_label)
     parameters = {"root_node_id": root_node_id}
 
     with get_session(database) as session:

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -20,7 +20,6 @@ SERVICE_UNAVAILABLE_MAX_RETRIES = 3
 # Module-level process-wide driver singleton
 _driver: neo4j.Driver | None = None
 _lock = threading.Lock()
-_atexit_registered = False
 
 # Base Neo4j functions
 
@@ -32,7 +31,7 @@ def get_uri() -> str:
 
 
 def init_driver() -> neo4j.Driver:
-    global _driver, _atexit_registered
+    global _driver
     if _driver is not None:
         return _driver
 
@@ -51,10 +50,8 @@ def init_driver() -> neo4j.Driver:
             )
             _driver.verify_connectivity()
 
-            # Register cleanup handler on first initialization
-            if not _atexit_registered:
-                atexit.register(close_driver)
-                _atexit_registered = True
+            # Register cleanup handler (only runs once since we're inside the _driver is None block)
+            atexit.register(close_driver)
 
     return _driver
 

--- a/api/src/backend/api/tests/test_attack_paths_database.py
+++ b/api/src/backend/api/tests/test_attack_paths_database.py
@@ -1,0 +1,333 @@
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestLazyInitialization:
+    """Test that Neo4j driver is initialized lazily on first use."""
+
+    @pytest.fixture(autouse=True)
+    def reset_module_state(self):
+        """Reset module-level singleton state before each test."""
+        import api.attack_paths.database as db_module
+
+        original_driver = db_module._driver
+        original_atexit_registered = db_module._atexit_registered
+
+        db_module._driver = None
+        db_module._atexit_registered = False
+
+        yield
+
+        db_module._driver = original_driver
+        db_module._atexit_registered = original_atexit_registered
+
+    def test_driver_not_initialized_at_import(self):
+        """Driver should be None after module import (no eager connection)."""
+        import api.attack_paths.database as db_module
+
+        assert db_module._driver is None
+
+    @patch("api.attack_paths.database.settings")
+    @patch("api.attack_paths.database.neo4j.GraphDatabase.driver")
+    def test_init_driver_creates_connection_on_first_call(
+        self, mock_driver_factory, mock_settings
+    ):
+        """init_driver() should create connection only when called."""
+        import api.attack_paths.database as db_module
+
+        mock_driver = MagicMock()
+        mock_driver_factory.return_value = mock_driver
+        mock_settings.DATABASES = {
+            "neo4j": {
+                "HOST": "localhost",
+                "PORT": 7687,
+                "USER": "neo4j",
+                "PASSWORD": "password",
+            }
+        }
+
+        assert db_module._driver is None
+
+        result = db_module.init_driver()
+
+        mock_driver_factory.assert_called_once()
+        mock_driver.verify_connectivity.assert_called_once()
+        assert result is mock_driver
+        assert db_module._driver is mock_driver
+
+    @patch("api.attack_paths.database.settings")
+    @patch("api.attack_paths.database.neo4j.GraphDatabase.driver")
+    def test_init_driver_returns_cached_driver_on_subsequent_calls(
+        self, mock_driver_factory, mock_settings
+    ):
+        """Subsequent calls should return cached driver without reconnecting."""
+        import api.attack_paths.database as db_module
+
+        mock_driver = MagicMock()
+        mock_driver_factory.return_value = mock_driver
+        mock_settings.DATABASES = {
+            "neo4j": {
+                "HOST": "localhost",
+                "PORT": 7687,
+                "USER": "neo4j",
+                "PASSWORD": "password",
+            }
+        }
+
+        first_result = db_module.init_driver()
+        second_result = db_module.init_driver()
+        third_result = db_module.init_driver()
+
+        # Only one connection attempt
+        assert mock_driver_factory.call_count == 1
+        assert mock_driver.verify_connectivity.call_count == 1
+
+        # All calls return same instance
+        assert first_result is second_result is third_result
+
+    @patch("api.attack_paths.database.settings")
+    @patch("api.attack_paths.database.neo4j.GraphDatabase.driver")
+    def test_get_driver_delegates_to_init_driver(
+        self, mock_driver_factory, mock_settings
+    ):
+        """get_driver() should use init_driver() for lazy initialization."""
+        import api.attack_paths.database as db_module
+
+        mock_driver = MagicMock()
+        mock_driver_factory.return_value = mock_driver
+        mock_settings.DATABASES = {
+            "neo4j": {
+                "HOST": "localhost",
+                "PORT": 7687,
+                "USER": "neo4j",
+                "PASSWORD": "password",
+            }
+        }
+
+        result = db_module.get_driver()
+
+        assert result is mock_driver
+        mock_driver_factory.assert_called_once()
+
+
+class TestAtexitRegistration:
+    """Test that atexit cleanup handler is registered correctly."""
+
+    @pytest.fixture(autouse=True)
+    def reset_module_state(self):
+        """Reset module-level singleton state before each test."""
+        import api.attack_paths.database as db_module
+
+        original_driver = db_module._driver
+        original_atexit_registered = db_module._atexit_registered
+
+        db_module._driver = None
+        db_module._atexit_registered = False
+
+        yield
+
+        db_module._driver = original_driver
+        db_module._atexit_registered = original_atexit_registered
+
+    @patch("api.attack_paths.database.settings")
+    @patch("api.attack_paths.database.atexit.register")
+    @patch("api.attack_paths.database.neo4j.GraphDatabase.driver")
+    def test_atexit_registered_on_first_init(
+        self, mock_driver_factory, mock_atexit_register, mock_settings
+    ):
+        """atexit.register should be called on first initialization."""
+        import api.attack_paths.database as db_module
+
+        mock_driver_factory.return_value = MagicMock()
+        mock_settings.DATABASES = {
+            "neo4j": {
+                "HOST": "localhost",
+                "PORT": 7687,
+                "USER": "neo4j",
+                "PASSWORD": "password",
+            }
+        }
+
+        db_module.init_driver()
+
+        mock_atexit_register.assert_called_once_with(db_module.close_driver)
+        assert db_module._atexit_registered is True
+
+    @patch("api.attack_paths.database.settings")
+    @patch("api.attack_paths.database.atexit.register")
+    @patch("api.attack_paths.database.neo4j.GraphDatabase.driver")
+    def test_atexit_registered_only_once(
+        self, mock_driver_factory, mock_atexit_register, mock_settings
+    ):
+        """atexit.register should only be called once across multiple inits."""
+        import api.attack_paths.database as db_module
+
+        mock_driver_factory.return_value = MagicMock()
+        mock_settings.DATABASES = {
+            "neo4j": {
+                "HOST": "localhost",
+                "PORT": 7687,
+                "USER": "neo4j",
+                "PASSWORD": "password",
+            }
+        }
+
+        db_module.init_driver()
+        db_module.init_driver()
+        db_module.init_driver()
+
+        # Only registered once
+        assert mock_atexit_register.call_count == 1
+
+    @patch("api.attack_paths.database.settings")
+    @patch("api.attack_paths.database.atexit.register")
+    @patch("api.attack_paths.database.neo4j.GraphDatabase.driver")
+    def test_atexit_not_registered_if_driver_already_exists(
+        self, mock_driver_factory, mock_atexit_register, mock_settings
+    ):
+        """If driver exists (fast path), atexit should not be re-registered."""
+        import api.attack_paths.database as db_module
+
+        mock_driver = MagicMock()
+        mock_driver_factory.return_value = mock_driver
+        mock_settings.DATABASES = {
+            "neo4j": {
+                "HOST": "localhost",
+                "PORT": 7687,
+                "USER": "neo4j",
+                "PASSWORD": "password",
+            }
+        }
+
+        # First call - registers atexit
+        db_module.init_driver()
+        assert mock_atexit_register.call_count == 1
+
+        # Simulate driver already exists (fast path in init_driver)
+        # Second call should hit the fast path and not touch atexit
+        db_module.init_driver()
+        assert mock_atexit_register.call_count == 1
+
+
+class TestCloseDriver:
+    """Test driver cleanup functionality."""
+
+    @pytest.fixture(autouse=True)
+    def reset_module_state(self):
+        """Reset module-level singleton state before each test."""
+        import api.attack_paths.database as db_module
+
+        original_driver = db_module._driver
+        original_atexit_registered = db_module._atexit_registered
+
+        db_module._driver = None
+        db_module._atexit_registered = False
+
+        yield
+
+        db_module._driver = original_driver
+        db_module._atexit_registered = original_atexit_registered
+
+    def test_close_driver_closes_and_clears_driver(self):
+        """close_driver() should close the driver and set it to None."""
+        import api.attack_paths.database as db_module
+
+        mock_driver = MagicMock()
+        db_module._driver = mock_driver
+
+        db_module.close_driver()
+
+        mock_driver.close.assert_called_once()
+        assert db_module._driver is None
+
+    def test_close_driver_handles_none_driver(self):
+        """close_driver() should handle case where driver is None."""
+        import api.attack_paths.database as db_module
+
+        db_module._driver = None
+
+        # Should not raise
+        db_module.close_driver()
+
+        assert db_module._driver is None
+
+    def test_close_driver_clears_driver_even_on_close_error(self):
+        """Driver should be cleared even if close() raises an exception."""
+        import api.attack_paths.database as db_module
+
+        mock_driver = MagicMock()
+        mock_driver.close.side_effect = Exception("Connection error")
+        db_module._driver = mock_driver
+
+        with pytest.raises(Exception, match="Connection error"):
+            db_module.close_driver()
+
+        # Driver should still be cleared
+        assert db_module._driver is None
+
+
+class TestThreadSafety:
+    """Test thread-safe initialization."""
+
+    @pytest.fixture(autouse=True)
+    def reset_module_state(self):
+        """Reset module-level singleton state before each test."""
+        import api.attack_paths.database as db_module
+
+        original_driver = db_module._driver
+        original_atexit_registered = db_module._atexit_registered
+
+        db_module._driver = None
+        db_module._atexit_registered = False
+
+        yield
+
+        db_module._driver = original_driver
+        db_module._atexit_registered = original_atexit_registered
+
+    @patch("api.attack_paths.database.settings")
+    @patch("api.attack_paths.database.neo4j.GraphDatabase.driver")
+    def test_concurrent_init_creates_single_driver(
+        self, mock_driver_factory, mock_settings
+    ):
+        """Multiple threads calling init_driver() should create only one driver."""
+        import api.attack_paths.database as db_module
+
+        mock_driver = MagicMock()
+        mock_driver_factory.return_value = mock_driver
+        mock_settings.DATABASES = {
+            "neo4j": {
+                "HOST": "localhost",
+                "PORT": 7687,
+                "USER": "neo4j",
+                "PASSWORD": "password",
+            }
+        }
+
+        results = []
+        errors = []
+
+        def call_init():
+            try:
+                result = db_module.init_driver()
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=call_init) for _ in range(10)]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Threads raised errors: {errors}"
+
+        # Only one driver created
+        assert mock_driver_factory.call_count == 1
+
+        # All threads got the same driver instance
+        assert all(r is mock_driver for r in results)
+        assert len(results) == 10


### PR DESCRIPTION
### Context
Regular scans were failing when Neo4j was unavailable because the Neo4j driver was being initialized eagerly at Django app startup. This affected Celery workers running regular security scans that don't require graph database functionality.

### Description

Changed Neo4j driver initialization from eager (at app startup) to lazy (on first use):
- Removed eager `init_driver()` call from `ApiConfig.ready()` in `apps.py`
- Moved `atexit.register(close_driver)` into `init_driver()` so cleanup is only registered when a connection is actually created
- Added comprehensive tests for the lazy initialization pattern

Before: App starts → Connect to Neo4j immediately → Fail if Neo4j is down
After: App starts → Do nothing → Connect only when attack paths feature is used

| Scenario | Before | After |
|----------|--------|-------|
| API server starts | Connects to Neo4j | No connection |
| Celery worker starts | Connects to Neo4j | No connection |
| Regular scan runs | Already connected (or fails) | No connection needed |
| Attack paths scan/query | Already connected | Connects on first use |

### Steps to review
1. Verify tests pass:
```
cd api && poetry run pytest src/backend/api/tests/test_attack_paths_database.py -v
```
   
3. Verify existing attack paths tests still pass:
```
cd api && poetry run pytest src/backend/api/tests/test_attack_paths.py src/backend/tasks/tests/test_attack_paths_scan.py -v
```
   
4. Code review the lazy initialization pattern in database.py:
   - Double-checked locking for thread safety
   - atexit registration inside the lock to ensure it happens once

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
