### PR TITLE
fix(ui): use local transitions for filter navigation to prevent silent reverts

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Filter navigations not coordinating with Suspense boundaries due to missing startTransition in ProviderTypeSelector, AccountsSelector, and muted findings checkbox [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Scans page pagination not updating table data because ScansTableWithPolling kept stale state from initial mount [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Duplicate `filter[search]` parameter in findings and scans API calls [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
+- Filter navigations silently reverting in production due to shared `useTransition()` context wrapping `router.push()` — each filter now uses a local transition while signaling the shared context for the DataTable loading indicator [(#10017)](https://github.com/prowler-cloud/prowler/pull/10017)
 
 ---
 

--- a/ui/app/(prowler)/_overview/_components/accounts-selector.tsx
+++ b/ui/app/(prowler)/_overview/_components/accounts-selector.tsx
@@ -47,11 +47,9 @@ export function AccountsSelector({ providers }: AccountsSelectorProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // Use shared transition context if available, otherwise fall back to local
-  const sharedTransition = useFilterTransitionOptional();
-  const [, localStartTransition] = useTransition();
-  const startTransition =
-    sharedTransition?.startTransition ?? localStartTransition;
+  // Signal shared pending state for DataTable loading indicator
+  const filterTransition = useFilterTransitionOptional();
+  const [, startTransition] = useTransition();
 
   const filterKey = "filter[provider_id__in]";
   const current = searchParams.get(filterKey) || "";
@@ -105,6 +103,7 @@ export function AccountsSelector({ providers }: AccountsSelectorProps) {
       params.set("page", "1");
     }
 
+    filterTransition?.signalFilterChange();
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     });

--- a/ui/app/(prowler)/_overview/_components/provider-type-selector.tsx
+++ b/ui/app/(prowler)/_overview/_components/provider-type-selector.tsx
@@ -127,11 +127,9 @@ export const ProviderTypeSelector = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // Use shared transition context if available, otherwise fall back to local
-  const sharedTransition = useFilterTransitionOptional();
-  const [, localStartTransition] = useTransition();
-  const startTransition =
-    sharedTransition?.startTransition ?? localStartTransition;
+  // Signal shared pending state for DataTable loading indicator
+  const filterTransition = useFilterTransitionOptional();
+  const [, startTransition] = useTransition();
 
   const currentProviders = searchParams.get("filter[provider_type__in]") || "";
   const selectedTypes = currentProviders
@@ -157,6 +155,7 @@ export const ProviderTypeSelector = ({
       params.set("page", "1");
     }
 
+    filterTransition?.signalFilterChange();
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     });

--- a/ui/components/filters/custom-checkbox-muted-findings.tsx
+++ b/ui/components/filters/custom-checkbox-muted-findings.tsx
@@ -17,11 +17,9 @@ export const CustomCheckboxMutedFindings = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  // Use shared transition context if available, otherwise fall back to local
-  const sharedTransition = useFilterTransitionOptional();
-  const [, localStartTransition] = useTransition();
-  const startTransition =
-    sharedTransition?.startTransition ?? localStartTransition;
+  // Signal shared pending state for DataTable loading indicator
+  const filterTransition = useFilterTransitionOptional();
+  const [, startTransition] = useTransition();
 
   // Get the current muted filter value from URL
   // Middleware ensures filter[muted] is always present when navigating to /findings
@@ -49,6 +47,7 @@ export const CustomCheckboxMutedFindings = () => {
       params.set("page", "1");
     }
 
+    filterTransition?.signalFilterChange();
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     });


### PR DESCRIPTION
### Context

Filter navigation in production was silently reverting — clicking a filter would briefly show the new state then snap back to the previous one. This was caused by sharing a single `useTransition()` from React context across multiple filter components to wrap `router.push()`.

### Description

- **Root cause**: Next.js silently reverts `router.push()` when multiple components share the same `useTransition` from context in production builds.
- **Fix**: Each filter component now uses its own local `useTransition()` for navigation, while the shared `FilterTransitionContext` is simplified to a signal-based pending state (`signalFilterChange()`) for the DataTable loading indicator.
- The pending state auto-resets when `searchParams` change (navigation completed), eliminating the need for a shared transition lifecycle.

### Steps to review

1. **Core change** — `ui/contexts/filter-transition-context.tsx`: The context no longer exposes `startTransition`. Instead it exposes `signalFilterChange()` (sets pending=true) and auto-resets via a `useEffect` on `searchParams`.
2. **Hook update** — `ui/hooks/use-url-filters.ts`: Uses local `useTransition()` for `router.push()`, calls `signalFilterChange()` before navigating.
3. **Filter components** — `accounts-selector.tsx`, `provider-type-selector.tsx`, `custom-checkbox-muted-findings.tsx`: Same pattern — local transition + signal.
4. **Test**: Navigate to findings/scans pages, apply filters rapidly, verify navigations are not reverted and the loading indicator still works.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.