### PR TITLE
fix(ui): fix filter navigation and pagination bugs in findings and scans pages

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - ProviderTypeSelector crash when an unknown provider type is not present in PROVIDER_DATA [(#9991)](https://github.com/prowler-cloud/prowler/pull/9991)
 - Infinite memory loop when opening modals from table row action dropdowns caused by HeroUI (React Aria) and Radix Dialog overlay conflict [(#9996)](https://github.com/prowler-cloud/prowler/pull/9996)
+- Filter navigations not coordinating with Suspense boundaries due to missing startTransition in ProviderTypeSelector, AccountsSelector, and muted findings checkbox [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
+- Scans page pagination not updating table data because ScansTableWithPolling kept stale state from initial mount [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
+- Duplicate `filter[search]` parameter in findings and scans API calls [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 
 ---
 

--- a/ui/actions/findings/findings.ts
+++ b/ui/actions/findings/findings.ts
@@ -25,7 +25,10 @@ export const getFindings = async ({
   if (sort) url.searchParams.append("sort", sort);
 
   Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
+    // Skip filter[search] since it's already added via the `query` param above
+    if (key !== "filter[search]") {
+      url.searchParams.append(key, String(value));
+    }
   });
 
   try {
@@ -63,7 +66,10 @@ export const getLatestFindings = async ({
   if (sort) url.searchParams.append("sort", sort);
 
   Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
+    // Skip filter[search] since it's already added via the `query` param above
+    if (key !== "filter[search]") {
+      url.searchParams.append(key, String(value));
+    }
   });
 
   try {

--- a/ui/actions/scans/scans.ts
+++ b/ui/actions/scans/scans.ts
@@ -37,7 +37,10 @@ export const getScans = async ({
 
   // Add dynamic filters (e.g., "filter[state]", "fields[scans]")
   Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
+    // Skip filter[search] since it's already added via the `query` param above
+    if (key !== "filter[search]") {
+      url.searchParams.append(key, String(value));
+    }
   });
 
   try {

--- a/ui/app/(prowler)/_overview/_components/accounts-selector.tsx
+++ b/ui/app/(prowler)/_overview/_components/accounts-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { ReactNode } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ReactNode, useTransition } from "react";
 
 import {
   AlibabaCloudProviderBadge,
@@ -22,6 +22,7 @@ import {
   MultiSelectTrigger,
   MultiSelectValue,
 } from "@/components/shadcn/select/multiselect";
+import { useFilterTransitionOptional } from "@/contexts";
 import type { ProviderProps, ProviderType } from "@/types/providers";
 
 const PROVIDER_ICON: Record<ProviderType, ReactNode> = {
@@ -43,7 +44,14 @@ interface AccountsSelectorProps {
 
 export function AccountsSelector({ providers }: AccountsSelectorProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  // Use shared transition context if available, otherwise fall back to local
+  const sharedTransition = useFilterTransitionOptional();
+  const [, localStartTransition] = useTransition();
+  const startTransition =
+    sharedTransition?.startTransition ?? localStartTransition;
 
   const filterKey = "filter[provider_id__in]";
   const current = searchParams.get(filterKey) || "";
@@ -92,7 +100,14 @@ export function AccountsSelector({ providers }: AccountsSelectorProps) {
       }
     }
 
-    router.push(`?${params.toString()}`, { scroll: false });
+    // Reset to page 1 when changing filter
+    if (params.has("page")) {
+      params.set("page", "1");
+    }
+
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    });
   };
 
   const selectedLabel = () => {

--- a/ui/app/(prowler)/_overview/_components/provider-type-selector.tsx
+++ b/ui/app/(prowler)/_overview/_components/provider-type-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { lazy, Suspense } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { lazy, Suspense, useTransition } from "react";
 
 import {
   MultiSelect,
@@ -10,6 +10,7 @@ import {
   MultiSelectTrigger,
   MultiSelectValue,
 } from "@/components/shadcn/select/multiselect";
+import { useFilterTransitionOptional } from "@/contexts";
 import { type ProviderProps, ProviderType } from "@/types/providers";
 
 const AWSProviderBadge = lazy(() =>
@@ -123,7 +124,14 @@ export const ProviderTypeSelector = ({
   providers,
 }: ProviderTypeSelectorProps) => {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  // Use shared transition context if available, otherwise fall back to local
+  const sharedTransition = useFilterTransitionOptional();
+  const [, localStartTransition] = useTransition();
+  const startTransition =
+    sharedTransition?.startTransition ?? localStartTransition;
 
   const currentProviders = searchParams.get("filter[provider_type__in]") || "";
   const selectedTypes = currentProviders
@@ -144,7 +152,14 @@ export const ProviderTypeSelector = ({
     // User should manually select accounts if they want to filter by specific accounts
     params.delete("filter[provider_id__in]");
 
-    router.push(`?${params.toString()}`, { scroll: false });
+    // Reset to page 1 when changing filter
+    if (params.has("page")) {
+      params.set("page", "1");
+    }
+
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    });
   };
 
   const availableTypes = Array.from(

--- a/ui/components/filters/custom-checkbox-muted-findings.tsx
+++ b/ui/components/filters/custom-checkbox-muted-findings.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
 
 import { Checkbox } from "@/components/shadcn";
+import { useFilterTransitionOptional } from "@/contexts";
 
 // Constants for muted filter URL values
 const MUTED_FILTER_VALUES = {
@@ -14,6 +16,12 @@ export const CustomCheckboxMutedFindings = () => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  // Use shared transition context if available, otherwise fall back to local
+  const sharedTransition = useFilterTransitionOptional();
+  const [, localStartTransition] = useTransition();
+  const startTransition =
+    sharedTransition?.startTransition ?? localStartTransition;
 
   // Get the current muted filter value from URL
   // Middleware ensures filter[muted] is always present when navigating to /findings
@@ -41,7 +49,9 @@ export const CustomCheckboxMutedFindings = () => {
       params.set("page", "1");
     }
 
-    router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    });
   };
 
   return (

--- a/ui/components/scans/table/scans/scans-table-with-polling.tsx
+++ b/ui/components/scans/table/scans/scans-table-with-polling.tsx
@@ -59,6 +59,14 @@ export function ScansTableWithPolling({
   const [scansData, setScansData] = useState<ScanProps[]>(initialData);
   const [meta, setMeta] = useState<MetaDataProps | undefined>(initialMeta);
 
+  // Sync state with server data when props change (e.g., pagination or filter changes).
+  // useState only uses its argument on first mount, so without this effect,
+  // navigating to page 2 would change the URL but keep showing page 1 data.
+  useEffect(() => {
+    setScansData(initialData);
+    setMeta(initialMeta);
+  }, [initialData, initialMeta]);
+
   const hasExecutingScan = scansData.some((scan) =>
     EXECUTING_STATES.includes(
       scan.attributes.state as (typeof EXECUTING_STATES)[number],


### PR DESCRIPTION
### Context

Multiple filter and pagination bugs in the findings and scans pages caused by missing `startTransition` coordination with Suspense boundaries and stale component state after Next.js 16 migration.

### Description

**Bug 1 — Findings filters not working on first page load:**
`ProviderTypeSelector`, `AccountsSelector`, and `CustomCheckboxMutedFindings` used raw `router.push()` without wrapping in `startTransition`. In Next.js 16 (with stricter Suspense behavior and no client-side caching by default), this broke coordination between filter changes and the `<Suspense>` boundary around `SSRDataTable`. Also adds page reset to 1 when provider/account filters change.

**Bug 2 — Scans page pagination broken:**
`ScansTableWithPolling` used `useState(initialData)` which only captures the value on first mount. When pagination changed the URL and the server component re-rendered with new data, the component kept showing stale page 1 data. Fixed by adding a `useEffect` to sync state when props change.

**Bug 3 — Duplicate `filter[search]` in API calls:**
`extractFiltersAndQuery()` returns both a `filters` object (containing `filter[search]`) and a separate `query` string. Server actions in `getFindings`, `getLatestFindings`, and `getScans` added `filter[search]` twice to the API URL. Fixed by skipping `filter[search]` in the filters iteration.

### Steps to review

1. Review `ui/app/(prowler)/_overview/_components/provider-type-selector.tsx` and `accounts-selector.tsx` — verify `startTransition` wrapping and page reset logic
2. Review `ui/components/filters/custom-checkbox-muted-findings.tsx` — same `startTransition` pattern
3. Review `ui/components/scans/table/scans/scans-table-with-polling.tsx` — verify `useEffect` sync
4. Review `ui/actions/findings/findings.ts` and `ui/actions/scans/scans.ts` — verify `filter[search]` skip
5. Test findings page: apply filters on first page load, verify they work
6. Test scans page: click pagination, verify table data updates
7. Run `pnpm run typecheck && pnpm run lint:check` — both pass

### Checklist

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.