### PR TITLE
fix(docs): standardize authentication page titles across providers

### DIFF
--- a/docs/user-guide/providers/cloudflare/authentication.mdx
+++ b/docs/user-guide/providers/cloudflare/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Cloudflare Authentication'
+title: 'Cloudflare Authentication in Prowler'
 ---
 
 Prowler for Cloudflare supports the following authentication methods:

--- a/docs/user-guide/providers/mongodbatlas/authentication.mdx
+++ b/docs/user-guide/providers/mongodbatlas/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'MongoDB Atlas Authentication'
+title: 'MongoDB Atlas Authentication in Prowler'
 ---
 
 MongoDB Atlas provider uses [HTTP Digest Authentication with API key pairs consisting of a public key and private key](https://www.mongodb.com/docs/atlas/configure-api-access/#grant-programmatic-access-to-service).

--- a/docs/user-guide/providers/oci/authentication.mdx
+++ b/docs/user-guide/providers/oci/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Oracle Cloud Infrastructure (OCI) Authentication'
+title: 'Oracle Cloud Infrastructure (OCI) Authentication in Prowler'
 ---
 
 This guide covers all authentication methods supported by Prowler for Oracle Cloud Infrastructure (OCI).


### PR DESCRIPTION
## Summary
- Add 'in Prowler' suffix to authentication page titles for Cloudflare, MongoDB Atlas, and OCI providers
- Aligns these pages with the naming convention used by other providers (AWS, Azure, GCP, GitHub, Microsoft 365, Alibaba Cloud, IaC)

## Files Changed
- `docs/user-guide/providers/cloudflare/authentication.mdx`: `Cloudflare Authentication` → `Cloudflare Authentication in Prowler`
- `docs/user-guide/providers/mongodbatlas/authentication.mdx`: `MongoDB Atlas Authentication` → `MongoDB Atlas Authentication in Prowler`
- `docs/user-guide/providers/oci/authentication.mdx`: `Oracle Cloud Infrastructure (OCI) Authentication` → `Oracle Cloud Infrastructure (OCI) Authentication in Prowler`

## Test plan
- [x] Verified all authentication titles now follow the consistent `{Provider} Authentication in Prowler` pattern