### PR TITLE
fix(sdk): make llm scan callback optional

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -43,6 +43,10 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Update Azure Entra ID service metadata to new format [(#9619)](https://github.com/prowler-cloud/prowler/pull/9619)
 - Update Azure Virtual Machines service metadata to new format [(#9629)](https://github.com/prowler-cloud/prowler/pull/9629)
 
+### 🐞 Fixed
+
+- LLM provider scan callback handling to avoid runtime errors when invoking `run()`
+
 ### 🔐 Security
 
 - Bumped `py-ocsf-models` to 0.8.1 and `cryptography` to 44.0.3 [(#10059)](https://github.com/prowler-cloud/prowler/pull/10059)

--- a/prowler/providers/llm/llm_provider.py
+++ b/prowler/providers/llm/llm_provider.py
@@ -229,12 +229,12 @@ class LlmProvider(Provider):
     def run(self) -> List[CheckReportLLM]:
         """Main method to run the LLM security scan"""
         try:
-            return self.run_scan()
+            return self.run_scan(streaming_callback=None)
         except Exception as error:
             logger.error(f"Error running LLM scan: {error}")
             return []
 
-    def run_scan(self, streaming_callback) -> List[CheckReportLLM]:
+    def run_scan(self, streaming_callback=None) -> List[CheckReportLLM]:
         """Run promptfoo red team scan and process its output."""
         report_path = None
         try:

--- a/tests/providers/llm/llm_provider_test.py
+++ b/tests/providers/llm/llm_provider_test.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, patch
+
+from prowler.providers.llm.llm_provider import LlmProvider
+
+
+class TestLlmProvider:
+    @staticmethod
+    def _create_minimal_config(tmp_path):
+        config_path = tmp_path / "llm_test_config.yaml"
+        config_path.write_text(
+            "targets:\n"
+            "  - id: openai:gpt-5\n"
+            "redteam:\n"
+            "  plugins: []\n",
+            encoding="utf-8",
+        )
+        return str(config_path)
+
+    @patch.object(LlmProvider, "run_scan")
+    def test_run_calls_run_scan_with_default_callback(self, mock_run_scan, tmp_path):
+        mock_run_scan.return_value = []
+        provider = LlmProvider(config_path=self._create_minimal_config(tmp_path))
+
+        result = provider.run()
+
+        mock_run_scan.assert_called_once_with(streaming_callback=None)
+        assert result == []
+
+    @patch("subprocess.Popen")
+    def test_run_scan_allows_missing_streaming_callback(self, mock_popen, tmp_path):
+        provider = LlmProvider(config_path=self._create_minimal_config(tmp_path))
+        mock_process = MagicMock()
+        mock_popen.return_value = mock_process
+
+        with patch.object(provider, "_stream_findings", return_value=[]) as mock_stream:
+            result = provider.run_scan()
+
+        assert result == []
+        mock_stream.assert_called_once_with(
+            mock_process,
+            "/tmp/prowler_promptfoo_results.jsonl",
+            None,
+        )


### PR DESCRIPTION
### Context

`LlmProvider.run()` was invoking `run_scan()` without a `streaming_callback` argument, while `run_scan` required one.  
That can trigger a runtime `TypeError` path and cause the scan flow to fail early.

### Description

- Default `run_scan` `streaming_callback` to `None`
- Make `run()` call `run_scan(streaming_callback=None)` explicitly
- Add regression tests for callback-optional behavior in `tests/providers/llm/llm_provider_test.py`
- Add SDK changelog entry in `prowler/CHANGELOG.md`

Dependencies required for this change: none.

### Steps to review

1. Check code changes:
   - `prowler/providers/llm/llm_provider.py`
   - `tests/providers/llm/llm_provider_test.py`
   - `prowler/CHANGELOG.md`
2. Run tests:
   ```bash
   venv/bin/pytest -q tests/providers/llm/llm_provider_test.py --maxfail=1
