### PR TITLE
feat(iam): add ECS Exec privilege escalation detection (ECS-006)

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - OCI regions updater script and CI workflow [(#10020)](https://github.com/prowler-cloud/prowler/pull/10020)
 - `image` provider for container image scanning with Trivy integration [(#9984)](https://github.com/prowler-cloud/prowler/pull/9984)
 - CSA CCM 4.0 for the Alibaba Cloud provider [(#10061)](https://github.com/prowler-cloud/prowler/pull/10061)
+- ECS Exec (ECS-006) privilege escalation detection via `ecs:ExecuteCommand` + `ecs:DescribeTasks` [(#10066)](https://github.com/prowler-cloud/prowler/pull/10066)
 
 ### 🔄 Changed
 

--- a/prowler/providers/aws/services/iam/lib/privilege_escalation.py
+++ b/prowler/providers/aws/services/iam/lib/privilege_escalation.py
@@ -254,6 +254,11 @@ privilege_escalation_policies_combination = {
         "iam:PassRole",
         "ecs:RunTask",
     },
+    # Prerequisite: Running ECS task with ECS Exec enabled and admin task role
+    "ECS+ExecuteCommand": {
+        "ecs:ExecuteCommand",
+        "ecs:DescribeTasks",
+    },
     # SageMaker-based privilege escalation patterns
     "PassRole+SageMakerCreateNotebookInstance": {
         "iam:PassRole",


### PR DESCRIPTION
### Context

Add detection for the ECS-006 privilege escalation path documented at [pathfinding.cloud](https://github.com/DataDog/pathfinding.cloud/tree/main/data/paths/ecs). An attacker with `ecs:ExecuteCommand` + `ecs:DescribeTasks` can shell into a running ECS container (when ECS Exec is enabled) and steal the task role's credentials from the metadata service.

### Description

Single entry added to the `privilege_escalation_policies_combination` dict in `prowler/providers/aws/services/iam/lib/privilege_escalation.py`:

- **`ECS+ExecuteCommand`**: flags policies granting `ecs:ExecuteCommand` and `ecs:DescribeTasks`
- Unlike existing ECS entries (`PassRole+ECS+StartTask`, `PassRole+ECS+RunTask`), this path does **not** require `iam:PassRole` — it exploits containers that are already running with a privileged role

### Steps to review

1. Verify the new dict entry in `privilege_escalation.py`
2. Run existing tests — they iterate over all dict entries automatically:
   ```bash
   pytest -vv tests/providers/aws/services/iam/lib/privilege_escalation_test.py
   pytest -vv tests/providers/aws/services/iam/iam_policy_allows_privilege_escalation/
   pytest -vv tests/providers/aws/services/iam/iam_inline_policy_allows_privilege_escalation/
   ```

### Checklist

- Are there new checks included in this PR? No (extends existing privilege escalation detection)
    - No permission updates needed
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - No permission updates needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.