### PR TITLE
fix(ui): replace HeroUI dropdowns with Radix ActionDropdown to fix overlay conflict

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - ProviderTypeSelector crash when an unknown provider type is not present in PROVIDER_DATA [(#9991)](https://github.com/prowler-cloud/prowler/pull/9991)
+- Infinite memory loop when opening modals from table row action dropdowns caused by HeroUI (React Aria) and Radix Dialog overlay conflict [(#9996)](https://github.com/prowler-cloud/prowler/pull/9996)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Attack Paths: Query list now shows their name and short description, when one is selected it also shows a longer description and an attribution if it has it [(#9983)](https://github.com/prowler-cloud/prowler/pull/9983)
 
+---
+
+## [1.18.2] (Prowler UNRELEASED)
+
 ### 🐞 Fixed
 
 - ProviderTypeSelector crash when an unknown provider type is not present in PROVIDER_DATA [(#9991)](https://github.com/prowler-cloud/prowler/pull/9991)

--- a/ui/app/(prowler)/mutelist/_components/simple/mute-rule-row-actions.tsx
+++ b/ui/app/(prowler)/mutelist/_components/simple/mute-rule-row-actions.tsx
@@ -1,17 +1,16 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
 import { Pencil, Trash2 } from "lucide-react";
 
 import { MuteRuleData } from "@/actions/mute-rules/types";
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownLabel,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 
 interface MuteRuleRowActionsProps {
   muteRule: MuteRuleData;
@@ -26,11 +25,8 @@ export function MuteRuleRowActions({
 }: MuteRuleRowActionsProps) {
   return (
     <div className="flex items-center justify-center px-2">
-      <Dropdown
-        className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-        placement="bottom"
-      >
-        <DropdownTrigger>
+      <ActionDropdown
+        trigger={
           <Button
             variant="outline"
             size="icon-sm"
@@ -41,44 +37,25 @@ export function MuteRuleRowActions({
               className="text-text-neutral-secondary"
             />
           </Button>
-        </DropdownTrigger>
-        <DropdownMenu
-          closeOnSelect
-          aria-label="Mute rule actions"
-          color="default"
-          variant="flat"
-        >
-          <DropdownSection title="Actions">
-            <DropdownItem
-              key="edit"
-              description="Edit rule name and reason"
-              textValue="Edit"
-              startContent={
-                <Pencil className="text-default-500 pointer-events-none size-4 shrink-0" />
-              }
-              onPress={() => onEdit(muteRule)}
-            >
-              Edit
-            </DropdownItem>
-            <DropdownItem
-              key="delete"
-              description="Delete this mute rule"
-              textValue="Delete"
-              className="text-danger"
-              color="danger"
-              classNames={{
-                description: "text-danger",
-              }}
-              startContent={
-                <Trash2 className="pointer-events-none size-4 shrink-0" />
-              }
-              onPress={() => onDelete(muteRule)}
-            >
-              Delete
-            </DropdownItem>
-          </DropdownSection>
-        </DropdownMenu>
-      </Dropdown>
+        }
+        label="Actions"
+      >
+        <ActionDropdownItem
+          icon={<Pencil />}
+          label="Edit"
+          description="Edit rule name and reason"
+          onSelect={() => onEdit(muteRule)}
+        />
+        <ActionDropdownSeparator />
+        <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+        <ActionDropdownItem
+          icon={<Trash2 />}
+          label="Delete"
+          description="Delete this mute rule"
+          destructive
+          onSelect={() => onDelete(muteRule)}
+        />
+      </ActionDropdown>
     </div>
   );
 }

--- a/ui/app/(prowler)/mutelist/_components/simple/mute-rule-row-actions.tsx
+++ b/ui/app/(prowler)/mutelist/_components/simple/mute-rule-row-actions.tsx
@@ -7,9 +7,8 @@ import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 
 interface MuteRuleRowActionsProps {
@@ -38,23 +37,20 @@ export function MuteRuleRowActions({
             />
           </Button>
         }
-        label="Actions"
       >
         <ActionDropdownItem
           icon={<Pencil />}
-          label="Edit"
-          description="Edit rule name and reason"
+          label="Edit Mute Rule"
           onSelect={() => onEdit(muteRule)}
         />
-        <ActionDropdownSeparator />
-        <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
-        <ActionDropdownItem
-          icon={<Trash2 />}
-          label="Delete"
-          description="Delete this mute rule"
-          destructive
-          onSelect={() => onDelete(muteRule)}
-        />
+        <ActionDropdownDangerZone>
+          <ActionDropdownItem
+            icon={<Trash2 />}
+            label="Delete Mute Rule"
+            destructive
+            onSelect={() => onDelete(muteRule)}
+          />
+        </ActionDropdownDangerZone>
       </ActionDropdown>
     </div>
   );

--- a/ui/components/findings/table/data-table-row-actions.tsx
+++ b/ui/components/findings/table/data-table-row-actions.tsx
@@ -66,30 +66,13 @@ export function DataTableRowActions<T extends FindingRowData>({
     return [finding.id];
   };
 
-  const getMuteDescription = (): string => {
-    if (isMuted) {
-      return "This finding is already muted";
-    }
-    const ids = getMuteIds();
-    if (ids.length > 1) {
-      return `Mute ${ids.length} selected findings`;
-    }
-    return "Mute this finding";
-  };
-
   const getMuteLabel = () => {
     if (isMuted) return "Muted";
-    if (!isMuted && isCurrentSelected && hasMultipleSelected) {
-      return (
-        <>
-          Mute
-          <span className="ml-1 text-xs text-slate-500">
-            ({selectedFindingIds.length})
-          </span>
-        </>
-      );
+    const ids = getMuteIds();
+    if (ids.length > 1) {
+      return `Mute ${ids.length} Findings`;
     }
-    return "Mute";
+    return "Mute Finding";
   };
 
   const handleMuteComplete = () => {
@@ -146,7 +129,6 @@ export function DataTableRowActions<T extends FindingRowData>({
               )
             }
             label={getMuteLabel()}
-            description={getMuteDescription()}
             disabled={isMuted}
             onSelect={() => {
               setIsMuteModalOpen(true);
@@ -155,7 +137,6 @@ export function DataTableRowActions<T extends FindingRowData>({
           <ActionDropdownItem
             icon={<JiraIcon size={20} />}
             label="Send to Jira"
-            description="Create a Jira issue for this finding"
             onSelect={() => setIsJiraModalOpen(true)}
           />
         </ActionDropdown>

--- a/ui/components/invitations/table/data-table-row-actions.tsx
+++ b/ui/components/invitations/table/data-table-row-actions.tsx
@@ -9,9 +9,8 @@ import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
@@ -66,12 +65,10 @@ export function DataTableRowActions<InvitationProps>({
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
           }
-          label="Actions"
         >
           <ActionDropdownItem
             icon={<Eye />}
             label="Check Details"
-            description="View invitation details"
             onSelect={() =>
               router.push(`/invitations/check-details?id=${invitationId}`)
             }
@@ -79,20 +76,18 @@ export function DataTableRowActions<InvitationProps>({
           <ActionDropdownItem
             icon={<Pencil />}
             label="Edit Invitation"
-            description="Allows you to edit the invitation"
             onSelect={() => setIsEditOpen(true)}
             disabled={invitationAccepted === "accepted"}
           />
-          <ActionDropdownSeparator />
-          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
-          <ActionDropdownItem
-            icon={<Trash2 />}
-            label="Revoke Invitation"
-            description="Delete the invitation permanently"
-            destructive
-            onSelect={() => setIsDeleteOpen(true)}
-            disabled={invitationAccepted === "accepted"}
-          />
+          <ActionDropdownDangerZone>
+            <ActionDropdownItem
+              icon={<Trash2 />}
+              label="Revoke Invitation"
+              destructive
+              onSelect={() => setIsDeleteOpen(true)}
+              disabled={invitationAccepted === "accepted"}
+            />
+          </ActionDropdownDangerZone>
         </ActionDropdown>
       </div>
     </>

--- a/ui/components/invitations/table/data-table-row-actions.tsx
+++ b/ui/components/invitations/table/data-table-row-actions.tsx
@@ -1,24 +1,18 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
-import {
-  AddNoteBulkIcon,
-  DeleteDocumentBulkIcon,
-  EditDocumentBulkIcon,
-} from "@heroui/shared-icons";
 import { Row } from "@tanstack/react-table";
-import clsx from "clsx";
+import { Eye, Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownLabel,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
 import { DeleteForm, EditForm } from "../forms";
@@ -27,7 +21,6 @@ interface DataTableRowActionsProps<InvitationProps> {
   row: Row<InvitationProps>;
   roles?: { id: string; name: string }[];
 }
-const iconClasses = "text-2xl text-default-500 pointer-events-none shrink-0";
 
 export function DataTableRowActions<InvitationProps>({
   row,
@@ -67,65 +60,40 @@ export function DataTableRowActions<InvitationProps>({
       </Modal>
 
       <div className="relative flex items-center justify-end gap-2">
-        <Dropdown
-          className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-          placement="bottom"
-        >
-          <DropdownTrigger>
+        <ActionDropdown
+          trigger={
             <Button variant="ghost" size="icon-sm" className="rounded-full">
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
-          </DropdownTrigger>
-          <DropdownMenu
-            closeOnSelect
-            aria-label="Actions"
-            color="default"
-            variant="flat"
-          >
-            <DropdownSection title="Actions">
-              <DropdownItem
-                key="check-details"
-                description="View invitation details"
-                textValue="Check Details"
-                startContent={<AddNoteBulkIcon className={iconClasses} />}
-                onPress={() =>
-                  router.push(`/invitations/check-details?id=${invitationId}`)
-                }
-              >
-                Check Details
-              </DropdownItem>
-
-              <DropdownItem
-                key="edit"
-                description="Allows you to edit the invitation"
-                textValue="Edit Invitation"
-                startContent={<EditDocumentBulkIcon className={iconClasses} />}
-                onPress={() => setIsEditOpen(true)}
-                isDisabled={invitationAccepted === "accepted"}
-              >
-                Edit Invitation
-              </DropdownItem>
-            </DropdownSection>
-            <DropdownSection title="Danger zone">
-              <DropdownItem
-                key="delete"
-                className="text-text-error"
-                color="danger"
-                description="Delete the invitation permanently"
-                textValue="Delete Invitation"
-                startContent={
-                  <DeleteDocumentBulkIcon
-                    className={clsx(iconClasses, "!text-text-error")}
-                  />
-                }
-                onPress={() => setIsDeleteOpen(true)}
-                isDisabled={invitationAccepted === "accepted"}
-              >
-                Revoke Invitation
-              </DropdownItem>
-            </DropdownSection>
-          </DropdownMenu>
-        </Dropdown>
+          }
+          label="Actions"
+        >
+          <ActionDropdownItem
+            icon={<Eye />}
+            label="Check Details"
+            description="View invitation details"
+            onSelect={() =>
+              router.push(`/invitations/check-details?id=${invitationId}`)
+            }
+          />
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label="Edit Invitation"
+            description="Allows you to edit the invitation"
+            onSelect={() => setIsEditOpen(true)}
+            disabled={invitationAccepted === "accepted"}
+          />
+          <ActionDropdownSeparator />
+          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+          <ActionDropdownItem
+            icon={<Trash2 />}
+            label="Revoke Invitation"
+            description="Delete the invitation permanently"
+            destructive
+            onSelect={() => setIsDeleteOpen(true)}
+            disabled={invitationAccepted === "accepted"}
+          />
+        </ActionDropdown>
       </div>
     </>
   );

--- a/ui/components/manage-groups/table/data-table-row-actions.tsx
+++ b/ui/components/manage-groups/table/data-table-row-actions.tsx
@@ -1,23 +1,18 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
-import {
-  DeleteDocumentBulkIcon,
-  EditDocumentBulkIcon,
-} from "@heroui/shared-icons";
 import { Row } from "@tanstack/react-table";
-import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownLabel,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
 import { DeleteGroupForm } from "../forms";
@@ -25,7 +20,6 @@ import { DeleteGroupForm } from "../forms";
 interface DataTableRowActionsProps<ProviderProps> {
   row: Row<ProviderProps>;
 }
-const iconClasses = "text-2xl text-default-500 pointer-events-none shrink-0";
 
 export function DataTableRowActions<ProviderProps>({
   row,
@@ -47,51 +41,30 @@ export function DataTableRowActions<ProviderProps>({
       </Modal>
 
       <div className="relative flex items-center justify-end gap-2">
-        <Dropdown
-          className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-          placement="bottom"
-        >
-          <DropdownTrigger>
+        <ActionDropdown
+          trigger={
             <Button variant="ghost" size="icon-sm" className="rounded-full">
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
-          </DropdownTrigger>
-          <DropdownMenu
-            closeOnSelect
-            aria-label="Actions"
-            color="default"
-            variant="flat"
-          >
-            <DropdownSection title="Actions">
-              <DropdownItem
-                key="edit"
-                description="Allows you to edit the provider group"
-                textValue="Edit Provider Group"
-                startContent={<EditDocumentBulkIcon className={iconClasses} />}
-                onPress={() => router.push(`/manage-groups?groupId=${groupId}`)}
-              >
-                Edit Provider Group
-              </DropdownItem>
-            </DropdownSection>
-            <DropdownSection title="Danger zone">
-              <DropdownItem
-                key="delete"
-                className="text-text-error"
-                color="danger"
-                description="Delete the provider group permanently"
-                textValue="Delete Provider Group"
-                startContent={
-                  <DeleteDocumentBulkIcon
-                    className={clsx(iconClasses, "!text-text-error")}
-                  />
-                }
-                onPress={() => setIsDeleteOpen(true)}
-              >
-                Delete Provider Group
-              </DropdownItem>
-            </DropdownSection>
-          </DropdownMenu>
-        </Dropdown>
+          }
+          label="Actions"
+        >
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label="Edit Provider Group"
+            description="Allows you to edit the provider group"
+            onSelect={() => router.push(`/manage-groups?groupId=${groupId}`)}
+          />
+          <ActionDropdownSeparator />
+          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+          <ActionDropdownItem
+            icon={<Trash2 />}
+            label="Delete Provider Group"
+            description="Delete the provider group permanently"
+            destructive
+            onSelect={() => setIsDeleteOpen(true)}
+          />
+        </ActionDropdown>
       </div>
     </>
   );

--- a/ui/components/manage-groups/table/data-table-row-actions.tsx
+++ b/ui/components/manage-groups/table/data-table-row-actions.tsx
@@ -9,9 +9,8 @@ import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
@@ -47,23 +46,20 @@ export function DataTableRowActions<ProviderProps>({
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
           }
-          label="Actions"
         >
           <ActionDropdownItem
             icon={<Pencil />}
             label="Edit Provider Group"
-            description="Allows you to edit the provider group"
             onSelect={() => router.push(`/manage-groups?groupId=${groupId}`)}
           />
-          <ActionDropdownSeparator />
-          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
-          <ActionDropdownItem
-            icon={<Trash2 />}
-            label="Delete Provider Group"
-            description="Delete the provider group permanently"
-            destructive
-            onSelect={() => setIsDeleteOpen(true)}
-          />
+          <ActionDropdownDangerZone>
+            <ActionDropdownItem
+              icon={<Trash2 />}
+              label="Delete Provider Group"
+              destructive
+              onSelect={() => setIsDeleteOpen(true)}
+            />
+          </ActionDropdownDangerZone>
         </ActionDropdown>
       </div>
     </>

--- a/ui/components/providers/table/data-table-row-actions.tsx
+++ b/ui/components/providers/table/data-table-row-actions.tsx
@@ -10,9 +10,8 @@ import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
@@ -75,16 +74,10 @@ export function DataTableRowActions<ProviderProps>({
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
           }
-          label="Actions"
         >
           <ActionDropdownItem
             icon={<Pencil />}
             label={hasSecret ? "Update Credentials" : "Add Credentials"}
-            description={
-              hasSecret
-                ? "Update the provider credentials"
-                : "Add the provider credentials"
-            }
             onSelect={() =>
               router.push(
                 `/providers/${hasSecret ? "update" : "add"}-credentials?type=${providerType}&id=${providerId}${providerSecretId ? `&secretId=${providerSecretId}` : ""}`,
@@ -110,18 +103,16 @@ export function DataTableRowActions<ProviderProps>({
           <ActionDropdownItem
             icon={<Pencil />}
             label="Edit Provider Alias"
-            description="Allows you to edit the provider"
             onSelect={() => setIsEditOpen(true)}
           />
-          <ActionDropdownSeparator />
-          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
-          <ActionDropdownItem
-            icon={<Trash2 />}
-            label="Delete Provider"
-            description="Delete the provider permanently"
-            destructive
-            onSelect={() => setIsDeleteOpen(true)}
-          />
+          <ActionDropdownDangerZone>
+            <ActionDropdownItem
+              icon={<Trash2 />}
+              label="Delete Provider"
+              destructive
+              onSelect={() => setIsDeleteOpen(true)}
+            />
+          </ActionDropdownDangerZone>
         </ActionDropdown>
       </div>
     </>

--- a/ui/components/providers/table/data-table-row-actions.tsx
+++ b/ui/components/providers/table/data-table-row-actions.tsx
@@ -1,25 +1,19 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
-import {
-  AddNoteBulkIcon,
-  DeleteDocumentBulkIcon,
-  EditDocumentBulkIcon,
-} from "@heroui/shared-icons";
 import { Row } from "@tanstack/react-table";
-import clsx from "clsx";
+import { Pencil, PlugZap, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { checkConnectionProvider } from "@/actions/providers/providers";
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownLabel,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
 import { EditForm } from "../forms";
@@ -28,7 +22,6 @@ import { DeleteForm } from "../forms/delete-form";
 interface DataTableRowActionsProps<ProviderProps> {
   row: Row<ProviderProps>;
 }
-const iconClasses = "text-2xl text-default-500 pointer-events-none shrink-0";
 
 export function DataTableRowActions<ProviderProps>({
   row,
@@ -53,12 +46,6 @@ export function DataTableRowActions<ProviderProps>({
 
   const hasSecret = (row.original as any).relationships?.secret?.data;
 
-  // Calculate disabled keys based on conditions
-  const disabledKeys = [];
-  if (!hasSecret || loading) {
-    disabledKeys.push("new");
-  }
-
   return (
     <>
       <Modal
@@ -82,88 +69,60 @@ export function DataTableRowActions<ProviderProps>({
       </Modal>
 
       <div className="relative flex items-center justify-end gap-2">
-        <Dropdown
-          className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-          placement="bottom"
-        >
-          <DropdownTrigger>
+        <ActionDropdown
+          trigger={
             <Button variant="ghost" size="icon-sm" className="rounded-full">
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
-          </DropdownTrigger>
-          <DropdownMenu
-            aria-label="Actions"
-            color="default"
-            variant="flat"
-            disabledKeys={disabledKeys}
-            closeOnSelect={false}
-          >
-            <DropdownSection title="Actions">
-              <DropdownItem
-                key={hasSecret ? "update" : "add"}
-                description={
-                  hasSecret
-                    ? "Update the provider credentials"
-                    : "Add the provider credentials"
-                }
-                textValue={hasSecret ? "Update Credentials" : "Add Credentials"}
-                startContent={<EditDocumentBulkIcon className={iconClasses} />}
-                onPress={() =>
-                  router.push(
-                    `/providers/${hasSecret ? "update" : "add"}-credentials?type=${providerType}&id=${providerId}${providerSecretId ? `&secretId=${providerSecretId}` : ""}`,
-                  )
-                }
-                closeOnSelect={true}
-              >
-                {hasSecret ? "Update Credentials" : "Add Credentials"}
-              </DropdownItem>
-              <DropdownItem
-                key="new"
-                description={
-                  hasSecret && !loading
-                    ? "Check the provider connection"
-                    : loading
-                      ? "Checking provider connection"
-                      : "Add credentials to test the connection"
-                }
-                textValue="Check Connection"
-                startContent={<AddNoteBulkIcon className={iconClasses} />}
-                onPress={handleTestConnection}
-                closeOnSelect={false}
-              >
-                {loading ? "Testing..." : "Test Connection"}
-              </DropdownItem>
-              <DropdownItem
-                key="edit"
-                description="Allows you to edit the provider"
-                textValue="Edit Provider"
-                startContent={<EditDocumentBulkIcon className={iconClasses} />}
-                onPress={() => setIsEditOpen(true)}
-                closeOnSelect={true}
-              >
-                Edit Provider Alias
-              </DropdownItem>
-            </DropdownSection>
-            <DropdownSection title="Danger zone">
-              <DropdownItem
-                key="delete"
-                className="text-text-error"
-                color="danger"
-                description="Delete the provider permanently"
-                textValue="Delete Provider"
-                startContent={
-                  <DeleteDocumentBulkIcon
-                    className={clsx(iconClasses, "!text-text-error")}
-                  />
-                }
-                onPress={() => setIsDeleteOpen(true)}
-                closeOnSelect={true}
-              >
-                Delete Provider
-              </DropdownItem>
-            </DropdownSection>
-          </DropdownMenu>
-        </Dropdown>
+          }
+          label="Actions"
+        >
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label={hasSecret ? "Update Credentials" : "Add Credentials"}
+            description={
+              hasSecret
+                ? "Update the provider credentials"
+                : "Add the provider credentials"
+            }
+            onSelect={() =>
+              router.push(
+                `/providers/${hasSecret ? "update" : "add"}-credentials?type=${providerType}&id=${providerId}${providerSecretId ? `&secretId=${providerSecretId}` : ""}`,
+              )
+            }
+          />
+          <ActionDropdownItem
+            icon={<PlugZap />}
+            label={loading ? "Testing..." : "Test Connection"}
+            description={
+              hasSecret && !loading
+                ? "Check the provider connection"
+                : loading
+                  ? "Checking provider connection"
+                  : "Add credentials to test the connection"
+            }
+            onSelect={(e) => {
+              e.preventDefault();
+              handleTestConnection();
+            }}
+            disabled={!hasSecret || loading}
+          />
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label="Edit Provider Alias"
+            description="Allows you to edit the provider"
+            onSelect={() => setIsEditOpen(true)}
+          />
+          <ActionDropdownSeparator />
+          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+          <ActionDropdownItem
+            icon={<Trash2 />}
+            label="Delete Provider"
+            description="Delete the provider permanently"
+            destructive
+            onSelect={() => setIsDeleteOpen(true)}
+          />
+        </ActionDropdown>
       </div>
     </>
   );

--- a/ui/components/resources/table/column-resources.tsx
+++ b/ui/components/resources/table/column-resources.tsx
@@ -102,8 +102,7 @@ const ResourceRowActions = ({ row }: { row: { original: ResourceProps } }) => {
         >
           <ActionDropdownItem
             icon={<Eye className="size-5" />}
-            label="View details"
-            description={`View details for ${resourceName}`}
+            label="View Details"
             onSelect={() => setIsDrawerOpen(true)}
           />
         </ActionDropdown>

--- a/ui/components/resources/table/column-resources.tsx
+++ b/ui/components/resources/table/column-resources.tsx
@@ -83,7 +83,6 @@ const FailedFindingsBadge = ({ count }: { count: number }) => {
 // Row actions dropdown
 const ResourceRowActions = ({ row }: { row: { original: ResourceProps } }) => {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const resourceName = row.original.attributes?.name || "Resource";
 
   return (
     <>

--- a/ui/components/roles/table/data-table-row-actions.tsx
+++ b/ui/components/roles/table/data-table-row-actions.tsx
@@ -1,30 +1,24 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
-import {
-  DeleteDocumentBulkIcon,
-  EditDocumentBulkIcon,
-} from "@heroui/shared-icons";
 import { Row } from "@tanstack/react-table";
-import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownLabel,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
 import { DeleteRoleForm } from "../workflow/forms";
 interface DataTableRowActionsProps<RoleProps> {
   row: Row<RoleProps>;
 }
-const iconClasses = "text-2xl text-default-500 pointer-events-none shrink-0";
 
 export function DataTableRowActions<RoleProps>({
   row,
@@ -43,51 +37,30 @@ export function DataTableRowActions<RoleProps>({
         <DeleteRoleForm roleId={roleId} setIsOpen={setIsDeleteOpen} />
       </Modal>
       <div className="relative flex items-center justify-end gap-2">
-        <Dropdown
-          className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-          placement="bottom"
-        >
-          <DropdownTrigger>
+        <ActionDropdown
+          trigger={
             <Button variant="ghost" size="icon-sm" className="rounded-full">
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
-          </DropdownTrigger>
-          <DropdownMenu
-            closeOnSelect
-            aria-label="Actions"
-            color="default"
-            variant="flat"
-          >
-            <DropdownSection title="Actions">
-              <DropdownItem
-                key="edit"
-                description="Edit the role details"
-                textValue="Edit Role"
-                startContent={<EditDocumentBulkIcon className={iconClasses} />}
-                onPress={() => router.push(`/roles/edit?roleId=${roleId}`)}
-              >
-                Edit Role
-              </DropdownItem>
-            </DropdownSection>
-            <DropdownSection title="Danger zone">
-              <DropdownItem
-                key="delete"
-                className="text-text-error"
-                color="danger"
-                description="Delete the role permanently"
-                textValue="Delete Role"
-                startContent={
-                  <DeleteDocumentBulkIcon
-                    className={clsx(iconClasses, "!text-text-error")}
-                  />
-                }
-                onPress={() => setIsDeleteOpen(true)}
-              >
-                Delete Role
-              </DropdownItem>
-            </DropdownSection>
-          </DropdownMenu>
-        </Dropdown>
+          }
+          label="Actions"
+        >
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label="Edit Role"
+            description="Edit the role details"
+            onSelect={() => router.push(`/roles/edit?roleId=${roleId}`)}
+          />
+          <ActionDropdownSeparator />
+          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+          <ActionDropdownItem
+            icon={<Trash2 />}
+            label="Delete Role"
+            description="Delete the role permanently"
+            destructive
+            onSelect={() => setIsDeleteOpen(true)}
+          />
+        </ActionDropdown>
       </div>
     </>
   );

--- a/ui/components/roles/table/data-table-row-actions.tsx
+++ b/ui/components/roles/table/data-table-row-actions.tsx
@@ -9,9 +9,8 @@ import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
@@ -43,23 +42,20 @@ export function DataTableRowActions<RoleProps>({
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
           }
-          label="Actions"
         >
           <ActionDropdownItem
             icon={<Pencil />}
             label="Edit Role"
-            description="Edit the role details"
             onSelect={() => router.push(`/roles/edit?roleId=${roleId}`)}
           />
-          <ActionDropdownSeparator />
-          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
-          <ActionDropdownItem
-            icon={<Trash2 />}
-            label="Delete Role"
-            description="Delete the role permanently"
-            destructive
-            onSelect={() => setIsDeleteOpen(true)}
-          />
+          <ActionDropdownDangerZone>
+            <ActionDropdownItem
+              icon={<Trash2 />}
+              label="Delete Role"
+              destructive
+              onSelect={() => setIsDeleteOpen(true)}
+            />
+          </ActionDropdownDangerZone>
         </ActionDropdown>
       </div>
     </>

--- a/ui/components/scans/table/scans/data-table-row-actions.tsx
+++ b/ui/components/scans/table/scans/data-table-row-actions.tsx
@@ -1,22 +1,16 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
-import {
-  // DeleteDocumentBulkIcon,
-  EditDocumentBulkIcon,
-} from "@heroui/shared-icons";
 import { Row } from "@tanstack/react-table";
-import { DownloadIcon } from "lucide-react";
+import { Download, Pencil } from "lucide-react";
 import { useState } from "react";
 
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 import { useToast } from "@/components/ui";
 import { downloadScanZip } from "@/lib/helper";
@@ -26,7 +20,6 @@ import { EditScanForm } from "../../forms";
 interface DataTableRowActionsProps<ScanProps> {
   row: Row<ScanProps>;
 }
-const iconClasses = "text-2xl text-default-500 pointer-events-none shrink-0";
 
 export function DataTableRowActions<ScanProps>({
   row,
@@ -52,46 +45,29 @@ export function DataTableRowActions<ScanProps>({
       </Modal>
 
       <div className="relative flex items-center justify-end gap-2">
-        <Dropdown
-          className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-          placement="bottom"
-        >
-          <DropdownTrigger>
+        <ActionDropdown
+          trigger={
             <Button variant="ghost" size="icon-sm" className="rounded-full">
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
-          </DropdownTrigger>
-          <DropdownMenu
-            closeOnSelect
-            aria-label="Actions"
-            color="default"
-            variant="flat"
-          >
-            <DropdownSection title="Download reports">
-              <DropdownItem
-                key="export"
-                description="Available only for completed scans"
-                textValue="Download .zip"
-                startContent={<DownloadIcon className={iconClasses} />}
-                onPress={() => downloadScanZip(scanId, toast)}
-                isDisabled={scanState !== "completed"}
-              >
-                Download .zip
-              </DropdownItem>
-            </DropdownSection>
-            <DropdownSection title="Actions">
-              <DropdownItem
-                key="edit"
-                description="Allows you to edit the scan name"
-                textValue="Edit Scan Name"
-                startContent={<EditDocumentBulkIcon className={iconClasses} />}
-                onPress={() => setIsEditOpen(true)}
-              >
-                Edit scan name
-              </DropdownItem>
-            </DropdownSection>
-          </DropdownMenu>
-        </Dropdown>
+          }
+          label="Download reports"
+        >
+          <ActionDropdownItem
+            icon={<Download />}
+            label="Download .zip"
+            description="Available only for completed scans"
+            onSelect={() => downloadScanZip(scanId, toast)}
+            disabled={scanState !== "completed"}
+          />
+          <ActionDropdownSeparator />
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label="Edit scan name"
+            description="Allows you to edit the scan name"
+            onSelect={() => setIsEditOpen(true)}
+          />
+        </ActionDropdown>
       </div>
     </>
   );

--- a/ui/components/scans/table/scans/data-table-row-actions.tsx
+++ b/ui/components/scans/table/scans/data-table-row-actions.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
   ActionDropdownItem,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 import { useToast } from "@/components/ui";
@@ -51,7 +50,6 @@ export function DataTableRowActions<ScanProps>({
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
           }
-          label="Download reports"
         >
           <ActionDropdownItem
             icon={<Download />}
@@ -60,11 +58,9 @@ export function DataTableRowActions<ScanProps>({
             onSelect={() => downloadScanZip(scanId, toast)}
             disabled={scanState !== "completed"}
           />
-          <ActionDropdownSeparator />
           <ActionDropdownItem
             icon={<Pencil />}
-            label="Edit scan name"
-            description="Allows you to edit the scan name"
+            label="Edit Scan Name"
             onSelect={() => setIsEditOpen(true)}
           />
         </ActionDropdown>

--- a/ui/components/shadcn/dropdown/action-dropdown.tsx
+++ b/ui/components/shadcn/dropdown/action-dropdown.tsx
@@ -91,7 +91,7 @@ export function ActionDropdownItem({
   return (
     <DropdownMenuItem
       className={cn(
-        "flex cursor-pointer items-center gap-2",
+        "flex cursor-pointer items-start gap-2",
         destructive && "text-destructive focus:text-destructive",
         className,
       )}
@@ -100,7 +100,7 @@ export function ActionDropdownItem({
       {icon && (
         <span
           className={cn(
-            "text-muted-foreground shrink-0 [&>svg]:size-5",
+            "text-muted-foreground mt-0.5 shrink-0 [&>svg]:size-4",
             destructive && "text-destructive",
           )}
         >

--- a/ui/components/shadcn/dropdown/action-dropdown.tsx
+++ b/ui/components/shadcn/dropdown/action-dropdown.tsx
@@ -9,7 +9,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./dropdown";
@@ -130,9 +129,3 @@ export function ActionDropdownDangerZone({
     </>
   );
 }
-
-// Re-export commonly used components for convenience
-export {
-  DropdownMenuLabel as ActionDropdownLabel,
-  DropdownMenuSeparator as ActionDropdownSeparator,
-} from "./dropdown";

--- a/ui/components/shadcn/dropdown/action-dropdown.tsx
+++ b/ui/components/shadcn/dropdown/action-dropdown.tsx
@@ -17,8 +17,6 @@ import {
 interface ActionDropdownProps {
   /** The dropdown trigger element. Defaults to a vertical dots icon button */
   trigger?: ReactNode;
-  /** Label shown at the top of the dropdown */
-  label?: string;
   /** Alignment of the dropdown content */
   align?: "start" | "center" | "end";
   /** Additional className for the content */
@@ -30,7 +28,6 @@ interface ActionDropdownProps {
 
 export function ActionDropdown({
   trigger,
-  label = "Actions",
   align = "end",
   className,
   ariaLabel = "Open actions menu",
@@ -52,16 +49,10 @@ export function ActionDropdown({
       <DropdownMenuContent
         align={align}
         className={cn(
-          "border-border-neutral-secondary bg-bg-neutral-secondary w-56",
+          "border-border-neutral-secondary bg-bg-neutral-secondary w-56 rounded-xl",
           className,
         )}
       >
-        {label && (
-          <>
-            <DropdownMenuLabel>{label}</DropdownMenuLabel>
-            <DropdownMenuSeparator />
-          </>
-        )}
         {children}
       </DropdownMenuContent>
     </DropdownMenu>
@@ -92,7 +83,7 @@ export function ActionDropdownItem({
     <DropdownMenuItem
       className={cn(
         "flex cursor-pointer items-start gap-2",
-        destructive && "text-destructive focus:text-destructive",
+        destructive && "text-text-error-primary focus:text-text-error-primary",
         className,
       )}
       {...props}
@@ -101,7 +92,7 @@ export function ActionDropdownItem({
         <span
           className={cn(
             "text-muted-foreground mt-0.5 shrink-0 [&>svg]:size-4",
-            destructive && "text-destructive",
+            destructive && "text-text-error-primary",
           )}
         >
           {icon}
@@ -113,7 +104,7 @@ export function ActionDropdownItem({
           <span
             className={cn(
               "text-muted-foreground text-xs",
-              destructive && "text-destructive/70",
+              destructive && "text-text-error-primary/70",
             )}
           >
             {description}
@@ -121,6 +112,22 @@ export function ActionDropdownItem({
         )}
       </div>
     </DropdownMenuItem>
+  );
+}
+
+export function ActionDropdownDangerZone({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <span className="text-text-neutral-tertiary px-2 py-1.5 text-xs">
+        Danger zone
+      </span>
+      {children}
+    </>
   );
 }
 

--- a/ui/components/shadcn/dropdown/index.ts
+++ b/ui/components/shadcn/dropdown/index.ts
@@ -2,8 +2,6 @@ export {
   ActionDropdown,
   ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "./action-dropdown";
 export {
   DropdownMenu,

--- a/ui/components/shadcn/dropdown/index.ts
+++ b/ui/components/shadcn/dropdown/index.ts
@@ -1,5 +1,6 @@
 export {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
   ActionDropdownLabel,
   ActionDropdownSeparator,

--- a/ui/components/users/profile/api-keys/data-table-row-actions.tsx
+++ b/ui/components/users/profile/api-keys/data-table-row-actions.tsx
@@ -1,21 +1,16 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
-import {
-  DeleteDocumentBulkIcon,
-  EditDocumentBulkIcon,
-} from "@heroui/shared-icons";
 import { Row } from "@tanstack/react-table";
-import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
 
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownLabel,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 
 import { EnrichedApiKey } from "./types";
 
@@ -24,8 +19,6 @@ interface DataTableRowActionsProps {
   onEdit: (apiKey: EnrichedApiKey) => void;
   onRevoke: (apiKey: EnrichedApiKey) => void;
 }
-
-const iconClasses = "text-2xl text-default-500 pointer-events-none shrink-0";
 
 export function DataTableRowActions({
   row,
@@ -39,53 +32,34 @@ export function DataTableRowActions({
 
   return (
     <div className="relative flex items-center justify-end gap-2">
-      <Dropdown
-        className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-        placement="bottom"
-      >
-        <DropdownTrigger>
+      <ActionDropdown
+        trigger={
           <Button variant="ghost" size="icon-sm" className="rounded-full">
             <VerticalDotsIcon className="text-slate-400" />
           </Button>
-        </DropdownTrigger>
-        <DropdownMenu
-          closeOnSelect
-          aria-label="API Key actions"
-          color="default"
-          variant="flat"
-        >
-          <DropdownSection title="Actions">
-            <DropdownItem
-              key="edit"
-              description="Edit the API key name"
-              textValue="Edit name"
-              startContent={<EditDocumentBulkIcon className={iconClasses} />}
-              onPress={() => onEdit(apiKey)}
-            >
-              Edit name
-            </DropdownItem>
-          </DropdownSection>
-          {canRevoke ? (
-            <DropdownSection title="Danger zone">
-              <DropdownItem
-                key="revoke"
-                className="text-text-error"
-                color="danger"
-                description="Revoke this API key permanently"
-                textValue="Revoke"
-                startContent={
-                  <DeleteDocumentBulkIcon
-                    className={clsx(iconClasses, "!text-text-error")}
-                  />
-                }
-                onPress={() => onRevoke(apiKey)}
-              >
-                Revoke
-              </DropdownItem>
-            </DropdownSection>
-          ) : null}
-        </DropdownMenu>
-      </Dropdown>
+        }
+        label="Actions"
+      >
+        <ActionDropdownItem
+          icon={<Pencil />}
+          label="Edit name"
+          description="Edit the API key name"
+          onSelect={() => onEdit(apiKey)}
+        />
+        {canRevoke && (
+          <>
+            <ActionDropdownSeparator />
+            <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+            <ActionDropdownItem
+              icon={<Trash2 />}
+              label="Revoke"
+              description="Revoke this API key permanently"
+              destructive
+              onSelect={() => onRevoke(apiKey)}
+            />
+          </>
+        )}
+      </ActionDropdown>
     </div>
   );
 }

--- a/ui/components/users/profile/api-keys/data-table-row-actions.tsx
+++ b/ui/components/users/profile/api-keys/data-table-row-actions.tsx
@@ -7,9 +7,8 @@ import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 
 import { EnrichedApiKey } from "./types";
@@ -38,26 +37,21 @@ export function DataTableRowActions({
             <VerticalDotsIcon className="text-slate-400" />
           </Button>
         }
-        label="Actions"
       >
         <ActionDropdownItem
           icon={<Pencil />}
-          label="Edit name"
-          description="Edit the API key name"
+          label="Edit API Key"
           onSelect={() => onEdit(apiKey)}
         />
         {canRevoke && (
-          <>
-            <ActionDropdownSeparator />
-            <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+          <ActionDropdownDangerZone>
             <ActionDropdownItem
               icon={<Trash2 />}
-              label="Revoke"
-              description="Revoke this API key permanently"
+              label="Revoke API Key"
               destructive
               onSelect={() => onRevoke(apiKey)}
             />
-          </>
+          </ActionDropdownDangerZone>
         )}
       </ActionDropdown>
     </div>

--- a/ui/components/users/table/data-table-row-actions.tsx
+++ b/ui/components/users/table/data-table-row-actions.tsx
@@ -1,22 +1,17 @@
 "use client";
 
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownMenu,
-  DropdownSection,
-  DropdownTrigger,
-} from "@heroui/dropdown";
-import {
-  DeleteDocumentBulkIcon,
-  EditDocumentBulkIcon,
-} from "@heroui/shared-icons";
 import { Row } from "@tanstack/react-table";
-import clsx from "clsx";
+import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
+import {
+  ActionDropdown,
+  ActionDropdownItem,
+  ActionDropdownLabel,
+  ActionDropdownSeparator,
+} from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
 import { DeleteForm, EditForm } from "../forms";
@@ -25,7 +20,6 @@ interface DataTableRowActionsProps<UserProps> {
   row: Row<UserProps>;
   roles?: { id: string; name: string }[];
 }
-const iconClasses = "text-2xl text-default-500 pointer-events-none shrink-0";
 
 export function DataTableRowActions<UserProps>({
   row,
@@ -66,51 +60,30 @@ export function DataTableRowActions<UserProps>({
       </Modal>
 
       <div className="relative flex items-center justify-end gap-2">
-        <Dropdown
-          className="border-border-neutral-secondary bg-bg-neutral-secondary border shadow-xl"
-          placement="bottom"
-        >
-          <DropdownTrigger>
+        <ActionDropdown
+          trigger={
             <Button variant="ghost" size="icon-sm" className="rounded-full">
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
-          </DropdownTrigger>
-          <DropdownMenu
-            closeOnSelect
-            aria-label="Actions"
-            color="default"
-            variant="flat"
-          >
-            <DropdownSection title="Actions">
-              <DropdownItem
-                key="edit"
-                description="Allows you to edit the user"
-                textValue="Edit User"
-                startContent={<EditDocumentBulkIcon className={iconClasses} />}
-                onPress={() => setIsEditOpen(true)}
-              >
-                Edit User
-              </DropdownItem>
-            </DropdownSection>
-            <DropdownSection title="Danger zone">
-              <DropdownItem
-                key="delete"
-                className="text-text-error"
-                color="danger"
-                description="Delete the user permanently"
-                textValue="Delete User"
-                startContent={
-                  <DeleteDocumentBulkIcon
-                    className={clsx(iconClasses, "!text-text-error")}
-                  />
-                }
-                onPress={() => setIsDeleteOpen(true)}
-              >
-                Delete User
-              </DropdownItem>
-            </DropdownSection>
-          </DropdownMenu>
-        </Dropdown>
+          }
+          label="Actions"
+        >
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label="Edit User"
+            description="Allows you to edit the user"
+            onSelect={() => setIsEditOpen(true)}
+          />
+          <ActionDropdownSeparator />
+          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
+          <ActionDropdownItem
+            icon={<Trash2 />}
+            label="Delete User"
+            description="Delete the user permanently"
+            destructive
+            onSelect={() => setIsDeleteOpen(true)}
+          />
+        </ActionDropdown>
       </div>
     </>
   );

--- a/ui/components/users/table/data-table-row-actions.tsx
+++ b/ui/components/users/table/data-table-row-actions.tsx
@@ -8,9 +8,8 @@ import { VerticalDotsIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import {
   ActionDropdown,
+  ActionDropdownDangerZone,
   ActionDropdownItem,
-  ActionDropdownLabel,
-  ActionDropdownSeparator,
 } from "@/components/shadcn/dropdown";
 import { Modal } from "@/components/shadcn/modal";
 
@@ -66,23 +65,20 @@ export function DataTableRowActions<UserProps>({
               <VerticalDotsIcon className="text-slate-400" />
             </Button>
           }
-          label="Actions"
         >
           <ActionDropdownItem
             icon={<Pencil />}
             label="Edit User"
-            description="Allows you to edit the user"
             onSelect={() => setIsEditOpen(true)}
           />
-          <ActionDropdownSeparator />
-          <ActionDropdownLabel>Danger zone</ActionDropdownLabel>
-          <ActionDropdownItem
-            icon={<Trash2 />}
-            label="Delete User"
-            description="Delete the user permanently"
-            destructive
-            onSelect={() => setIsDeleteOpen(true)}
-          />
+          <ActionDropdownDangerZone>
+            <ActionDropdownItem
+              icon={<Trash2 />}
+              label="Delete User"
+              destructive
+              onSelect={() => setIsDeleteOpen(true)}
+            />
+          </ActionDropdownDangerZone>
         </ActionDropdown>
       </div>
     </>


### PR DESCRIPTION
### Context

Fix [PROWLER-1067](https://prowlerpro.atlassian.net/browse/PROWLER-1067)

HeroUI Dropdown (React Aria) and the new shadcn Modal (Radix Dialog) have incompatible overlay systems that compete for `pointer-events`, `aria-hidden`, and focus trapping on the body element. This caused an infinite memory loop when clicking any action button in table row dropdowns, crashing the browser tab.

### Description

- Migrated all 8 `data-table-row-actions` files from `@heroui/dropdown` to Radix-based `ActionDropdown` (`modal={false}`) to fix the overlay conflict
- Added `ActionDropdownDangerZone` component with separator, "Danger zone" label (`text-text-neutral-tertiary`, 12px), and `text-text-error-primary` color for destructive items
- Updated dropdown styling: removed "Actions" header, added `rounded-xl` (12px border radius)
- Cleaned up redundant descriptions across all dropdowns, keeping only contextual ones (e.g., disabled state explanations)
- Standardized all action labels to Title Case pattern ("Verb + Entity") and fixed icon alignment (`items-start` + `mt-0.5`)
- Net reduction of 274 lines across 13 files

### Steps to review

1. **Shared component** — Review `ui/components/shadcn/dropdown/action-dropdown.tsx`: removed `label` prop default, added `rounded-xl`, new `ActionDropdownDangerZone` wrapper, destructive color changed to `text-text-error-primary`
2. **Danger zone pattern** — Each file now uses `<ActionDropdownDangerZone>` instead of manual `<Separator /> + <Label>Danger zone</Label>`
3. **Providers dropdown** — `ui/components/providers/table/data-table-row-actions.tsx` keeps `description` on Test Connection (explains disabled state) and `e.preventDefault()` for async operation
4. **Findings dropdown** — `ui/components/findings/table/data-table-row-actions.tsx`: mute label now includes count directly ("Mute 3 Findings"), removed separate description function
5. **Consistency check** — All labels follow "Verb + Entity" in Title Case (Edit User, Delete Role, Revoke API Key, etc.)
6. **Test locally** — Open any table with row actions → verify dropdown has rounded corners, no "Actions" header, destructive items in red, "Danger zone" label in muted gray

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


[PROWLER-1067]: https://prowlerpro.atlassian.net/browse/PROWLER-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