### PR TITLE
fix(ui): guard against unknown provider types in ProviderTypeSelector

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.18.1] (Prowler UNRELEASED)
+## [1.19.0] (Prowler UNRELEASED)
+
+### 🔄 Changed
+
+- Attack Paths: Query list now shows their name and short description, when one is selected it also shows a longer description and an attribution if it has it [(#9983)](https://github.com/prowler-cloud/prowler/pull/9983)
+
+### 🐞 Fixed
+
+- ProviderTypeSelector crash when an unknown provider type is not present in PROVIDER_DATA [(#9991)](https://github.com/prowler-cloud/prowler/pull/9991)
+
+---
+
+## [1.18.1] (Prowler v5.18.1)
 
 ### 🐞 Fixed
 

--- a/ui/app/(prowler)/_overview/_components/provider-type-selector.tsx
+++ b/ui/app/(prowler)/_overview/_components/provider-type-selector.tsx
@@ -153,7 +153,7 @@ export const ProviderTypeSelector = ({
         // .filter((p) => p.attributes.connection?.connected)
         .map((p) => p.attributes.provider),
     ),
-  ) as ProviderType[];
+  ).filter((type): type is ProviderType => type in PROVIDER_DATA);
 
   const renderIcon = (providerType: ProviderType) => {
     const IconComponent = PROVIDER_DATA[providerType].icon;

--- a/ui/app/(prowler)/providers/page.tsx
+++ b/ui/app/(prowler)/providers/page.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/providers/table";
 import { ContentLayout } from "@/components/ui";
 import { DataTable } from "@/components/ui/table";
-import { ProviderProps, SearchParamsProps } from "@/types";
+import { PROVIDER_TYPES, ProviderProps, SearchParamsProps } from "@/types";
 
 export default async function Providers({
   searchParams,
@@ -89,15 +89,22 @@ const ProvidersTable = async ({
         return acc;
       }, {}) || {};
 
+  // Exclude provider types not yet supported in the UI
   const enrichedProviders =
-    providersData?.data?.map((provider: ProviderProps) => {
-      const groupNames =
-        provider.relationships?.provider_groups?.data?.map(
-          (group: { id: string }) =>
-            providerGroupDict[group.id] || "Unknown Group",
-        ) || [];
-      return { ...provider, groupNames };
-    }) || [];
+    providersData?.data
+      ?.filter((provider: ProviderProps) =>
+        (PROVIDER_TYPES as readonly string[]).includes(
+          provider.attributes.provider,
+        ),
+      )
+      .map((provider: ProviderProps) => {
+        const groupNames =
+          provider.relationships?.provider_groups?.data?.map(
+            (group: { id: string }) =>
+              providerGroupDict[group.id] || "Unknown Group",
+          ) || [];
+        return { ...provider, groupNames };
+      }) || [];
 
   return (
     <>


### PR DESCRIPTION
### Context

Fix PROWLER-1031

The `ProviderTypeSelector` component crashes with `TypeError: Cannot read properties of undefined (reading 'label')` when the API returns provider types the UI doesn't recognize (e.g., `openstack`, `cloudflare`, `nhn`, `llm`).

### Description

- Replace unsafe `as ProviderType[]` cast with a runtime type guard filter (`.filter((type): type is ProviderType => type in PROVIDER_DATA)`)
- Unknown provider types returned by the API are now safely excluded from the dropdown instead of causing a crash
- The SDK has 14 providers but the UI only supports 10 — this fix handles the mismatch gracefully

### Steps to review

1. Open `ui/app/(prowler)/_overview/_components/provider-type-selector.tsx` line 156
2. Verify the `.filter()` type guard correctly narrows the type to `ProviderType`
3. Confirm that known providers (aws, azure, gcp, etc.) still render normally in the Overview selector
4. Confirm no crash occurs when an unrecognized provider type is present in the API response

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- Are there API changes included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.