### PR TITLE
refactor(ui): centralize provider type filter sanitization in server actions

### DIFF
--- a/ui/actions/findings/findings.ts
+++ b/ui/actions/findings/findings.ts
@@ -3,6 +3,7 @@
 import { redirect } from "next/navigation";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 export const getFindings = async ({
   page = 1,
@@ -24,12 +25,7 @@ export const getFindings = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    // Skip filter[search] since it's already added via the `query` param above
-    if (key !== "filter[search]") {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const findings = await fetch(url.toString(), {
@@ -65,12 +61,7 @@ export const getLatestFindings = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    // Skip filter[search] since it's already added via the `query` param above
-    if (key !== "filter[search]") {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const findings = await fetch(url.toString(), {
@@ -96,20 +87,13 @@ export const getMetadataInfo = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    // Define filters to exclude
-    const excludedFilters = [
+  appendSanitizedProviderTypeFilters(url, filters, {
+    excludedKeyIncludes: [
       "region__in",
       "service__in",
       "resource_type__in",
       "resource_groups__in",
-    ];
-    if (
-      key !== "filter[search]" &&
-      !excludedFilters.some((filter) => key.includes(filter))
-    ) {
-      url.searchParams.append(key, String(value));
-    }
+    ],
   });
 
   try {
@@ -136,20 +120,13 @@ export const getLatestMetadataInfo = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    // Define filters to exclude
-    const excludedFilters = [
+  appendSanitizedProviderTypeFilters(url, filters, {
+    excludedKeyIncludes: [
       "region__in",
       "service__in",
       "resource_type__in",
       "resource_groups__in",
-    ];
-    if (
-      key !== "filter[search]" &&
-      !excludedFilters.some((filter) => key.includes(filter))
-    ) {
-      url.searchParams.append(key, String(value));
-    }
+    ],
   });
 
   try {

--- a/ui/actions/overview/attack-surface/attack-surface.ts
+++ b/ui/actions/overview/attack-surface/attack-surface.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { AttackSurfaceOverviewResponse } from "./types";
@@ -14,12 +15,7 @@ export const getAttackSurfaceOverview = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/attack-surfaces`);
 
-  // Handle multiple filters
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]" && value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/overview/compliance-watchlist/compliance-watchlist.ts
+++ b/ui/actions/overview/compliance-watchlist/compliance-watchlist.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { ComplianceWatchlistResponse } from "./compliance-watchlist.types";
@@ -15,11 +16,7 @@ export const getComplianceWatchlist = async ({
 
   // Append filter parameters (provider_id, provider_type, etc.)
   // Exclude filter[search] as this endpoint doesn't support text search
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]" && value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), { headers });

--- a/ui/actions/overview/findings/findings.ts
+++ b/ui/actions/overview/findings/findings.ts
@@ -3,6 +3,7 @@
 import { redirect } from "next/navigation";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { FindingsSeverityOverviewResponse } from "./types";
@@ -28,17 +29,8 @@ export const getFindingsByStatus = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  // Handle multiple filters, but exclude muted filter as overviews endpoint doesn't support it
-  Object.entries(filters).forEach(([key, value]) => {
-    // The overviews/findings endpoint does not support status or muted filters
-    // (allowed filters include date, region, provider fields). Exclude unsupported ones.
-    if (
-      key !== "filter[search]" &&
-      key !== "filter[muted]" &&
-      key !== "filter[status]"
-    ) {
-      url.searchParams.append(key, String(value));
-    }
+  appendSanitizedProviderTypeFilters(url, filters, {
+    excludedKeys: ["filter[search]", "filter[muted]", "filter[status]"],
   });
 
   try {
@@ -62,15 +54,8 @@ export const getFindingsBySeverity = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/findings_severity`);
 
-  // Handle multiple filters, but exclude unsupported filters
-  Object.entries(filters).forEach(([key, value]) => {
-    if (
-      key !== "filter[search]" &&
-      key !== "filter[muted]" &&
-      value !== undefined
-    ) {
-      url.searchParams.append(key, String(value));
-    }
+  appendSanitizedProviderTypeFilters(url, filters, {
+    excludedKeys: ["filter[search]", "filter[muted]"],
   });
 
   try {

--- a/ui/actions/overview/providers/providers.ts
+++ b/ui/actions/overview/providers/providers.ts
@@ -3,6 +3,7 @@
 import { redirect } from "next/navigation";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { ProvidersOverviewResponse } from "./types";
@@ -28,11 +29,7 @@ export const getProvidersOverview = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]" && value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/overview/regions/regions.ts
+++ b/ui/actions/overview/regions/regions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { RegionsOverviewResponse } from "./types";
@@ -14,12 +15,7 @@ export const getRegionsOverview = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/regions`);
 
-  // Handle multiple filters
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]" && value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/overview/resources-inventory/resources-inventory.ts
+++ b/ui/actions/overview/resources-inventory/resources-inventory.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { ResourceGroupOverviewResponse } from "./types";
@@ -14,12 +15,7 @@ export const getResourceGroupOverview = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/resource-groups`);
 
-  // Handle multiple filters
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]" && value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/overview/risk-radar/risk-radar.ts
+++ b/ui/actions/overview/risk-radar/risk-radar.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { CategoryOverviewResponse } from "./types";
@@ -14,12 +15,7 @@ export const getCategoryOverview = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/categories`);
 
-  // Handle multiple filters
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]" && value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/overview/services/services.ts
+++ b/ui/actions/overview/services/services.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { ServicesOverviewResponse } from "./types";
@@ -14,11 +15,7 @@ export const getServicesOverview = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/services`);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]" && value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/overview/severity-trends/severity-trends.ts
+++ b/ui/actions/overview/severity-trends/severity-trends.ts
@@ -5,6 +5,7 @@ import {
   type TimeRange,
 } from "@/app/(prowler)/_overview/severity-over-time/_constants/time-range.constants";
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 import { adaptSeverityTrendsResponse } from "./severity-trends.adapter";
@@ -27,11 +28,7 @@ const getFindingsSeverityTrends = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/findings_severity/timeseries`);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    if (value !== undefined) {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/overview/threat-score/threat-score.ts
+++ b/ui/actions/overview/threat-score/threat-score.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 export const getThreatScore = async ({
@@ -12,12 +13,7 @@ export const getThreatScore = async ({
 
   const url = new URL(`${apiBaseUrl}/overviews/threatscore`);
 
-  // Handle multiple filters
-  Object.entries(filters).forEach(([key, value]) => {
-    if (key !== "filter[search]") {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/resources/resources.ts
+++ b/ui/actions/resources/resources.ts
@@ -3,6 +3,7 @@
 import { redirect } from "next/navigation";
 
 import { apiBaseUrl, getAuthHeaders } from "@/lib";
+import { appendSanitizedProviderTypeFilters } from "@/lib/provider-filters";
 import { handleApiResponse } from "@/lib/server-actions-helper";
 
 export const getResources = async ({
@@ -17,7 +18,7 @@ export const getResources = async ({
   page?: number;
   query?: string;
   sort?: string;
-  filters?: Record<string, string>;
+  filters?: Record<string, string | string[] | undefined>;
   pageSize?: number;
   include?: string;
   fields?: string[];
@@ -38,9 +39,7 @@ export const getResources = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {
@@ -66,7 +65,7 @@ export const getLatestResources = async ({
   page?: number;
   query?: string;
   sort?: string;
-  filters?: Record<string, string>;
+  filters?: Record<string, string | string[] | undefined>;
   pageSize?: number;
   include?: string;
   fields?: string[];
@@ -87,9 +86,7 @@ export const getLatestResources = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {
@@ -107,6 +104,10 @@ export const getMetadataInfo = async ({
   query = "",
   sort = "",
   filters = {},
+}: {
+  query?: string;
+  sort?: string;
+  filters?: Record<string, string | string[] | undefined>;
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -115,9 +116,7 @@ export const getMetadataInfo = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {
@@ -135,6 +134,10 @@ export const getLatestMetadataInfo = async ({
   query = "",
   sort = "",
   filters = {},
+}: {
+  query?: string;
+  sort?: string;
+  filters?: Record<string, string | string[] | undefined>;
 }) => {
   const headers = await getAuthHeaders({ contentType: false });
 
@@ -143,9 +146,7 @@ export const getLatestMetadataInfo = async ({
   if (query) url.searchParams.append("filter[search]", query);
   if (sort) url.searchParams.append("sort", sort);
 
-  Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.append(key, String(value));
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/actions/scans/scans.ts
+++ b/ui/actions/scans/scans.ts
@@ -7,6 +7,10 @@ import {
   COMPLIANCE_REPORT_DISPLAY_NAMES,
   type ComplianceReportType,
 } from "@/lib/compliance/compliance-report-types";
+import {
+  appendSanitizedProviderTypeFilters,
+  sanitizeProviderTypesCsv,
+} from "@/lib/provider-filters";
 import { addScanOperation } from "@/lib/sentry-breadcrumbs";
 import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
 export const getScans = async ({
@@ -35,13 +39,7 @@ export const getScans = async ({
     url.searchParams.append(`fields[${key}]`, String(value));
   });
 
-  // Add dynamic filters (e.g., "filter[state]", "fields[scans]")
-  Object.entries(filters).forEach(([key, value]) => {
-    // Skip filter[search] since it's already added via the `query` param above
-    if (key !== "filter[search]") {
-      url.searchParams.append(key, String(value));
-    }
-  });
+  appendSanitizedProviderTypeFilters(url, filters);
 
   try {
     const response = await fetch(url.toString(), { headers });
@@ -58,6 +56,10 @@ export const getScansByState = async () => {
   const url = new URL(`${apiBaseUrl}/scans`);
   // Request only the necessary fields to optimize the response
   url.searchParams.append("fields[scans]", "state");
+  url.searchParams.append(
+    "filter[provider_type__in]",
+    sanitizeProviderTypesCsv(),
+  );
 
   try {
     const response = await fetch(url.toString(), {

--- a/ui/app/(prowler)/providers/page.tsx
+++ b/ui/app/(prowler)/providers/page.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/providers/table";
 import { ContentLayout } from "@/components/ui";
 import { DataTable } from "@/components/ui/table";
-import { PROVIDER_TYPES, ProviderProps, SearchParamsProps } from "@/types";
+import { ProviderProps, SearchParamsProps } from "@/types";
 
 export default async function Providers({
   searchParams,
@@ -89,22 +89,15 @@ const ProvidersTable = async ({
         return acc;
       }, {}) || {};
 
-  // Exclude provider types not yet supported in the UI
   const enrichedProviders =
-    providersData?.data
-      ?.filter((provider: ProviderProps) =>
-        (PROVIDER_TYPES as readonly string[]).includes(
-          provider.attributes.provider,
-        ),
-      )
-      .map((provider: ProviderProps) => {
-        const groupNames =
-          provider.relationships?.provider_groups?.data?.map(
-            (group: { id: string }) =>
-              providerGroupDict[group.id] || "Unknown Group",
-          ) || [];
-        return { ...provider, groupNames };
-      }) || [];
+    providersData?.data?.map((provider: ProviderProps) => {
+      const groupNames =
+        provider.relationships?.provider_groups?.data?.map(
+          (group: { id: string }) =>
+            providerGroupDict[group.id] || "Unknown Group",
+        ) || [];
+      return { ...provider, groupNames };
+    }) || [];
 
   return (
     <>

--- a/ui/lib/provider-filters.ts
+++ b/ui/lib/provider-filters.ts
@@ -1,0 +1,148 @@
+import { PROVIDER_TYPES, type ProviderType } from "@/types/providers";
+
+export type ProviderFilterValue = string | string[] | undefined;
+export type ProviderFilters = Record<string, ProviderFilterValue>;
+
+interface AppendProviderFiltersOptions {
+  ensuredInFilterKey?: string;
+  excludedKeys?: string[];
+  excludedKeyIncludes?: string[];
+}
+
+type AppendSanitizedProviderTypeFiltersOptions = Omit<
+  AppendProviderFiltersOptions,
+  "ensuredInFilterKey"
+>;
+
+const SUPPORTED_PROVIDER_TYPES_CSV = PROVIDER_TYPES.join(",");
+export const PROVIDER_IN_FILTER_KEY = "filter[provider__in]";
+export const PROVIDER_TYPE_IN_FILTER_KEY = "filter[provider_type__in]";
+
+const PROVIDER_IN_KEYS = new Set([
+  PROVIDER_IN_FILTER_KEY,
+  "provider__in",
+  PROVIDER_TYPE_IN_FILTER_KEY,
+  "provider_type__in",
+]);
+
+const PROVIDER_SINGLE_KEYS = new Set([
+  "filter[provider_type]",
+  "provider_type",
+]);
+
+const toCsvString = (value: unknown): string => {
+  if (Array.isArray(value)) return value.join(",");
+  if (typeof value === "string") return value;
+  return "";
+};
+
+const isSupportedProviderType = (value: string): value is ProviderType =>
+  (PROVIDER_TYPES as readonly string[]).includes(value);
+
+export const sanitizeProviderTypesCsv = (value?: unknown): string => {
+  const rawValue = toCsvString(value);
+  if (!rawValue.trim()) return SUPPORTED_PROVIDER_TYPES_CSV;
+
+  const supportedProviderTypes = Array.from(
+    new Set(
+      rawValue
+        .split(",")
+        .map((providerType) => providerType.trim())
+        .filter(isSupportedProviderType),
+    ),
+  );
+
+  return supportedProviderTypes.length > 0
+    ? supportedProviderTypes.join(",")
+    : SUPPORTED_PROVIDER_TYPES_CSV;
+};
+
+export const sanitizeProviderType = (
+  value?: unknown,
+): ProviderType | undefined => {
+  const rawValue = toCsvString(value);
+  if (!rawValue.trim()) return undefined;
+
+  return rawValue
+    .split(",")
+    .map((providerType) => providerType.trim())
+    .find(isSupportedProviderType);
+};
+
+export const sanitizeProviderFilters = (
+  filters: ProviderFilters = {},
+  ensuredInFilterKey?: string,
+): ProviderFilters => {
+  const sanitizedFilters: ProviderFilters = { ...filters };
+
+  Object.keys(sanitizedFilters).forEach((key) => {
+    if (PROVIDER_IN_KEYS.has(key)) {
+      sanitizedFilters[key] = sanitizeProviderTypesCsv(sanitizedFilters[key]);
+      return;
+    }
+
+    if (PROVIDER_SINGLE_KEYS.has(key)) {
+      const providerType = sanitizeProviderType(sanitizedFilters[key]);
+      if (providerType) {
+        sanitizedFilters[key] = providerType;
+      } else {
+        delete sanitizedFilters[key];
+      }
+    }
+  });
+
+  if (ensuredInFilterKey) {
+    sanitizedFilters[ensuredInFilterKey] = sanitizeProviderTypesCsv(
+      sanitizedFilters[ensuredInFilterKey],
+    );
+  }
+
+  return sanitizedFilters;
+};
+
+export const appendSanitizedProviderFilters = (
+  url: URL,
+  filters: ProviderFilters = {},
+  {
+    ensuredInFilterKey,
+    excludedKeys = ["filter[search]"],
+    excludedKeyIncludes = [],
+  }: AppendProviderFiltersOptions = {},
+): ProviderFilters => {
+  const sanitizedFilters = sanitizeProviderFilters(filters, ensuredInFilterKey);
+  const excludedKeysSet = new Set(excludedKeys);
+
+  Object.entries(sanitizedFilters).forEach(([key, value]) => {
+    if (
+      value === undefined ||
+      excludedKeysSet.has(key) ||
+      excludedKeyIncludes.some((excludedKey) => key.includes(excludedKey))
+    ) {
+      return;
+    }
+
+    url.searchParams.append(key, String(value));
+  });
+
+  return sanitizedFilters;
+};
+
+export const appendSanitizedProviderTypeFilters = (
+  url: URL,
+  filters: ProviderFilters = {},
+  options: AppendSanitizedProviderTypeFiltersOptions = {},
+): ProviderFilters =>
+  appendSanitizedProviderFilters(url, filters, {
+    ...options,
+    ensuredInFilterKey: PROVIDER_TYPE_IN_FILTER_KEY,
+  });
+
+export const appendSanitizedProviderInFilters = (
+  url: URL,
+  filters: ProviderFilters = {},
+  options: AppendSanitizedProviderTypeFiltersOptions = {},
+): ProviderFilters =>
+  appendSanitizedProviderFilters(url, filters, {
+    ...options,
+    ensuredInFilterKey: PROVIDER_IN_FILTER_KEY,
+  });

--- a/ui/lib/provider-filters.ts
+++ b/ui/lib/provider-filters.ts
@@ -18,9 +18,7 @@ const SUPPORTED_PROVIDER_TYPES_CSV = PROVIDER_TYPES.join(",");
 export const PROVIDER_IN_FILTER_KEY = "filter[provider__in]";
 export const PROVIDER_TYPE_IN_FILTER_KEY = "filter[provider_type__in]";
 
-const PROVIDER_IN_KEYS = new Set([
-  PROVIDER_IN_FILTER_KEY,
-  "provider__in",
+const PROVIDER_TYPE_IN_KEYS = new Set([
   PROVIDER_TYPE_IN_FILTER_KEY,
   "provider_type__in",
 ]);
@@ -76,7 +74,7 @@ export const sanitizeProviderFilters = (
   const sanitizedFilters: ProviderFilters = { ...filters };
 
   Object.keys(sanitizedFilters).forEach((key) => {
-    if (PROVIDER_IN_KEYS.has(key)) {
+    if (PROVIDER_TYPE_IN_KEYS.has(key)) {
       sanitizedFilters[key] = sanitizeProviderTypesCsv(sanitizedFilters[key]);
       return;
     }
@@ -108,7 +106,7 @@ export const appendSanitizedProviderFilters = (
     excludedKeys = ["filter[search]"],
     excludedKeyIncludes = [],
   }: AppendProviderFiltersOptions = {},
-): ProviderFilters => {
+): void => {
   const sanitizedFilters = sanitizeProviderFilters(filters, ensuredInFilterKey);
   const excludedKeysSet = new Set(excludedKeys);
 
@@ -123,15 +121,13 @@ export const appendSanitizedProviderFilters = (
 
     url.searchParams.append(key, String(value));
   });
-
-  return sanitizedFilters;
 };
 
 export const appendSanitizedProviderTypeFilters = (
   url: URL,
   filters: ProviderFilters = {},
   options: AppendSanitizedProviderTypeFiltersOptions = {},
-): ProviderFilters =>
+): void =>
   appendSanitizedProviderFilters(url, filters, {
     ...options,
     ensuredInFilterKey: PROVIDER_TYPE_IN_FILTER_KEY,
@@ -141,7 +137,7 @@ export const appendSanitizedProviderInFilters = (
   url: URL,
   filters: ProviderFilters = {},
   options: AppendSanitizedProviderTypeFiltersOptions = {},
-): ProviderFilters =>
+): void =>
   appendSanitizedProviderFilters(url, filters, {
     ...options,
     ensuredInFilterKey: PROVIDER_IN_FILTER_KEY,


### PR DESCRIPTION
### Context

Fix PROWLER-1080

Server actions across findings, resources, providers, scans, and overview modules each contain duplicated inline logic for appending filters to API URLs. This logic does not validate provider type values, allowing unsupported types to reach the API. The providers page also filters unsupported types client-side after fetching, which is inefficient.

### Description

- Extract shared provider filter sanitization into `ui/lib/provider-filters.ts` with utilities: `sanitizeProviderTypesCsv`, `sanitizeProviderType`, `appendSanitizedProviderTypeFilters`, `appendSanitizedProviderInFilters`
- Replace all inline `Object.entries(filters).forEach(...)` patterns across 14 server action files with centralized helpers
- Validate `provider_type__in` and `provider__in` filter values against the supported `PROVIDER_TYPES` list before sending to the API
- Remove client-side provider type filtering in the providers page (`page.tsx`), now handled server-side via sanitized filters
- Tighten filter parameter types from `Record<string, string>` / `Record<string, unknown>` to `Record<string, string | string[] | undefined>`

### Steps to review

1. Start with `ui/lib/provider-filters.ts` — this is the new centralized module. Review `sanitizeProviderTypesCsv` and `sanitizeProviderFilters` for correctness
2. Check `ui/actions/findings/findings.ts` as a representative example of how inline filter logic was replaced with `appendSanitizedProviderTypeFilters(url, filters)`
3. Review `ui/actions/providers/providers.ts` — uses `appendSanitizedProviderInFilters` (different filter key for provider ID vs type)
4. Check `ui/app/(prowler)/providers/page.tsx` — the `PROVIDER_TYPES` client-side filter was removed since sanitization now happens server-side
5. Spot-check a few overview actions (e.g., `attack-surface.ts`, `regions.ts`) to confirm the pattern is consistent

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### UI
- [x] All issue/task requirements work as expected on the UI

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.