### PR TITLE
fix(sdk): mute HPACK library logs to prevent token leakage

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🐞 Fixed
 
 - `--repository` and `--organization` flags combined interaction in GitHub provider, qualifying unqualified repository names with organization [(#10001)](https://github.com/prowler-cloud/prowler/pull/10001)
+- HPACK library logging tokens in debug mode for Azure, M365, and Cloudflare providers [(#10010)](https://github.com/prowler-cloud/prowler/pull/10010)
 
 ---
 

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import re
 from argparse import ArgumentTypeError
@@ -218,8 +219,6 @@ class AzureProvider(Provider):
         logger.info("Setting Azure provider ...")
 
         # Mute HPACK library logs to prevent token leakage in debug mode
-        import logging
-
         logging.getLogger("hpack").setLevel(logging.CRITICAL)
 
         logger.info("Checking if any credentials mode is set ...")

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -217,6 +217,11 @@ class AzureProvider(Provider):
         """
         logger.info("Setting Azure provider ...")
 
+        # Mute HPACK library logs to prevent token leakage in debug mode
+        import logging
+
+        logging.getLogger("hpack").setLevel(logging.CRITICAL)
+
         logger.info("Checking if any credentials mode is set ...")
 
         # Validate the authentication arguments

--- a/prowler/providers/cloudflare/cloudflare_provider.py
+++ b/prowler/providers/cloudflare/cloudflare_provider.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Iterable
 
@@ -56,8 +57,6 @@ class CloudflareProvider(Provider):
         logger.info("Instantiating Cloudflare provider...")
 
         # Mute HPACK library logs to prevent token leakage in debug mode
-        import logging
-
         logging.getLogger("hpack").setLevel(logging.CRITICAL)
 
         if config_content:

--- a/prowler/providers/cloudflare/cloudflare_provider.py
+++ b/prowler/providers/cloudflare/cloudflare_provider.py
@@ -55,6 +55,11 @@ class CloudflareProvider(Provider):
     ):
         logger.info("Instantiating Cloudflare provider...")
 
+        # Mute HPACK library logs to prevent token leakage in debug mode
+        import logging
+
+        logging.getLogger("hpack").setLevel(logging.CRITICAL)
+
         if config_content:
             self._audit_config = config_content
         else:

--- a/prowler/providers/github/github_provider.py
+++ b/prowler/providers/github/github_provider.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from os import environ
 from typing import Union
@@ -134,8 +135,6 @@ class GithubProvider(Provider):
         logger.info("Instantiating GitHub Provider...")
 
         # Mute GitHub library logs to reduce noise since it is already handled by the Prowler logger
-        import logging
-
         logging.getLogger("github").setLevel(logging.CRITICAL)
         logging.getLogger("github.GithubRetry").setLevel(logging.CRITICAL)
 

--- a/prowler/providers/m365/m365_provider.py
+++ b/prowler/providers/m365/m365_provider.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import logging
 import os
 from argparse import ArgumentTypeError
 from os import getenv
@@ -158,8 +159,6 @@ class M365Provider(Provider):
         logger.info("Setting M365 provider ...")
 
         # Mute HPACK library logs to prevent token leakage in debug mode
-        import logging
-
         logging.getLogger("hpack").setLevel(logging.CRITICAL)
 
         logger.info("Checking if any credentials mode is set ...")

--- a/prowler/providers/m365/m365_provider.py
+++ b/prowler/providers/m365/m365_provider.py
@@ -157,6 +157,11 @@ class M365Provider(Provider):
         """
         logger.info("Setting M365 provider ...")
 
+        # Mute HPACK library logs to prevent token leakage in debug mode
+        import logging
+
+        logging.getLogger("hpack").setLevel(logging.CRITICAL)
+
         logger.info("Checking if any credentials mode is set ...")
 
         # Validate the authentication arguments


### PR DESCRIPTION
### Context

The HPACK library (used for HTTP/2 header compression) was logging sensitive information like JWT tokens and Bearer tokens in debug mode. This affects providers that use HTTP/2 via `httpx` → `h2` → `hpack`.

### Description

- Add logging filter to mute HPACK logs in Azure provider
- Add logging filter to mute HPACK logs in M365 provider  
- Add logging filter to mute HPACK logs in Cloudflare provider

This follows the same pattern already used in the GitHub provider (lines 136-140) to mute noisy library logs.

### Steps to review

1. Verify the HPACK logger is set to CRITICAL level in all three providers
2. Run Prowler with debug logging enabled (`-vvv`) against Azure/M365/Cloudflare to confirm tokens are no longer leaked

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.