### PR TITLE
fix(ui): move default muted filter from middleware to client-side hook

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Filter navigations not coordinating with Suspense boundaries due to missing startTransition in ProviderTypeSelector, AccountsSelector, and muted findings checkbox [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Scans page pagination not updating table data because ScansTableWithPolling kept stale state from initial mount [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
 - Duplicate `filter[search]` parameter in findings and scans API calls [(#10013)](https://github.com/prowler-cloud/prowler/pull/10013)
-- All filters on `/findings` silently reverting on first click in production [(#10025)](https://github.com/prowler-cloud/prowler/pull/10025)
+- All filters on `/findings` silently reverting on first click in production [(#10034)](https://github.com/prowler-cloud/prowler/pull/10034)
 
 ---
 

--- a/ui/hooks/use-url-filters.ts
+++ b/ui/hooks/use-url-filters.ts
@@ -2,6 +2,9 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
+const FINDINGS_PATH = "/findings";
+const DEFAULT_MUTED_FILTER = "false";
+
 /**
  * Custom hook to handle URL filters and automatically reset
  * pagination when filters change.
@@ -15,7 +18,16 @@ export const useUrlFilters = () => {
   const pathname = usePathname();
   const isPending = false;
 
+  const ensureFindingsDefaultMuted = (params: URLSearchParams) => {
+    // Findings defaults to excluding muted findings unless user sets it explicitly.
+    if (pathname === FINDINGS_PATH && !params.has("filter[muted]")) {
+      params.set("filter[muted]", DEFAULT_MUTED_FILTER);
+    }
+  };
+
   const navigate = (params: URLSearchParams) => {
+    ensureFindingsDefaultMuted(params);
+
     const queryString = params.toString();
     const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
     router.push(targetUrl, { scroll: false });

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -50,20 +50,6 @@ export default auth((req: NextRequest & { auth: any }) => {
     }
   }
 
-  // Redirect /findings to include default muted filter if not present
-  if (
-    pathname === "/findings" &&
-    !req.nextUrl.searchParams.has("filter[muted]")
-  ) {
-    const findingsUrl = new URL("/findings", req.url);
-    // Preserve existing search params
-    req.nextUrl.searchParams.forEach((value, key) => {
-      findingsUrl.searchParams.set(key, value);
-    });
-    findingsUrl.searchParams.set("filter[muted]", "false");
-    return NextResponse.redirect(findingsUrl);
-  }
-
   return NextResponse.next();
 });
 


### PR DESCRIPTION
### Context

In the deployed environment (production with Next.js 16), filters on `/findings` were not updating the URL on the first page.
The same flow worked in local development, and `/resources` worked as expected.

### Description

**Root cause:** `/findings` had a `proxy` redirect forcing `filter[muted]=false` when the param was missing. That extra navigation, combined with client-side filter navigations, created a production race condition and could silently revert the first filter update.

**What this PR changes:**

- Removes the forced `/findings` redirect from `ui/proxy.ts`.
- Moves the default `filter[muted]=false` behavior into client-side filter navigation (`ui/hooks/use-url-filters.ts`), only for `/findings` and only when the param is missing.
- Preserves the API's 3 muted states:
  - `filter[muted]=false`
  - `filter[muted]=true`
  - no `filter[muted]` param (no edge-level forcing)

**Files changed:**

- `ui/proxy.ts`
- `ui/hooks/use-url-filters.ts`

### Steps to review

1. Review the removal of the redirect logic in `ui/proxy.ts` (lines 53-64 removed).
2. Review the new `ensureFindingsDefaultMuted()` helper in `ui/hooks/use-url-filters.ts` — it injects `filter[muted]=false` client-side only when on `/findings` and the param is missing.
3. Verify that `navigate()` calls `ensureFindingsDefaultMuted()` before building the URL.
4. Confirm `pnpm run typecheck` passes in `ui/`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### Validation

- `pnpm run typecheck` in `ui`: OK.
- Deployed functional validation: manual QA pending.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.