### PR TITLE
fix(ui): reapply filter transition opacity overlay on filter changes

### DIFF
--- a/ui/hooks/use-url-filters.ts
+++ b/ui/hooks/use-url-filters.ts
@@ -2,6 +2,8 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
+import { useFilterTransitionOptional } from "@/contexts";
+
 const FINDINGS_PATH = "/findings";
 const DEFAULT_MUTED_FILTER = "false";
 
@@ -16,6 +18,7 @@ export const useUrlFilters = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const filterTransition = useFilterTransitionOptional();
   const isPending = false;
 
   const ensureFindingsDefaultMuted = (params: URLSearchParams) => {
@@ -29,7 +32,10 @@ export const useUrlFilters = () => {
     ensureFindingsDefaultMuted(params);
 
     const queryString = params.toString();
+    if (queryString === searchParams.toString()) return;
+
     const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
+    filterTransition?.signalFilterChange();
     router.push(targetUrl, { scroll: false });
   };
 


### PR DESCRIPTION
### Context

After the revert in #10032, the filter transition opacity overlay was no longer applied when filters changed. This re-integrates the `signalFilterChange` call into `useUrlFilters` with an added navigation guard that was missing in the original implementation.

### Description

- Re-import and use `useFilterTransitionOptional` from contexts in `useUrlFilters`
- Add navigation guard (`if (queryString === searchParams.toString()) return`) to prevent redundant `router.push` calls
- Call `filterTransition?.signalFilterChange()` before `router.push` to trigger the opacity overlay on filter change

### Steps to review

1. Open `ui/hooks/use-url-filters.ts` and review the 3 additions:
   - Line 5: import of `useFilterTransitionOptional`
   - Line 35: early return guard for unchanged query strings
   - Line 38: `signalFilterChange()` call before navigation
2. Verify the opacity overlay appears on data tables when changing filters on `/findings`
3. Verify filters still work correctly on `/resources` (which doesn't use `FilterTransitionWrapper`)

### Checklist

- [x] Review if backport is needed.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.