### PR TITLE
chore(api): prepare changelog for 5.18.0 release

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
-## [1.19.0] (Prowler UNRELEASED)
+## [1.19.0] (Prowler v5.18.0)
 
 ### 🚀 Added
 
@@ -18,10 +18,6 @@ All notable changes to the **Prowler API** are documented in this file.
 - Lazy-load providers and compliance data to reduce API/worker startup memory and time [(#9857)](https://github.com/prowler-cloud/prowler/pull/9857)
 - Attack Paths: Pinned Cartography to version `0.126.1`, adding AWS scans for SageMaker, CloudFront and Bedrock [(#9893)](https://github.com/prowler-cloud/prowler/issues/9893)
 - Remove unused indexes [(#9904)](https://github.com/prowler-cloud/prowler/pull/9904)
-
----
-
-## [1.18.2] (Prowler UNRELEASED)
 
 ### 🐞 Fixed
 


### PR DESCRIPTION
### Description

Prepare `api/CHANGELOG.md` for release 5.18.0.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.