### PR TITLE
fix(attack-paths): correct aws-security-groups-open-internet-facing query

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [1.18.2] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Attack Paths: `aws-security-groups-open-internet-facing` query returning no results due to incorrect relationship matching [(#PROWLER-875)](https://github.com/prowler-cloud/prowler/pull/PROWLER-875)
+
+---
+
 ## [1.18.1] (Prowler v5.17.1)
 
 ### Fixed


### PR DESCRIPTION
### Context

The Attack Path query "Identify internet-facing resources with open security groups" was returning no results while "Identify internet-exposed EC2 instances" correctly identified EC2 instances with open security groups.

### Description

The query was broken due to:
1. **Wrong WHERE clause placement**: `WHERE open.scheme = 'internet-facing'` was placed after an `OPTIONAL MATCH` for DNS records, making it ineffective
2. **Wrong property check**: `scheme = 'internet-facing'` is for Load Balancers, not EC2 instances (which use `exposed_internet = true`)
3. **Explicit relationship types**: Used specific relationship types that didn't match Cartography's schema

Fixed by simplifying the query to use implicit relationships like other working queries in the same file.

### Steps to review

1. Compare with the working `aws-ec2-instances-internet-exposed` query pattern
2. Verify the fix matches the Cartography Neo4j schema for EC2SecurityGroup relationships
3. Test with an EC2 instance that has `exposed_internet = true` and a security group allowing 0.0.0.0/0

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- N/A (API-only change)

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
