### PR TITLE
[CHAIN] feat(ui): add expandable row support to DataTable

### DIFF
--- a/ui/app/(prowler)/demo-expandable-table/page.tsx
+++ b/ui/app/(prowler)/demo-expandable-table/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { CloudIcon, FolderIcon, ServerIcon } from "lucide-react";
+
+import { DataTable } from "@/components/ui/table/data-table";
+import { DataTableExpandAllToggle } from "@/components/ui/table/data-table-expand-all-toggle";
+import { DataTableExpandableCell } from "@/components/ui/table/data-table-expandable-cell";
+
+/**
+ * Demo page for the Expandable DataTable component.
+ *
+ * Showcases:
+ * 1. Hierarchical rows with expand/collapse
+ * 2. Expand all / collapse all toggle
+ * 3. Row selection with child auto-selection
+ */
+
+interface HierarchicalProvider {
+  id: string;
+  name: string;
+  type: "organization" | "ou" | "account";
+  status: "connected" | "disconnected" | "pending";
+  resourceCount: number;
+  children?: HierarchicalProvider[];
+}
+
+const tableData: HierarchicalProvider[] = [
+  {
+    id: "org-1",
+    name: "AWS Organization",
+    type: "organization",
+    status: "connected",
+    resourceCount: 1250,
+    children: [
+      {
+        id: "ou-prod",
+        name: "Production OU",
+        type: "ou",
+        status: "connected",
+        resourceCount: 800,
+        children: [
+          {
+            id: "acc-prod-1",
+            name: "prod-web-services",
+            type: "account",
+            status: "connected",
+            resourceCount: 450,
+          },
+          {
+            id: "acc-prod-2",
+            name: "prod-databases",
+            type: "account",
+            status: "connected",
+            resourceCount: 350,
+          },
+        ],
+      },
+      {
+        id: "ou-dev",
+        name: "Development OU",
+        type: "ou",
+        status: "connected",
+        resourceCount: 450,
+        children: [
+          {
+            id: "acc-dev-1",
+            name: "dev-sandbox",
+            type: "account",
+            status: "pending",
+            resourceCount: 200,
+          },
+          {
+            id: "acc-dev-2",
+            name: "dev-testing",
+            type: "account",
+            status: "disconnected",
+            resourceCount: 250,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const STATUS_COLORS = {
+  connected: "text-green-500",
+  disconnected: "text-red-500",
+  pending: "text-yellow-500",
+} as const;
+
+const TYPE_ICONS = {
+  organization: ServerIcon,
+  ou: FolderIcon,
+  account: CloudIcon,
+} as const;
+
+const columns: ColumnDef<HierarchicalProvider>[] = [
+  {
+    accessorKey: "name",
+    size: 300,
+    header: ({ table }) => (
+      <div className="flex items-center gap-2">
+        <DataTableExpandAllToggle table={table} />
+        <span>Name</span>
+      </div>
+    ),
+    cell: ({ row }) => {
+      const Icon = TYPE_ICONS[row.original.type];
+      return (
+        <DataTableExpandableCell row={row}>
+          <div className="flex items-center gap-2">
+            <Icon className="h-4 w-4 shrink-0" />
+            <span>{row.original.name}</span>
+          </div>
+        </DataTableExpandableCell>
+      );
+    },
+  },
+  {
+    accessorKey: "type",
+    size: 120,
+    header: "Type",
+    cell: ({ row }) => <span className="capitalize">{row.original.type}</span>,
+  },
+  {
+    accessorKey: "status",
+    size: 120,
+    header: "Status",
+    cell: ({ row }) => (
+      <span className={STATUS_COLORS[row.original.status]}>
+        {row.original.status}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "resourceCount",
+    size: 100,
+    header: "Resources",
+    cell: ({ row }) => row.original.resourceCount.toLocaleString(),
+  },
+];
+
+export default function DemoExpandableTablePage() {
+  return (
+    <div className="container mx-auto space-y-12 p-8">
+      <h1 className="text-3xl font-bold">Expandable DataTable Demo</h1>
+
+      {/* Expandable DataTable */}
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">Expandable DataTable</h2>
+          <p className="text-text-neutral-secondary text-sm">
+            Table with hierarchical rows. Click chevron to expand/collapse, or
+            use the header icon to expand/collapse all.
+          </p>
+        </div>
+
+        <DataTable
+          columns={columns}
+          data={tableData}
+          getSubRows={(row) => row.children}
+          defaultExpanded={true}
+        />
+      </section>
+
+      {/* Expandable DataTable with Row Selection */}
+      <section className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">
+            Expandable DataTable with Row Selection
+          </h2>
+          <p className="text-text-neutral-secondary text-sm">
+            Selecting a parent auto-selects all children
+            (enableSubRowSelection).
+          </p>
+        </div>
+
+        <DataTable
+          columns={columns}
+          data={tableData}
+          getSubRows={(row) => row.children}
+          enableRowSelection
+          enableSubRowSelection
+          defaultExpanded={{ "org-1": true, "ou-prod": true }}
+        />
+      </section>
+    </div>
+  );
+}

--- a/ui/components/ui/table/data-table-animated-row.tsx
+++ b/ui/components/ui/table/data-table-animated-row.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Cell, flexRender, Row } from "@tanstack/react-table";
+import { motion } from "framer-motion";
+
+import { cn } from "@/lib/utils";
+
+interface DataTableAnimatedRowProps<TData> {
+  row: Row<TData>;
+}
+
+/**
+ * DataTableAnimatedRow renders a table row with smooth expand/collapse animations.
+ *
+ * The trick: You cannot animate <tr> height directly (tables ignore it).
+ * Instead, we wrap each cell's content in a motion.div and animate THAT.
+ *
+ * How it works:
+ * 1. The <tr> itself is not animated
+ * 2. Each <td> contains a motion.div wrapper
+ * 3. The wrapper animates height from 0 to "auto"
+ * 4. overflow-hidden clips content during animation
+ * 5. Padding is on the inner content, not the td
+ */
+export function DataTableAnimatedRow<TData>({
+  row,
+}: DataTableAnimatedRowProps<TData>) {
+  return (
+    <motion.tr
+      initial="collapsed"
+      animate="open"
+      exit="collapsed"
+      variants={{
+        open: { opacity: 1 },
+        collapsed: { opacity: 0 },
+      }}
+      transition={{ duration: 0.2 }}
+      data-state={row.getIsSelected() ? "selected" : undefined}
+      className={cn(
+        "transition-colors",
+        "[&>td:first-child]:rounded-l-full [&>td:last-child]:rounded-r-full",
+        "hover:bg-bg-neutral-tertiary",
+        "data-[state=selected]:bg-bg-neutral-tertiary",
+      )}
+    >
+      {row.getVisibleCells().map((cell: Cell<TData, unknown>) => (
+        <td key={cell.id} className="overflow-hidden p-0">
+          <motion.div
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            variants={{
+              open: {
+                height: "auto",
+                opacity: 1,
+                transition: {
+                  height: { duration: 0.2, ease: "easeOut" },
+                  opacity: { duration: 0.15, delay: 0.05 },
+                },
+              },
+              collapsed: {
+                height: 0,
+                opacity: 0,
+                transition: {
+                  height: { duration: 0.2, ease: "easeIn" },
+                  opacity: { duration: 0.1 },
+                },
+              },
+            }}
+            className="overflow-hidden"
+          >
+            <div className="px-1.5 py-2 first:pl-3 last:pr-3">
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </div>
+          </motion.div>
+        </td>
+      ))}
+    </motion.tr>
+  );
+}

--- a/ui/components/ui/table/data-table-expand-all-toggle.tsx
+++ b/ui/components/ui/table/data-table-expand-all-toggle.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Table } from "@tanstack/react-table";
+import { Maximize2Icon, Minimize2Icon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface DataTableExpandAllToggleProps<TData> {
+  table: Table<TData>;
+}
+
+/**
+ * DataTableExpandAllToggle provides a button in the table header to expand
+ * or collapse all rows at once.
+ *
+ * Features:
+ * - Shows Maximize2 icon when rows are collapsed (click to expand all)
+ * - Shows Minimize2 icon when rows are expanded (click to collapse all)
+ * - Accessible with proper aria-label
+ * - Only renders when the table has expandable rows
+ *
+ * @example
+ * ```tsx
+ * // In column definition header:
+ * {
+ *   id: "name",
+ *   header: ({ table }) => (
+ *     <div className="flex items-center gap-2">
+ *       <DataTableExpandAllToggle table={table} />
+ *       <span>Name</span>
+ *     </div>
+ *   ),
+ *   cell: ({ row }) => (
+ *     <DataTableExpandableCell row={row}>
+ *       <span>{row.original.name}</span>
+ *     </DataTableExpandableCell>
+ *   ),
+ * }
+ * ```
+ */
+export function DataTableExpandAllToggle<TData>({
+  table,
+}: DataTableExpandAllToggleProps<TData>) {
+  const isAllExpanded = table.getIsAllRowsExpanded();
+  const canExpand = table.getCanSomeRowsExpand();
+
+  if (!canExpand) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={() => table.toggleAllRowsExpanded(!isAllExpanded)}
+      className={cn(
+        "rounded p-1 transition-colors",
+        "hover:bg-prowler-white/10",
+        "focus-visible:ring-border-input-primary-press focus-visible:ring-2 focus-visible:outline-none",
+      )}
+      aria-label={isAllExpanded ? "Collapse all rows" : "Expand all rows"}
+      aria-expanded={isAllExpanded}
+    >
+      {isAllExpanded ? (
+        <Minimize2Icon className="h-4 w-4" />
+      ) : (
+        <Maximize2Icon className="h-4 w-4" />
+      )}
+    </button>
+  );
+}

--- a/ui/components/ui/table/data-table-expand-toggle.tsx
+++ b/ui/components/ui/table/data-table-expand-toggle.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Row } from "@tanstack/react-table";
+import { ChevronRightIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface DataTableExpandToggleProps<TData> {
+  row: Row<TData>;
+}
+
+/**
+ * DataTableExpandToggle provides a clickable chevron button for expanding/collapsing
+ * table rows that have sub-rows.
+ *
+ * Features:
+ * - Only shows for rows that can expand (have sub-rows)
+ * - Provides consistent spacing for rows without sub-rows
+ * - Animates chevron rotation on expand/collapse
+ * - Accessible with proper aria-label
+ *
+ * @example
+ * ```tsx
+ * // In column definition:
+ * {
+ *   id: "expand",
+ *   cell: ({ row }) => <DataTableExpandToggle row={row} />,
+ * }
+ * ```
+ */
+export function DataTableExpandToggle<TData>({
+  row,
+}: DataTableExpandToggleProps<TData>) {
+  if (!row.getCanExpand()) {
+    // Return a spacer div for alignment when row has no sub-rows
+    return <div className="w-4" />;
+  }
+
+  return (
+    <button
+      onClick={row.getToggleExpandedHandler()}
+      className={cn(
+        "rounded p-1 transition-colors",
+        "hover:bg-prowler-white/10",
+        "focus-visible:ring-border-input-primary-press focus-visible:ring-2 focus-visible:outline-none",
+      )}
+      aria-label={row.getIsExpanded() ? "Collapse row" : "Expand row"}
+      aria-expanded={row.getIsExpanded()}
+    >
+      <ChevronRightIcon
+        className={cn(
+          "h-4 w-4 transition-transform duration-200",
+          row.getIsExpanded() && "rotate-90",
+        )}
+      />
+    </button>
+  );
+}

--- a/ui/components/ui/table/data-table-expandable-cell.tsx
+++ b/ui/components/ui/table/data-table-expandable-cell.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Row } from "@tanstack/react-table";
+import { CornerDownRightIcon } from "lucide-react";
+
+import { DataTableExpandToggle } from "./data-table-expand-toggle";
+
+interface DataTableExpandableCellProps<TData> {
+  row: Row<TData>;
+  children: React.ReactNode;
+  /** Whether to show the expand/collapse toggle (default: true) */
+  showToggle?: boolean;
+}
+
+/**
+ * DataTableExpandableCell is a wrapper component for table cells that need
+ * to display content with proper indentation for nested rows.
+ *
+ * Features:
+ * - Automatically indents content based on row depth
+ * - Shows CornerDownRight icon for child rows (depth > 0)
+ * - Optionally includes the expand/collapse toggle for parent rows
+ * - Maintains proper alignment for all nesting levels
+ *
+ * @example
+ * ```tsx
+ * // In column definition:
+ * {
+ *   accessorKey: "name",
+ *   header: "Name",
+ *   cell: ({ row }) => (
+ *     <DataTableExpandableCell row={row}>
+ *       <span>{row.original.name}</span>
+ *     </DataTableExpandableCell>
+ *   ),
+ * }
+ * ```
+ */
+export function DataTableExpandableCell<TData>({
+  row,
+  children,
+  showToggle = true,
+}: DataTableExpandableCellProps<TData>) {
+  const isChildRow = row.depth > 0;
+  const canExpand = row.getCanExpand();
+
+  return (
+    <div
+      className="flex items-center gap-2"
+      style={{ paddingLeft: `${row.depth * 1.5}rem` }}
+    >
+      {showToggle && (
+        <>
+          {canExpand ? (
+            <DataTableExpandToggle row={row} />
+          ) : isChildRow ? (
+            <CornerDownRightIcon className="h-4 w-4 shrink-0" />
+          ) : (
+            <div className="w-4" />
+          )}
+        </>
+      )}
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|-------|-------|
| **Feature Branch** | `feat/PROWLER-774-Findings-Hierarchical-Tree-View-Check-Resources` |
| **Main PR** | [#9909](https://github.com/prowler-cloud/prowler/pull/9909) |
| **Chain Position** | 2 of 6 (first implementation PR) |

### Chain Overview

```
         ┌─────────────────┐
         │ 876. API Model  │  <- Analysis (no PR)
         └────────┬────────┘
                  │
     ┌────────────┼────────────┐
     │            │            │
     ▼            ▼            ▼
┌─────────┐ ┌───────────┐ ┌───────────┐
│   877   │ │ 📍 #9912  │ │    880    │
│ Groups  │ │ DataTable │ │  Server   │
│  (API)  │ │   (930)   │ │ Actions   │
└────┬────┘ └─────┬─────┘ └─────┬─────┘
     │            │             │
     │            └──────┬──────┘
     │                   ▼
     │            ┌───────────┐
     │            │    881    │
     │            │   View    │
     │            └─────┬─────┘
     │                  │
     └────────┬─────────┘
              ▼
       ┌───────────┐
       │    882    │
       │ Integrate │
       └─────┬─────┘
             │
             ▼
       ┌───────────┐
       │  #9909    │
       │ → master  │
       └───────────┘
```

---

### Context

Part of chained PRs for Findings Hierarchical Tree View. This sub-task implements the foundational expandable DataTable component that will be used for the hierarchical findings view.

**Blocks:** 881 (Implement View)

---

### Description

Extends existing DataTable component with recursive row expansion support for hierarchical data display.

**Changes:**
- Add `getSubRows` prop for TanStack Table hierarchical data
- Add `expanded` and `onExpandedChange` for controlled expansion state
- Add `enableSubRowSelection` prop for nested row selection
- Add `defaultExpanded` prop for initial expansion state
- New `DataTableExpandableCell` component with depth-based indentation
- New `DataTableExpandToggle` component for row expand/collapse
- New `DataTableExpandAllToggle` for bulk expand/collapse
- New `DataTableAnimatedRow` with Framer Motion animations
- Demo page at `/demo-expandable-table`

---

### Steps to review

1. Check demo page at `/demo-expandable-table`
2. Verify expand/collapse individual rows works
3. Test expand/collapse all toggle
4. Verify row selection with sub-rows
5. Check animations are smooth

---

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.