### PR TITLE
docs(ui): mark changelog v1.18.1 as released with Prowler v5.18.1

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ---
 
-## [1.18.1] (Prowler UNRELEASED)
+## [1.18.1] (Prowler v5.18.1)
 
 ### 🐞 Fixed
 


### PR DESCRIPTION
### Context

The UI changelog `[1.18.1]` section was left with `(Prowler UNRELEASED)` after the v5.18.1 release. It should read `(Prowler v5.18.1)`.

### Description

- Update `ui/CHANGELOG.md` version header from `(Prowler UNRELEASED)` to `(Prowler v5.18.1)` for the already-released `[1.18.1]` section

### Steps to review

1. Open `ui/CHANGELOG.md` and confirm the `[1.18.1]` header now reads `(Prowler v5.18.1)`

### Checklist

- [x] Review if backport is needed.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

> N/A — this is a docs-only fix to the changelog itself.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.