### PR TITLE
docs(developer-guide): add AI Skills reference to introduction

### DIFF
--- a/docs/developer-guide/introduction.mdx
+++ b/docs/developer-guide/introduction.mdx
@@ -155,6 +155,8 @@ If you are using AI assistants to help with your contributions, Prowler provides
 
 - **AGENTS.md Files**: Each component of the Prowler monorepo includes an `AGENTS.md` file that contains specific guidelines for AI agents working on that component. These files provide context about project structure, coding standards, and best practices. When working on a specific component, refer to the relevant `AGENTS.md` file (e.g., `prowler/AGENTS.md`, `ui/AGENTS.md`, `api/AGENTS.md`) to ensure your AI assistant follows the appropriate guidelines.
 
+- **AI Skills System**: The [AI Skills system](/developer-guide/ai-skills) provides on-demand patterns, templates, and best practices for AI agents. Skills help AI assistants understand Prowler's conventions and generate code that aligns with project standards. The skills are located in the `skills/` directory and are registered in the `AGENTS.md` files.
+
 These resources help ensure that AI-assisted contributions maintain consistency with Prowler's codebase and development practices.
 
 ### Dependency Management


### PR DESCRIPTION
## Context

The AI-Driven Contributions section in the developer guide introduction mentions AGENTS.md files and the MCP Server, but does not reference the AI Skills system which already has its own documentation page (`ai-skills.mdx`).

## Description

Add AI Skills System to the AI-Driven Contributions section in `docs/developer-guide/introduction.mdx`, linking to the existing `/developer-guide/ai-skills` documentation page for better discoverability.

## Steps to Review

1. Review the change in `docs/developer-guide/introduction.mdx`
2. Verify the link to `/developer-guide/ai-skills` is correct
3. Confirm the description follows the existing bullet point format

## Checklist

- [x] I have followed the contributing guidelines
- [x] I have verified the documentation renders correctly
- [x] No breaking changes introduced