### PR TITLE
fix(azure): standardize resource_id values across Azure checks

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - AI Skills: Added a skill for creating new Attack Paths queries in openCypher, compatible with Neo4j and Neptune [(#9975)](https://github.com/prowler-cloud/prowler/pull/9975)
 
+### 🐞 Fixed
+
+- Standardize resource_id values across Azure checks to use actual Azure resource IDs [(#9994)](https://github.com/prowler-cloud/prowler/pull/9994)
+
 ### 🔄 Changed
 
 - Update Azure Monitor service metadata to new format [(#9622)](https://github.com/prowler-cloud/prowler/pull/9622)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### 🐞 Fixed
 
-- Standardize resource_id values across Azure checks to use actual Azure resource IDs [(#9994)](https://github.com/prowler-cloud/prowler/pull/9994)
+- Standardize resource_id values across Azure checks to use actual Azure resource IDs and prevent duplicate resource entries [(#9994)](https://github.com/prowler-cloud/prowler/pull/9994)
 
 ### 🔄 Changed
 

--- a/prowler/providers/azure/services/apim/apim_threat_detection_llm_jacking/apim_threat_detection_llm_jacking.py
+++ b/prowler/providers/azure/services/apim/apim_threat_detection_llm_jacking/apim_threat_detection_llm_jacking.py
@@ -97,8 +97,10 @@ class apim_threat_detection_llm_jacking(Check):
             # 4. If no threats were found after checking all principals, create a single PASS report
             if not found_potential_llm_jacking_attackers:
                 report = Check_Report_Azure(self.metadata(), resource={})
-                report.resource_name = "Azure API Management"
-                report.resource_id = "Azure API Management"
+                report.resource_name = subscription
+                report.resource_id = (
+                    f"/subscriptions/{apim_client.subscriptions[subscription]}"
+                )
                 report.subscription = subscription
                 report.status = "PASS"
                 report.status_extended = f"No potential LLM Jacking attacks detected across all monitored APIM instances in the last {threat_detection_minutes} minutes."

--- a/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
+++ b/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
@@ -9,22 +9,19 @@ class appinsights_ensure_is_configured(Check):
         findings = []
 
         for subscription_name, components in appinsights_client.components.items():
-            if not components:
-                report = Check_Report_Azure(metadata=self.metadata(), resource={})
-                report.subscription = subscription_name
-                report.resource_name = subscription_name
-                report.resource_id = f"/subscriptions/{appinsights_client.subscriptions[subscription_name]}"
+            report = Check_Report_Azure(metadata=self.metadata(), resource={})
+            report.status = "PASS"
+            report.subscription = subscription_name
+            report.resource_name = subscription_name
+            report.resource_id = (
+                f"/subscriptions/{appinsights_client.subscriptions[subscription_name]}"
+            )
+            report.status_extended = f"There is at least one AppInsight configured in subscription {subscription_name}."
+
+            if len(components) < 1:
                 report.status = "FAIL"
-                report.status_extended = f"There are no AppInsights configured in subscription {subscription_name}."
-                findings.append(report)
-            else:
-                for component in components.values():
-                    report = Check_Report_Azure(
-                        metadata=self.metadata(), resource=component
-                    )
-                    report.subscription = subscription_name
-                    report.status = "PASS"
-                    report.status_extended = f"AppInsight {component.resource_name} is configured in subscription {subscription_name}."
-                    findings.append(report)
+                report.status_extended = f"There are no AppInsight configured in subscription {subscription_name}."
+
+            findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
+++ b/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
@@ -9,17 +9,22 @@ class appinsights_ensure_is_configured(Check):
         findings = []
 
         for subscription_name, components in appinsights_client.components.items():
-            report = Check_Report_Azure(metadata=self.metadata(), resource={})
-            report.status = "PASS"
-            report.subscription = subscription_name
-            report.resource_name = "AppInsights"
-            report.resource_id = "AppInsights"
-            report.status_extended = f"There is at least one AppInsight configured in subscription {subscription_name}."
-
-            if len(components) < 1:
+            if not components:
+                report = Check_Report_Azure(metadata=self.metadata(), resource={})
+                report.subscription = subscription_name
+                report.resource_name = subscription_name
+                report.resource_id = f"/subscriptions/{appinsights_client.subscriptions[subscription_name]}"
                 report.status = "FAIL"
-                report.status_extended = f"There are no AppInsight configured in subscription {subscription_name}."
-
-            findings.append(report)
+                report.status_extended = f"There are no AppInsights configured in subscription {subscription_name}."
+                findings.append(report)
+            else:
+                for component in components:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=component
+                    )
+                    report.subscription = subscription_name
+                    report.status = "PASS"
+                    report.status_extended = f"AppInsight {component.name} is configured in subscription {subscription_name}."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
+++ b/prowler/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured.py
@@ -18,13 +18,13 @@ class appinsights_ensure_is_configured(Check):
                 report.status_extended = f"There are no AppInsights configured in subscription {subscription_name}."
                 findings.append(report)
             else:
-                for component in components:
+                for component in components.values():
                     report = Check_Report_Azure(
                         metadata=self.metadata(), resource=component
                     )
                     report.subscription = subscription_name
                     report.status = "PASS"
-                    report.status_extended = f"AppInsight {component.name} is configured in subscription {subscription_name}."
+                    report.status_extended = f"AppInsight {component.resource_name} is configured in subscription {subscription_name}."
                     findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on.py
@@ -14,8 +14,10 @@ class defender_ensure_iot_hub_defender_is_on(Check):
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.status = "FAIL"
                 report.subscription = subscription_name
-                report.resource_name = "IoT Hub Defender"
-                report.resource_id = "IoT Hub Defender"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{defender_client.subscriptions[subscription_name]}"
+                )
                 report.status_extended = f"No IoT Security Solutions found in the subscription {subscription_name}."
                 findings.append(report)
             else:

--- a/prowler/providers/azure/services/defender/defender_ensure_mcas_is_enabled/defender_ensure_mcas_is_enabled.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_mcas_is_enabled/defender_ensure_mcas_is_enabled.py
@@ -13,8 +13,10 @@ class defender_ensure_mcas_is_enabled(Check):
             if "MCAS" not in settings:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "MCAS"
-                report.resource_id = "MCAS"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{defender_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"Microsoft Defender for Cloud Apps not exists for subscription {subscription_name}."
             else:
@@ -22,7 +24,6 @@ class defender_ensure_mcas_is_enabled(Check):
                     metadata=self.metadata(), resource=settings["MCAS"]
                 )
                 report.subscription = subscription_name
-                report.resource_name = "MCAS"
                 if settings["MCAS"].enabled:
                     report.status = "PASS"
                     report.status_extended = f"Microsoft Defender for Cloud Apps is enabled for subscription {subscription_name}."

--- a/prowler/providers/azure/services/defender/defender_ensure_wdatp_is_enabled/defender_ensure_wdatp_is_enabled.py
+++ b/prowler/providers/azure/services/defender/defender_ensure_wdatp_is_enabled/defender_ensure_wdatp_is_enabled.py
@@ -13,8 +13,10 @@ class defender_ensure_wdatp_is_enabled(Check):
             if "WDATP" not in settings:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "WDATP"
-                report.resource_id = "WDATP"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{defender_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"Microsoft Defender for Endpoint integration not exists for subscription {subscription_name}."
             else:
@@ -22,7 +24,6 @@ class defender_ensure_wdatp_is_enabled(Check):
                     metadata=self.metadata(), resource=settings["WDATP"]
                 )
                 report.subscription = subscription_name
-                report.resource_name = "WDATP"
                 if settings["WDATP"].enabled:
                     report.status = "PASS"
                     report.status_extended = f"Microsoft Defender for Endpoint integration is enabled for subscription {subscription_name}."

--- a/prowler/providers/azure/services/defender/defender_service.py
+++ b/prowler/providers/azure/services/defender/defender_service.py
@@ -136,6 +136,7 @@ class Defender(AzureService):
                         {
                             setting.name: Setting(
                                 resource_id=setting.id,
+                                resource_name=setting.name or setting.id,
                                 resource_type=setting.type,
                                 kind=setting.kind,
                                 enabled=setting.enabled,
@@ -311,6 +312,7 @@ class Assesment(BaseModel):
 
 class Setting(BaseModel):
     resource_id: str
+    resource_name: str
     resource_type: str
     kind: str
     enabled: bool

--- a/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
+++ b/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
@@ -32,13 +32,10 @@ class entra_conditional_access_policy_require_mfa_for_management_api(Check):
                     )
                     break
             else:
-                report = Check_Report_Azure(
-                    metadata=self.metadata(),
-                    resource=conditional_access_policies,
-                )
+                report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = f"Tenant: {tenant_name}"
-                report.resource_name = "Conditional Access Policy"
-                report.resource_id = "Conditional Access Policy"
+                report.resource_name = tenant_name
+                report.resource_id = tenant_name
                 report.status = "FAIL"
                 report.status_extended = (
                     "Conditional Access Policy does not require MFA for management API."

--- a/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
+++ b/prowler/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
@@ -7,8 +7,10 @@ class entra_conditional_access_policy_require_mfa_for_management_api(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
 
+        tenant_id = entra_client.tenant_ids[0]
+
         for (
-            tenant_name,
+            tenant_domain,
             conditional_access_policies,
         ) in entra_client.conditional_access_policy.items():
             for policy in conditional_access_policies.values():
@@ -25,17 +27,20 @@ class entra_conditional_access_policy_require_mfa_for_management_api(Check):
                     report = Check_Report_Azure(
                         metadata=self.metadata(), resource=policy
                     )
-                    report.subscription = f"Tenant: {tenant_name}"
+                    report.subscription = f"Tenant: {tenant_domain}"
                     report.status = "PASS"
                     report.status_extended = (
                         "Conditional Access Policy requires MFA for management API."
                     )
                     break
             else:
-                report = Check_Report_Azure(metadata=self.metadata(), resource={})
-                report.subscription = f"Tenant: {tenant_name}"
-                report.resource_name = tenant_name
-                report.resource_id = tenant_name
+                report = Check_Report_Azure(
+                    metadata=self.metadata(),
+                    resource=conditional_access_policies,
+                )
+                report.subscription = f"Tenant: {tenant_domain}"
+                report.resource_name = tenant_domain
+                report.resource_id = tenant_id
                 report.status = "FAIL"
                 report.status_extended = (
                     "Conditional Access Policy does not require MFA for management API."

--- a/prowler/providers/azure/services/entra/entra_global_admin_in_less_than_five_users/entra_global_admin_in_less_than_five_users.py
+++ b/prowler/providers/azure/services/entra/entra_global_admin_in_less_than_five_users/entra_global_admin_in_less_than_five_users.py
@@ -16,11 +16,7 @@ class entra_global_admin_in_less_than_five_users(Check):
             report.resource_name = "Global Administrator"
 
             if "Global Administrator" in directory_roles:
-                report.resource_id = getattr(
-                    directory_roles["Global Administrator"],
-                    "id",
-                    "Global Administrator",
-                )
+                report.resource_id = directory_roles["Global Administrator"].id
 
                 num_global_admins = len(
                     getattr(directory_roles["Global Administrator"], "members", [])

--- a/prowler/providers/azure/services/entra/entra_global_admin_in_less_than_five_users/entra_global_admin_in_less_than_five_users.py
+++ b/prowler/providers/azure/services/entra/entra_global_admin_in_less_than_five_users/entra_global_admin_in_less_than_five_users.py
@@ -16,7 +16,11 @@ class entra_global_admin_in_less_than_five_users(Check):
             report.resource_name = "Global Administrator"
 
             if "Global Administrator" in directory_roles:
-                report.resource_id = directory_roles["Global Administrator"].id
+                report.resource_id = getattr(
+                    directory_roles["Global Administrator"],
+                    "id",
+                    "Global Administrator",
+                )
 
                 num_global_admins = len(
                     getattr(directory_roles["Global Administrator"], "members", [])

--- a/prowler/providers/azure/services/entra/entra_policy_default_users_cannot_create_security_groups/entra_policy_default_users_cannot_create_security_groups.py
+++ b/prowler/providers/azure/services/entra/entra_policy_default_users_cannot_create_security_groups/entra_policy_default_users_cannot_create_security_groups.py
@@ -10,7 +10,7 @@ class entra_policy_default_users_cannot_create_security_groups(Check):
             report = Check_Report_Azure(metadata=self.metadata(), resource=auth_policy)
             report.subscription = f"Tenant: {tenant_domain}"
             report.resource_name = getattr(auth_policy, "name", "Authorization Policy")
-            report.resource_id = getattr(auth_policy, "id", "authorizationPolicy")
+            report.resource_id = auth_policy.id
             report.status = "FAIL"
             report.status_extended = "Non-privileged users are able to create security groups via the Access Panel and the Azure administration portal."
 

--- a/prowler/providers/azure/services/entra/entra_policy_ensure_default_user_cannot_create_apps/entra_policy_ensure_default_user_cannot_create_apps.py
+++ b/prowler/providers/azure/services/entra/entra_policy_ensure_default_user_cannot_create_apps/entra_policy_ensure_default_user_cannot_create_apps.py
@@ -10,7 +10,7 @@ class entra_policy_ensure_default_user_cannot_create_apps(Check):
             report = Check_Report_Azure(metadata=self.metadata(), resource=auth_policy)
             report.subscription = f"Tenant: {tenant_domain}"
             report.resource_name = getattr(auth_policy, "name", "Authorization Policy")
-            report.resource_id = getattr(auth_policy, "id", "authorizationPolicy")
+            report.resource_id = auth_policy.id
             report.status = "FAIL"
             report.status_extended = "App creation is not disabled for non-admin users."
 

--- a/prowler/providers/azure/services/entra/entra_policy_ensure_default_user_cannot_create_tenants/entra_policy_ensure_default_user_cannot_create_tenants.py
+++ b/prowler/providers/azure/services/entra/entra_policy_ensure_default_user_cannot_create_tenants/entra_policy_ensure_default_user_cannot_create_tenants.py
@@ -10,7 +10,7 @@ class entra_policy_ensure_default_user_cannot_create_tenants(Check):
             report = Check_Report_Azure(metadata=self.metadata(), resource=auth_policy)
             report.subscription = f"Tenant: {tenant_domain}"
             report.resource_name = getattr(auth_policy, "name", "Authorization Policy")
-            report.resource_id = getattr(auth_policy, "id", "authorizationPolicy")
+            report.resource_id = auth_policy.id
             report.status = "FAIL"
             report.status_extended = (
                 "Tenants creation is not disabled for non-admin users."

--- a/prowler/providers/azure/services/entra/entra_policy_guest_invite_only_for_admin_roles/entra_policy_guest_invite_only_for_admin_roles.py
+++ b/prowler/providers/azure/services/entra/entra_policy_guest_invite_only_for_admin_roles/entra_policy_guest_invite_only_for_admin_roles.py
@@ -10,7 +10,7 @@ class entra_policy_guest_invite_only_for_admin_roles(Check):
             report = Check_Report_Azure(metadata=self.metadata(), resource=auth_policy)
             report.subscription = f"Tenant: {tenant_domain}"
             report.resource_name = getattr(auth_policy, "name", "Authorization Policy")
-            report.resource_id = getattr(auth_policy, "id", "authorizationPolicy")
+            report.resource_id = auth_policy.id
             report.status = "FAIL"
             report.status_extended = "Guest invitations are not restricted to users with specific administrative roles only."
 

--- a/prowler/providers/azure/services/entra/entra_policy_guest_users_access_restrictions/entra_policy_guest_users_access_restrictions.py
+++ b/prowler/providers/azure/services/entra/entra_policy_guest_users_access_restrictions/entra_policy_guest_users_access_restrictions.py
@@ -11,7 +11,7 @@ class entra_policy_guest_users_access_restrictions(Check):
             report = Check_Report_Azure(metadata=self.metadata(), resource=auth_policy)
             report.subscription = f"Tenant: {tenant_domain}"
             report.resource_name = getattr(auth_policy, "name", "Authorization Policy")
-            report.resource_id = getattr(auth_policy, "id", "authorizationPolicy")
+            report.resource_id = auth_policy.id
             report.status = "FAIL"
             report.status_extended = "Guest user access is not restricted to properties and memberships of their own directory objects"
 

--- a/prowler/providers/azure/services/entra/entra_policy_restricts_user_consent_for_apps/entra_policy_restricts_user_consent_for_apps.py
+++ b/prowler/providers/azure/services/entra/entra_policy_restricts_user_consent_for_apps/entra_policy_restricts_user_consent_for_apps.py
@@ -10,7 +10,7 @@ class entra_policy_restricts_user_consent_for_apps(Check):
             report = Check_Report_Azure(metadata=self.metadata(), resource=auth_policy)
             report.subscription = f"Tenant: {tenant_domain}"
             report.resource_name = getattr(auth_policy, "name", "Authorization Policy")
-            report.resource_id = getattr(auth_policy, "id", "authorizationPolicy")
+            report.resource_id = auth_policy.id
             report.status = "FAIL"
             report.status_extended = "Entra allows users to consent apps accessing company data on their behalf"
 

--- a/prowler/providers/azure/services/entra/entra_policy_user_consent_for_verified_apps/entra_policy_user_consent_for_verified_apps.py
+++ b/prowler/providers/azure/services/entra/entra_policy_user_consent_for_verified_apps/entra_policy_user_consent_for_verified_apps.py
@@ -10,7 +10,7 @@ class entra_policy_user_consent_for_verified_apps(Check):
             report = Check_Report_Azure(metadata=self.metadata(), resource=auth_policy)
             report.subscription = f"Tenant: {tenant_domain}"
             report.resource_name = getattr(auth_policy, "name", "Authorization Policy")
-            report.resource_id = getattr(auth_policy, "id", "authorizationPolicy")
+            report.resource_id = auth_policy.id
             report.status = "PASS"
             report.status_extended = "Entra does not allow users to consent non-verified apps accessing company data on their behalf."
 

--- a/prowler/providers/azure/services/entra/entra_service.py
+++ b/prowler/providers/azure/services/entra/entra_service.py
@@ -16,6 +16,8 @@ class Entra(AzureService):
     def __init__(self, provider: AzureProvider):
         super().__init__(GraphServiceClient, provider)
 
+        self.tenant_ids = provider.identity.tenant_ids
+
         created_loop = False
         try:
             loop = asyncio.get_running_loop()

--- a/prowler/providers/azure/services/entra/entra_service.py
+++ b/prowler/providers/azure/services/entra/entra_service.py
@@ -216,6 +216,7 @@ class Entra(AzureService):
                     group_settings[tenant].update(
                         {
                             group_setting.id: GroupSetting(
+                                id=group_setting.id,
                                 name=getattr(group_setting, "display_name", None),
                                 template_id=getattr(group_setting, "template_id", None),
                                 settings=[
@@ -436,6 +437,7 @@ class SettingValue(BaseModel):
 
 
 class GroupSetting(BaseModel):
+    id: str
     name: Optional[str] = None
     template_id: Optional[str] = None
     settings: List[SettingValue]

--- a/prowler/providers/azure/services/entra/entra_trusted_named_locations_exists/entra_trusted_named_locations_exists.py
+++ b/prowler/providers/azure/services/entra/entra_trusted_named_locations_exists/entra_trusted_named_locations_exists.py
@@ -6,14 +6,16 @@ class entra_trusted_named_locations_exists(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
 
-        for tenant, named_locations in entra_client.named_locations.items():
+        tenant_id = entra_client.tenant_ids[0]
+
+        for tenant_domain, named_locations in entra_client.named_locations.items():
             trusted_location_found = False
             for named_location in named_locations.values():
                 if named_location.ip_ranges_addresses and named_location.is_trusted:
                     report = Check_Report_Azure(
                         metadata=self.metadata(), resource=named_location
                     )
-                    report.subscription = f"Tenant: {tenant}"
+                    report.subscription = f"Tenant: {tenant_domain}"
                     report.status = "PASS"
                     report.status_extended = f"Trusted location {named_location.name} exists with trusted IP ranges: {[ip_range for ip_range in named_location.ip_ranges_addresses if ip_range]}"
                     findings.append(report)
@@ -22,9 +24,9 @@ class entra_trusted_named_locations_exists(Check):
             if not trusted_location_found:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.status = "FAIL"
-                report.subscription = f"Tenant: {tenant}"
-                report.resource_name = tenant
-                report.resource_id = tenant
+                report.subscription = f"Tenant: {tenant_domain}"
+                report.resource_name = tenant_domain
+                report.resource_id = tenant_id
                 report.status_extended = (
                     "There is no trusted location with IP ranges defined."
                 )

--- a/prowler/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups.py
+++ b/prowler/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups.py
@@ -7,17 +7,17 @@ class entra_users_cannot_create_microsoft_365_groups(Check):
         findings = []
 
         for tenant_domain, group_settings in entra_client.group_settings.items():
-            report = Check_Report_Azure(
-                metadata=self.metadata(), resource=group_settings
-            )
-            report.status = "FAIL"
-            report.subscription = f"Tenant: {tenant_domain}"
-            report.resource_name = "Microsoft365 Groups"
-            report.resource_id = "Microsoft365 Groups"
-            report.status_extended = "Users can create Microsoft 365 groups."
-
+            group_unified_found = False
             for group_setting in group_settings.values():
                 if group_setting.name == "Group.Unified":
+                    group_unified_found = True
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=group_setting
+                    )
+                    report.subscription = f"Tenant: {tenant_domain}"
+                    report.status = "FAIL"
+                    report.status_extended = "Users can create Microsoft 365 groups."
+
                     for setting_value in group_setting.settings:
                         if (
                             getattr(setting_value, "name", "") == "EnableGroupCreation"
@@ -29,6 +29,16 @@ class entra_users_cannot_create_microsoft_365_groups(Check):
                             )
                             break
 
-            findings.append(report)
+                    findings.append(report)
+                    break
+
+            if not group_unified_found:
+                report = Check_Report_Azure(metadata=self.metadata(), resource={})
+                report.subscription = f"Tenant: {tenant_domain}"
+                report.resource_name = tenant_domain
+                report.resource_id = tenant_domain
+                report.status = "FAIL"
+                report.status_extended = "Users can create Microsoft 365 groups."
+                findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups.py
+++ b/prowler/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups.py
@@ -6,6 +6,8 @@ class entra_users_cannot_create_microsoft_365_groups(Check):
     def execute(self) -> Check_Report_Azure:
         findings = []
 
+        tenant_id = entra_client.tenant_ids[0]
+
         for tenant_domain, group_settings in entra_client.group_settings.items():
             group_unified_found = False
             for group_setting in group_settings.values():
@@ -36,7 +38,7 @@ class entra_users_cannot_create_microsoft_365_groups(Check):
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = f"Tenant: {tenant_domain}"
                 report.resource_name = tenant_domain
-                report.resource_id = tenant_domain
+                report.resource_id = tenant_id
                 report.status = "FAIL"
                 report.status_extended = "Users can create Microsoft 365 groups."
                 findings.append(report)

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_policy_assignment/monitor_alert_create_policy_assignment.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_policy_assignment/monitor_alert_create_policy_assignment.py
@@ -25,8 +25,10 @@ class monitor_alert_create_policy_assignment(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for creating Policy Assignments in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_nsg/monitor_alert_create_update_nsg.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_nsg/monitor_alert_create_update_nsg.py
@@ -25,8 +25,10 @@ class monitor_alert_create_update_nsg(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for creating/updating Network Security Groups in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_public_ip_address_rule/monitor_alert_create_update_public_ip_address_rule.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_public_ip_address_rule/monitor_alert_create_update_public_ip_address_rule.py
@@ -25,8 +25,10 @@ class monitor_alert_create_update_public_ip_address_rule(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for creating/updating Public IP address rule in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_security_solution/monitor_alert_create_update_security_solution.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_security_solution/monitor_alert_create_update_security_solution.py
@@ -25,8 +25,10 @@ class monitor_alert_create_update_security_solution(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for creating/updating Security Solution in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_create_update_sqlserver_fr/monitor_alert_create_update_sqlserver_fr.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_create_update_sqlserver_fr/monitor_alert_create_update_sqlserver_fr.py
@@ -25,8 +25,10 @@ class monitor_alert_create_update_sqlserver_fr(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for creating/updating SQL Server firewall rule in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_nsg/monitor_alert_delete_nsg.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_nsg/monitor_alert_delete_nsg.py
@@ -27,8 +27,10 @@ class monitor_alert_delete_nsg(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for deleting Network Security Groups in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_policy_assignment/monitor_alert_delete_policy_assignment.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_policy_assignment/monitor_alert_delete_policy_assignment.py
@@ -25,8 +25,10 @@ class monitor_alert_delete_policy_assignment(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for deleting policy assignment in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_public_ip_address_rule/monitor_alert_delete_public_ip_address_rule.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_public_ip_address_rule/monitor_alert_delete_public_ip_address_rule.py
@@ -25,8 +25,10 @@ class monitor_alert_delete_public_ip_address_rule(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for deleting public IP address rule in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_security_solution/monitor_alert_delete_security_solution.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_security_solution/monitor_alert_delete_security_solution.py
@@ -25,8 +25,10 @@ class monitor_alert_delete_security_solution(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for deleting Security Solution in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_delete_sqlserver_fr/monitor_alert_delete_sqlserver_fr.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_delete_sqlserver_fr/monitor_alert_delete_sqlserver_fr.py
@@ -25,8 +25,10 @@ class monitor_alert_delete_sqlserver_fr(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is not an alert for deleting SQL Server firewall rule in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_alert_service_health_exists/monitor_alert_service_health_exists.py
+++ b/prowler/providers/azure/services/monitor/monitor_alert_service_health_exists/monitor_alert_service_health_exists.py
@@ -38,8 +38,10 @@ class monitor_alert_service_health_exists(Check):
             else:
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
-                report.resource_name = "Monitor"
-                report.resource_id = "Monitor"
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
                 report.status = "FAIL"
                 report.status_extended = f"There is no activity log alert for Service Health in subscription {subscription_name}."
 

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
@@ -10,49 +10,46 @@ class monitor_diagnostic_setting_with_appropriate_categories(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            if not diagnostic_settings:
-                report = Check_Report_Azure(metadata=self.metadata(), resource={})
-                report.subscription = subscription_name
-                report.resource_name = subscription_name
-                report.resource_id = (
-                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
-                )
-                report.status = "FAIL"
-                report.status_extended = f"There are no diagnostic settings capturing appropriate categories in subscription {subscription_name}."
-                findings.append(report)
-            else:
-                for diagnostic_setting in diagnostic_settings:
-                    report = Check_Report_Azure(
-                        metadata=self.metadata(), resource=diagnostic_setting
-                    )
-                    report.subscription = subscription_name
-                    report.status = "FAIL"
-                    report.status_extended = f"Diagnostic setting {diagnostic_setting.name} does not capture appropriate categories in subscription {subscription_name}."
-
-                    administrative_enabled = False
-                    security_enabled = False
-                    alert_enabled = False
-                    policy_enabled = False
-
-                    for log in diagnostic_setting.logs:
-                        if log.category == "Administrative" and log.enabled:
-                            administrative_enabled = True
-                        if log.category == "Security" and log.enabled:
-                            security_enabled = True
-                        if log.category == "Alert" and log.enabled:
-                            alert_enabled = True
-                        if log.category == "Policy" and log.enabled:
-                            policy_enabled = True
+            report = Check_Report_Azure(metadata=self.metadata(), resource={})
+            report.subscription = subscription_name
+            report.resource_name = subscription_name
+            report.resource_id = (
+                f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+            )
+            report.status = "FAIL"
+            report.status_extended = f"There are no diagnostic settings capturing appropriate categories in subscription {subscription_name}."
+            administrative_enabled = False
+            security_enabled = False
+            service_health_enabled = False
+            alert_enabled = False
+            for diagnostic_setting in diagnostic_settings:
+                for log in diagnostic_setting.logs:
+                    if log.category == "Administrative" and log.enabled:
+                        administrative_enabled = True
+                    if log.category == "Security" and log.enabled:
+                        security_enabled = True
+                    if log.category == "Alert" and log.enabled:
+                        service_health_enabled = True
+                    if log.category == "Policy" and log.enabled:
+                        alert_enabled = True
 
                     if (
                         administrative_enabled
                         and security_enabled
+                        and service_health_enabled
                         and alert_enabled
-                        and policy_enabled
                     ):
                         report.status = "PASS"
-                        report.status_extended = f"Diagnostic setting {diagnostic_setting.name} captures appropriate categories in subscription {subscription_name}."
+                        report.status_extended = f"There is at least one diagnostic setting capturing appropriate categories in subscription {subscription_name}."
+                        break
+                if (
+                    administrative_enabled
+                    and security_enabled
+                    and service_health_enabled
+                    and alert_enabled
+                ):
+                    break
 
-                    findings.append(report)
+            findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
@@ -10,45 +10,49 @@ class monitor_diagnostic_setting_with_appropriate_categories(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            report = Check_Report_Azure(metadata=self.metadata(), resource={})
-            report.subscription = subscription_name
-            report.resource_name = subscription_name
-            report.resource_id = (
-                f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
-            )
-            report.status = "FAIL"
-            report.status_extended = f"There are no diagnostic settings capturing appropriate categories in subscription {subscription_name}."
-            administrative_enabled = False
-            security_enabled = False
-            service_health_enabled = False
-            alert_enabled = False
+            compliant_setting = None
+
             for diagnostic_setting in diagnostic_settings:
+                administrative_enabled = False
+                security_enabled = False
+                alert_enabled = False
+                policy_enabled = False
+
                 for log in diagnostic_setting.logs:
                     if log.category == "Administrative" and log.enabled:
                         administrative_enabled = True
                     if log.category == "Security" and log.enabled:
                         security_enabled = True
                     if log.category == "Alert" and log.enabled:
-                        service_health_enabled = True
-                    if log.category == "Policy" and log.enabled:
                         alert_enabled = True
+                    if log.category == "Policy" and log.enabled:
+                        policy_enabled = True
 
-                    if (
-                        administrative_enabled
-                        and security_enabled
-                        and service_health_enabled
-                        and alert_enabled
-                    ):
-                        report.status = "PASS"
-                        report.status_extended = f"There is at least one diagnostic setting capturing appropriate categories in subscription {subscription_name}."
-                        break
                 if (
                     administrative_enabled
                     and security_enabled
-                    and service_health_enabled
                     and alert_enabled
+                    and policy_enabled
                 ):
+                    compliant_setting = diagnostic_setting
                     break
+
+            if compliant_setting:
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource=compliant_setting
+                )
+                report.subscription = subscription_name
+                report.status = "PASS"
+                report.status_extended = f"Diagnostic setting {compliant_setting.name} captures appropriate categories in subscription {subscription_name}."
+            else:
+                report = Check_Report_Azure(metadata=self.metadata(), resource={})
+                report.subscription = subscription_name
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
+                report.status = "FAIL"
+                report.status_extended = f"No diagnostic setting captures all appropriate categories (Administrative, Security, Alert, Policy) in subscription {subscription_name}."
 
             findings.append(report)
 

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories.py
@@ -10,44 +10,49 @@ class monitor_diagnostic_setting_with_appropriate_categories(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            report = Check_Report_Azure(metadata=self.metadata(), resource={})
-            report.subscription = subscription_name
-            report.resource_name = "Monitor"
-            report.resource_id = "Monitor"
-            report.status = "FAIL"
-            report.status_extended = f"There are no diagnostic settings capturing appropiate categories in subscription {subscription_name}."
-            administrative_enabled = False
-            security_enabled = False
-            service_health_enabled = False
-            alert_enabled = False
-            for diagnostic_setting in diagnostic_settings:
-                for log in diagnostic_setting.logs:
-                    if log.category == "Administrative" and log.enabled:
-                        administrative_enabled = True
-                    if log.category == "Security" and log.enabled:
-                        security_enabled = True
-                    if log.category == "Alert" and log.enabled:
-                        service_health_enabled = True
-                    if log.category == "Policy" and log.enabled:
-                        alert_enabled = True
+            if not diagnostic_settings:
+                report = Check_Report_Azure(metadata=self.metadata(), resource={})
+                report.subscription = subscription_name
+                report.resource_name = subscription_name
+                report.resource_id = (
+                    f"/subscriptions/{monitor_client.subscriptions[subscription_name]}"
+                )
+                report.status = "FAIL"
+                report.status_extended = f"There are no diagnostic settings capturing appropriate categories in subscription {subscription_name}."
+                findings.append(report)
+            else:
+                for diagnostic_setting in diagnostic_settings:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=diagnostic_setting
+                    )
+                    report.subscription = subscription_name
+                    report.status = "FAIL"
+                    report.status_extended = f"Diagnostic setting {diagnostic_setting.name} does not capture appropriate categories in subscription {subscription_name}."
+
+                    administrative_enabled = False
+                    security_enabled = False
+                    alert_enabled = False
+                    policy_enabled = False
+
+                    for log in diagnostic_setting.logs:
+                        if log.category == "Administrative" and log.enabled:
+                            administrative_enabled = True
+                        if log.category == "Security" and log.enabled:
+                            security_enabled = True
+                        if log.category == "Alert" and log.enabled:
+                            alert_enabled = True
+                        if log.category == "Policy" and log.enabled:
+                            policy_enabled = True
 
                     if (
                         administrative_enabled
                         and security_enabled
-                        and service_health_enabled
                         and alert_enabled
+                        and policy_enabled
                     ):
                         report.status = "PASS"
-                        report.status_extended = f"There is at least one diagnostic setting capturing appropiate categories in subscription {subscription_name}."
-                        break
-                if (
-                    administrative_enabled
-                    and security_enabled
-                    and service_health_enabled
-                    and alert_enabled
-                ):
-                    break
+                        report.status_extended = f"Diagnostic setting {diagnostic_setting.name} captures appropriate categories in subscription {subscription_name}."
 
-            findings.append(report)
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
+++ b/prowler/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists.py
@@ -10,7 +10,17 @@ class monitor_diagnostic_settings_exists(Check):
             subscription_name,
             diagnostic_settings,
         ) in monitor_client.diagnostics_settings.items():
-            if not diagnostic_settings:
+            if diagnostic_settings:
+                # At least one diagnostic setting exists - report on the first one
+                diagnostic_setting = diagnostic_settings[0]
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource=diagnostic_setting
+                )
+                report.subscription = subscription_name
+                report.status = "PASS"
+                report.status_extended = f"Diagnostic setting {diagnostic_setting.name} found in subscription {subscription_name}."
+            else:
+                # No diagnostic settings - report on subscription
                 report = Check_Report_Azure(metadata=self.metadata(), resource={})
                 report.subscription = subscription_name
                 report.resource_name = subscription_name
@@ -21,15 +31,7 @@ class monitor_diagnostic_settings_exists(Check):
                 report.status_extended = (
                     f"No diagnostic settings found in subscription {subscription_name}."
                 )
-                findings.append(report)
-            else:
-                for diagnostic_setting in diagnostic_settings:
-                    report = Check_Report_Azure(
-                        metadata=self.metadata(), resource=diagnostic_setting
-                    )
-                    report.subscription = subscription_name
-                    report.status = "PASS"
-                    report.status_extended = f"Diagnostic setting {diagnostic_setting.name} found in subscription {subscription_name}."
-                    findings.append(report)
+
+            findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
+++ b/prowler/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists.py
@@ -7,23 +7,25 @@ class network_bastion_host_exists(Check):
         findings = []
         for subscription, bastion_hosts in network_client.bastion_hosts.items():
             if not bastion_hosts:
-                status = "FAIL"
-                status_extended = (
+                report = Check_Report_Azure(metadata=self.metadata(), resource={})
+                report.subscription = subscription
+                report.resource_name = subscription
+                report.resource_id = (
+                    f"/subscriptions/{network_client.subscriptions[subscription]}"
+                )
+                report.status = "FAIL"
+                report.status_extended = (
                     f"Bastion Host from subscription {subscription} does not exist"
                 )
+                findings.append(report)
             else:
-                bastion_names = ", ".join(
-                    [bastion_host.name for bastion_host in bastion_hosts]
-                )
-                status = "PASS"
-                status_extended = f"Bastion Host from subscription {subscription} available are: {bastion_names}"
-
-            report = Check_Report_Azure(metadata=self.metadata(), resource={})
-            report.subscription = subscription
-            report.resource_name = "Bastion Host"
-            report.resource_id = "Bastion Host"
-            report.status = status
-            report.status_extended = status_extended
-            findings.append(report)
+                for bastion_host in bastion_hosts:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=bastion_host
+                    )
+                    report.subscription = subscription
+                    report.status = "PASS"
+                    report.status_extended = f"Bastion Host {bastion_host.name} exists in subscription {subscription}."
+                    findings.append(report)
 
         return findings

--- a/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
+++ b/prowler/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled.py
@@ -6,23 +6,31 @@ class network_watcher_enabled(Check):
     def execute(self) -> list[Check_Report_Azure]:
         findings = []
         for subscription, network_watchers in network_client.network_watchers.items():
-            report = Check_Report_Azure(metadata=self.metadata(), resource={})
-            report.subscription = subscription
-            report.resource_name = "Network Watcher"
-            report.location = "global"
-            report.resource_id = f"/subscriptions/{network_client.subscriptions[subscription]}/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_*"
-
             missing_locations = set(network_client.locations[subscription]) - set(
                 network_watcher.location for network_watcher in network_watchers
             )
 
             if missing_locations:
+                # Report against the subscription when network watchers are missing
+                report = Check_Report_Azure(metadata=self.metadata(), resource={})
+                report.subscription = subscription
+                report.resource_name = subscription
+                report.resource_id = (
+                    f"/subscriptions/{network_client.subscriptions[subscription]}"
+                )
+                report.location = "global"
                 report.status = "FAIL"
                 report.status_extended = f"Network Watcher is not enabled for the following locations in subscription '{subscription}': {', '.join(missing_locations)}."
+                findings.append(report)
             else:
-                report.status = "PASS"
-                report.status_extended = f"Network Watcher is enabled for all locations in subscription '{subscription}'."
-
-            findings.append(report)
+                # Report each network watcher that exists
+                for network_watcher in network_watchers:
+                    report = Check_Report_Azure(
+                        metadata=self.metadata(), resource=network_watcher
+                    )
+                    report.subscription = subscription
+                    report.status = "PASS"
+                    report.status_extended = f"Network Watcher {network_watcher.name} is enabled in location {network_watcher.location} in subscription '{subscription}'."
+                    findings.append(report)
 
         return findings

--- a/tests/providers/azure/services/apim/apim_threat_detection_llm_jacking/apim_threat_detection_llm_jacking_test.py
+++ b/tests/providers/azure/services/apim/apim_threat_detection_llm_jacking/apim_threat_detection_llm_jacking_test.py
@@ -184,6 +184,7 @@ class Test_apim_threat_detection_llm_jacking:
                 )
             ]
         }
+        apim_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         apim_client.audit_config = {
             "apim_threat_detection_llm_jacking_threshold": 0.9,
             "apim_threat_detection_llm_jacking_minutes": 1440,
@@ -301,6 +302,7 @@ class Test_apim_threat_detection_llm_jacking:
                 )
             ]
         }
+        apim_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         apim_client.audit_config = {
             "apim_threat_detection_llm_jacking_threshold": 0.9,
             "apim_threat_detection_llm_jacking_minutes": 1440,
@@ -365,6 +367,7 @@ class Test_apim_threat_detection_llm_jacking:
                 )
             ]
         }
+        apim_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         apim_client.audit_config = {
             "apim_threat_detection_llm_jacking_threshold": 0.9,
             "apim_threat_detection_llm_jacking_minutes": 1440,
@@ -435,6 +438,10 @@ class Test_apim_threat_detection_llm_jacking:
                     log_analytics_workspace_id="/subscriptions/another-sub/resourceGroups/test-rg/providers/Microsoft.OperationalInsights/workspaces/another-workspace",
                 )
             ],
+        }
+        apim_client.subscriptions = {
+            AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID,
+            "another-subscription": "another-subscription-id",
         }
         apim_client.audit_config = {
             "apim_threat_detection_llm_jacking_threshold": 0.9,

--- a/tests/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured_test.py
+++ b/tests/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured_test.py
@@ -33,6 +33,9 @@ class Test_appinsights_ensure_is_configured:
     def test_no_appinsights(self):
         appinsights_client = mock.MagicMock
         appinsights_client.components = {AZURE_SUBSCRIPTION_ID: {}}
+        appinsights_client.subscriptions = {
+            AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID
+        }
 
         with (
             mock.patch(
@@ -53,20 +56,20 @@ class Test_appinsights_ensure_is_configured:
             assert len(result) == 1
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].status == "FAIL"
-            assert result[0].resource_id == "AppInsights"
-            assert result[0].resource_name == "AppInsights"
-            assert result[0].location == "global"
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
             assert (
                 result[0].status_extended
-                == f"There are no AppInsight configured in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There are no AppInsights configured in subscription {AZURE_SUBSCRIPTION_ID}."
             )
 
     def test_appinsights_configured(self):
+        resource_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/test-rg/providers/microsoft.insights/components/AppInsightsTest"
         appinsights_client = mock.MagicMock
         appinsights_client.components = {
             AZURE_SUBSCRIPTION_ID: {
                 "app_id-1": Component(
-                    resource_id="/subscriptions/resource_id",
+                    resource_id=resource_id,
                     resource_name="AppInsightsTest",
                     location="westeurope",
                     instrumentation_key="",
@@ -93,10 +96,10 @@ class Test_appinsights_ensure_is_configured:
             assert len(result) == 1
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].status == "PASS"
-            assert result[0].resource_id == "AppInsights"
-            assert result[0].resource_name == "AppInsights"
-            assert result[0].location == "global"
+            assert result[0].resource_id == resource_id
+            assert result[0].resource_name == "AppInsightsTest"
+            assert result[0].location == "westeurope"
             assert (
                 result[0].status_extended
-                == f"There is at least one AppInsight configured in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"AppInsight AppInsightsTest is configured in subscription {AZURE_SUBSCRIPTION_ID}."
             )

--- a/tests/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured_test.py
+++ b/tests/providers/azure/services/appinsights/appinsights_ensure_is_configured/appinsights_ensure_is_configured_test.py
@@ -60,21 +60,23 @@ class Test_appinsights_ensure_is_configured:
             assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
             assert (
                 result[0].status_extended
-                == f"There are no AppInsights configured in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There are no AppInsight configured in subscription {AZURE_SUBSCRIPTION_ID}."
             )
 
     def test_appinsights_configured(self):
-        resource_id = f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/test-rg/providers/microsoft.insights/components/AppInsightsTest"
         appinsights_client = mock.MagicMock
         appinsights_client.components = {
             AZURE_SUBSCRIPTION_ID: {
                 "app_id-1": Component(
-                    resource_id=resource_id,
+                    resource_id=f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/test-rg/providers/microsoft.insights/components/AppInsightsTest",
                     resource_name="AppInsightsTest",
                     location="westeurope",
                     instrumentation_key="",
                 )
             }
+        }
+        appinsights_client.subscriptions = {
+            AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID
         }
 
         with (
@@ -96,10 +98,10 @@ class Test_appinsights_ensure_is_configured:
             assert len(result) == 1
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].status == "PASS"
-            assert result[0].resource_id == resource_id
-            assert result[0].resource_name == "AppInsightsTest"
-            assert result[0].location == "westeurope"
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].location == "global"
             assert (
                 result[0].status_extended
-                == f"AppInsight AppInsightsTest is configured in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There is at least one AppInsight configured in subscription {AZURE_SUBSCRIPTION_ID}."
             )

--- a/tests/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_iot_hub_defender_is_on/defender_ensure_iot_hub_defender_is_on_test.py
@@ -36,6 +36,7 @@ class Test_defender_ensure_iot_hub_defender_is_on:
     def test_defender_no_iot_hub_solutions(self):
         defender_client = mock.MagicMock
         defender_client.iot_security_solutions = {AZURE_SUBSCRIPTION_ID: {}}
+        defender_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
 
         with (
             mock.patch(
@@ -59,8 +60,8 @@ class Test_defender_ensure_iot_hub_defender_is_on:
                 result[0].status_extended
                 == f"No IoT Security Solutions found in the subscription {AZURE_SUBSCRIPTION_ID}."
             )
-            assert result[0].resource_name == "IoT Hub Defender"
-            assert result[0].resource_id == "IoT Hub Defender"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
 
     def test_defender_iot_hub_solution_disabled(self):
         resource_id = str(uuid4())

--- a/tests/providers/azure/services/defender/defender_ensure_mcas_is_enabled/defender_ensure_mcas_is_enabled_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_mcas_is_enabled/defender_ensure_mcas_is_enabled_test.py
@@ -68,7 +68,7 @@ class Test_defender_ensure_mcas_is_enabled:
                 == f"Microsoft Defender for Cloud Apps is disabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "MCAS"
+            # resource_name comes from the Setting object via Check_Report_Azure constructor
             assert result[0].resource_id == resource_id
 
     def test_defender_mcas_enabled(self):
@@ -108,12 +108,13 @@ class Test_defender_ensure_mcas_is_enabled:
                 == f"Microsoft Defender for Cloud Apps is enabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "MCAS"
+            # resource_name comes from the Setting object via Check_Report_Azure constructor
             assert result[0].resource_id == resource_id
 
     def test_defender_mcas_no_settings(self):
         defender_client = mock.MagicMock
         defender_client.settings = {AZURE_SUBSCRIPTION_ID: {}}
+        defender_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
 
         with (
             mock.patch(
@@ -138,5 +139,5 @@ class Test_defender_ensure_mcas_is_enabled:
                 == f"Microsoft Defender for Cloud Apps not exists for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "MCAS"
-            assert result[0].resource_id == "MCAS"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"

--- a/tests/providers/azure/services/defender/defender_ensure_mcas_is_enabled/defender_ensure_mcas_is_enabled_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_mcas_is_enabled/defender_ensure_mcas_is_enabled_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_mcas_is_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "MCAS": Setting(
                     resource_id=resource_id,
+                    resource_name="MCAS",
                     resource_type="Microsoft.Security/locations/settings",
                     kind="DataExportSettings",
                     enabled=False,
@@ -68,7 +69,7 @@ class Test_defender_ensure_mcas_is_enabled:
                 == f"Microsoft Defender for Cloud Apps is disabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            # resource_name comes from the Setting object via Check_Report_Azure constructor
+            assert result[0].resource_name == "MCAS"
             assert result[0].resource_id == resource_id
 
     def test_defender_mcas_enabled(self):
@@ -78,6 +79,7 @@ class Test_defender_ensure_mcas_is_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "MCAS": Setting(
                     resource_id=resource_id,
+                    resource_name="MCAS",
                     resource_type="Microsoft.Security/locations/settings",
                     kind="DataExportSettings",
                     enabled=True,
@@ -108,7 +110,7 @@ class Test_defender_ensure_mcas_is_enabled:
                 == f"Microsoft Defender for Cloud Apps is enabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            # resource_name comes from the Setting object via Check_Report_Azure constructor
+            assert result[0].resource_name == "MCAS"
             assert result[0].resource_id == resource_id
 
     def test_defender_mcas_no_settings(self):

--- a/tests/providers/azure/services/defender/defender_ensure_wdatp_is_enabled/defender_ensure_wdatp_is_enabled_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_wdatp_is_enabled/defender_ensure_wdatp_is_enabled_test.py
@@ -68,7 +68,7 @@ class Test_defender_ensure_wdatp_is_enabled:
                 == f"Microsoft Defender for Endpoint integration is disabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "WDATP"
+            # resource_name comes from the Setting object via Check_Report_Azure constructor
             assert result[0].resource_id == resource_id
 
     def test_defender_wdatp_enabled(self):
@@ -108,12 +108,13 @@ class Test_defender_ensure_wdatp_is_enabled:
                 == f"Microsoft Defender for Endpoint integration is enabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "WDATP"
+            # resource_name comes from the Setting object via Check_Report_Azure constructor
             assert result[0].resource_id == resource_id
 
     def test_defender_wdatp_no_settings(self):
         defender_client = mock.MagicMock
         defender_client.settings = {AZURE_SUBSCRIPTION_ID: {}}
+        defender_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
 
         with (
             mock.patch(
@@ -138,5 +139,5 @@ class Test_defender_ensure_wdatp_is_enabled:
                 == f"Microsoft Defender for Endpoint integration not exists for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "WDATP"
-            assert result[0].resource_id == "WDATP"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"

--- a/tests/providers/azure/services/defender/defender_ensure_wdatp_is_enabled/defender_ensure_wdatp_is_enabled_test.py
+++ b/tests/providers/azure/services/defender/defender_ensure_wdatp_is_enabled/defender_ensure_wdatp_is_enabled_test.py
@@ -38,6 +38,7 @@ class Test_defender_ensure_wdatp_is_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "WDATP": Setting(
                     resource_id=resource_id,
+                    resource_name="WDATP",
                     resource_type="Microsoft.Security/locations/settings",
                     kind="DataExportSettings",
                     enabled=False,
@@ -68,7 +69,7 @@ class Test_defender_ensure_wdatp_is_enabled:
                 == f"Microsoft Defender for Endpoint integration is disabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            # resource_name comes from the Setting object via Check_Report_Azure constructor
+            assert result[0].resource_name == "WDATP"
             assert result[0].resource_id == resource_id
 
     def test_defender_wdatp_enabled(self):
@@ -78,6 +79,7 @@ class Test_defender_ensure_wdatp_is_enabled:
             AZURE_SUBSCRIPTION_ID: {
                 "WDATP": Setting(
                     resource_id=resource_id,
+                    resource_name="WDATP",
                     resource_type="Microsoft.Security/locations/settings",
                     kind="DataExportSettings",
                     enabled=True,
@@ -108,7 +110,7 @@ class Test_defender_ensure_wdatp_is_enabled:
                 == f"Microsoft Defender for Endpoint integration is enabled for subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            # resource_name comes from the Setting object via Check_Report_Azure constructor
+            assert result[0].resource_name == "WDATP"
             assert result[0].resource_id == resource_id
 
     def test_defender_wdatp_no_settings(self):

--- a/tests/providers/azure/services/defender/defender_service_test.py
+++ b/tests/providers/azure/services/defender/defender_service_test.py
@@ -84,6 +84,7 @@ def mock_defender_get_settings(_):
         AZURE_SUBSCRIPTION_ID: {
             "MCAS": Setting(
                 resource_id="/subscriptions/resource_id",
+                resource_name="MCAS",
                 resource_type="Microsoft.Security/locations/settings",
                 kind="DataExportSettings",
                 enabled=True,

--- a/tests/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api_test.py
+++ b/tests/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api_test.py
@@ -1,7 +1,11 @@
 from unittest import mock
 from uuid import uuid4
 
-from tests.providers.azure.azure_fixtures import DOMAIN, set_mocked_azure_provider
+from tests.providers.azure.azure_fixtures import (
+    DOMAIN,
+    TENANT_IDS,
+    set_mocked_azure_provider,
+)
 
 
 class Test_entra_conditional_access_policy_require_mfa_for_management_api:
@@ -23,6 +27,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             )
 
             entra_client.conditional_access_policy = {}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
@@ -47,6 +52,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
 
             # No policies configured
             entra_client.conditional_access_policy = {DOMAIN: {}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
@@ -54,7 +60,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -91,6 +97,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             )
 
             entra_client.conditional_access_policy = {DOMAIN: {policy_id: policy}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
@@ -99,7 +106,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             # When policy exists but doesn't meet requirements, resource defaults to tenant
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -136,6 +143,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             )
 
             entra_client.conditional_access_policy = {DOMAIN: {policy_id: policy}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
@@ -180,6 +188,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             )
 
             entra_client.conditional_access_policy = {DOMAIN: {policy_id: policy}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
@@ -188,7 +197,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             # When policy is disabled, resource defaults to tenant
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -225,6 +234,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             )
 
             entra_client.conditional_access_policy = {DOMAIN: {policy_id: policy}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
@@ -233,7 +243,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             # When policy doesn't target management API, resource defaults to tenant
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -270,6 +280,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             )
 
             entra_client.conditional_access_policy = {DOMAIN: {policy_id: policy}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
@@ -278,7 +289,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             # When policy doesn't include all users, resource defaults to tenant
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."

--- a/tests/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api_test.py
+++ b/tests/providers/azure/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api_test.py
@@ -45,6 +45,7 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
                 entra_conditional_access_policy_require_mfa_for_management_api,
             )
 
+            # No policies configured
             entra_client.conditional_access_policy = {DOMAIN: {}}
 
             check = entra_conditional_access_policy_require_mfa_for_management_api()
@@ -52,8 +53,8 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Conditional Access Policy"
-            assert result[0].resource_id == "Conditional Access Policy"
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -96,8 +97,9 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Conditional Access Policy"
-            assert result[0].resource_id == "Conditional Access Policy"
+            # When policy exists but doesn't meet requirements, resource defaults to tenant
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -184,8 +186,9 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Conditional Access Policy"
-            assert result[0].resource_id == "Conditional Access Policy"
+            # When policy is disabled, resource defaults to tenant
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -228,8 +231,9 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Conditional Access Policy"
-            assert result[0].resource_id == "Conditional Access Policy"
+            # When policy doesn't target management API, resource defaults to tenant
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."
@@ -272,8 +276,9 @@ class Test_entra_conditional_access_policy_require_mfa_for_management_api:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Conditional Access Policy"
-            assert result[0].resource_id == "Conditional Access Policy"
+            # When policy doesn't include all users, resource defaults to tenant
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
             assert (
                 result[0].status_extended
                 == "Conditional Access Policy does not require MFA for management API."

--- a/tests/providers/azure/services/entra/entra_policy_default_users_cannot_create_security_groups/entra_policy_default_users_cannot_create_security_groups_test.py
+++ b/tests/providers/azure/services/entra/entra_policy_default_users_cannot_create_security_groups/entra_policy_default_users_cannot_create_security_groups_test.py
@@ -29,7 +29,7 @@ class Test_entra_policy_default_users_cannot_create_security_groups:
 
     def test_entra_tenant_empty(self):
         entra_client = mock.MagicMock
-        entra_client.authorization_policy = {DOMAIN: {}}
+        id = str(uuid4())
 
         with (
             mock.patch(
@@ -44,6 +44,20 @@ class Test_entra_policy_default_users_cannot_create_security_groups:
             from prowler.providers.azure.services.entra.entra_policy_default_users_cannot_create_security_groups.entra_policy_default_users_cannot_create_security_groups import (
                 entra_policy_default_users_cannot_create_security_groups,
             )
+            from prowler.providers.azure.services.entra.entra_service import (
+                AuthorizationPolicy,
+            )
+
+            # Policy with no default user role permissions
+            entra_client.authorization_policy = {
+                DOMAIN: AuthorizationPolicy(
+                    id=id,
+                    name="Authorization Policy",
+                    description="Default policy",
+                    guest_invite_settings="everyone",
+                    guest_user_role_id=uuid4(),
+                )
+            }
 
             check = entra_policy_default_users_cannot_create_security_groups()
             result = check.execute()
@@ -51,7 +65,7 @@ class Test_entra_policy_default_users_cannot_create_security_groups:
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Authorization Policy"
-            assert result[0].resource_id == "authorizationPolicy"
+            assert result[0].resource_id == id
             assert (
                 result[0].status_extended
                 == "Non-privileged users are able to create security groups via the Access Panel and the Azure administration portal."

--- a/tests/providers/azure/services/entra/entra_policy_ensure_default_user_cannot_create_apps/entra_policy_ensure_default_user_cannot_create_apps_test.py
+++ b/tests/providers/azure/services/entra/entra_policy_ensure_default_user_cannot_create_apps/entra_policy_ensure_default_user_cannot_create_apps_test.py
@@ -30,6 +30,7 @@ class Test_entra_policy_ensure_default_user_cannot_create_apps:
 
     def test_entra_tenant_empty(self):
         entra_client = mock.MagicMock
+        id = str(uuid4())
 
         with (
             mock.patch(
@@ -44,8 +45,20 @@ class Test_entra_policy_ensure_default_user_cannot_create_apps:
             from prowler.providers.azure.services.entra.entra_policy_ensure_default_user_cannot_create_apps.entra_policy_ensure_default_user_cannot_create_apps import (
                 entra_policy_ensure_default_user_cannot_create_apps,
             )
+            from prowler.providers.azure.services.entra.entra_service import (
+                AuthorizationPolicy,
+            )
 
-            entra_client.authorization_policy = {DOMAIN: {}}
+            # Policy with no default user role permissions
+            entra_client.authorization_policy = {
+                DOMAIN: AuthorizationPolicy(
+                    id=id,
+                    name="Authorization Policy",
+                    description="Default policy",
+                    guest_invite_settings="none",
+                    guest_user_role_id=uuid4(),
+                )
+            }
 
             check = entra_policy_ensure_default_user_cannot_create_apps()
             result = check.execute()
@@ -53,7 +66,7 @@ class Test_entra_policy_ensure_default_user_cannot_create_apps:
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Authorization Policy"
-            assert result[0].resource_id == "authorizationPolicy"
+            assert result[0].resource_id == id
             assert (
                 result[0].status_extended
                 == "App creation is not disabled for non-admin users."

--- a/tests/providers/azure/services/entra/entra_policy_guest_users_access_restrictions/entra_policy_guest_users_access_restrictions_test.py
+++ b/tests/providers/azure/services/entra/entra_policy_guest_users_access_restrictions/entra_policy_guest_users_access_restrictions_test.py
@@ -30,6 +30,7 @@ class Test_entra_policy_guest_users_access_restrictions:
 
     def test_entra_tenant_empty(self):
         entra_client = mock.MagicMock
+        id = str(uuid4())
 
         with (
             mock.patch(
@@ -44,8 +45,20 @@ class Test_entra_policy_guest_users_access_restrictions:
             from prowler.providers.azure.services.entra.entra_policy_guest_users_access_restrictions.entra_policy_guest_users_access_restrictions import (
                 entra_policy_guest_users_access_restrictions,
             )
+            from prowler.providers.azure.services.entra.entra_service import (
+                AuthorizationPolicy,
+            )
 
-            entra_client.authorization_policy = {DOMAIN: {}}
+            # Policy with guest user role set to same as member (not restricted)
+            entra_client.authorization_policy = {
+                DOMAIN: AuthorizationPolicy(
+                    id=id,
+                    name="Authorization Policy",
+                    description="",
+                    guest_invite_settings="none",
+                    guest_user_role_id=UUID("a0b1b346-4d3e-4e8b-98f8-753987be4970"),
+                )
+            }
 
             check = entra_policy_guest_users_access_restrictions()
             result = check.execute()
@@ -53,7 +66,7 @@ class Test_entra_policy_guest_users_access_restrictions:
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Authorization Policy"
-            assert result[0].resource_id == "authorizationPolicy"
+            assert result[0].resource_id == id
             assert (
                 result[0].status_extended
                 == "Guest user access is not restricted to properties and memberships of their own directory objects"

--- a/tests/providers/azure/services/entra/entra_policy_restricts_user_consent_for_apps/entra_policy_restricts_user_consent_for_apps_test.py
+++ b/tests/providers/azure/services/entra/entra_policy_restricts_user_consent_for_apps/entra_policy_restricts_user_consent_for_apps_test.py
@@ -30,6 +30,7 @@ class Test_entra_policy_restricts_user_consent_for_apps:
 
     def test_entra_tenant_empty(self):
         entra_client = mock.MagicMock
+        id = str(uuid4())
 
         with (
             mock.patch(
@@ -44,8 +45,20 @@ class Test_entra_policy_restricts_user_consent_for_apps:
             from prowler.providers.azure.services.entra.entra_policy_restricts_user_consent_for_apps.entra_policy_restricts_user_consent_for_apps import (
                 entra_policy_restricts_user_consent_for_apps,
             )
+            from prowler.providers.azure.services.entra.entra_service import (
+                AuthorizationPolicy,
+            )
 
-            entra_client.authorization_policy = {DOMAIN: {}}
+            # Policy with no default user role permissions
+            entra_client.authorization_policy = {
+                DOMAIN: AuthorizationPolicy(
+                    id=id,
+                    name="Authorization Policy",
+                    description="Default policy",
+                    guest_invite_settings="none",
+                    guest_user_role_id=uuid4(),
+                )
+            }
 
             check = entra_policy_restricts_user_consent_for_apps()
             result = check.execute()
@@ -53,7 +66,7 @@ class Test_entra_policy_restricts_user_consent_for_apps:
             assert result[0].status == "FAIL"
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Authorization Policy"
-            assert result[0].resource_id == "authorizationPolicy"
+            assert result[0].resource_id == id
             assert (
                 result[0].status_extended
                 == "Entra allows users to consent apps accessing company data on their behalf"

--- a/tests/providers/azure/services/entra/entra_service_test.py
+++ b/tests/providers/azure/services/entra/entra_service_test.py
@@ -41,6 +41,7 @@ async def mock_entra_get_group_settings(_):
     return {
         DOMAIN: {
             "id-1": GroupSetting(
+                id="id-1",
                 name="Test",
                 template_id="id-group-setting",
                 settings=[],

--- a/tests/providers/azure/services/entra/entra_trusted_named_locations_exists/entra_trusted_named_locations_exists_test.py
+++ b/tests/providers/azure/services/entra/entra_trusted_named_locations_exists/entra_trusted_named_locations_exists_test.py
@@ -1,6 +1,10 @@
 from unittest import mock
 
-from tests.providers.azure.azure_fixtures import DOMAIN, set_mocked_azure_provider
+from tests.providers.azure.azure_fixtures import (
+    DOMAIN,
+    TENANT_IDS,
+    set_mocked_azure_provider,
+)
 
 
 class Test_entra_trusted_named_locations_exists:
@@ -22,6 +26,7 @@ class Test_entra_trusted_named_locations_exists:
             )
 
             entra_client.named_locations = {}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_trusted_named_locations_exists()
             result = check.execute()
@@ -46,6 +51,7 @@ class Test_entra_trusted_named_locations_exists:
 
             # No named locations configured
             entra_client.named_locations = {DOMAIN: {}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_trusted_named_locations_exists()
             result = check.execute()
@@ -57,7 +63,7 @@ class Test_entra_trusted_named_locations_exists:
             )
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
 
     def test_entra_named_location_with_ip_ranges(self):
         entra_client = mock.MagicMock
@@ -89,6 +95,7 @@ class Test_entra_trusted_named_locations_exists:
                     )
                 }
             }
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_trusted_named_locations_exists()
             result = check.execute()
@@ -132,6 +139,7 @@ class Test_entra_trusted_named_locations_exists:
                     )
                 }
             }
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_trusted_named_locations_exists()
             result = check.execute()
@@ -144,7 +152,7 @@ class Test_entra_trusted_named_locations_exists:
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             # When no trusted location found, resource defaults to tenant
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
 
     def test_entra_new_named_location_with_ip_ranges_not_trusted(self):
         entra_client = mock.MagicMock
@@ -176,6 +184,7 @@ class Test_entra_trusted_named_locations_exists:
                     )
                 }
             }
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_trusted_named_locations_exists()
             result = check.execute()
@@ -188,4 +197,4 @@ class Test_entra_trusted_named_locations_exists:
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             # When location exists but is not trusted, resource defaults to tenant
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]

--- a/tests/providers/azure/services/entra/entra_trusted_named_locations_exists/entra_trusted_named_locations_exists_test.py
+++ b/tests/providers/azure/services/entra/entra_trusted_named_locations_exists/entra_trusted_named_locations_exists_test.py
@@ -44,6 +44,7 @@ class Test_entra_trusted_named_locations_exists:
                 entra_trusted_named_locations_exists,
             )
 
+            # No named locations configured
             entra_client.named_locations = {DOMAIN: {}}
 
             check = entra_trusted_named_locations_exists()
@@ -55,8 +56,8 @@ class Test_entra_trusted_named_locations_exists:
                 == "There is no trusted location with IP ranges defined."
             )
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Named Locations"
-            assert result[0].resource_id == "Named Locations"
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
 
     def test_entra_named_location_with_ip_ranges(self):
         entra_client = mock.MagicMock
@@ -95,7 +96,7 @@ class Test_entra_trusted_named_locations_exists:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == "Exits trusted location with trusted IP ranges, this IPs ranges are: ['192.168.0.1/24']"
+                == "Trusted location Test Location exists with trusted IP ranges: ['192.168.0.1/24']"
             )
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Test Location"
@@ -141,8 +142,9 @@ class Test_entra_trusted_named_locations_exists:
                 == "There is no trusted location with IP ranges defined."
             )
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Named Locations"
-            assert result[0].resource_id == "Named Locations"
+            # When no trusted location found, resource defaults to tenant
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
 
     def test_entra_new_named_location_with_ip_ranges_not_trusted(self):
         entra_client = mock.MagicMock
@@ -184,5 +186,6 @@ class Test_entra_trusted_named_locations_exists:
                 == "There is no trusted location with IP ranges defined."
             )
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Named Locations"
-            assert result[0].resource_id == "Named Locations"
+            # When location exists but is not trusted, resource defaults to tenant
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN

--- a/tests/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups_test.py
+++ b/tests/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups_test.py
@@ -45,6 +45,7 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
                 entra_users_cannot_create_microsoft_365_groups,
             )
 
+            # Empty group settings - no Group.Unified found
             entra_client.group_settings = {DOMAIN: {}}
 
             check = entra_users_cannot_create_microsoft_365_groups()
@@ -53,8 +54,8 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "Users can create Microsoft 365 groups."
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Microsoft365 Groups"
-            assert result[0].resource_id == "Microsoft365 Groups"
+            assert result[0].resource_name == DOMAIN
+            assert result[0].resource_id == DOMAIN
 
     def test_entra_users_cannot_create_microsoft_365_groups(self):
         entra_client = mock.MagicMock
@@ -100,8 +101,9 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
                 result[0].status_extended == "Users cannot create Microsoft 365 groups."
             )
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Microsoft365 Groups"
-            assert result[0].resource_id == "Microsoft365 Groups"
+            assert result[0].resource_name == "Group.Unified"
+            # GroupSetting model doesn't have id field, so resource_id is empty
+            assert result[0].resource_id == ""
 
     def test_entra_users_can_create_microsoft_365_groups(self):
         entra_client = mock.MagicMock
@@ -145,8 +147,9 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "Users can create Microsoft 365 groups."
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Microsoft365 Groups"
-            assert result[0].resource_id == "Microsoft365 Groups"
+            assert result[0].resource_name == "Group.Unified"
+            # GroupSetting model doesn't have id field, so resource_id is empty
+            assert result[0].resource_id == ""
 
     def test_entra_users_can_create_microsoft_365_groups_no_setting(self):
         entra_client = mock.MagicMock
@@ -187,5 +190,6 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             assert result[0].status == "FAIL"
             assert result[0].status_extended == "Users can create Microsoft 365 groups."
             assert result[0].subscription == f"Tenant: {DOMAIN}"
-            assert result[0].resource_name == "Microsoft365 Groups"
-            assert result[0].resource_id == "Microsoft365 Groups"
+            assert result[0].resource_name == "Group.Unified"
+            # GroupSetting model doesn't have id field, so resource_id is empty
+            assert result[0].resource_id == ""

--- a/tests/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups_test.py
+++ b/tests/providers/azure/services/entra/entra_users_cannot_create_microsoft_365_groups/entra_users_cannot_create_microsoft_365_groups_test.py
@@ -1,7 +1,11 @@
 from unittest import mock
 from uuid import uuid4
 
-from tests.providers.azure.azure_fixtures import DOMAIN, set_mocked_azure_provider
+from tests.providers.azure.azure_fixtures import (
+    DOMAIN,
+    TENANT_IDS,
+    set_mocked_azure_provider,
+)
 
 
 class Test_entra_users_cannot_create_microsoft_365_groups:
@@ -23,6 +27,7 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             )
 
             entra_client.group_settings = {}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_users_cannot_create_microsoft_365_groups()
             result = check.execute()
@@ -47,6 +52,7 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
 
             # Empty group settings - no Group.Unified found
             entra_client.group_settings = {DOMAIN: {}}
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_users_cannot_create_microsoft_365_groups()
             result = check.execute()
@@ -55,7 +61,7 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             assert result[0].status_extended == "Users can create Microsoft 365 groups."
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == DOMAIN
-            assert result[0].resource_id == DOMAIN
+            assert result[0].resource_id == TENANT_IDS[0]
 
     def test_entra_users_cannot_create_microsoft_365_groups(self):
         entra_client = mock.MagicMock
@@ -86,12 +92,14 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             entra_client.group_settings = {
                 DOMAIN: {
                     id: GroupSetting(
+                        id=id,
                         name="Group.Unified",
                         template_id=template_id,
                         settings=[setting],
                     )
                 }
             }
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_users_cannot_create_microsoft_365_groups()
             result = check.execute()
@@ -102,8 +110,7 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             )
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Group.Unified"
-            # GroupSetting model doesn't have id field, so resource_id is empty
-            assert result[0].resource_id == ""
+            assert result[0].resource_id == id
 
     def test_entra_users_can_create_microsoft_365_groups(self):
         entra_client = mock.MagicMock
@@ -134,12 +141,14 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             entra_client.group_settings = {
                 DOMAIN: {
                     id: GroupSetting(
+                        id=id,
                         name="Group.Unified",
                         template_id=template_id,
                         settings=[setting],
                     )
                 }
             }
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_users_cannot_create_microsoft_365_groups()
             result = check.execute()
@@ -148,8 +157,7 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             assert result[0].status_extended == "Users can create Microsoft 365 groups."
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Group.Unified"
-            # GroupSetting model doesn't have id field, so resource_id is empty
-            assert result[0].resource_id == ""
+            assert result[0].resource_id == id
 
     def test_entra_users_can_create_microsoft_365_groups_no_setting(self):
         entra_client = mock.MagicMock
@@ -177,12 +185,14 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             entra_client.group_settings = {
                 DOMAIN: {
                     id: GroupSetting(
+                        id=id,
                         name="Group.Unified",
                         template_id=template_id,
                         settings=[],
                     )
                 }
             }
+            entra_client.tenant_ids = TENANT_IDS
 
             check = entra_users_cannot_create_microsoft_365_groups()
             result = check.execute()
@@ -191,5 +201,4 @@ class Test_entra_users_cannot_create_microsoft_365_groups:
             assert result[0].status_extended == "Users can create Microsoft 365 groups."
             assert result[0].subscription == f"Tenant: {DOMAIN}"
             assert result[0].resource_name == "Group.Unified"
-            # GroupSetting model doesn't have id field, so resource_id is empty
-            assert result[0].resource_id == ""
+            assert result[0].resource_id == id

--- a/tests/providers/azure/services/monitor/monitor_alert_create_policy_assignment/monitor_alert_create_policy_assignment_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_create_policy_assignment/monitor_alert_create_policy_assignment_test.py
@@ -34,6 +34,7 @@ class Test_monitor_alert_create_policy_assignment:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -53,8 +54,8 @@ class Test_monitor_alert_create_policy_assignment:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for creating Policy Assignments in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_create_update_nsg/monitor_alert_create_update_nsg_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_create_update_nsg/monitor_alert_create_update_nsg_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_create_update_nsg:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_create_update_nsg:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for creating/updating Network Security Groups in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_create_update_public_ip_address_rule/monitor_alert_create_update_public_ip_address_rule_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_create_update_public_ip_address_rule/monitor_alert_create_update_public_ip_address_rule_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_create_update_security_solution:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_create_update_security_solution:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for creating/updating Public IP address rule in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_create_update_security_solution/monitor_alert_create_update_security_solution_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_create_update_security_solution/monitor_alert_create_update_security_solution_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_create_update_security_solution:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_create_update_security_solution:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for creating/updating Security Solution in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_create_update_sqlserver_fr/monitor_alert_create_update_sqlserver_fr_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_create_update_sqlserver_fr/monitor_alert_create_update_sqlserver_fr_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_create_update_sqlserver_fr:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_create_update_sqlserver_fr:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for creating/updating SQL Server firewall rule in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_delete_nsg/monitor_alert_delete_nsg_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_delete_nsg/monitor_alert_delete_nsg_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_delete_nsg:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_delete_nsg:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for deleting Network Security Groups in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_delete_policy_assignment/monitor_alert_delete_policy_assignment_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_delete_policy_assignment/monitor_alert_delete_policy_assignment_test.py
@@ -34,6 +34,7 @@ class Test_monitor_alert_delete_policy_assignment:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -53,8 +54,8 @@ class Test_monitor_alert_delete_policy_assignment:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for deleting policy assignment in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_delete_public_ip_address_rule/monitor_alert_delete_public_ip_address_rule_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_delete_public_ip_address_rule/monitor_alert_delete_public_ip_address_rule_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_create_update_security_solution:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_create_update_security_solution:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for deleting public IP address rule in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_delete_security_solution/monitor_alert_delete_security_solution_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_delete_security_solution/monitor_alert_delete_security_solution_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_create_update_security_solution:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_create_update_security_solution:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for deleting Security Solution in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_delete_sqlserver_fr/monitor_alert_delete_sqlserver_fr_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_delete_sqlserver_fr/monitor_alert_delete_sqlserver_fr_test.py
@@ -33,6 +33,7 @@ class Test_monitor_alert_delete_sqlserver_fr:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -52,8 +53,8 @@ class Test_monitor_alert_delete_sqlserver_fr:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is not an alert for deleting SQL Server firewall rule in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_alert_service_health_exists/monitor_alert_service_health_exists_test.py
+++ b/tests/providers/azure/services/monitor/monitor_alert_service_health_exists/monitor_alert_service_health_exists_test.py
@@ -31,6 +31,7 @@ class Test_monitor_alert_service_health_exists:
     def test_no_alert_rules(self):
         monitor_client = mock.MagicMock()
         monitor_client.alert_rules = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -50,8 +51,8 @@ class Test_monitor_alert_service_health_exists:
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is no activity log alert for Service Health in subscription {AZURE_SUBSCRIPTION_ID}."
@@ -151,13 +152,16 @@ class Test_monitor_alert_service_health_exists:
                     ),
                 ]
             }
+            monitor_client.subscriptions = {
+                AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID
+            }
             check = monitor_alert_service_health_exists()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Monitor"
-            assert result[0].resource_id == "Monitor"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"There is no activity log alert for Service Health in subscription {AZURE_SUBSCRIPTION_ID}."

--- a/tests/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories_test.py
+++ b/tests/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories_test.py
@@ -58,7 +58,7 @@ class Test_monitor_diagnostic_setting_with_appropriate_categories:
             assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
             assert (
                 result[0].status_extended
-                == f"There are no diagnostic settings capturing appropriate categories in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"No diagnostic setting captures all appropriate categories (Administrative, Security, Alert, Policy) in subscription {AZURE_SUBSCRIPTION_ID}."
             )
 
     def test_diagnostic_settings_configured(self):
@@ -119,8 +119,8 @@ class Test_monitor_diagnostic_setting_with_appropriate_categories:
             }
             check = monitor_diagnostic_setting_with_appropriate_categories()
             result = check.execute()
-            # Now generates one finding per diagnostic setting
-            assert len(result) == 2
+            # Now returns only one finding per subscription (first compliant setting found)
+            assert len(result) == 1
             # First diagnostic setting has all required categories enabled
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].status == "PASS"
@@ -129,13 +129,4 @@ class Test_monitor_diagnostic_setting_with_appropriate_categories:
             assert (
                 result[0].status_extended
                 == f"Diagnostic setting name captures appropriate categories in subscription {AZURE_SUBSCRIPTION_ID}."
-            )
-            # Second diagnostic setting is missing Administrative category
-            assert result[1].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[1].status == "FAIL"
-            assert result[1].resource_id == "id2"
-            assert result[1].resource_name == "name2"
-            assert (
-                result[1].status_extended
-                == f"Diagnostic setting name2 does not capture appropriate categories in subscription {AZURE_SUBSCRIPTION_ID}."
             )

--- a/tests/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories_test.py
+++ b/tests/providers/azure/services/monitor/monitor_diagnostic_setting_with_appropriate_categories/monitor_diagnostic_setting_with_appropriate_categories_test.py
@@ -23,7 +23,6 @@ class Test_monitor_diagnostic_setting_with_appropriate_categories:
                 new=monitor_client,
             ),
         ):
-
             from prowler.providers.azure.services.monitor.monitor_diagnostic_setting_with_appropriate_categories.monitor_diagnostic_setting_with_appropriate_categories import (
                 monitor_diagnostic_setting_with_appropriate_categories,
             )
@@ -35,6 +34,7 @@ class Test_monitor_diagnostic_setting_with_appropriate_categories:
     def test_no_diagnostic_settings(self):
         monitor_client = mock.MagicMock
         monitor_client.diagnostics_settings = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -54,11 +54,11 @@ class Test_monitor_diagnostic_setting_with_appropriate_categories:
             assert len(result) == 1
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].status == "FAIL"
-            assert result[0].resource_id == "Monitor"
-            assert result[0].resource_name == "Monitor"
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
             assert (
                 result[0].status_extended
-                == f"There are no diagnostic settings capturing appropiate categories in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"There are no diagnostic settings capturing appropriate categories in subscription {AZURE_SUBSCRIPTION_ID}."
             )
 
     def test_diagnostic_settings_configured(self):
@@ -119,12 +119,23 @@ class Test_monitor_diagnostic_setting_with_appropriate_categories:
             }
             check = monitor_diagnostic_setting_with_appropriate_categories()
             result = check.execute()
-            assert len(result) == 1
+            # Now generates one finding per diagnostic setting
+            assert len(result) == 2
+            # First diagnostic setting has all required categories enabled
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].status == "PASS"
-            assert result[0].resource_id == "Monitor"
-            assert result[0].resource_name == "Monitor"
+            assert result[0].resource_id == "id"
+            assert result[0].resource_name == "name"
             assert (
                 result[0].status_extended
-                == f"There is at least one diagnostic setting capturing appropiate categories in subscription {AZURE_SUBSCRIPTION_ID}."
+                == f"Diagnostic setting name captures appropriate categories in subscription {AZURE_SUBSCRIPTION_ID}."
+            )
+            # Second diagnostic setting is missing Administrative category
+            assert result[1].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[1].status == "FAIL"
+            assert result[1].resource_id == "id2"
+            assert result[1].resource_name == "name2"
+            assert (
+                result[1].status_extended
+                == f"Diagnostic setting name2 does not capture appropriate categories in subscription {AZURE_SUBSCRIPTION_ID}."
             )

--- a/tests/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists_test.py
+++ b/tests/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists_test.py
@@ -7,7 +7,6 @@ from tests.providers.azure.azure_fixtures import (
 
 
 class Test_monitor_diagnostic_settings_exists:
-
     def test_monitor_diagnostic_settings_exists_no_subscriptions(
         self,
     ):
@@ -35,6 +34,7 @@ class Test_monitor_diagnostic_settings_exists:
     def test_no_diagnostic_settings(self):
         monitor_client = mock.MagicMock
         monitor_client.diagnostics_settings = {AZURE_SUBSCRIPTION_ID: []}
+        monitor_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
         with (
             mock.patch(
                 "prowler.providers.common.provider.Provider.get_global_provider",
@@ -54,6 +54,8 @@ class Test_monitor_diagnostic_settings_exists:
             assert len(result) == 1
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
             assert result[0].status == "FAIL"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert (
                 result[0].status_extended
                 == f"No diagnostic settings found in subscription {AZURE_SUBSCRIPTION_ID}."
@@ -186,10 +188,16 @@ class Test_monitor_diagnostic_settings_exists:
                 }
                 check = monitor_diagnostic_settings_exists()
                 result = check.execute()
-                assert len(result) == 1
+                assert len(result) == 2
                 assert result[0].subscription == AZURE_SUBSCRIPTION_ID
                 assert result[0].status == "PASS"
+                assert result[0].resource_name == "name"
+                assert result[0].resource_id == "id"
                 assert (
                     result[0].status_extended
-                    == f"Diagnostic settings found in subscription {AZURE_SUBSCRIPTION_ID}."
+                    == f"Diagnostic setting name found in subscription {AZURE_SUBSCRIPTION_ID}."
                 )
+                assert result[1].subscription == AZURE_SUBSCRIPTION_ID
+                assert result[1].status == "PASS"
+                assert result[1].resource_name == "name2"
+                assert result[1].resource_id == "id2"

--- a/tests/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists_test.py
+++ b/tests/providers/azure/services/monitor/monitor_diagnostic_settings_exists/monitor_diagnostic_settings_exists_test.py
@@ -188,7 +188,8 @@ class Test_monitor_diagnostic_settings_exists:
                 }
                 check = monitor_diagnostic_settings_exists()
                 result = check.execute()
-                assert len(result) == 2
+                # Now returns only one finding per subscription (first diagnostic setting found)
+                assert len(result) == 1
                 assert result[0].subscription == AZURE_SUBSCRIPTION_ID
                 assert result[0].status == "PASS"
                 assert result[0].resource_name == "name"
@@ -197,7 +198,3 @@ class Test_monitor_diagnostic_settings_exists:
                     result[0].status_extended
                     == f"Diagnostic setting name found in subscription {AZURE_SUBSCRIPTION_ID}."
                 )
-                assert result[1].subscription == AZURE_SUBSCRIPTION_ID
-                assert result[1].status == "PASS"
-                assert result[1].resource_name == "name2"
-                assert result[1].resource_id == "id2"

--- a/tests/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists_test.py
+++ b/tests/providers/azure/services/network/network_bastion_host_exists/network_bastion_host_exists_test.py
@@ -12,6 +12,7 @@ class Test_network_bastion_host_exists:
     def test_no_bastion_hosts(self):
         network_client = mock.MagicMock
         network_client.bastion_hosts = {AZURE_SUBSCRIPTION_ID: []}
+        network_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_ID}
 
         with (
             mock.patch(
@@ -40,8 +41,8 @@ class Test_network_bastion_host_exists:
                 == f"Bastion Host from subscription {AZURE_SUBSCRIPTION_ID} does not exist"
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Bastion Host"
-            assert result[0].resource_id == "Bastion Host"
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
 
     def test_network_bastion_host_exists(self):
         network_client = mock.MagicMock
@@ -82,8 +83,8 @@ class Test_network_bastion_host_exists:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Bastion Host from subscription {AZURE_SUBSCRIPTION_ID} available are: {bastion_host_name}"
+                == f"Bastion Host {bastion_host_name} exists in subscription {AZURE_SUBSCRIPTION_ID}."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID
-            assert result[0].resource_name == "Bastion Host"
-            assert result[0].resource_id == "Bastion Host"
+            assert result[0].resource_name == bastion_host_name
+            assert result[0].resource_id == bastion_host_id

--- a/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
+++ b/tests/providers/azure/services/network/network_watcher_enabled/network_watcher_enabled_test.py
@@ -84,8 +84,8 @@ class Test_network_watcher_enabled:
                 == f"Network Watcher is not enabled for the following locations in subscription '{AZURE_SUBSCRIPTION_NAME}': location."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_NAME
-            assert result[0].resource_name == network_watcher_name
-            assert result[0].resource_id == network_watcher_id
+            assert result[0].resource_name == AZURE_SUBSCRIPTION_NAME
+            assert result[0].resource_id == f"/subscriptions/{AZURE_SUBSCRIPTION_ID}"
             assert result[0].location == "global"
 
     def test_network_valid_network_watchers(self):
@@ -131,9 +131,8 @@ class Test_network_watcher_enabled:
             assert result[0].status == "PASS"
             assert (
                 result[0].status_extended
-                == f"Network Watcher is enabled for all locations in subscription '{AZURE_SUBSCRIPTION_NAME}'."
+                == f"Network Watcher {network_watcher_name} is enabled in location location in subscription '{AZURE_SUBSCRIPTION_NAME}'."
             )
             assert result[0].subscription == AZURE_SUBSCRIPTION_NAME
             assert result[0].resource_name == network_watcher_name
             assert result[0].resource_id == network_watcher_id
-            assert result[0].location == "global"


### PR DESCRIPTION
### Context

Azure checks were using hardcoded strings like `"Monitor"`, `"AppInsights"`, `"Conditional Access Policy"` as resource_id values instead of actual Azure resource IDs. This made it difficult to identify which specific resources had security issues.

### Description

This PR standardizes resource_id values across 31 Azure checks following a consistent principle:
- **If the child resource exists** → use the child resource's actual Azure ID
- **If the child resource doesn't exist** → use the parent resource ID (subscription ID for most services, tenant domain for Entra)

**Services affected:**
- APIM (1 check)
- AppInsights (1 check)
- Defender (3 checks)
- Entra (7 checks)
- Monitor (13 checks)
- Network (6 checks)

**Test updates:**
- Updated 30 test files to match new resource_id expectations
- Added `subscriptions` mock to tests that were missing it
- Replaced empty dict mocks with proper model objects in Entra tests

### Steps to review

1. Review the check changes to verify the resource_id standardization pattern
2. Run Azure tests to verify all pass:
   ```bash
   poetry run pytest tests/providers/azure/services/apim/ tests/providers/azure/services/appinsights/ tests/providers/azure/services/defender/ tests/providers/azure/services/entra/ tests/providers/azure/services/monitor/ tests/providers/azure/services/network/ -v
   ```
3. Verify the pattern is consistent: child resource ID when exists, parent ID when not

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md - Not needed
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.