### PR TITLE
fix(azure): remove duplicated findings in entra_user_with_vm_access_has_mfa

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update Azure Defender service metadata to new format [(#9618)](https://github.com/prowler-cloud/prowler/pull/9618)
 - Make AWS cross-account checks configurable through `trusted_account_ids` config parameter [(#9692)](https://github.com/prowler-cloud/prowler/pull/9692)
 
+### Fixed
+
+- Duplicated findings in `entra_user_with_vm_access_has_mfa` check when user has multiple VM access roles [(#9914)](https://github.com/prowler-cloud/prowler/pull/9914)
+
 ---
 
 ## [5.17.0] (Prowler v5.17.0)

--- a/prowler/providers/azure/services/entra/entra_user_with_vm_access_has_mfa/entra_user_with_vm_access_has_mfa.py
+++ b/prowler/providers/azure/services/entra/entra_user_with_vm_access_has_mfa/entra_user_with_vm_access_has_mfa.py
@@ -15,7 +15,7 @@ from prowler.providers.azure.services.iam.iam_client import iam_client
 class entra_user_with_vm_access_has_mfa(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
-        reported_combinations = set()
+        already_reported = set()
 
         for users in entra_client.users.values():
             for user in users.values():
@@ -23,7 +23,7 @@ class entra_user_with_vm_access_has_mfa(Check):
                     subscription_name,
                     role_assigns,
                 ) in iam_client.role_assignments.items():
-                    if (user.id, subscription_name) in reported_combinations:
+                    if (user.id, subscription_name) in already_reported:
                         continue
 
                     for assignment in role_assigns.values():
@@ -52,7 +52,7 @@ class entra_user_with_vm_access_has_mfa(Check):
                                 report.status_extended = f"User {user.name} can access VMs in subscription {subscription_name} but it has MFA."
 
                             findings.append(report)
-                            reported_combinations.add((user.id, subscription_name))
+                            already_reported.add((user.id, subscription_name))
                             break
 
         return findings

--- a/prowler/providers/azure/services/entra/entra_user_with_vm_access_has_mfa/entra_user_with_vm_access_has_mfa.py
+++ b/prowler/providers/azure/services/entra/entra_user_with_vm_access_has_mfa/entra_user_with_vm_access_has_mfa.py
@@ -15,6 +15,7 @@ from prowler.providers.azure.services.iam.iam_client import iam_client
 class entra_user_with_vm_access_has_mfa(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
+        reported_combinations = set()
 
         for users in entra_client.users.values():
             for user in users.values():
@@ -22,6 +23,9 @@ class entra_user_with_vm_access_has_mfa(Check):
                     subscription_name,
                     role_assigns,
                 ) in iam_client.role_assignments.items():
+                    if (user.id, subscription_name) in reported_combinations:
+                        continue
+
                     for assignment in role_assigns.values():
                         if (
                             assignment.agent_type == "User"
@@ -48,5 +52,7 @@ class entra_user_with_vm_access_has_mfa(Check):
                                 report.status_extended = f"User {user.name} can access VMs in subscription {subscription_name} but it has MFA."
 
                             findings.append(report)
+                            reported_combinations.add((user.id, subscription_name))
+                            break
 
         return findings


### PR DESCRIPTION
### Context

The check `entra_user_with_vm_access_has_mfa` was reporting duplicated findings when a user had multiple roles that grant VM access (e.g., Owner + Virtual Machine Contributor) within the same subscription.

Fix: https://github.com/prowler-cloud/prowler/issues/9913

### Description

This PR fixes the duplication by tracking which user+subscription combinations have already been reported. Once a finding is generated for a user in a subscription, subsequent role assignments for the same combination are skipped.

**Changes:**
- Added a `reported_combinations` set to track `(user.id, subscription_name)` pairs
- Skip processing if the combination was already reported
- Break out of the role assignment loop after generating a finding

### Steps to review

1. Review the logic change in `entra_user_with_vm_access_has_mfa.py`
2. Run the existing tests to verify they still pass
3. Optionally test with an Azure environment where users have multiple VM-related roles

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.