### PR TITLE
fix(ui): re-integrate signalFilterChange into useUrlFilters and always reset page on filter change

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Filter navigations not coordinating with Suspense boundaries due to missing startTransition in ProviderTypeSelector, AccountsSelector, and muted findings checkbox [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Scans page pagination not updating table data because ScansTableWithPolling kept stale state from initial mount [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Duplicate `filter[search]` parameter in findings and scans API calls [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
-- All filters on `/findings` silently reverting on first click in production [(#10025)](https://github.com/prowler-cloud/prowler/pull/10025)
+- All filters on `/findings` silently reverting on first click in production [(#10028)](https://github.com/prowler-cloud/prowler/pull/10028)
 
 ---
 

--- a/ui/contexts/filter-transition-context.tsx
+++ b/ui/contexts/filter-transition-context.tsx
@@ -43,12 +43,8 @@ interface FilterTransitionProviderProps {
 /**
  * Provides a shared pending state for filter changes.
  *
- * Filter components signal the start of navigation via signalFilterChange(),
- * and use their own local useTransition() for the actual router.push().
- * This avoids a known Next.js production bug where a shared useTransition()
- * wrapping router.push() causes the navigation to be silently reverted.
- *
- * The pending state auto-resets when searchParams change (navigation completed).
+ * Filter navigation calls signalFilterChange() before router.push().
+ * The pending state auto-resets when searchParams change.
  */
 export const FilterTransitionProvider = ({
   children,


### PR DESCRIPTION
### Context

Follow-up to #10025 which removed `useTransition` and `signalFilterChange` from `useUrlFilters`. This PR re-integrates `signalFilterChange()` via the optional filter transition context so the shared pending UI state works correctly, and fixes the page-reset logic to always set `page=1` on filter changes.

### Description

- **Re-integrate `signalFilterChange`**: `useUrlFilters` now imports `useFilterTransitionOptional` and calls `signalFilterChange()` before `router.push()`, enabling the pending spinner in `FilterTransitionProvider`.
- **Early return guard**: Skip navigation when the query string is unchanged (avoids redundant fetches).
- **Always reset page to 1**: Previously only reset page when `page` param existed; now always sets `page=1` on filter change. This guarantees a query-string change even on page 1 (no existing page param), preventing silent no-ops.
- **Remove unused `isPending`**: Was hardcoded to `false`; no longer exported.
- **Simplify JSDoc**: Updated `FilterTransitionProvider` comment to reflect current behavior.

### Steps to review

1. Review `ui/hooks/use-url-filters.ts` — check the `navigate()` function for the early return guard and `signalFilterChange()` call
2. Review the three page-reset locations (`updateFilter`, `clearFilter`, `navigateWithParams`) — all now unconditionally set `page=1`
3. Review `ui/contexts/filter-transition-context.tsx` — JSDoc simplification only
4. Test filter changes on `/findings` and `/resources` to verify pending state appears and page resets correctly

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed.

#### UI
- [x] All issue/task requirements work as expected on the UI

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.