### PR TITLE
fix(api): handle provider deletion race condition in attack paths scan

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🐞 Fixed
 
 - Attack Paths: Orphaned temporary Neo4j databases are now cleaned up on scan failure and provider deletion [(#10101)](https://github.com/prowler-cloud/prowler/pull/10101)
+- Attack Paths: scan no longer raises `DatabaseError` when provider is deleted mid-scan [(#10116)](https://github.com/prowler-cloud/prowler/pull/10116)
 
 ### 🔐 Security
 

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -383,6 +383,7 @@ class AttackPathsScanRLSTask(RLSTask):
     name="attack-paths-scan-perform",
     queue="attack-paths-scans",
 )
+@handle_provider_deletion
 def perform_attack_paths_scan_task(self, tenant_id: str, scan_id: str):
     """
     Execute an Attack Paths scan for the given provider within the current tenant RLS context.


### PR DESCRIPTION
### Description

Fixes the race condition where a provider is deleted while an attack Paths scan is running.                                   

Applied the `@handle_provider_deletion` decorator (already used by every other scan task) to the Attack Paths task. Broadened the decorator's except clause from `IntegrityError` to `DatabaseError`, since `save(update_fields=...)` on a CASCADE-deleted row raises the latter (`IntegrityError` is a subclass of `DatabaseError`, so existing behavior is preserved). Protected the scan error handler from secondary failures that could mask the original exception.

### Steps to review

Launch the tests.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.