### PR TITLE
fix(attack-paths): Start Neo4j at startup for API only

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Attack paths findings loading query to use streaming generator for O(batch_size) memory instead of O(total_findings) [(#9862)](https://github.com/prowler-cloud/prowler/pull/9862)
 - Lazy load Neo4j driver [(#9868)](https://github.com/prowler-cloud/prowler/pull/9868)
 - Use `Findings.all_objects` to avoid the `ActiveProviderPartitionedManager` [(#9869)](https://github.com/prowler-cloud/prowler/pull/9869)
-- Lazy load Neo4j driver for workers oly [(#9872)](https://github.com/prowler-cloud/prowler/pull/9872)
+- Lazy load Neo4j driver for workers only [(#9872)](https://github.com/prowler-cloud/prowler/pull/9872)
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Attack paths findings loading query to use streaming generator for O(batch_size) memory instead of O(total_findings) [(#9862)](https://github.com/prowler-cloud/prowler/pull/9862)
 - Lazy load Neo4j driver [(#9868)](https://github.com/prowler-cloud/prowler/pull/9868)
 - Use `Findings.all_objects` to avoid the `ActiveProviderPartitionedManager` [(#9869)](https://github.com/prowler-cloud/prowler/pull/9869)
+- Lazy load Neo4j driver for workers oly [(#9872)](https://github.com/prowler-cloud/prowler/pull/9872)
 
 ---
 

--- a/api/src/backend/api/apps.py
+++ b/api/src/backend/api/apps.py
@@ -30,6 +30,7 @@ class ApiConfig(AppConfig):
     def ready(self):
         from api import schema_extensions  # noqa: F401
         from api import signals  # noqa: F401
+        from api.attack_paths import database as graph_database
 
         # Generate required cryptographic keys if not present, but only if:
         #   `"manage.py" not in sys.argv[0]`: If an external server (e.g., Gunicorn) is running the app
@@ -39,6 +40,35 @@ class ApiConfig(AppConfig):
             "RUN_MAIN"
         ):
             self._ensure_crypto_keys()
+
+        # Commands that don't need Neo4j
+        SKIP_NEO4J_DJANGO_COMMANDS = [
+            "makemigrations",
+            "migrate",
+            "pgpartition",
+            "check",
+            "help",
+            "showmigrations",
+            "check_and_fix_socialaccount_sites_migration",
+        ]
+
+        # Skip Neo4j initialization during tests, some Django commands, and Celery
+        if getattr(settings, "TESTING", False) or (
+            len(sys.argv) > 1
+            and (
+                (
+                    "manage.py" in sys.argv[0]
+                    and sys.argv[1] in SKIP_NEO4J_DJANGO_COMMANDS
+                )
+                or "celery" in sys.argv[0]
+            )
+        ):
+            logger.info(
+                "Skipping Neo4j initialization because tests, some Django commands or Celery"
+            )
+
+        else:
+            graph_database.init_driver()
 
         # Neo4j driver is initialized lazily on first use (see api.attack_paths.database)
         # This avoids connection attempts during regular scans that don't need graph database

--- a/api/src/backend/api/apps.py
+++ b/api/src/backend/api/apps.py
@@ -70,8 +70,8 @@ class ApiConfig(AppConfig):
         else:
             graph_database.init_driver()
 
-        # Neo4j driver is initialized lazily on first use (see api.attack_paths.database)
-        # This avoids connection attempts during regular scans that don't need graph database
+        # Neo4j driver is initialized at API startup (see api.attack_paths.database)
+        # It remains lazy for Celery workers and selected Django commands
 
     def _ensure_crypto_keys(self):
         """

--- a/api/src/backend/api/tests/test_attack_paths_database.py
+++ b/api/src/backend/api/tests/test_attack_paths_database.py
@@ -1,8 +1,9 @@
 """
 Tests for Neo4j database lazy initialization.
 
-The Neo4j driver should only connect when actually needed (lazy initialization),
-not at Django app startup. This allows regular scans to run without Neo4j.
+The Neo4j driver connects on first use by default. API processes may
+eagerly initialize the driver during app startup, while Celery workers
+remain lazy. These tests validate the database module behavior itself.
 """
 
 import threading


### PR DESCRIPTION
### Description

Ensures Neo4j connects during API startup while keeping Celery and management commands lazy.

### Steps to review

Run tests and start whole application in a local environment.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
