### PR TITLE
fix(jira): truncate summary to 255 characters to prevent INVALID_INPUT error

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### Fixed
 
 - Duplicated findings in `entra_user_with_vm_access_has_mfa` check when user has multiple VM access roles [(#9914)](https://github.com/prowler-cloud/prowler/pull/9914)
+- Jira integration failing with `INVALID_INPUT` error when sending findings with long resource UIDs exceeding 255-character summary limit [(#9926)](https://github.com/prowler-cloud/prowler/pull/9926)
 
 ---
 

--- a/prowler/lib/outputs/jira/jira.py
+++ b/prowler/lib/outputs/jira/jira.py
@@ -1875,12 +1875,12 @@ class Jira:
                     summary_parts.append(finding.resource_uid)
 
                 summary = " - ".join(summary_parts[1:])
-                summary = f"{summary_parts[0]} {summary}"
+                summary = f"{summary_parts[0]} {summary}"[:255]
 
                 payload = {
                     "fields": {
                         "project": {"key": project_key},
-                        "summary": f"[Prowler] {finding.metadata.Severity.value.upper()} - {finding.metadata.CheckID} - {finding.resource_uid}",
+                        "summary": summary,
                         "description": adf_description,
                         "issuetype": {"name": issue_type},
                         "customfield_10148": {"value": "SDK"},
@@ -2081,7 +2081,7 @@ class Jira:
             if resource_uid:
                 summary_parts.append(resource_uid)
             summary = " - ".join(summary_parts[1:])
-            summary = f"{summary_parts[0]} {summary}"
+            summary = f"{summary_parts[0]} {summary}"[:255]
 
             payload = {
                 "fields": {


### PR DESCRIPTION
### Context

Fixes #9919

The Jira integration fails with a generic `INVALID_INPUT` error when attempting to send findings with long resource UIDs to Jira.

### Description

The `send_findings` method was building the Jira issue summary inline without using the truncated `summary` variable, causing the summary to exceed Jira's 255-character limit for findings with long identifiers.

The fix ensures the pre-built and truncated `summary` variable is used in the API payload instead of reconstructing it inline.

### Steps to review

1. Review the change in `prowler/lib/outputs/jira/jira.py`
2. Verify the `summary` variable (which is truncated to 255 chars) is now used in the payload
3. Test sending a finding with a long resource UID (>122 chars) to Jira

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.