### PR TITLE
fix(api): handle AccessDenied during AssumeRole in events endpoint

### DIFF
--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -284,7 +284,10 @@ from api.v1.serializers import (
     UserSerializer,
     UserUpdateSerializer,
 )
-from prowler.providers.aws.exceptions.exceptions import AWSCredentialsError
+from prowler.providers.aws.exceptions.exceptions import (
+    AWSAssumeRoleError,
+    AWSCredentialsError,
+)
 from prowler.providers.aws.lib.cloudtrail_timeline.cloudtrail_timeline import (
     CloudTrailTimeline,
 )
@@ -3043,6 +3046,11 @@ class ResourceViewSet(PaginateByPkMixin, BaseRLSViewSet):
             # 502 because this is an upstream auth failure, not API auth failure
             raise UpstreamAuthenticationError(
                 detail="Credentials not found for this provider. Please reconnect the provider."
+            )
+        except AWSAssumeRoleError:
+            # AssumeRole failed - usually IAM permission issue (not authorized to sts:AssumeRole)
+            raise UpstreamAccessDeniedError(
+                detail="Cannot assume role for this provider. Check IAM Role permissions and trust relationship."
             )
         except AWSCredentialsError:
             # Handles expired tokens, invalid keys, profile not found, etc.


### PR DESCRIPTION
### Description

Handle AccessDenied during AssumeRole in events endpoint.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [ x Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
