### PR TITLE
fix(ui): optimize scans page polling to avoid redundant API calls

### DIFF
--- a/.github/test-impact.yml
+++ b/.github/test-impact.yml
@@ -14,7 +14,7 @@ ignored:
     - "*.md"
     - "**/*.md"
     - mkdocs.yml
-    
+
     # Config files that don't affect runtime
     - .gitignore
     - .gitattributes
@@ -23,7 +23,7 @@ ignored:
     - .backportrc.json
     - CODEOWNERS
     - LICENSE
-    
+
     # IDE/Editor configs
     - .vscode/**
     - .idea/**
@@ -31,10 +31,13 @@ ignored:
     # Examples and contrib (not production code)
     - examples/**
     - contrib/**
-    
+
     # Skills (AI agent configs, not runtime)
     - skills/**
-    
+
+    # E2E setup helpers (not runnable tests)
+    - ui/tests/setups/**
+
     # Permissions docs
     - permissions/**
 
@@ -47,18 +50,18 @@ critical:
     - prowler/config/**
     - prowler/exceptions/**
     - prowler/providers/common/**
-    
+
     # API Core
     - api/src/backend/api/models.py
     - api/src/backend/config/**
     - api/src/backend/conftest.py
-    
+
     # UI Core
     - ui/lib/**
     - ui/types/**
     - ui/config/**
     - ui/middleware.ts
-    
+
     # CI/CD changes
     - .github/workflows/**
     - .github/test-impact.yml

--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -25,7 +25,7 @@ jobs:
   e2e-tests:
     needs: impact-analysis
     if: |
-      github.repository == 'prowler-cloud/prowler' && 
+      github.repository == 'prowler-cloud/prowler' &&
       (needs.impact-analysis.outputs.has-ui-e2e == 'true' || needs.impact-analysis.outputs.run-all == 'true')
     runs-on: ubuntu-latest
     env:
@@ -200,7 +200,14 @@ jobs:
             # e.g., "ui/tests/providers/**" -> "tests/providers"
             TEST_PATHS="${{ env.E2E_TEST_PATHS }}"
             # Remove ui/ prefix and convert ** to empty (playwright handles recursion)
-            TEST_PATHS=$(echo "$TEST_PATHS" | sed 's|ui/||g' | sed 's|\*\*||g' | tr ' ' '\n' | sort -u | tr '\n' ' ')
+            TEST_PATHS=$(echo "$TEST_PATHS" | sed 's|ui/||g' | sed 's|\*\*||g' | tr ' ' '\n' | sort -u)
+            # Drop auth setup helpers (not runnable test suites)
+            TEST_PATHS=$(echo "$TEST_PATHS" | grep -v '^tests/setups/')
+            if [[ -z "$TEST_PATHS" ]]; then
+              echo "No runnable E2E test paths after filtering setups"
+              exit 0
+            fi
+            TEST_PATHS=$(echo "$TEST_PATHS" | tr '\n' ' ')
             echo "Resolved test paths: $TEST_PATHS"
             pnpm exec playwright test $TEST_PATHS
           fi
@@ -222,8 +229,8 @@ jobs:
   skip-e2e:
     needs: impact-analysis
     if: |
-      github.repository == 'prowler-cloud/prowler' && 
-      needs.impact-analysis.outputs.has-ui-e2e != 'true' && 
+      github.repository == 'prowler-cloud/prowler' &&
+      needs.impact-analysis.outputs.has-ui-e2e != 'true' &&
       needs.impact-analysis.outputs.run-all != 'true'
     runs-on: ubuntu-latest
     steps:

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.18.1] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Scans page polling now only refreshes scan table data instead of re-rendering the entire server component tree, eliminating redundant API calls to providers, findings, and compliance endpoints every 5 seconds
+
+---
+
 ## [1.18.0] (Prowler v5.18.0)
 
 ### 🔄 Changed

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -1,21 +1,19 @@
 import { Suspense } from "react";
 
 import { getAllProviders } from "@/actions/providers";
-import { getScans, getScansByState } from "@/actions/scans";
+import { getScans } from "@/actions/scans";
 import { auth } from "@/auth.config";
 import { MutedFindingsConfigButton } from "@/components/providers";
 import {
-  AutoRefresh,
   NoProvidersAdded,
   NoProvidersConnected,
   ScansFilters,
 } from "@/components/scans";
 import { LaunchScanWorkflow } from "@/components/scans/launch-workflow";
 import { SkeletonTableScans } from "@/components/scans/table";
-import { ColumnGetScans } from "@/components/scans/table/scans";
+import { ScansTableWithPolling } from "@/components/scans/table/scans";
 import { ContentLayout } from "@/components/ui";
 import { CustomBanner } from "@/components/ui/custom/custom-banner";
-import { DataTable } from "@/components/ui/table";
 import {
   createProviderDetailsMapping,
   extractProviderUIDs,
@@ -57,15 +55,6 @@ export default async function Scans({
 
   const hasManageScansPermission = session?.user?.permissions?.manage_scans;
 
-  // Get scans data to check for executing scans
-  const scansData = await getScansByState();
-
-  const hasExecutingScan = scansData?.data?.some(
-    (scan: ScanProps) =>
-      scan.attributes.state === "executing" ||
-      scan.attributes.state === "available",
-  );
-
   // Extract provider UIDs and create provider details mapping for filtering
   const providerUIDs = providersData ? extractProviderUIDs(providersData) : [];
   const providerDetails = providersData
@@ -82,7 +71,6 @@ export default async function Scans({
 
   return (
     <ContentLayout title="Scans" icon="lucide:timer">
-      <AutoRefresh hasExecutingScan={hasExecutingScan} />
       <>
         <>
           {!hasManageScansPermission ? (
@@ -177,11 +165,10 @@ const SSRDataTableScans = async ({
     }) || [];
 
   return (
-    <DataTable
-      key={`scans-${Date.now()}`}
-      columns={ColumnGetScans}
-      data={expandedScansData || []}
-      metadata={meta}
+    <ScansTableWithPolling
+      initialData={expandedScansData}
+      initialMeta={meta}
+      searchParams={searchParams}
     />
   );
 };

--- a/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
+++ b/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
@@ -13,6 +13,7 @@ import { Form } from "@/components/ui/form";
 import { toast } from "@/components/ui/toast";
 import { onDemandScanFormSchema } from "@/types";
 
+import { SCAN_LAUNCHED_EVENT } from "../table/scans/scans-table-with-polling";
 import { SelectScanProvider } from "./select-scan-provider";
 
 type ProviderInfo = {
@@ -85,6 +86,8 @@ export const LaunchScanWorkflow = ({
       });
       // Reset form after successful submission
       form.reset();
+      // Notify the scans table to refresh and pick up the new scan
+      window.dispatchEvent(new Event(SCAN_LAUNCHED_EVENT));
     }
   };
 

--- a/ui/components/scans/table/scans/index.ts
+++ b/ui/components/scans/table/scans/index.ts
@@ -1,3 +1,4 @@
 export * from "./column-get-scans";
 export * from "./data-table-row-actions";
 export * from "./data-table-row-details";
+export * from "./scans-table-with-polling";

--- a/ui/components/scans/table/scans/scans-table-with-polling.tsx
+++ b/ui/components/scans/table/scans/scans-table-with-polling.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { getScans } from "@/actions/scans";
+import { AutoRefresh } from "@/components/scans";
+import { DataTable } from "@/components/ui/table";
+import { MetaDataProps, ScanProps, SearchParamsProps } from "@/types";
+
+import { ColumnGetScans } from "./column-get-scans";
+
+interface ScansTableWithPollingProps {
+  initialData: ScanProps[];
+  initialMeta?: MetaDataProps;
+  searchParams: SearchParamsProps;
+}
+
+const EXECUTING_STATES = ["executing", "available"] as const;
+
+function expandScansWithProviderInfo(
+  scans: ScanProps[],
+  included?: Array<{ type: string; id: string; attributes: any }>,
+) {
+  return (
+    scans?.map((scan) => {
+      const providerId = scan.relationships?.provider?.data?.id;
+
+      if (!providerId) {
+        return { ...scan, providerInfo: undefined };
+      }
+
+      const providerData = included?.find(
+        (item) => item.type === "providers" && item.id === providerId,
+      );
+
+      if (!providerData) {
+        return { ...scan, providerInfo: undefined };
+      }
+
+      return {
+        ...scan,
+        providerInfo: {
+          provider: providerData.attributes.provider,
+          uid: providerData.attributes.uid,
+          alias: providerData.attributes.alias,
+        },
+      };
+    }) || []
+  );
+}
+
+export function ScansTableWithPolling({
+  initialData,
+  initialMeta,
+  searchParams,
+}: ScansTableWithPollingProps) {
+  const [scansData, setScansData] = useState<ScanProps[]>(initialData);
+  const [meta, setMeta] = useState<MetaDataProps | undefined>(initialMeta);
+
+  const hasExecutingScan = scansData.some((scan) =>
+    EXECUTING_STATES.includes(
+      scan.attributes.state as (typeof EXECUTING_STATES)[number],
+    ),
+  );
+
+  const handleRefresh = useCallback(async () => {
+    const page = parseInt(searchParams.page?.toString() || "1", 10);
+    const pageSize = parseInt(searchParams.pageSize?.toString() || "10", 10);
+    const sort = searchParams.sort?.toString();
+
+    const filters = Object.fromEntries(
+      Object.entries(searchParams).filter(
+        ([key]) => key.startsWith("filter[") && key !== "scanId",
+      ),
+    );
+
+    const query = (filters["filter[search]"] as string) || "";
+
+    const result = await getScans({
+      query,
+      page,
+      sort,
+      filters,
+      pageSize,
+      include: "provider",
+    });
+
+    if (result?.data) {
+      const expanded = expandScansWithProviderInfo(
+        result.data,
+        result.included,
+      );
+      setScansData(expanded);
+
+      if (result && "meta" in result) {
+        setMeta(result.meta as MetaDataProps);
+      }
+    }
+  }, [searchParams]);
+
+  return (
+    <>
+      <AutoRefresh
+        hasExecutingScan={hasExecutingScan}
+        onRefresh={handleRefresh}
+      />
+      <DataTable
+        key={`scans-${scansData.length}-${meta?.pagination?.page}`}
+        columns={ColumnGetScans}
+        data={scansData}
+        metadata={meta}
+      />
+    </>
+  );
+}

--- a/ui/components/scans/table/scans/scans-table-with-polling.tsx
+++ b/ui/components/scans/table/scans/scans-table-with-polling.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { getScans } from "@/actions/scans";
 import { AutoRefresh } from "@/components/scans";
@@ -8,6 +8,8 @@ import { DataTable } from "@/components/ui/table";
 import { MetaDataProps, ScanProps, SearchParamsProps } from "@/types";
 
 import { ColumnGetScans } from "./column-get-scans";
+
+export const SCAN_LAUNCHED_EVENT = "scan-launched";
 
 interface ScansTableWithPollingProps {
   initialData: ScanProps[];
@@ -97,6 +99,15 @@ export function ScansTableWithPolling({
       }
     }
   }, [searchParams]);
+
+  // Listen for scan launch events to trigger an immediate refresh
+  useEffect(() => {
+    const handler = () => {
+      handleRefresh();
+    };
+    window.addEventListener(SCAN_LAUNCHED_EVENT, handler);
+    return () => window.removeEventListener(SCAN_LAUNCHED_EVENT, handler);
+  }, [handleRefresh]);
 
   return (
     <>

--- a/ui/components/ui/custom/custom-table-link.tsx
+++ b/ui/components/ui/custom/custom-table-link.tsx
@@ -21,7 +21,9 @@ export const TableLink = ({ href, label, isDisabled }: TableLinkProps) => {
 
   return (
     <Button asChild variant="link" size="sm" className="text-xs">
-      <Link href={href}>{label}</Link>
+      <Link href={href} prefetch={false}>
+        {label}
+      </Link>
     </Button>
   );
 };

--- a/ui/tests/scans/scans-page.ts
+++ b/ui/tests/scans/scans-page.ts
@@ -105,6 +105,7 @@ export class ScansPage extends BasePage {
     await expect(this.scanTable).toBeVisible();
 
     // Find a row that contains the account ID (provider UID in Cloud Provider column)
+    // Note: Use a more specific locator strategy if possible in the future
     const rowWithAccountId = this.scanTable
       .locator("tbody tr")
       .filter({ hasText: accountId })


### PR DESCRIPTION
### Context

The scans page uses `router.refresh()` every 5 seconds while a scan is executing to update the progress bar. This triggers a full Server Component tree re-render, causing redundant API calls to providers, findings, and compliance endpoints on every cycle.

### Description

**Problem:** Each 5-second polling cycle was making 4+ API requests (minimum):
1. `getProviders()` from the layout — unnecessary
2. `getAllProviders()` from the scans page (paginated, potentially multiple requests) — unnecessary
3. `getScansByState()` — unnecessary (can be derived from getScans response)
4. `getScans()` — the only one actually needed

Additionally, Next.js `<Link>` components in the table were prefetching `/findings` and `/compliance` routes for every visible row on each re-render.

**Solution:**
- Replace `router.refresh()` with client-side polling using the existing `onRefresh` callback in `AutoRefresh`
- Create `ScansTableWithPolling` component that manages scan data in local state and only calls `getScans` on each poll cycle
- Add `prefetch={false}` to `TableLink` to prevent unnecessary route prefetching
- Derive `hasExecutingScan` from the `getScans` response, eliminating the separate `getScansByState` call

**Result:** From 4+ API requests every 5 seconds down to 1.

### Steps to review

1. Navigate to the Scans page
2. Launch a scan
3. Observe Network tab: only `getScans` requests should fire every 5 seconds
4. Verify the progress bar still updates correctly
5. Verify no prefetch requests to `/findings` or `/compliance` routes
6. Once scan completes, verify polling stops automatically

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.