### PR TITLE
fix(github): combine --repository and --organization flags for scan scoping

### DIFF
--- a/docs/user-guide/providers/github/authentication.mdx
+++ b/docs/user-guide/providers/github/authentication.mdx
@@ -38,6 +38,7 @@ GitHub has deprecated Personal Access Tokens (classic) in favor of fine-grained 
 
 4. **Configure Token Settings**
     - **Token name**: Give your token a descriptive name (e.g., "Prowler Security Scanner")
+    - **Resource owner**: Select the account that owns the resources to scan — either a personal account or a specific organization
     - **Expiration**: Set an appropriate expiration date (recommended: 90 days or less)
     - **Repository access**: Choose "All repositories" or "Only select repositories" based on your needs
 
@@ -56,11 +57,11 @@ GitHub has deprecated Personal Access Tokens (classic) in favor of fine-grained 
         - **Metadata**: Read-only access
         - **Pull requests**: Read-only access
 
-    - **Organization permissions:**
+    - **Organization permissions** (available when an organization is selected as Resource Owner):
         - **Administration**: Read-only access
         - **Members**: Read-only access
 
-    - **Account permissions:**
+    - **Account permissions** (available when a personal account is selected as Resource Owner):
         - **Email addresses**: Read-only access
 
 6. **Copy and Store the Token**

--- a/docs/user-guide/providers/github/getting-started-github.mdx
+++ b/docs/user-guide/providers/github/getting-started-github.mdx
@@ -124,6 +124,22 @@ To scan multiple organizations, specify them as space-separated arguments:
 prowler github --organization org-1 org-2
 ```
 
+#### Scanning Specific Repositories Within an Organization
+
+To scan specific repositories within an organization, combine the `--organization` and `--repository` flags. The `--organization` flag qualifies unqualified repository names automatically:
+
+```console
+prowler github --organization my-organization --repository my-repo
+```
+
+This scans only `my-organization/my-repo`. Fully qualified repository names (`owner/repo-name`) are also supported alongside `--organization`:
+
+```console
+prowler github --organization my-org --repository my-repo other-owner/other-repo
+```
+
+In this case, `my-repo` is qualified as `my-org/my-repo`, while `other-owner/other-repo` is used as-is.
+
 <Note>
 The `--repository` and `--organization` flags can be combined with any authentication method.
 </Note>

--- a/docs/user-guide/providers/github/getting-started-github.mdx
+++ b/docs/user-guide/providers/github/getting-started-github.mdx
@@ -54,7 +54,7 @@ title: 'Getting Started with GitHub'
 </Tabs>
 ## Prowler CLI
 
-### Automatic Login Method Detection
+### Authentication
 
 If no login method is explicitly provided, Prowler will automatically attempt to authenticate using environment variables in the following order of precedence:
 
@@ -68,15 +68,15 @@ Ensure the corresponding environment variables are set up before running Prowler
 </Note>
 For more details on how to set up authentication with GitHub, see [Authentication > GitHub](/user-guide/providers/github/authentication).
 
-### Personal Access Token (PAT)
+#### Personal Access Token (PAT)
 
-Use this method by providing your personal access token directly.
+Use this method by providing a personal access token directly.
 
 ```console
 prowler github --personal-access-token pat
 ```
 
-### OAuth App Token
+#### OAuth App Token
 
 Authenticate using an OAuth app token.
 
@@ -84,9 +84,46 @@ Authenticate using an OAuth app token.
 prowler github --oauth-app-token oauth_token
 ```
 
-### GitHub App Credentials
+#### GitHub App Credentials
+
 Use GitHub App credentials by specifying the App ID and the private key path.
 
 ```console
 prowler github --github-app-id app_id --github-app-key-path app_key_path
 ```
+
+### Scan Scoping
+
+By default, Prowler scans all repositories accessible to the authenticated user or organization. To limit the scan to specific repositories or organizations, use the following flags.
+
+#### Scanning Specific Repositories
+
+To restrict the scan to one or more repositories, use the `--repository` flag followed by the repository name(s) in `owner/repo-name` format:
+
+```console
+prowler github --repository owner/repo-name
+```
+
+To scan multiple repositories, specify them as space-separated arguments:
+
+```console
+prowler github --repository owner/repo-name-1 owner/repo-name-2
+```
+
+#### Scanning Specific Organizations
+
+To restrict the scan to one or more organizations or user accounts, use the `--organization` flag:
+
+```console
+prowler github --organization my-organization
+```
+
+To scan multiple organizations, specify them as space-separated arguments:
+
+```console
+prowler github --organization org-1 org-2
+```
+
+<Note>
+The `--repository` and `--organization` flags can be combined with any authentication method.
+</Note>

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ## [5.19.0] (Prowler UNRELEASED)
 
