### PR TITLE
fix(ui): remove useTransition and shared context from useUrlFilters

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Filter navigations not coordinating with Suspense boundaries due to missing startTransition in ProviderTypeSelector, AccountsSelector, and muted findings checkbox [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Scans page pagination not updating table data because ScansTableWithPolling kept stale state from initial mount [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Duplicate `filter[search]` parameter in findings and scans API calls [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
-- All filters on `/findings` silently reverting on first click in production [(#10021)](https://github.com/prowler-cloud/prowler/pull/10021)
+- All filters on `/findings` silently reverting on first click in production [(#10025)](https://github.com/prowler-cloud/prowler/pull/10025)
 
 ---
 

--- a/ui/hooks/use-url-filters.ts
+++ b/ui/hooks/use-url-filters.ts
@@ -1,25 +1,25 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useTransition } from "react";
 
 /**
  * Custom hook to handle URL filters and automatically reset
  * pagination when filters change.
  *
- * Uses useTransition to prevent full page reloads when filters change,
- * keeping the current UI visible while the new data loads.
- *
- * Each instance owns its own useTransition — no shared state updates
- * during navigation. This avoids a production bug where urgent state
- * updates (from a shared context) caused re-render cascades that
- * silently aborted pending router.push transitions.
+ * Uses client-side router navigation to update query params without
+ * full page reloads when filters change.
  */
 export const useUrlFilters = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const [isPending, startTransition] = useTransition();
+  const isPending = false;
+
+  const navigate = (params: URLSearchParams) => {
+    const queryString = params.toString();
+    const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
+    router.push(targetUrl, { scroll: false });
+  };
 
   const updateFilter = (key: string, value: string | string[] | null) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -49,9 +49,7 @@ export const useUrlFilters = () => {
       params.set(filterKey, nextValue);
     }
 
-    startTransition(() => {
-      router.push(`${pathname}?${params.toString()}`, { scroll: false });
-    });
+    navigate(params);
   };
 
   const clearFilter = (key: string) => {
@@ -65,9 +63,7 @@ export const useUrlFilters = () => {
       params.set("page", "1");
     }
 
-    startTransition(() => {
-      router.push(`${pathname}?${params.toString()}`, { scroll: false });
-    });
+    navigate(params);
   };
 
   const clearAllFilters = () => {
@@ -80,9 +76,7 @@ export const useUrlFilters = () => {
 
     params.delete("page");
 
-    startTransition(() => {
-      router.push(`${pathname}?${params.toString()}`, { scroll: false });
-    });
+    navigate(params);
   };
 
   const hasFilters = () => {
@@ -107,9 +101,7 @@ export const useUrlFilters = () => {
       params.set("page", "1");
     }
 
-    startTransition(() => {
-      router.push(`${pathname}?${params.toString()}`, { scroll: false });
-    });
+    navigate(params);
   };
 
   return {

--- a/ui/hooks/use-url-filters.ts
+++ b/ui/hooks/use-url-filters.ts
@@ -3,8 +3,6 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTransition } from "react";
 
-import { useFilterTransitionOptional } from "@/contexts";
-
 /**
  * Custom hook to handle URL filters and automatically reset
  * pagination when filters change.
@@ -12,19 +10,16 @@ import { useFilterTransitionOptional } from "@/contexts";
  * Uses useTransition to prevent full page reloads when filters change,
  * keeping the current UI visible while the new data loads.
  *
- * When used within a FilterTransitionProvider, the transition state is shared
- * across all components using this hook, enabling coordinated loading indicators.
+ * Each instance owns its own useTransition — no shared state updates
+ * during navigation. This avoids a production bug where urgent state
+ * updates (from a shared context) caused re-render cascades that
+ * silently aborted pending router.push transitions.
  */
 export const useUrlFilters = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-
-  // Signal shared pending state for DataTable loading indicator
-  const filterTransition = useFilterTransitionOptional();
-  const [localIsPending, startTransition] = useTransition();
-
-  const isPending = filterTransition?.isPending ?? localIsPending;
+  const [isPending, startTransition] = useTransition();
 
   const updateFilter = (key: string, value: string | string[] | null) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -54,7 +49,6 @@ export const useUrlFilters = () => {
       params.set(filterKey, nextValue);
     }
 
-    filterTransition?.signalFilterChange();
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     });
@@ -71,7 +65,6 @@ export const useUrlFilters = () => {
       params.set("page", "1");
     }
 
-    filterTransition?.signalFilterChange();
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     });
@@ -87,7 +80,6 @@ export const useUrlFilters = () => {
 
     params.delete("page");
 
-    filterTransition?.signalFilterChange();
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     });
@@ -115,7 +107,6 @@ export const useUrlFilters = () => {
       params.set("page", "1");
     }
 
-    filterTransition?.signalFilterChange();
     startTransition(() => {
       router.push(`${pathname}?${params.toString()}`, { scroll: false });
     });


### PR DESCRIPTION
### Context

Follow-up to #10021. Removes the remaining `useTransition` and shared `FilterTransitionContext` coupling from `useUrlFilters`, which was the other half of the production bug causing silent filter reverts on `/findings`.

### Description

- Remove `useTransition` wrapper around `router.push` calls in `useUrlFilters`, replacing with direct navigation
- Remove dependency on `useFilterTransitionOptional` shared context (`signalFilterChange`)
- Extract a local `navigate()` helper that builds the target URL and calls `router.push` directly
- Set `isPending` to `false` (no transition state needed since navigation is no longer wrapped)

### Steps to review

1. Read `ui/hooks/use-url-filters.ts` — confirm all `startTransition` and `signalFilterChange` references are removed
2. Verify `navigate()` correctly builds URLs (empty query string → bare pathname)
3. Check that `isPending` is still exported (consumers may reference it) and is now always `false`
4. Test filters on `/findings`, `/resources`, and `/overview` in a production build (`pnpm build && pnpm start`) — confirm no silent reverts on first click

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.