### PR TITLE
revert: re-integrate signalFilterChange into useUrlFilters (#10028)

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Filter navigations not coordinating with Suspense boundaries due to missing startTransition in ProviderTypeSelector, AccountsSelector, and muted findings checkbox [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Scans page pagination not updating table data because ScansTableWithPolling kept stale state from initial mount [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Duplicate `filter[search]` parameter in findings and scans API calls [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
-- All filters on `/findings` silently reverting on first click in production [(#10028)](https://github.com/prowler-cloud/prowler/pull/10028)
+- All filters on `/findings` silently reverting on first click in production [(#10025)](https://github.com/prowler-cloud/prowler/pull/10025)
 
 ---
 

--- a/ui/contexts/filter-transition-context.tsx
+++ b/ui/contexts/filter-transition-context.tsx
@@ -43,8 +43,12 @@ interface FilterTransitionProviderProps {
 /**
  * Provides a shared pending state for filter changes.
  *
- * Filter navigation calls signalFilterChange() before router.push().
- * The pending state auto-resets when searchParams change.
+ * Filter components signal the start of navigation via signalFilterChange(),
+ * and use their own local useTransition() for the actual router.push().
+ * This avoids a known Next.js production bug where a shared useTransition()
+ * wrapping router.push() causes the navigation to be silently reverted.
+ *
+ * The pending state auto-resets when searchParams change (navigation completed).
  */
 export const FilterTransitionProvider = ({
   children,

--- a/ui/hooks/use-url-filters.ts
+++ b/ui/hooks/use-url-filters.ts
@@ -2,8 +2,6 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { useFilterTransitionOptional } from "@/contexts";
-
 /**
  * Custom hook to handle URL filters and automatically reset
  * pagination when filters change.
@@ -15,14 +13,11 @@ export const useUrlFilters = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const filterTransition = useFilterTransitionOptional();
+  const isPending = false;
 
   const navigate = (params: URLSearchParams) => {
     const queryString = params.toString();
-    if (queryString === searchParams.toString()) return;
-
     const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
-    filterTransition?.signalFilterChange();
     router.push(targetUrl, { scroll: false });
   };
 
@@ -43,9 +38,10 @@ export const useUrlFilters = () => {
     // If effective value is unchanged, do nothing (avoids redundant fetches)
     if (currentValue === nextValue) return;
 
-    // Always reset to first page when filters change.
-    // This also guarantees a query-string change on page 1 (no existing page param).
-    params.set("page", "1");
+    // Only reset page to 1 if page parameter already exists
+    if (params.has("page")) {
+      params.set("page", "1");
+    }
 
     if (nextValue === null) {
       params.delete(filterKey);
@@ -62,8 +58,10 @@ export const useUrlFilters = () => {
 
     params.delete(filterKey);
 
-    // Always reset to first page when filters change.
-    params.set("page", "1");
+    // Only reset page to 1 if page parameter already exists
+    if (params.has("page")) {
+      params.set("page", "1");
+    }
 
     navigate(params);
   };
@@ -98,8 +96,10 @@ export const useUrlFilters = () => {
     const params = new URLSearchParams(searchParams.toString());
     modifier(params);
 
-    // Always reset to first page when filters change.
-    params.set("page", "1");
+    // Only reset page to 1 if page parameter already exists
+    if (params.has("page")) {
+      params.set("page", "1");
+    }
 
     navigate(params);
   };
@@ -109,6 +109,7 @@ export const useUrlFilters = () => {
     clearFilter,
     clearAllFilters,
     hasFilters,
+    isPending,
     navigateWithParams,
   };
 };


### PR DESCRIPTION
### Context

Reverts #10028 — the changes need further testing before being applied.

### Description

- Reverts the re-integration of `signalFilterChange()` into `useUrlFilters`
- Reverts the always-set-page=1 logic change
- Reverts the CHANGELOG PR reference update

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.