-### 🔄 Changed
-
-- Update Azure Monitor service metadata to new format [(#9622)](https://github.com/prowler-cloud/prowler/pull/9622)
-
 ### 🚀 Added
 
 - AI Skills: Added a skill for creating new Attack Paths queries in openCypher, compatible with Neo4j and Neptune [(#9975)](https://github.com/prowler-cloud/prowler/pull/9975)
+
+### 🔄 Changed
+
+- Update Azure Monitor service metadata to new format [(#9622)](https://github.com/prowler-cloud/prowler/pull/9622)
 
 ## [5.18.2] (Prowler UNRELEASED)
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -7,7 +7,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🚀 Added
 
 - AI Skills: Added a skill for creating new Attack Paths queries in openCypher, compatible with Neo4j and Neptune [(#9975)](https://github.com/prowler-cloud/prowler/pull/9975)
-- Resource owner guidance to GitHub fine-grained PAT setup in authentication docs [(#10001)](https://github.com/prowler-cloud/prowler/pull/10001)
 
 ## [5.18.2] (Prowler UNRELEASED)
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -4,15 +4,15 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ## [5.19.0] (Prowler UNRELEASED)
 
+### 🔄 Changed
+
+- Update Azure Monitor service metadata to new format [(#9622)](https://github.com/prowler-cloud/prowler/pull/9622)
+
 ### 🚀 Added
 
 - AI Skills: Added a skill for creating new Attack Paths queries in openCypher, compatible with Neo4j and Neptune [(#9975)](https://github.com/prowler-cloud/prowler/pull/9975)
 
 ## [5.18.2] (Prowler UNRELEASED)
-
-### 🔄 Changed
-
-- Update Azure Monitor service metadata to new format [(#9622)](https://github.com/prowler-cloud/prowler/pull/9622)
 
 ### 🐞 Fixed
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ## [5.19.0] (Prowler UNRELEASED)
 
+### 🐞 Fixed
+
+- `--repository` and `--organization` flags combined interaction in GitHub provider, qualifying unqualified repository names with organization [(#10001)](https://github.com/prowler-cloud/prowler/pull/10001)
+
 ### 🚀 Added
 
 - AI Skills: Added a skill for creating new Attack Paths queries in openCypher, compatible with Neo4j and Neptune [(#9975)](https://github.com/prowler-cloud/prowler/pull/9975)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -4,13 +4,16 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ## [5.19.0] (Prowler UNRELEASED)
 
-### 🐞 Fixed
-
-- `--repository` and `--organization` flags combined interaction in GitHub provider, qualifying unqualified repository names with organization [(#10001)](https://github.com/prowler-cloud/prowler/pull/10001)
-
 ### 🚀 Added
 
 - AI Skills: Added a skill for creating new Attack Paths queries in openCypher, compatible with Neo4j and Neptune [(#9975)](https://github.com/prowler-cloud/prowler/pull/9975)
+- Resource owner guidance to GitHub fine-grained PAT setup in authentication docs [(#10001)](https://github.com/prowler-cloud/prowler/pull/10001)
+
+## [5.18.2] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- `--repository` and `--organization` flags combined interaction in GitHub provider, qualifying unqualified repository names with organization [(#10001)](https://github.com/prowler-cloud/prowler/pull/10001)
 
 ---
 

--- a/skills/prowler-changelog/SKILL.md
+++ b/skills/prowler-changelog/SKILL.md
@@ -74,6 +74,7 @@ allowed-tools: Read, Edit, Write, Glob, Grep, Bash
 - One entry per PR (can link multiple PRs for related changes)
 - No period at the end
 - Do NOT start with redundant verbs (section header already provides the action)
+- **CRITICAL: Preserve section order** — when adding a new section to the UNRELEASED block, insert it in the correct position relative to existing sections (Added → Changed → Deprecated → Removed → Fixed → Security). Never append a new section at the top or bottom without checking order
 
 ### Semantic Versioning Rules
 
@@ -177,6 +178,13 @@ This maintains chronological order within each section (oldest at top, newest at
 ### Bad Entries
 
 ```markdown
+# BAD - Wrong section order (Fixed before Added)
+### 🐞 Fixed
+- Some bug fix [(#123)](...)
+
+### 🚀 Added
+- Some new feature [(#456)](...)
+
 - Fixed bug.                              # Too vague, has period
 - Added new feature for users             # Missing PR link, redundant verb
 - Add search bar [(#123)]                 # Redundant verb (section already says "Added")


### PR DESCRIPTION
### Context

When using `--repository` with unqualified names (e.g., `my-repo` instead of `owner/my-repo`), the CLI previously rejected them. Combined with `--organization`, unqualified names should be automatically qualified. Additionally, using both flags together caused duplicate results because repositories and organizations were fetched independently.

### Description

- **SDK:** Fix `--repository` and `--organization` flag interaction in `repository_service.py`. Unqualified repository names are now automatically qualified with each provided organization. Fully qualified names are used as-is. When both flags are provided, only the specified repositories are fetched (no separate org-wide fetch).
- **Tests:** Replace the previous combined-scoping test with five targeted tests covering: fully qualified repos with org, unqualified repos qualified by org, multiple organizations, unqualified repos without org (skipped with warning), and mixed qualified/unqualified repos.
- **Docs:** Add "Scan Scoping" section to the GitHub getting started guide documenting `--repository` and `--organization` flags with usage examples. Restructure CLI authentication methods under a dedicated "Authentication" subsection.
- **Docs:** Add resource owner guidance to the fine-grained PAT setup in the GitHub authentication page, including permission section availability notes based on the selected resource owner.
- **Changelog/Skills:** Fix UNRELEASED section order in SDK CHANGELOG (Added → Fixed) and add docs entry. Reinforce section-ordering rule in the changelog skill with a critical rule and bad example.

### Steps to review

1. Review the logic change in `prowler/providers/github/services/repository/repository_service.py`
2. Verify test coverage in `tests/providers/github/services/repository/repository_service_test.py`
3. Review documentation in `docs/user-guide/providers/github/getting-started-github.mdx`
4. Review authentication docs in `docs/user-guide/providers/github/authentication.mdx`
5. Verify CHANGELOG section order and new entry in `prowler/CHANGELOG.md`
6. Review reinforced ordering rule in `skills/prowler-changelog/SKILL.md`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.