### PR TITLE
docs(SECURITY.md): Update Link to Security

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,4 +62,4 @@ We strive to resolve all problems as quickly as possible, and we would like to p
 
 ---
 
-For more information about our security policies, please refer to our [Security](https://docs.prowler.com/projects/prowler-open-source/en/latest/security/) section in our documentation.
+For more information about our security policies, please refer to our [Security](https://docs.prowler.com/security) section in our documentation.


### PR DESCRIPTION
### Context

Update the broken Security link at the bottom of the page.

### Description

The Security link at the bottom of the document pointed to a page that no longer exists. I've updated it to point at what I think is the new Security section of the Prowler Docs.

### Steps to review

Click the Security link at the bottom of the page and confirm it re-directs you to the correct section of the Prowler docs.

### License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
