### PR TITLE
feat(ui): add AWS Organizations bulk connect flow

### DIFF
--- a/ui/components/providers/organizations/hooks/error-utils.ts
+++ b/ui/components/providers/organizations/hooks/error-utils.ts
@@ -1,0 +1,18 @@
+interface ErrorResult {
+  error?: string;
+  errors?: Array<{ detail?: string }>;
+}
+
+export function extractErrorMessage(
+  response: unknown,
+  fallback: string,
+): string {
+  if (!response || typeof response !== "object") {
+    return fallback;
+  }
+
+  const responseRecord = response as ErrorResult;
+  const detailedError = responseRecord.errors?.[0]?.detail;
+
+  return detailedError || responseRecord.error || fallback;
+}

--- a/ui/components/providers/organizations/hooks/use-org-account-selection-flow.test.ts
+++ b/ui/components/providers/organizations/hooks/use-org-account-selection-flow.test.ts
@@ -1,0 +1,284 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useOrgSetupStore } from "@/store/organizations/store";
+import { APPLY_STATUS } from "@/types/organizations";
+
+import { useOrgAccountSelectionFlow } from "./use-org-account-selection-flow";
+
+const organizationsActionsMock = vi.hoisted(() => ({
+  applyDiscovery: vi.fn(),
+}));
+
+const providersActionsMock = vi.hoisted(() => ({
+  checkConnectionProvider: vi.fn(),
+  getProvider: vi.fn(),
+}));
+
+vi.mock(
+  "@/actions/organizations/organizations",
+  () => organizationsActionsMock,
+);
+vi.mock("@/actions/providers/providers", () => providersActionsMock);
+
+const TEST_ACCOUNTS = ["111111111111", "222222222222"] as const;
+
+function setupDiscoveryAndSelection(
+  selectedAccountIds: string[] = [TEST_ACCOUNTS[0]],
+) {
+  useOrgSetupStore
+    .getState()
+    .setOrganization("org-1", "My Organization", "o-abc123def4");
+  useOrgSetupStore.getState().setDiscovery("discovery-1", {
+    roots: [{ id: "r-root", arn: "arn:root", name: "Root", policy_types: [] }],
+    organizational_units: [],
+    accounts: [
+      {
+        id: TEST_ACCOUNTS[0],
+        name: "Account One",
+        arn: `arn:aws:organizations::${TEST_ACCOUNTS[0]}:account/o-123/${TEST_ACCOUNTS[0]}`,
+        email: "one@example.com",
+        status: "ACTIVE",
+        joined_method: "CREATED",
+        joined_timestamp: "2024-01-01T00:00:00Z",
+        parent_id: "r-root",
+        registration: {
+          provider_exists: false,
+          provider_id: null,
+          organization_relation: "link_required",
+          organizational_unit_relation: "not_applicable",
+          provider_secret_state: "will_create",
+          apply_status: APPLY_STATUS.READY,
+          blocked_reasons: [],
+        },
+      },
+      {
+        id: TEST_ACCOUNTS[1],
+        name: "Account Two",
+        arn: `arn:aws:organizations::${TEST_ACCOUNTS[1]}:account/o-123/${TEST_ACCOUNTS[1]}`,
+        email: "two@example.com",
+        status: "ACTIVE",
+        joined_method: "CREATED",
+        joined_timestamp: "2024-01-01T00:00:00Z",
+        parent_id: "r-root",
+        registration: {
+          provider_exists: false,
+          provider_id: null,
+          organization_relation: "link_required",
+          organizational_unit_relation: "not_applicable",
+          provider_secret_state: "will_create",
+          apply_status: APPLY_STATUS.READY,
+          blocked_reasons: [],
+        },
+      },
+    ],
+  });
+  useOrgSetupStore.getState().setSelectedAccountIds(selectedAccountIds);
+}
+
+function buildApplySuccessResult(accountIds: string[]) {
+  const accountProviderMappings = accountIds.map((accountId, index) => ({
+    account_id: accountId,
+    provider_id: `provider-${String.fromCharCode(97 + index)}`,
+  }));
+  const providers = accountProviderMappings.map((mapping) => ({
+    id: mapping.provider_id,
+  }));
+
+  return {
+    data: {
+      attributes: {
+        account_provider_mappings: accountProviderMappings,
+      },
+      relationships: {
+        providers: {
+          data: providers,
+        },
+      },
+    },
+  };
+}
+
+describe("useOrgAccountSelectionFlow", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    useOrgSetupStore.getState().reset();
+    organizationsActionsMock.applyDiscovery.mockReset();
+    providersActionsMock.checkConnectionProvider.mockReset();
+    providersActionsMock.getProvider.mockReset();
+    setupDiscoveryAndSelection();
+  });
+
+  it("applies selected accounts, tests all connections, and advances on full success", async () => {
+    // Given
+    organizationsActionsMock.applyDiscovery.mockResolvedValue(
+      buildApplySuccessResult([TEST_ACCOUNTS[0]]),
+    );
+    providersActionsMock.checkConnectionProvider.mockResolvedValue({
+      data: {},
+    });
+    const onNext = vi.fn();
+    const onFooterChange = vi.fn();
+    let latestFooterConfig: {
+      onAction?: () => void;
+    } | null = null;
+    onFooterChange.mockImplementation((config) => {
+      latestFooterConfig = config;
+    });
+
+    renderHook(() =>
+      useOrgAccountSelectionFlow({
+        onBack: vi.fn(),
+        onNext,
+        onSkip: vi.fn(),
+        onFooterChange,
+      }),
+    );
+
+    // When
+    await waitFor(() => {
+      expect(latestFooterConfig?.onAction).toBeDefined();
+    });
+    act(() => {
+      latestFooterConfig?.onAction?.();
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(organizationsActionsMock.applyDiscovery).toHaveBeenCalledWith(
+        "org-1",
+        "discovery-1",
+        [{ id: TEST_ACCOUNTS[0] }],
+        [],
+      );
+      expect(
+        providersActionsMock.checkConnectionProvider,
+      ).toHaveBeenCalledTimes(1);
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("retests only failed providers when retrying without changing account selection", async () => {
+    // Given
+    setupDiscoveryAndSelection([...TEST_ACCOUNTS]);
+    organizationsActionsMock.applyDiscovery.mockResolvedValue(
+      buildApplySuccessResult([...TEST_ACCOUNTS]),
+    );
+    const testedProviderIds: string[] = [];
+    const providerAttempts: Record<string, number> = {};
+    providersActionsMock.checkConnectionProvider.mockImplementation(
+      async (formData: FormData) => {
+        const providerId = String(formData.get("providerId"));
+        testedProviderIds.push(providerId);
+        providerAttempts[providerId] = (providerAttempts[providerId] ?? 0) + 1;
+
+        if (providerId === "provider-a" && providerAttempts[providerId] === 1) {
+          return { error: "Connection failed." };
+        }
+        return { data: {} };
+      },
+    );
+    const onNext = vi.fn();
+    const onFooterChange = vi.fn();
+    let latestFooterConfig: {
+      onAction?: () => void;
+      actionDisabled?: boolean;
+    } | null = null;
+    onFooterChange.mockImplementation((config) => {
+      latestFooterConfig = config;
+    });
+
+    renderHook(() =>
+      useOrgAccountSelectionFlow({
+        onBack: vi.fn(),
+        onNext,
+        onSkip: vi.fn(),
+        onFooterChange,
+      }),
+    );
+
+    // When
+    await waitFor(() => {
+      expect(latestFooterConfig?.onAction).toBeDefined();
+      expect(latestFooterConfig?.actionDisabled).toBe(false);
+    });
+    act(() => {
+      latestFooterConfig?.onAction?.();
+    });
+
+    await waitFor(() => {
+      expect(
+        providersActionsMock.checkConnectionProvider,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      latestFooterConfig?.onAction?.();
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(organizationsActionsMock.applyDiscovery).toHaveBeenCalledTimes(1);
+      expect(
+        providersActionsMock.checkConnectionProvider,
+      ).toHaveBeenCalledTimes(3);
+      expect(onNext).toHaveBeenCalledTimes(1);
+    });
+    expect(testedProviderIds.filter((id) => id === "provider-a")).toHaveLength(
+      2,
+    );
+    expect(testedProviderIds.filter((id) => id === "provider-b")).toHaveLength(
+      1,
+    );
+  });
+
+  it("keeps Test Connections action visible after reselection in testing view", async () => {
+    // Given
+    organizationsActionsMock.applyDiscovery.mockResolvedValue({
+      errors: [{ detail: "Apply failed." }],
+    });
+    const onFooterChange = vi.fn();
+    let latestFooterConfig: {
+      showAction?: boolean;
+      actionDisabled?: boolean;
+      onAction?: () => void;
+    } | null = null;
+    onFooterChange.mockImplementation((config) => {
+      latestFooterConfig = config;
+    });
+
+    const { result } = renderHook(() =>
+      useOrgAccountSelectionFlow({
+        onBack: vi.fn(),
+        onNext: vi.fn(),
+        onSkip: vi.fn(),
+        onFooterChange,
+      }),
+    );
+
+    // When
+    await waitFor(() => {
+      expect(latestFooterConfig?.showAction).toBe(true);
+      expect(latestFooterConfig?.onAction).toBeDefined();
+    });
+    act(() => {
+      latestFooterConfig?.onAction?.();
+    });
+
+    await waitFor(() => {
+      expect(organizationsActionsMock.applyDiscovery).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.handleTreeSelectionChange(["222222222222"]);
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(latestFooterConfig?.showAction).toBe(true);
+      expect(latestFooterConfig?.actionDisabled).toBe(false);
+      expect(latestFooterConfig?.onAction).toBeDefined();
+    });
+  });
+});

--- a/ui/components/providers/organizations/hooks/use-org-account-selection-flow.test.ts
+++ b/ui/components/providers/organizations/hooks/use-org-account-selection-flow.test.ts
@@ -281,4 +281,52 @@ describe("useOrgAccountSelectionFlow", () => {
       expect(latestFooterConfig?.onAction).toBeDefined();
     });
   });
+
+  it("uses latest selected accounts when applying discovery", async () => {
+    // Given
+    setupDiscoveryAndSelection([TEST_ACCOUNTS[0]]);
+    organizationsActionsMock.applyDiscovery.mockResolvedValue(
+      buildApplySuccessResult([TEST_ACCOUNTS[1]]),
+    );
+    providersActionsMock.checkConnectionProvider.mockResolvedValue({
+      data: {},
+    });
+    const onFooterChange = vi.fn();
+    let latestFooterConfig: {
+      onAction?: () => void;
+    } | null = null;
+    onFooterChange.mockImplementation((config) => {
+      latestFooterConfig = config;
+    });
+
+    renderHook(() =>
+      useOrgAccountSelectionFlow({
+        onBack: vi.fn(),
+        onNext: vi.fn(),
+        onSkip: vi.fn(),
+        onFooterChange,
+      }),
+    );
+
+    // When
+    act(() => {
+      useOrgSetupStore.getState().setSelectedAccountIds([TEST_ACCOUNTS[1]]);
+    });
+    await waitFor(() => {
+      expect(latestFooterConfig?.onAction).toBeDefined();
+    });
+    act(() => {
+      latestFooterConfig?.onAction?.();
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(organizationsActionsMock.applyDiscovery).toHaveBeenCalledWith(
+        "org-1",
+        "discovery-1",
+        [{ id: TEST_ACCOUNTS[1] }],
+        [],
+      );
+    });
+  });
 });

--- a/ui/components/providers/organizations/hooks/use-org-account-selection-flow.ts
+++ b/ui/components/providers/organizations/hooks/use-org-account-selection-flow.ts
@@ -1,0 +1,547 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { applyDiscovery } from "@/actions/organizations/organizations";
+import { getOuIdsForSelectedAccounts } from "@/actions/organizations/organizations.adapter";
+import {
+  checkConnectionProvider,
+  getProvider,
+} from "@/actions/providers/providers";
+import {
+  WIZARD_FOOTER_ACTION_TYPE,
+  WizardFooterConfig,
+} from "@/components/providers/wizard/steps/footer-controls";
+import { useOrgSetupStore } from "@/store/organizations/store";
+import {
+  CONNECTION_TEST_STATUS,
+  ConnectionTestStatus,
+} from "@/types/organizations";
+import { TREE_ITEM_STATUS, TreeDataItem } from "@/types/tree";
+
+import {
+  buildAccountToProviderMap,
+  canAdvanceToLaunchStep,
+  getLaunchableProviderIds,
+  pollConnectionTask,
+  runWithConcurrencyLimit,
+} from "../org-account-selection.utils";
+
+interface SelectionState {
+  hasSelectableDescendants: boolean;
+  allSelectableDescendantsSelected: boolean;
+}
+
+function collectFullySelectedNodeIds(
+  node: TreeDataItem,
+  selectedAccountIdSet: Set<string>,
+  selectableAccountIdSet: Set<string>,
+  selectedNodeIds: Set<string>,
+): SelectionState {
+  if (selectableAccountIdSet.has(node.id)) {
+    return {
+      hasSelectableDescendants: true,
+      allSelectableDescendantsSelected: selectedAccountIdSet.has(node.id),
+    };
+  }
+
+  const children = node.children ?? [];
+  let hasSelectableDescendants = false;
+  let allSelectableDescendantsSelected = true;
+
+  for (const child of children) {
+    const childSelectionState = collectFullySelectedNodeIds(
+      child,
+      selectedAccountIdSet,
+      selectableAccountIdSet,
+      selectedNodeIds,
+    );
+
+    if (!childSelectionState.hasSelectableDescendants) {
+      continue;
+    }
+
+    hasSelectableDescendants = true;
+    allSelectableDescendantsSelected =
+      allSelectableDescendantsSelected &&
+      childSelectionState.allSelectableDescendantsSelected;
+  }
+
+  if (hasSelectableDescendants && allSelectableDescendantsSelected) {
+    selectedNodeIds.add(node.id);
+  }
+
+  return {
+    hasSelectableDescendants,
+    allSelectableDescendantsSelected,
+  };
+}
+
+function buildTreeSelectedIds(
+  treeData: TreeDataItem[],
+  selectedAccountIds: string[],
+  selectableAccountIdSet: Set<string>,
+): string[] {
+  const selectedAccountIdSet = new Set(selectedAccountIds);
+  const selectedNodeIds = new Set<string>();
+
+  for (const rootNode of treeData) {
+    collectFullySelectedNodeIds(
+      rootNode,
+      selectedAccountIdSet,
+      selectableAccountIdSet,
+      selectedNodeIds,
+    );
+  }
+
+  return [...selectedAccountIds, ...Array.from(selectedNodeIds)];
+}
+
+function buildTreeWithConnectionState(
+  nodes: TreeDataItem[],
+  selectedAccountIdsSet: Set<string>,
+  accountToProviderMap: Map<string, string>,
+  connectionResults: Record<string, ConnectionTestStatus>,
+  connectionErrors: Record<string, string>,
+  showPendingState: boolean,
+): TreeDataItem[] {
+  return nodes.map((node) => {
+    const children = node.children
+      ? buildTreeWithConnectionState(
+          node.children,
+          selectedAccountIdsSet,
+          accountToProviderMap,
+          connectionResults,
+          connectionErrors,
+          showPendingState,
+        )
+      : undefined;
+
+    let isLoading = node.isLoading;
+    let status = node.status;
+    let errorMessage = node.errorMessage;
+
+    if (selectedAccountIdsSet.has(node.id)) {
+      const providerId = accountToProviderMap.get(node.id);
+      const connectionStatus = providerId
+        ? connectionResults[providerId]
+        : undefined;
+
+      if (connectionStatus === CONNECTION_TEST_STATUS.SUCCESS) {
+        isLoading = false;
+        status = TREE_ITEM_STATUS.SUCCESS;
+        errorMessage = undefined;
+      } else if (connectionStatus === CONNECTION_TEST_STATUS.ERROR) {
+        isLoading = false;
+        status = TREE_ITEM_STATUS.ERROR;
+        errorMessage =
+          (providerId && connectionErrors[providerId]) || "Connection failed.";
+      } else if (
+        showPendingState ||
+        connectionStatus === CONNECTION_TEST_STATUS.PENDING
+      ) {
+        isLoading = true;
+        status = undefined;
+        errorMessage = undefined;
+      }
+    }
+
+    return {
+      ...node,
+      children,
+      isLoading,
+      status,
+      errorMessage,
+    };
+  });
+}
+
+function extractErrorMessage(response: unknown, fallback: string): string {
+  if (!response || typeof response !== "object") {
+    return fallback;
+  }
+
+  const responseRecord = response as {
+    error?: string;
+    errors?: Array<{ detail?: string }>;
+  };
+  const detailedError = responseRecord.errors?.[0]?.detail;
+  return detailedError || responseRecord.error || fallback;
+}
+
+function getSelectionKey(ids: string[]) {
+  return [...ids].sort().join(",");
+}
+
+interface UseOrgAccountSelectionFlowProps {
+  onBack: () => void;
+  onNext: () => void;
+  onSkip: () => void;
+  onFooterChange: (config: WizardFooterConfig) => void;
+}
+
+export function useOrgAccountSelectionFlow({
+  onBack,
+  onNext,
+  onSkip,
+  onFooterChange,
+}: UseOrgAccountSelectionFlowProps) {
+  const {
+    organizationId,
+    organizationExternalId,
+    discoveryId,
+    discoveryResult,
+    treeData,
+    accountLookup,
+    selectableAccountIds,
+    selectableAccountIdSet,
+    selectedAccountIds,
+    accountAliases,
+    createdProviderIds,
+    connectionResults,
+    connectionErrors,
+    setSelectedAccountIds,
+    setAccountAlias,
+    setCreatedProviderIds,
+    clearValidationState,
+    setConnectionError,
+    setConnectionResult,
+  } = useOrgSetupStore();
+
+  const [isTestingView, setIsTestingView] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+  const [isTesting, setIsTesting] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [accountToProviderMap, setAccountToProviderMap] = useState<
+    Map<string, string>
+  >(new Map());
+  const isMountedRef = useRef(true);
+  const hasAppliedRef = useRef(false);
+  const lastAppliedSelectionKeyRef = useRef<string>("");
+  const startTestingActionRef = useRef<() => void>(() => {});
+
+  const sanitizedSelectedAccountIds = selectedAccountIds.filter((id) =>
+    selectableAccountIdSet.has(id),
+  );
+  const selectedAccountKey = getSelectionKey(sanitizedSelectedAccountIds);
+  const selectedIdsForTree = buildTreeSelectedIds(
+    treeData,
+    sanitizedSelectedAccountIds,
+    selectableAccountIdSet,
+  );
+  const selectedAccountIdSet = new Set(sanitizedSelectedAccountIds);
+  const selectedCount = sanitizedSelectedAccountIds.length;
+  const totalAccounts = selectableAccountIds.length;
+  const hasConnectionErrors = Object.values(connectionResults).some(
+    (status) => status === CONNECTION_TEST_STATUS.ERROR,
+  );
+  const launchableProviderIds = getLaunchableProviderIds(
+    createdProviderIds,
+    connectionResults,
+  );
+  const canAdvanceToLaunch = canAdvanceToLaunchStep(
+    createdProviderIds,
+    connectionResults,
+  );
+  const showHeaderHelperText = !isTestingView || isApplying || isTesting;
+  const isSelectionLocked = isApplying || isTesting;
+  const treeDataWithConnectionState = isTestingView
+    ? buildTreeWithConnectionState(
+        treeData,
+        selectedAccountIdSet,
+        accountToProviderMap,
+        connectionResults,
+        connectionErrors,
+        isApplying || isTesting,
+      )
+    : treeData;
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const testAllConnections = async (providerIds: string[]) => {
+    setIsTesting(true);
+
+    for (const id of providerIds) {
+      setConnectionResult(id, CONNECTION_TEST_STATUS.PENDING);
+      setConnectionError(id, null);
+    }
+
+    await runWithConcurrencyLimit(providerIds, 5, async (providerId) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      try {
+        const formData = new FormData();
+        formData.set("providerId", providerId);
+
+        const checkResult = await checkConnectionProvider(formData);
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        if (checkResult?.error || checkResult?.errors?.length) {
+          setConnectionResult(providerId, CONNECTION_TEST_STATUS.ERROR);
+          setConnectionError(
+            providerId,
+            extractErrorMessage(checkResult, "Connection test failed."),
+          );
+          return;
+        }
+
+        const taskId = checkResult?.data?.id;
+        if (!taskId) {
+          setConnectionResult(providerId, CONNECTION_TEST_STATUS.SUCCESS);
+          setConnectionError(providerId, null);
+          return;
+        }
+
+        const taskResult = await pollConnectionTask(taskId);
+        if (!isMountedRef.current) {
+          return;
+        }
+        setConnectionResult(
+          providerId,
+          taskResult.success
+            ? CONNECTION_TEST_STATUS.SUCCESS
+            : CONNECTION_TEST_STATUS.ERROR,
+        );
+        setConnectionError(
+          providerId,
+          taskResult.success
+            ? null
+            : taskResult.error || "Connection failed for this account.",
+        );
+      } catch {
+        if (!isMountedRef.current) {
+          return;
+        }
+        setConnectionResult(providerId, CONNECTION_TEST_STATUS.ERROR);
+        setConnectionError(
+          providerId,
+          "Unexpected error during connection test.",
+        );
+      }
+    });
+
+    if (!isMountedRef.current) {
+      return;
+    }
+    setIsTesting(false);
+
+    const latestResults = useOrgSetupStore.getState().connectionResults;
+    const allPassed =
+      providerIds.length > 0 &&
+      providerIds.every(
+        (providerId) =>
+          latestResults[providerId] === CONNECTION_TEST_STATUS.SUCCESS,
+      );
+
+    if (allPassed) {
+      onNext();
+    }
+  };
+
+  const handleApplyAndTest = async () => {
+    if (!organizationId || !discoveryId || !discoveryResult) {
+      return;
+    }
+
+    setApplyError(null);
+    setIsApplying(true);
+
+    const accounts = sanitizedSelectedAccountIds.map((id) => ({
+      id,
+      ...(accountAliases[id] ? { alias: accountAliases[id] } : {}),
+    }));
+    const ouIds = getOuIdsForSelectedAccounts(
+      discoveryResult,
+      sanitizedSelectedAccountIds,
+    );
+    const organizationalUnits = ouIds.map((id) => ({ id }));
+
+    const result = await applyDiscovery(
+      organizationId,
+      discoveryId,
+      accounts,
+      organizationalUnits,
+    );
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    if (result?.error || result?.errors?.length) {
+      setApplyError(extractErrorMessage(result, "Failed to apply discovery."));
+      setIsApplying(false);
+      hasAppliedRef.current = false;
+      return;
+    }
+
+    const providerIds: string[] =
+      result.data?.relationships?.providers?.data?.map(
+        (provider: { id: string }) => provider.id,
+      ) ?? [];
+
+    setCreatedProviderIds(providerIds);
+    const mapping = await buildAccountToProviderMap({
+      selectedAccountIds: sanitizedSelectedAccountIds,
+      providerIds,
+      applyResult: result,
+      resolveProviderUidById: async (providerId) => {
+        const providerFormData = new FormData();
+        providerFormData.set("id", providerId);
+        const providerResponse = await getProvider(providerFormData);
+
+        if (providerResponse?.error || providerResponse?.errors?.length) {
+          return null;
+        }
+
+        return typeof providerResponse?.data?.attributes?.uid === "string"
+          ? providerResponse.data.attributes.uid
+          : null;
+      },
+    });
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    setAccountToProviderMap(mapping);
+    setIsApplying(false);
+    lastAppliedSelectionKeyRef.current = selectedAccountKey;
+
+    await testAllConnections(providerIds);
+  };
+
+  const handleStartTesting = () => {
+    setIsTestingView(true);
+
+    if (applyError) {
+      setApplyError(null);
+      hasAppliedRef.current = false;
+      lastAppliedSelectionKeyRef.current = "";
+    }
+
+    const shouldApplySelection =
+      !hasAppliedRef.current ||
+      lastAppliedSelectionKeyRef.current !== selectedAccountKey;
+
+    if (shouldApplySelection) {
+      hasAppliedRef.current = true;
+      void handleApplyAndTest();
+      return;
+    }
+
+    const failedProviderIds = createdProviderIds.filter(
+      (providerId) =>
+        connectionResults[providerId] === CONNECTION_TEST_STATUS.ERROR,
+    );
+    const providerIdsToTest =
+      failedProviderIds.length > 0 ? failedProviderIds : createdProviderIds;
+    void testAllConnections(providerIdsToTest);
+  };
+  startTestingActionRef.current = handleStartTesting;
+
+  useEffect(() => {
+    if (!isTestingView) {
+      onFooterChange({
+        showBack: true,
+        backLabel: "Back",
+        onBack,
+        showSecondaryAction: false,
+        secondaryActionLabel: "",
+        secondaryActionVariant: "outline",
+        secondaryActionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
+        showAction: true,
+        actionLabel: "Test Connections",
+        actionDisabled: selectedCount === 0,
+        actionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
+        onAction: () => {
+          startTestingActionRef.current();
+        },
+      });
+      return;
+    }
+
+    const canRetry = hasConnectionErrors || Boolean(applyError);
+    const hasSelectedAccounts = selectedCount > 0;
+
+    onFooterChange({
+      showBack: true,
+      backLabel: "Back",
+      backDisabled: isApplying || isTesting,
+      onBack: () => setIsTestingView(false),
+      showSecondaryAction: true,
+      secondaryActionLabel: "Skip Connection Validation",
+      secondaryActionDisabled: isApplying || isTesting || !canAdvanceToLaunch,
+      secondaryActionVariant: "link",
+      secondaryActionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
+      onSecondaryAction: () => {
+        setCreatedProviderIds(launchableProviderIds);
+        onSkip();
+      },
+      showAction: isApplying || isTesting || canRetry || hasSelectedAccounts,
+      actionLabel: "Test Connections",
+      actionDisabled: isApplying || isTesting || !hasSelectedAccounts,
+      actionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
+      onAction: hasSelectedAccounts
+        ? () => {
+            startTestingActionRef.current();
+          }
+        : undefined,
+    });
+  }, [
+    applyError,
+    hasConnectionErrors,
+    isApplying,
+    isTesting,
+    isTestingView,
+    launchableProviderIds,
+    onBack,
+    onFooterChange,
+    onSkip,
+    selectedCount,
+    canAdvanceToLaunch,
+    setCreatedProviderIds,
+  ]);
+
+  const handleTreeSelectionChange = (ids: string[]) => {
+    const filteredIds = ids.filter((id) => selectableAccountIdSet.has(id));
+    const nextSelectedAccountKey = getSelectionKey(filteredIds);
+
+    if (nextSelectedAccountKey !== selectedAccountKey) {
+      hasAppliedRef.current = false;
+      lastAppliedSelectionKeyRef.current = "";
+      setApplyError(null);
+      setAccountToProviderMap(new Map());
+      clearValidationState();
+    }
+
+    setSelectedAccountIds(filteredIds);
+  };
+
+  return {
+    accountAliases,
+    accountLookup,
+    applyError,
+    canAdvanceToLaunch,
+    discoveryResult,
+    handleTreeSelectionChange,
+    hasConnectionErrors,
+    isTesting,
+    isTestingView,
+    isSelectionLocked,
+    organizationExternalId,
+    selectedCount,
+    selectedIdsForTree,
+    setAccountAlias,
+    showHeaderHelperText,
+    totalAccounts,
+    treeDataWithConnectionState,
+  };
+}

--- a/ui/components/providers/organizations/hooks/use-org-account-selection-flow.ts
+++ b/ui/components/providers/organizations/hooks/use-org-account-selection-flow.ts
@@ -26,6 +26,7 @@ import {
   pollConnectionTask,
   runWithConcurrencyLimit,
 } from "../org-account-selection.utils";
+import { extractErrorMessage } from "./error-utils";
 
 interface SelectionState {
   hasSelectableDescendants: boolean;
@@ -156,19 +157,6 @@ function buildTreeWithConnectionState(
   });
 }
 
-function extractErrorMessage(response: unknown, fallback: string): string {
-  if (!response || typeof response !== "object") {
-    return fallback;
-  }
-
-  const responseRecord = response as {
-    error?: string;
-    errors?: Array<{ detail?: string }>;
-  };
-  const detailedError = responseRecord.errors?.[0]?.detail;
-  return detailedError || responseRecord.error || fallback;
-}
-
 function getSelectionKey(ids: string[]) {
   return [...ids].sort().join(",");
 }
@@ -216,6 +204,7 @@ export function useOrgAccountSelectionFlow({
     Map<string, string>
   >(new Map());
   const isMountedRef = useRef(true);
+  const connectionTestAbortControllerRef = useRef<AbortController | null>(null);
   const hasAppliedRef = useRef(false);
   const lastAppliedSelectionKeyRef = useRef<string>("");
   const startTestingActionRef = useRef<() => void>(() => {});
@@ -261,10 +250,16 @@ export function useOrgAccountSelectionFlow({
 
     return () => {
       isMountedRef.current = false;
+      connectionTestAbortControllerRef.current?.abort();
     };
   }, []);
 
   const testAllConnections = async (providerIds: string[]) => {
+    connectionTestAbortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    connectionTestAbortControllerRef.current = abortController;
+    const { signal } = abortController;
+
     setIsTesting(true);
 
     for (const id of providerIds) {
@@ -272,68 +267,76 @@ export function useOrgAccountSelectionFlow({
       setConnectionError(id, null);
     }
 
-    await runWithConcurrencyLimit(providerIds, 5, async (providerId) => {
-      if (!isMountedRef.current) {
-        return;
-      }
-
-      try {
-        const formData = new FormData();
-        formData.set("providerId", providerId);
-
-        const checkResult = await checkConnectionProvider(formData);
-        if (!isMountedRef.current) {
+    try {
+      await runWithConcurrencyLimit(providerIds, 5, async (providerId) => {
+        if (!isMountedRef.current || signal.aborted) {
           return;
         }
 
-        if (checkResult?.error || checkResult?.errors?.length) {
+        try {
+          const formData = new FormData();
+          formData.set("providerId", providerId);
+
+          const checkResult = await checkConnectionProvider(formData);
+          if (!isMountedRef.current || signal.aborted) {
+            return;
+          }
+
+          if (checkResult?.error || checkResult?.errors?.length) {
+            setConnectionResult(providerId, CONNECTION_TEST_STATUS.ERROR);
+            setConnectionError(
+              providerId,
+              extractErrorMessage(checkResult, "Connection test failed."),
+            );
+            return;
+          }
+
+          const taskId = checkResult?.data?.id;
+          if (!taskId) {
+            setConnectionResult(providerId, CONNECTION_TEST_STATUS.SUCCESS);
+            setConnectionError(providerId, null);
+            return;
+          }
+
+          const taskResult = await pollConnectionTask(taskId, { signal });
+          if (!isMountedRef.current || signal.aborted) {
+            return;
+          }
+          setConnectionResult(
+            providerId,
+            taskResult.success
+              ? CONNECTION_TEST_STATUS.SUCCESS
+              : CONNECTION_TEST_STATUS.ERROR,
+          );
+          setConnectionError(
+            providerId,
+            taskResult.success
+              ? null
+              : taskResult.error || "Connection failed for this account.",
+          );
+        } catch {
+          if (!isMountedRef.current || signal.aborted) {
+            return;
+          }
           setConnectionResult(providerId, CONNECTION_TEST_STATUS.ERROR);
           setConnectionError(
             providerId,
-            extractErrorMessage(checkResult, "Connection test failed."),
+            "Unexpected error during connection test.",
           );
-          return;
         }
-
-        const taskId = checkResult?.data?.id;
-        if (!taskId) {
-          setConnectionResult(providerId, CONNECTION_TEST_STATUS.SUCCESS);
-          setConnectionError(providerId, null);
-          return;
+      });
+    } finally {
+      if (connectionTestAbortControllerRef.current === abortController) {
+        connectionTestAbortControllerRef.current = null;
+        if (isMountedRef.current) {
+          setIsTesting(false);
         }
-
-        const taskResult = await pollConnectionTask(taskId);
-        if (!isMountedRef.current) {
-          return;
-        }
-        setConnectionResult(
-          providerId,
-          taskResult.success
-            ? CONNECTION_TEST_STATUS.SUCCESS
-            : CONNECTION_TEST_STATUS.ERROR,
-        );
-        setConnectionError(
-          providerId,
-          taskResult.success
-            ? null
-            : taskResult.error || "Connection failed for this account.",
-        );
-      } catch {
-        if (!isMountedRef.current) {
-          return;
-        }
-        setConnectionResult(providerId, CONNECTION_TEST_STATUS.ERROR);
-        setConnectionError(
-          providerId,
-          "Unexpected error during connection test.",
-        );
       }
-    });
+    }
 
-    if (!isMountedRef.current) {
+    if (!isMountedRef.current || signal.aborted) {
       return;
     }
-    setIsTesting(false);
 
     const latestResults = useOrgSetupStore.getState().connectionResults;
     const allPassed =
@@ -356,13 +359,18 @@ export function useOrgAccountSelectionFlow({
     setApplyError(null);
     setIsApplying(true);
 
-    const accounts = sanitizedSelectedAccountIds.map((id) => ({
+    const currentSelectedAccountIds = useOrgSetupStore
+      .getState()
+      .selectedAccountIds.filter((id) => selectableAccountIdSet.has(id));
+    const currentSelectionKey = getSelectionKey(currentSelectedAccountIds);
+
+    const accounts = currentSelectedAccountIds.map((id) => ({
       id,
       ...(accountAliases[id] ? { alias: accountAliases[id] } : {}),
     }));
     const ouIds = getOuIdsForSelectedAccounts(
       discoveryResult,
-      sanitizedSelectedAccountIds,
+      currentSelectedAccountIds,
     );
     const organizationalUnits = ouIds.map((id) => ({ id }));
 
@@ -390,7 +398,7 @@ export function useOrgAccountSelectionFlow({
 
     setCreatedProviderIds(providerIds);
     const mapping = await buildAccountToProviderMap({
-      selectedAccountIds: sanitizedSelectedAccountIds,
+      selectedAccountIds: currentSelectedAccountIds,
       providerIds,
       applyResult: result,
       resolveProviderUidById: async (providerId) => {
@@ -413,7 +421,7 @@ export function useOrgAccountSelectionFlow({
 
     setAccountToProviderMap(mapping);
     setIsApplying(false);
-    lastAppliedSelectionKeyRef.current = selectedAccountKey;
+    lastAppliedSelectionKeyRef.current = currentSelectionKey;
 
     await testAllConnections(providerIds);
   };

--- a/ui/components/providers/organizations/hooks/use-org-setup-submission.test.ts
+++ b/ui/components/providers/organizations/hooks/use-org-setup-submission.test.ts
@@ -1,0 +1,193 @@
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type PropsWithChildren, StrictMode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useOrgSetupStore } from "@/store/organizations/store";
+import { APPLY_STATUS, DISCOVERY_STATUS } from "@/types/organizations";
+
+import { useOrgSetupSubmission } from "./use-org-setup-submission";
+
+const organizationsActionsMock = vi.hoisted(() => ({
+  createOrganization: vi.fn(),
+  createOrganizationSecret: vi.fn(),
+  getDiscovery: vi.fn(),
+  listOrganizationsByExternalId: vi.fn(),
+  listOrganizationSecretsByOrganizationId: vi.fn(),
+  triggerDiscovery: vi.fn(),
+  updateOrganizationSecret: vi.fn(),
+}));
+
+vi.mock(
+  "@/actions/organizations/organizations",
+  () => organizationsActionsMock,
+);
+
+function StrictModeWrapper({ children }: PropsWithChildren) {
+  return createElement(StrictMode, null, children);
+}
+
+describe("useOrgSetupSubmission", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    useOrgSetupStore.getState().reset();
+    for (const mockFn of Object.values(organizationsActionsMock)) {
+      mockFn.mockReset();
+    }
+  });
+
+  it("completes the setup chain and stores selectable accounts", async () => {
+    // Given
+    const onNext = vi.fn();
+    const setFieldError = vi.fn();
+    const discoveryResult = {
+      roots: [
+        { id: "r-root", arn: "arn:root", name: "Root", policy_types: [] },
+      ],
+      organizational_units: [],
+      accounts: [
+        {
+          id: "111111111111",
+          name: "Account One",
+          arn: "arn:aws:organizations::111111111111:account/o-123/111111111111",
+          email: "one@example.com",
+          status: "ACTIVE",
+          joined_method: "CREATED",
+          joined_timestamp: "2024-01-01T00:00:00Z",
+          parent_id: "r-root",
+          registration: {
+            provider_exists: false,
+            provider_id: null,
+            organization_relation: "link_required",
+            organizational_unit_relation: "not_applicable",
+            provider_secret_state: "will_create",
+            apply_status: APPLY_STATUS.READY,
+            blocked_reasons: [],
+          },
+        },
+        {
+          id: "222222222222",
+          name: "Account Two",
+          arn: "arn:aws:organizations::222222222222:account/o-123/222222222222",
+          email: "two@example.com",
+          status: "ACTIVE",
+          joined_method: "CREATED",
+          joined_timestamp: "2024-01-01T00:00:00Z",
+          parent_id: "r-root",
+          registration: {
+            provider_exists: false,
+            provider_id: null,
+            organization_relation: "link_required",
+            organizational_unit_relation: "not_applicable",
+            provider_secret_state: "will_create",
+            apply_status: APPLY_STATUS.BLOCKED,
+            blocked_reasons: ["Already linked"],
+          },
+        },
+      ],
+    };
+
+    organizationsActionsMock.listOrganizationsByExternalId.mockResolvedValue({
+      data: [],
+    });
+    organizationsActionsMock.createOrganization.mockResolvedValue({
+      data: { id: "org-1" },
+    });
+    organizationsActionsMock.listOrganizationSecretsByOrganizationId.mockResolvedValue(
+      {
+        data: [],
+      },
+    );
+    organizationsActionsMock.createOrganizationSecret.mockResolvedValue({
+      data: { id: "secret-1" },
+    });
+    organizationsActionsMock.triggerDiscovery.mockResolvedValue({
+      data: { id: "discovery-1" },
+    });
+    organizationsActionsMock.getDiscovery.mockResolvedValue({
+      data: {
+        attributes: {
+          status: DISCOVERY_STATUS.SUCCEEDED,
+          result: discoveryResult,
+        },
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useOrgSetupSubmission({
+          stackSetExternalId: "tenant-external-id",
+          onNext,
+          setFieldError,
+        }),
+      { wrapper: StrictModeWrapper },
+    );
+
+    // When
+    await act(async () => {
+      await result.current.submitOrganizationSetup({
+        organizationName: "Acme",
+        awsOrgId: "o-abc123def4",
+        roleArn: "arn:aws:iam::123456789012:role/ProwlerOrgRole",
+      });
+    });
+
+    // Then
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(setFieldError).not.toHaveBeenCalled();
+
+    const state = useOrgSetupStore.getState();
+    expect(state.organizationId).toBe("org-1");
+    expect(state.organizationExternalId).toBe("o-abc123def4");
+    expect(state.discoveryId).toBe("discovery-1");
+    expect(state.selectedAccountIds).toEqual(["111111111111"]);
+    expect(state.selectableAccountIds).toEqual(["111111111111"]);
+  });
+
+  it("maps external_id server errors to awsOrgId field errors", async () => {
+    // Given
+    const onNext = vi.fn();
+    const setFieldError = vi.fn();
+    organizationsActionsMock.listOrganizationsByExternalId.mockResolvedValue({
+      data: [],
+    });
+    organizationsActionsMock.createOrganization.mockResolvedValue({
+      errors: [
+        {
+          detail: "Organization with this external_id already exists.",
+          source: { pointer: "/data/attributes/external_id" },
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useOrgSetupSubmission({
+        stackSetExternalId: "tenant-external-id",
+        onNext,
+        setFieldError,
+      }),
+    );
+
+    // When
+    await act(async () => {
+      await result.current.submitOrganizationSetup({
+        organizationName: "Acme",
+        awsOrgId: "o-abc123def4",
+        roleArn: "arn:aws:iam::123456789012:role/ProwlerOrgRole",
+      });
+    });
+
+    // Then
+    expect(setFieldError).toHaveBeenCalledWith(
+      "awsOrgId",
+      "Organization with this external_id already exists.",
+    );
+    expect(result.current.apiError).toBe(
+      "Organization with this external_id already exists.",
+    );
+    expect(onNext).not.toHaveBeenCalled();
+    expect(
+      organizationsActionsMock.createOrganizationSecret,
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/ui/components/providers/organizations/hooks/use-org-setup-submission.ts
+++ b/ui/components/providers/organizations/hooks/use-org-setup-submission.ts
@@ -1,0 +1,320 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  createOrganization,
+  createOrganizationSecret,
+  getDiscovery,
+  listOrganizationsByExternalId,
+  listOrganizationSecretsByOrganizationId,
+  triggerDiscovery,
+  updateOrganizationSecret,
+} from "@/actions/organizations/organizations";
+import { getSelectableAccountIds } from "@/actions/organizations/organizations.adapter";
+import { useOrgSetupStore } from "@/store/organizations/store";
+import { DISCOVERY_STATUS, DiscoveryResult } from "@/types/organizations";
+
+const DISCOVERY_POLL_INTERVAL_MS = 3000;
+const DISCOVERY_MAX_RETRIES = 60;
+
+function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const timeoutId = window.setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        window.clearTimeout(timeoutId);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}
+
+interface OrgSetupSubmissionData {
+  organizationName?: string;
+  awsOrgId: string;
+  roleArn: string;
+}
+
+interface UseOrgSetupSubmissionProps {
+  stackSetExternalId: string;
+  onNext: () => void;
+  setFieldError: (
+    field: "awsOrgId" | "organizationName",
+    message: string,
+  ) => void;
+}
+
+interface ServerErrorResult {
+  error?: string;
+  errors?: Array<{ detail: string; source?: { pointer: string } }>;
+}
+
+export function useOrgSetupSubmission({
+  stackSetExternalId,
+  onNext,
+  setFieldError,
+}: UseOrgSetupSubmissionProps) {
+  const [apiError, setApiError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+  const discoveryAbortControllerRef = useRef<AbortController | null>(null);
+  const {
+    setOrganization,
+    setDiscovery,
+    setSelectedAccountIds,
+    clearValidationState,
+  } = useOrgSetupStore();
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+      discoveryAbortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const handleServerError = (result: ServerErrorResult, context: string) => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    if (result.errors?.length) {
+      for (const err of result.errors) {
+        const pointer = err.source?.pointer ?? "";
+
+        if (pointer.includes("external_id") && context === "Organization") {
+          setFieldError("awsOrgId", err.detail);
+          setApiError(err.detail);
+        } else if (pointer.includes("name")) {
+          setFieldError("organizationName", err.detail);
+        } else {
+          setApiError(err.detail);
+        }
+      }
+    } else {
+      setApiError(result.error ?? `Failed to create ${context}`);
+    }
+  };
+
+  const pollDiscoveryResult = async (
+    organizationId: string,
+    discoveryId: string,
+    signal: AbortSignal,
+  ): Promise<DiscoveryResult | null> => {
+    for (let attempt = 0; attempt < DISCOVERY_MAX_RETRIES; attempt += 1) {
+      if (signal.aborted || !isMountedRef.current) {
+        return null;
+      }
+
+      const result = await getDiscovery(organizationId, discoveryId);
+      if (signal.aborted || !isMountedRef.current) {
+        return null;
+      }
+
+      if (result?.error) {
+        setApiError(
+          `Authentication failed. Please verify the StackSet deployment and Role ARN, then try again. ${result.error}`,
+        );
+        return null;
+      }
+
+      const status = result.data.attributes.status;
+
+      if (status === DISCOVERY_STATUS.SUCCEEDED) {
+        return result.data.attributes.result as DiscoveryResult;
+      }
+
+      if (status === DISCOVERY_STATUS.FAILED) {
+        const backendError = result.data.attributes.error;
+        setApiError(
+          backendError
+            ? `Authentication failed. Please verify the StackSet deployment and Role ARN, then try again. ${backendError}`
+            : "Authentication failed. Please verify the StackSet deployment and Role ARN, then try again.",
+        );
+        return null;
+      }
+
+      await sleepWithAbort(DISCOVERY_POLL_INTERVAL_MS, signal);
+    }
+
+    if (signal.aborted || !isMountedRef.current) {
+      return null;
+    }
+
+    setApiError(
+      "Authentication timed out. Please verify the credentials and try again.",
+    );
+    return null;
+  };
+
+  const submitOrganizationSetup = async (data: OrgSetupSubmissionData) => {
+    discoveryAbortControllerRef.current?.abort();
+    const abortController = new AbortController();
+    discoveryAbortControllerRef.current = abortController;
+    const isCancelled = () =>
+      !isMountedRef.current || abortController.signal.aborted;
+    const setApiErrorIfActive = (message: string) => {
+      if (!isCancelled()) {
+        setApiError(message);
+      }
+    };
+
+    try {
+      if (!isCancelled()) {
+        setApiError(null);
+      }
+      clearValidationState();
+
+      const resolvedOrganizationName =
+        data.organizationName?.trim() || data.awsOrgId;
+
+      const existingOrganizationsResult = await listOrganizationsByExternalId(
+        data.awsOrgId,
+      );
+      if (isCancelled()) {
+        return;
+      }
+
+      if (existingOrganizationsResult?.error) {
+        setApiErrorIfActive(existingOrganizationsResult.error);
+        return;
+      }
+
+      const existingOrganization = Array.isArray(
+        existingOrganizationsResult?.data,
+      )
+        ? existingOrganizationsResult.data.find(
+            (organization: {
+              id: string;
+              attributes?: { external_id?: string; org_type?: string };
+            }) =>
+              organization?.attributes?.external_id === data.awsOrgId &&
+              organization?.attributes?.org_type === "aws",
+          )
+        : null;
+
+      let orgId = existingOrganization?.id as string | undefined;
+
+      if (!orgId) {
+        const orgFormData = new FormData();
+        orgFormData.set("name", resolvedOrganizationName);
+        orgFormData.set("externalId", data.awsOrgId);
+
+        const orgResult = await createOrganization(orgFormData);
+        if (isCancelled()) {
+          return;
+        }
+
+        if (orgResult?.error || orgResult?.errors?.length) {
+          handleServerError(orgResult, "Organization");
+          return;
+        }
+
+        orgId = orgResult.data.id;
+      }
+
+      if (!orgId) {
+        setApiErrorIfActive(
+          "Unable to resolve organization ID for authentication.",
+        );
+        return;
+      }
+
+      const organizationNameForStore =
+        existingOrganization?.attributes?.name ?? resolvedOrganizationName;
+      setOrganization(orgId, organizationNameForStore, data.awsOrgId);
+
+      const existingSecretsResult =
+        await listOrganizationSecretsByOrganizationId(orgId);
+      if (isCancelled()) {
+        return;
+      }
+
+      if (existingSecretsResult?.error) {
+        setApiErrorIfActive(existingSecretsResult.error);
+        return;
+      }
+
+      const existingSecretId =
+        Array.isArray(existingSecretsResult?.data) &&
+        existingSecretsResult.data.length > 0
+          ? (existingSecretsResult.data[0]?.id as string | undefined)
+          : undefined;
+
+      let secretResult;
+      if (existingSecretId) {
+        const patchSecretFormData = new FormData();
+        patchSecretFormData.set("organizationSecretId", existingSecretId);
+        patchSecretFormData.set("roleArn", data.roleArn);
+        patchSecretFormData.set("externalId", stackSetExternalId);
+        secretResult = await updateOrganizationSecret(patchSecretFormData);
+      } else {
+        const createSecretFormData = new FormData();
+        createSecretFormData.set("organizationId", orgId);
+        createSecretFormData.set("roleArn", data.roleArn);
+        createSecretFormData.set("externalId", stackSetExternalId);
+        secretResult = await createOrganizationSecret(createSecretFormData);
+      }
+      if (isCancelled()) {
+        return;
+      }
+
+      if (secretResult?.error) {
+        handleServerError(secretResult, "Secret");
+        return;
+      }
+
+      const discoveryResult = await triggerDiscovery(orgId);
+      if (isCancelled()) {
+        return;
+      }
+
+      if (discoveryResult?.error) {
+        setApiErrorIfActive(discoveryResult.error);
+        return;
+      }
+
+      const discoveryId = discoveryResult.data.id;
+      const resolvedDiscoveryResult = await pollDiscoveryResult(
+        orgId,
+        discoveryId,
+        abortController.signal,
+      );
+
+      if (!resolvedDiscoveryResult || isCancelled()) {
+        return;
+      }
+
+      const selectableAccountIds = getSelectableAccountIds(
+        resolvedDiscoveryResult,
+      );
+      setDiscovery(discoveryId, resolvedDiscoveryResult);
+      setSelectedAccountIds(selectableAccountIds);
+      onNext();
+    } catch {
+      if (!isCancelled()) {
+        setApiError(
+          "Authentication failed. Please verify the StackSet deployment and Role ARN, then try again.",
+        );
+      }
+    } finally {
+      if (discoveryAbortControllerRef.current === abortController) {
+        discoveryAbortControllerRef.current = null;
+      }
+    }
+  };
+
+  return {
+    apiError,
+    setApiError,
+    submitOrganizationSetup,
+  };
+}

--- a/ui/components/providers/organizations/hooks/use-org-setup-submission.ts
+++ b/ui/components/providers/organizations/hooks/use-org-setup-submission.ts
@@ -15,6 +15,8 @@ import { getSelectableAccountIds } from "@/actions/organizations/organizations.a
 import { useOrgSetupStore } from "@/store/organizations/store";
 import { DISCOVERY_STATUS, DiscoveryResult } from "@/types/organizations";
 
+import { extractErrorMessage } from "./error-utils";
+
 const DISCOVERY_POLL_INTERVAL_MS = 3000;
 const DISCOVERY_MAX_RETRIES = 60;
 
@@ -100,7 +102,7 @@ export function useOrgSetupSubmission({
         }
       }
     } else {
-      setApiError(result.error ?? `Failed to create ${context}`);
+      setApiError(extractErrorMessage(result, `Failed to create ${context}`));
     }
   };
 

--- a/ui/components/providers/organizations/org-account-selection.test.tsx
+++ b/ui/components/providers/organizations/org-account-selection.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { APPLY_STATUS } from "@/types/organizations";
+
+import { OrgAccountSelection } from "./org-account-selection";
+
+const { useOrgAccountSelectionFlowMock, handleTreeSelectionChangeMock } =
+  vi.hoisted(() => ({
+    useOrgAccountSelectionFlowMock: vi.fn(),
+    handleTreeSelectionChangeMock: vi.fn(),
+  }));
+
+vi.mock("./hooks/use-org-account-selection-flow", () => ({
+  useOrgAccountSelectionFlow: useOrgAccountSelectionFlowMock,
+}));
+
+describe("OrgAccountSelection", () => {
+  let baseFlowState: Record<string, unknown>;
+
+  beforeEach(() => {
+    useOrgAccountSelectionFlowMock.mockReset();
+    handleTreeSelectionChangeMock.mockReset();
+
+    const accountLookup = new Map([
+      [
+        "222222222222",
+        {
+          id: "222222222222",
+          name: "Account Two",
+          arn: "arn:aws:organizations::222222222222:account/o-123/222222222222",
+          email: "two@example.com",
+          status: "ACTIVE",
+          joined_method: "CREATED",
+          joined_timestamp: "2024-01-01T00:00:00Z",
+          parent_id: "r-root",
+          registration: {
+            provider_exists: false,
+            provider_id: null,
+            organization_relation: "link_required",
+            organizational_unit_relation: "not_applicable",
+            provider_secret_state: "will_create",
+            apply_status: APPLY_STATUS.READY,
+            blocked_reasons: [],
+          },
+        },
+      ],
+    ]);
+
+    baseFlowState = {
+      accountAliases: {},
+      accountLookup,
+      applyError: null,
+      canAdvanceToLaunch: false,
+      discoveryResult: {
+        roots: [],
+        organizational_units: [],
+        accounts: [],
+      },
+      handleTreeSelectionChange: handleTreeSelectionChangeMock,
+      hasConnectionErrors: true,
+      isTesting: false,
+      isTestingView: true,
+      isSelectionLocked: false,
+      organizationExternalId: "o-abc123def4",
+      selectedCount: 1,
+      selectedIdsForTree: [],
+      setAccountAlias: vi.fn(),
+      showHeaderHelperText: true,
+      totalAccounts: 2,
+      treeDataWithConnectionState: [
+        {
+          id: "222222222222",
+          name: "222222222222 - Account Two",
+        },
+      ],
+    };
+
+    useOrgAccountSelectionFlowMock.mockReturnValue(baseFlowState);
+  });
+
+  it("allows changing account selection after finishing connection tests", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(
+      <OrgAccountSelection
+        onBack={vi.fn()}
+        onNext={vi.fn()}
+        onSkip={vi.fn()}
+        onFooterChange={vi.fn()}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("checkbox"));
+
+    // Then
+    expect(handleTreeSelectionChangeMock).toHaveBeenCalledWith([
+      "222222222222",
+    ]);
+  });
+
+  it("locks account selection while apply or connection test is running", async () => {
+    // Given
+    const user = userEvent.setup();
+    useOrgAccountSelectionFlowMock.mockReturnValue({
+      ...baseFlowState,
+      isSelectionLocked: true,
+    });
+    render(
+      <OrgAccountSelection
+        onBack={vi.fn()}
+        onNext={vi.fn()}
+        onSkip={vi.fn()}
+        onFooterChange={vi.fn()}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("checkbox"));
+
+    // Then
+    expect(handleTreeSelectionChangeMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/components/providers/organizations/org-account-selection.tsx
+++ b/ui/components/providers/organizations/org-account-selection.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
 
-import {
-  WIZARD_FOOTER_ACTION_TYPE,
-  WizardFooterConfig,
-} from "@/components/providers/wizard/steps/footer-controls";
+import { AWSProviderBadge } from "@/components/icons/providers-badge";
+import { WizardFooterConfig } from "@/components/providers/wizard/steps/footer-controls";
+import { Alert, AlertDescription } from "@/components/shadcn/alert";
+import { TreeView } from "@/components/shadcn/tree-view";
+
+import { useOrgAccountSelectionFlow } from "./hooks/use-org-account-selection-flow";
+import { OrgAccountTreeItem, TREE_ITEM_MODE } from "./org-account-tree-item";
 
 interface OrgAccountSelectionProps {
   onBack: () => void;
@@ -20,28 +23,108 @@ export function OrgAccountSelection({
   onSkip,
   onFooterChange,
 }: OrgAccountSelectionProps) {
-  useEffect(() => {
-    onFooterChange({
-      showBack: true,
-      backLabel: "Back",
-      onBack,
-      showSecondaryAction: true,
-      secondaryActionLabel: "Skip",
-      secondaryActionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
-      onSecondaryAction: onSkip,
-      showAction: true,
-      actionLabel: "Continue",
-      actionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
-      onAction: onNext,
-    });
-  }, [onBack, onFooterChange, onNext, onSkip]);
+  const {
+    accountAliases,
+    accountLookup,
+    applyError,
+    canAdvanceToLaunch,
+    discoveryResult,
+    handleTreeSelectionChange,
+    hasConnectionErrors,
+    isTesting,
+    isTestingView,
+    isSelectionLocked,
+    organizationExternalId,
+    selectedCount,
+    selectedIdsForTree,
+    setAccountAlias,
+    showHeaderHelperText,
+    totalAccounts,
+    treeDataWithConnectionState,
+  } = useOrgAccountSelectionFlow({
+    onBack,
+    onNext,
+    onSkip,
+    onFooterChange,
+  });
+
+  if (!discoveryResult) {
+    return (
+      <div className="text-muted-foreground py-8 text-center text-sm">
+        No discovery data available.
+      </div>
+    );
+  }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col justify-center gap-2 py-6">
-      <h3 className="text-base font-semibold">Account selection</h3>
-      <p className="text-muted-foreground text-sm">
-        Account discovery and selection are introduced in the next chained PR.
-      </p>
+    <div className="flex min-h-0 flex-1 flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-4">
+          <AWSProviderBadge size={32} />
+          <h3 className="text-base font-semibold">My Organization</h3>
+        </div>
+
+        <div className="ml-12 flex items-center gap-3">
+          <span className="text-text-neutral-tertiary text-xs">UID:</span>
+          <div className="bg-bg-neutral-tertiary border-border-input-primary inline-flex h-10 items-center rounded-full border px-4">
+            <span className="text-xs font-medium">
+              {organizationExternalId || "N/A"}
+            </span>
+          </div>
+        </div>
+
+        {showHeaderHelperText && (
+          <p className="text-muted-foreground text-sm">
+            {isTestingView
+              ? "Testing account connections..."
+              : "Confirm all accounts under this Organization you want to add to Prowler."}{" "}
+            {!isTestingView &&
+              `${selectedCount} of ${totalAccounts} accounts selected.`}
+          </p>
+        )}
+      </div>
+
+      {isTestingView && applyError && (
+        <Alert variant="error">
+          <AlertTriangle />
+          <AlertDescription className="text-text-error-primary">
+            {applyError}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {isTestingView && hasConnectionErrors && !isTesting && (
+        <Alert variant="error">
+          <AlertTriangle />
+          <AlertDescription className="text-text-error-primary">
+            {canAdvanceToLaunch
+              ? "There was a problem connecting to some accounts. Hover each account to check the error."
+              : "No accounts connected successfully. Fix the connection errors and retry before launching scans."}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="border-border-neutral-secondary min-h-0 flex-1 overflow-y-auto rounded-md border p-2">
+        <TreeView
+          data={treeDataWithConnectionState}
+          showCheckboxes
+          enableSelectChildren
+          expandAll
+          selectedIds={selectedIdsForTree}
+          onSelectionChange={
+            isSelectionLocked ? () => {} : handleTreeSelectionChange
+          }
+          renderItem={(params) => (
+            <OrgAccountTreeItem
+              params={params}
+              mode={TREE_ITEM_MODE.SELECTION}
+              accountLookup={accountLookup}
+              aliases={accountAliases}
+              onAliasChange={setAccountAlias}
+            />
+          )}
+        />
+      </div>
     </div>
   );
 }

--- a/ui/components/providers/organizations/org-account-selection.utils.test.ts
+++ b/ui/components/providers/organizations/org-account-selection.utils.test.ts
@@ -131,6 +131,32 @@ describe("pollConnectionTask", () => {
       error: "Role trust policy mismatch.",
     });
   });
+
+  it("stops polling when aborted", async () => {
+    // Given
+    const abortController = new AbortController();
+    const getTaskById = vi
+      .fn()
+      .mockResolvedValue({ data: { attributes: { state: "executing" } } });
+    const sleep = vi.fn(async () => {
+      abortController.abort();
+    });
+
+    // When
+    const result = await pollConnectionTask("task-1", {
+      getTaskById,
+      sleep,
+      signal: abortController.signal,
+      maxRetries: 5,
+    });
+
+    // Then
+    expect(getTaskById).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      success: false,
+      error: "Connection test cancelled.",
+    });
+  });
 });
 
 describe("launch gating", () => {

--- a/ui/components/providers/organizations/org-account-selection.utils.test.ts
+++ b/ui/components/providers/organizations/org-account-selection.utils.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CONNECTION_TEST_STATUS } from "@/types/organizations";
+
+import {
+  buildAccountToProviderMap,
+  canAdvanceToLaunchStep,
+  getLaunchableProviderIds,
+  pollConnectionTask,
+  runWithConcurrencyLimit,
+} from "./org-account-selection.utils";
+
+describe("buildAccountToProviderMap", () => {
+  it("uses explicit account-provider mappings when apply response is unordered", async () => {
+    // Given
+    const resolveProviderUidById = vi.fn();
+    const selectedAccountIds = ["111111111111", "222222222222"];
+    const providerIds = ["provider-b", "provider-a"];
+    const applyResult = {
+      data: {
+        attributes: {
+          account_provider_mappings: [
+            {
+              account_id: "111111111111",
+              provider_id: "provider-a",
+            },
+            {
+              account_id: "222222222222",
+              provider_id: "provider-b",
+            },
+          ],
+        },
+      },
+    };
+
+    // When
+    const map = await buildAccountToProviderMap({
+      selectedAccountIds,
+      providerIds,
+      applyResult,
+      resolveProviderUidById,
+    });
+
+    // Then
+    expect(map.get("111111111111")).toBe("provider-a");
+    expect(map.get("222222222222")).toBe("provider-b");
+    expect(resolveProviderUidById).not.toHaveBeenCalled();
+  });
+
+  it("falls back to provider uid matching when explicit mappings are missing", async () => {
+    // Given
+    const selectedAccountIds = ["111111111111", "222222222222"];
+    const providerIds = ["provider-a", "provider-b", "provider-c"];
+    const resolveProviderUidById = vi.fn(async (providerId: string) => {
+      if (providerId === "provider-a") return "222222222222";
+      if (providerId === "provider-c") return "111111111111";
+      return "999999999999";
+    });
+
+    // When
+    const map = await buildAccountToProviderMap({
+      selectedAccountIds,
+      providerIds,
+      applyResult: {},
+      resolveProviderUidById,
+    });
+
+    // Then
+    expect(map.get("111111111111")).toBe("provider-c");
+    expect(map.get("222222222222")).toBe("provider-a");
+  });
+});
+
+describe("runWithConcurrencyLimit", () => {
+  it("processes work with the configured concurrency cap", async () => {
+    // Given
+    const items = Array.from({ length: 8 }, (_, index) => index + 1);
+    let activeWorkers = 0;
+    let maxActiveWorkers = 0;
+
+    // When
+    const results = await runWithConcurrencyLimit(items, 3, async (item) => {
+      activeWorkers += 1;
+      maxActiveWorkers = Math.max(maxActiveWorkers, activeWorkers);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      activeWorkers -= 1;
+      return item * 2;
+    });
+
+    // Then
+    expect(maxActiveWorkers).toBeLessThanOrEqual(3);
+    expect(results).toEqual([2, 4, 6, 8, 10, 12, 14, 16]);
+  });
+});
+
+describe("pollConnectionTask", () => {
+  it("uses progressive delays and returns connection result from the final task payload", async () => {
+    // Given
+    const sleeps: number[] = [];
+    const getTaskById = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { attributes: { state: "executing" } },
+      })
+      .mockResolvedValueOnce({
+        data: { attributes: { state: "executing" } },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          attributes: {
+            state: "completed",
+            result: { connected: false, error: "Role trust policy mismatch." },
+          },
+        },
+      });
+
+    // When
+    const result = await pollConnectionTask("task-1", {
+      getTaskById,
+      sleep: async (delay) => {
+        sleeps.push(delay);
+      },
+      maxRetries: 5,
+    });
+
+    // Then
+    expect(sleeps).toEqual([2000, 3000]);
+    expect(getTaskById).toHaveBeenCalledTimes(3);
+    expect(result).toEqual({
+      success: false,
+      error: "Role trust policy mismatch.",
+    });
+  });
+});
+
+describe("launch gating", () => {
+  it("blocks advancing when all tested providers failed", () => {
+    // Given
+    const providerIds = ["provider-a", "provider-b"];
+    const connectionResults = {
+      "provider-a": CONNECTION_TEST_STATUS.ERROR,
+      "provider-b": CONNECTION_TEST_STATUS.ERROR,
+    };
+
+    // When
+    const launchableProviderIds = getLaunchableProviderIds(
+      providerIds,
+      connectionResults,
+    );
+    const canAdvance = canAdvanceToLaunchStep(providerIds, connectionResults);
+
+    // Then
+    expect(launchableProviderIds).toEqual([]);
+    expect(canAdvance).toBe(false);
+  });
+
+  it("allows advancing and keeps only successful providers", () => {
+    // Given
+    const providerIds = ["provider-a", "provider-b"];
+    const connectionResults = {
+      "provider-a": CONNECTION_TEST_STATUS.SUCCESS,
+      "provider-b": CONNECTION_TEST_STATUS.ERROR,
+    };
+
+    // When
+    const launchableProviderIds = getLaunchableProviderIds(
+      providerIds,
+      connectionResults,
+    );
+    const canAdvance = canAdvanceToLaunchStep(providerIds, connectionResults);
+
+    // Then
+    expect(launchableProviderIds).toEqual(["provider-a"]);
+    expect(canAdvance).toBe(true);
+  });
+});

--- a/ui/components/providers/organizations/org-account-selection.utils.ts
+++ b/ui/components/providers/organizations/org-account-selection.utils.ts
@@ -23,6 +23,7 @@ interface PollConnectionTaskOptions {
   sleep?: (ms: number) => Promise<void>;
   maxRetries?: number;
   delaysMs?: number[];
+  signal?: AbortSignal;
 }
 
 export interface PollConnectionTaskResult {
@@ -40,6 +41,41 @@ function getPollingDelay(attempt: number, delaysMs: number[]): number {
   }
   const delayIndex = Math.min(attempt, delaysMs.length - 1);
   return delaysMs[delayIndex] ?? delaysMs[delaysMs.length - 1];
+}
+
+function sleepWithAbort(
+  ms: number,
+  sleep: (ms: number) => Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!signal) {
+    return sleep(ms);
+  }
+
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    let settled = false;
+    const handleAbort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve();
+    };
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    void sleep(ms).finally(() => {
+      if (!settled) {
+        settled = true;
+        signal.removeEventListener("abort", handleAbort);
+        resolve();
+      }
+    });
+  });
 }
 
 function normalizeAccountProviderMapping(
@@ -189,6 +225,7 @@ export async function pollConnectionTask(
       new Promise((resolve) => setTimeout(resolve, ms)),
     maxRetries = 20,
     delaysMs = [...DEFAULT_POLL_DELAYS_MS],
+    signal,
   }: PollConnectionTaskOptions = {},
 ): Promise<PollConnectionTaskResult> {
   const inProgressStates = new Set([
@@ -206,7 +243,14 @@ export async function pollConnectionTask(
     });
 
   for (let attempt = 0; attempt < maxRetries; attempt += 1) {
+    if (signal?.aborted) {
+      return { success: false, error: "Connection test cancelled." };
+    }
+
     const taskResponse = await taskFetcher(taskId);
+    if (signal?.aborted) {
+      return { success: false, error: "Connection test cancelled." };
+    }
 
     if (isRecord(taskResponse) && typeof taskResponse.error === "string") {
       return { success: false, error: taskResponse.error };
@@ -248,7 +292,7 @@ export async function pollConnectionTask(
       return { success: false, error: "Unexpected task state." };
     }
 
-    await sleep(getPollingDelay(attempt, delaysMs));
+    await sleepWithAbort(getPollingDelay(attempt, delaysMs), sleep, signal);
   }
 
   return { success: false, error: "Connection test timed out." };

--- a/ui/components/providers/organizations/org-account-selection.utils.ts
+++ b/ui/components/providers/organizations/org-account-selection.utils.ts
@@ -1,0 +1,272 @@
+import {
+  CONNECTION_TEST_STATUS,
+  ConnectionTestStatus,
+} from "@/types/organizations";
+
+const DEFAULT_CONCURRENCY_LIMIT = 5;
+const DEFAULT_POLL_DELAYS_MS = [2000, 3000, 5000] as const;
+
+interface AccountProviderMapping {
+  account_id: string;
+  provider_id: string;
+}
+
+interface BuildAccountToProviderMapParams {
+  selectedAccountIds: string[];
+  providerIds: string[];
+  applyResult: unknown;
+  resolveProviderUidById: (providerId: string) => Promise<string | null>;
+}
+
+interface PollConnectionTaskOptions {
+  getTaskById?: (taskId: string) => Promise<unknown>;
+  sleep?: (ms: number) => Promise<void>;
+  maxRetries?: number;
+  delaysMs?: number[];
+}
+
+export interface PollConnectionTaskResult {
+  success: boolean;
+  error?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getPollingDelay(attempt: number, delaysMs: number[]): number {
+  if (delaysMs.length === 0) {
+    return DEFAULT_POLL_DELAYS_MS[DEFAULT_POLL_DELAYS_MS.length - 1];
+  }
+  const delayIndex = Math.min(attempt, delaysMs.length - 1);
+  return delaysMs[delayIndex] ?? delaysMs[delaysMs.length - 1];
+}
+
+function normalizeAccountProviderMapping(
+  value: unknown,
+): AccountProviderMapping | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const attributes = isRecord(value.attributes) ? value.attributes : null;
+  const accountId =
+    (typeof value.account_id === "string" && value.account_id) ||
+    (typeof attributes?.account_id === "string" && attributes.account_id) ||
+    (typeof value.id === "string" && value.id) ||
+    null;
+
+  const providerId =
+    (typeof value.provider_id === "string" && value.provider_id) ||
+    (typeof attributes?.provider_id === "string" && attributes.provider_id) ||
+    null;
+
+  if (!accountId || !providerId) {
+    return null;
+  }
+
+  return {
+    account_id: accountId,
+    provider_id: providerId,
+  };
+}
+
+function extractAccountProviderMappings(applyResult: unknown) {
+  if (!isRecord(applyResult)) {
+    return [];
+  }
+
+  const data = isRecord(applyResult.data) ? applyResult.data : null;
+  if (!data) {
+    return [];
+  }
+
+  const attributes = isRecord(data.attributes) ? data.attributes : null;
+  const relationships = isRecord(data.relationships)
+    ? data.relationships
+    : null;
+
+  const attributeMappings = Array.isArray(attributes?.account_provider_mappings)
+    ? attributes.account_provider_mappings
+    : [];
+  const relationshipNode = isRecord(relationships?.account_provider_mappings)
+    ? relationships.account_provider_mappings
+    : null;
+  const relationshipMappings = Array.isArray(relationshipNode?.data)
+    ? relationshipNode.data
+    : [];
+
+  return [...attributeMappings, ...relationshipMappings]
+    .map(normalizeAccountProviderMapping)
+    .filter((mapping): mapping is AccountProviderMapping => mapping !== null);
+}
+
+export async function runWithConcurrencyLimit<T, R>(
+  items: T[],
+  concurrencyLimit: number,
+  worker: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const normalizedConcurrency = Math.max(1, Math.floor(concurrencyLimit));
+  const results = new Array<R>(items.length);
+  let currentIndex = 0;
+
+  const runWorker = async () => {
+    while (currentIndex < items.length) {
+      const assignedIndex = currentIndex;
+      currentIndex += 1;
+      results[assignedIndex] = await worker(
+        items[assignedIndex],
+        assignedIndex,
+      );
+    }
+  };
+
+  const workers = Array.from(
+    { length: Math.min(normalizedConcurrency, items.length) },
+    () => runWorker(),
+  );
+
+  await Promise.all(workers);
+  return results;
+}
+
+export async function buildAccountToProviderMap({
+  selectedAccountIds,
+  providerIds,
+  applyResult,
+  resolveProviderUidById,
+}: BuildAccountToProviderMapParams): Promise<Map<string, string>> {
+  const selectedAccountIdSet = new Set(selectedAccountIds);
+
+  const explicitMappings = extractAccountProviderMappings(applyResult);
+  if (explicitMappings.length > 0) {
+    const mappedProviders = new Map<string, string>();
+
+    for (const mapping of explicitMappings) {
+      if (!selectedAccountIdSet.has(mapping.account_id)) {
+        continue;
+      }
+      mappedProviders.set(mapping.account_id, mapping.provider_id);
+    }
+
+    if (mappedProviders.size > 0) {
+      return mappedProviders;
+    }
+  }
+
+  const fallbackEntries = await runWithConcurrencyLimit(
+    providerIds,
+    DEFAULT_CONCURRENCY_LIMIT,
+    async (providerId) => {
+      const providerUid = await resolveProviderUidById(providerId);
+      if (!providerUid || !selectedAccountIdSet.has(providerUid)) {
+        return null;
+      }
+      return { accountId: providerUid, providerId };
+    },
+  );
+
+  const fallbackMapping = new Map<string, string>();
+  for (const entry of fallbackEntries) {
+    if (!entry) {
+      continue;
+    }
+    fallbackMapping.set(entry.accountId, entry.providerId);
+  }
+
+  return fallbackMapping;
+}
+
+export async function pollConnectionTask(
+  taskId: string,
+  {
+    getTaskById,
+    sleep = async (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms)),
+    maxRetries = 20,
+    delaysMs = [...DEFAULT_POLL_DELAYS_MS],
+  }: PollConnectionTaskOptions = {},
+): Promise<PollConnectionTaskResult> {
+  const inProgressStates = new Set([
+    "available",
+    "scheduled",
+    "executing",
+    "pending",
+    "running",
+  ]);
+  const taskFetcher =
+    getTaskById ??
+    (async (currentTaskId: string) => {
+      const { getTask } = await import("@/actions/task/tasks");
+      return getTask(currentTaskId);
+    });
+
+  for (let attempt = 0; attempt < maxRetries; attempt += 1) {
+    const taskResponse = await taskFetcher(taskId);
+
+    if (isRecord(taskResponse) && typeof taskResponse.error === "string") {
+      return { success: false, error: taskResponse.error };
+    }
+
+    const data =
+      isRecord(taskResponse) && isRecord(taskResponse.data)
+        ? taskResponse.data
+        : null;
+    const attributes = isRecord(data?.attributes) ? data.attributes : null;
+    const state =
+      typeof attributes?.state === "string" ? attributes.state : null;
+    const result = isRecord(attributes?.result) ? attributes.result : null;
+
+    if (state === "completed") {
+      const connected =
+        typeof result?.connected === "boolean" ? result.connected : true;
+      if (connected) {
+        return { success: true };
+      }
+      return {
+        success: false,
+        error:
+          (typeof result?.error === "string" && result.error) ||
+          "Connection failed for this account.",
+      };
+    }
+
+    if (state === "failed") {
+      return {
+        success: false,
+        error:
+          (typeof result?.error === "string" && result.error) ||
+          "Connection test task failed.",
+      };
+    }
+
+    if (!state || !inProgressStates.has(state)) {
+      return { success: false, error: "Unexpected task state." };
+    }
+
+    await sleep(getPollingDelay(attempt, delaysMs));
+  }
+
+  return { success: false, error: "Connection test timed out." };
+}
+
+export function getLaunchableProviderIds(
+  providerIds: string[],
+  connectionResults: Record<string, ConnectionTestStatus>,
+): string[] {
+  return providerIds.filter(
+    (providerId) =>
+      connectionResults[providerId] === CONNECTION_TEST_STATUS.SUCCESS,
+  );
+}
+
+export function canAdvanceToLaunchStep(
+  providerIds: string[],
+  connectionResults: Record<string, ConnectionTestStatus>,
+): boolean {
+  return getLaunchableProviderIds(providerIds, connectionResults).length > 0;
+}

--- a/ui/components/providers/organizations/org-account-tree-item.tsx
+++ b/ui/components/providers/organizations/org-account-tree-item.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+
+import { Input } from "@/components/shadcn/input/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn/tooltip";
+import { cn } from "@/lib/utils";
+import { APPLY_STATUS, DiscoveredAccount } from "@/types/organizations";
+import { TreeRenderItemParams } from "@/types/tree";
+
+const TREE_ITEM_MODE = {
+  SELECTION: "selection",
+} as const;
+
+type TreeItemMode = (typeof TREE_ITEM_MODE)[keyof typeof TREE_ITEM_MODE];
+
+interface OrgAccountTreeItemProps {
+  params: TreeRenderItemParams;
+  mode: TreeItemMode;
+  accountLookup: Map<string, DiscoveredAccount>;
+  aliases: Record<string, string>;
+  onAliasChange?: (accountId: string, alias: string) => void;
+}
+
+export function OrgAccountTreeItem({
+  params,
+  mode,
+  accountLookup,
+  aliases,
+  onAliasChange,
+}: OrgAccountTreeItemProps) {
+  const { item, isLeaf } = params;
+  const account = accountLookup.get(item.id);
+  const isOuNode = item.id.startsWith("ou-");
+  const ItemIcon = item.icon;
+  const idColumnClass = "w-44 shrink-0";
+  const aliasInputClass = "h-9 w-full max-w-64 text-sm";
+
+  // OU nodes: show OU id + alias/name (input in selection mode).
+  if (!account && isOuNode) {
+    const ouDisplayName = aliases[item.id] ?? item.name;
+    const isSelectionMode = mode === TREE_ITEM_MODE.SELECTION && onAliasChange;
+
+    return (
+      <div className="flex flex-1 items-center gap-3">
+        <div className={`${idColumnClass} flex items-center gap-2`}>
+          {ItemIcon && (
+            <ItemIcon className="text-muted-foreground size-4 shrink-0" />
+          )}
+          <span className="text-sm">{item.id}</span>
+        </div>
+        <div className="min-w-0 flex-1">
+          {isSelectionMode ? (
+            <Input
+              className={aliasInputClass}
+              placeholder="Name (optional)"
+              value={ouDisplayName}
+              onChange={(e) => onAliasChange(item.id, e.target.value)}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span className="text-muted-foreground line-clamp-1 text-xs">
+              {ouDisplayName}
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Any remaining non-account node (unexpected fallback).
+  if (!account || !isLeaf) {
+    return <span className="text-sm font-medium">{item.name}</span>;
+  }
+
+  const isBlocked = account.registration?.apply_status === APPLY_STATUS.BLOCKED;
+  const blockedReasons = account.registration?.blocked_reasons ?? [];
+
+  return (
+    <div className="flex flex-1 items-center gap-3">
+      {/* Account ID */}
+      <div className={cn(idColumnClass, "flex items-center gap-2")}>
+        {ItemIcon && (
+          <ItemIcon className="text-muted-foreground size-4 shrink-0" />
+        )}
+        <span className={cn("text-sm", isBlocked && "text-muted-foreground")}>
+          {account.id}
+        </span>
+      </div>
+
+      {/* Name / alias input */}
+      <div className="min-w-0 flex-1">
+        {mode === TREE_ITEM_MODE.SELECTION && !isBlocked && onAliasChange ? (
+          <Input
+            className={aliasInputClass}
+            placeholder="Name (optional)"
+            value={aliases[account.id] ?? account.name}
+            onChange={(e) => onAliasChange(account.id, e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span className="text-muted-foreground line-clamp-1 text-xs">
+            {aliases[account.id] || account.name}
+          </span>
+        )}
+      </div>
+
+      {/* Blocked reason tooltip */}
+      {isBlocked && blockedReasons.length > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <AlertCircle className="text-destructive size-4 shrink-0" />
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="text-xs">{blockedReasons.join(", ")}</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+
+export { TREE_ITEM_MODE, type TreeItemMode };

--- a/ui/components/providers/organizations/org-launch-scan.test.tsx
+++ b/ui/components/providers/organizations/org-launch-scan.test.tsx
@@ -1,0 +1,79 @@
+import { act, render, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useOrgSetupStore } from "@/store/organizations/store";
+
+import { OrgLaunchScan } from "./org-launch-scan";
+
+const { launchOrganizationScansMock, pushMock, toastMock } = vi.hoisted(() => ({
+  launchOrganizationScansMock: vi.fn(),
+  pushMock: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock("@/actions/scans/scans", () => ({
+  launchOrganizationScans: launchOrganizationScansMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+vi.mock("@/components/ui", () => ({
+  ToastAction: ({ children, ...props }: ComponentProps<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+  useToast: () => ({
+    toast: toastMock,
+  }),
+}));
+
+describe("OrgLaunchScan", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    launchOrganizationScansMock.mockReset();
+    pushMock.mockReset();
+    toastMock.mockReset();
+    useOrgSetupStore.getState().reset();
+    useOrgSetupStore
+      .getState()
+      .setOrganization("org-1", "My Organization", "o-abc123def4");
+    useOrgSetupStore.getState().setCreatedProviderIds(["provider-1"]);
+  });
+
+  it("shows a success toast with an action linking to scans", async () => {
+    // Given
+    launchOrganizationScansMock.mockResolvedValue({ successCount: 1 });
+    const onFooterChange = vi.fn();
+
+    render(
+      <OrgLaunchScan
+        onClose={vi.fn()}
+        onBack={vi.fn()}
+        onFooterChange={onFooterChange}
+      />,
+    );
+
+    // When
+    await waitFor(() => {
+      expect(onFooterChange).toHaveBeenCalled();
+    });
+    const footerConfig = onFooterChange.mock.calls.at(-1)?.[0];
+    await act(async () => {
+      footerConfig.onAction?.();
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1);
+    });
+    const toastPayload = toastMock.mock.calls[0]?.[0];
+    expect(toastPayload.title).toBe("Scan Launched");
+    expect(toastPayload.action).toBeDefined();
+    expect(toastPayload.action.props.children.props.href).toBe("/scans");
+  });
+});

--- a/ui/components/providers/organizations/org-launch-scan.tsx
+++ b/ui/components/providers/organizations/org-launch-scan.tsx
@@ -1,11 +1,27 @@
 "use client";
 
-import { useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 
+import { launchOrganizationScans } from "@/actions/scans/scans";
+import { AWSProviderBadge } from "@/components/icons/providers-badge";
 import {
   WIZARD_FOOTER_ACTION_TYPE,
   WizardFooterConfig,
 } from "@/components/providers/wizard/steps/footer-controls";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select/select";
+import { TreeSpinner } from "@/components/shadcn/tree-view/tree-spinner";
+import { TreeStatusIcon } from "@/components/shadcn/tree-view/tree-status-icon";
+import { ToastAction, useToast } from "@/components/ui";
+import { useOrgSetupStore } from "@/store/organizations/store";
+import { TREE_ITEM_STATUS } from "@/types/tree";
 
 interface OrgLaunchScanProps {
   onClose: () => void;
@@ -13,29 +29,149 @@ interface OrgLaunchScanProps {
   onFooterChange: (config: WizardFooterConfig) => void;
 }
 
+const SCAN_SCHEDULE = {
+  DAILY: "daily",
+  SINGLE: "single",
+} as const;
+
+type ScanScheduleOption = (typeof SCAN_SCHEDULE)[keyof typeof SCAN_SCHEDULE];
+
 export function OrgLaunchScan({
   onClose,
   onBack,
   onFooterChange,
 }: OrgLaunchScanProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const { organizationExternalId, createdProviderIds, reset } =
+    useOrgSetupStore();
+
+  const [isLaunching, setIsLaunching] = useState(false);
+  const [scheduleOption, setScheduleOption] = useState<ScanScheduleOption>(
+    SCAN_SCHEDULE.DAILY,
+  );
+  const launchActionRef = useRef<() => void>(() => {});
+
+  const handleLaunchScan = async () => {
+    setIsLaunching(true);
+
+    const result = await launchOrganizationScans(
+      createdProviderIds,
+      scheduleOption,
+    );
+    const successCount = result.successCount;
+
+    setIsLaunching(false);
+    reset();
+    onClose();
+    router.push("/providers");
+
+    toast({
+      title: "Scan Launched",
+      description:
+        scheduleOption === SCAN_SCHEDULE.DAILY
+          ? `Daily scan scheduled for ${successCount} account${successCount !== 1 ? "s" : ""}.`
+          : `Single scan launched for ${successCount} account${successCount !== 1 ? "s" : ""}.`,
+      action: (
+        <ToastAction altText="Go to scans" asChild>
+          <Link href="/scans">Go to scans</Link>
+        </ToastAction>
+      ),
+    });
+  };
+
+  launchActionRef.current = () => {
+    void handleLaunchScan();
+  };
+
   useEffect(() => {
     onFooterChange({
       showBack: true,
       backLabel: "Back",
+      backDisabled: isLaunching,
       onBack,
       showAction: true,
-      actionLabel: "Close",
+      actionLabel: "Launch scan",
+      actionDisabled: isLaunching || createdProviderIds.length === 0,
       actionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
-      onAction: onClose,
+      onAction: () => {
+        launchActionRef.current();
+      },
     });
-  }, [onBack, onClose, onFooterChange]);
+  }, [createdProviderIds.length, isLaunching, onBack, onFooterChange]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col justify-center gap-2 py-6">
-      <h3 className="text-base font-semibold">Launch scan</h3>
-      <p className="text-muted-foreground text-sm">
-        Organizations scan launch flow is completed in the next chained PR.
-      </p>
+    <div className="flex min-h-0 flex-1 flex-col gap-8">
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-4">
+          <AWSProviderBadge size={32} />
+          <h3 className="text-base font-semibold">My Organization</h3>
+        </div>
+
+        <div className="ml-12 flex items-center gap-3">
+          <span className="text-text-neutral-tertiary text-xs">UID:</span>
+          <div className="bg-bg-neutral-tertiary border-border-input-primary inline-flex h-10 items-center rounded-full border px-4">
+            <span className="text-xs font-medium">
+              {organizationExternalId || "N/A"}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {isLaunching ? (
+        <div className="flex min-h-[220px] items-center justify-center">
+          <div className="flex items-center gap-3 py-2">
+            <TreeSpinner className="size-6" />
+            <p className="text-sm font-medium">Launching scans...</p>
+          </div>
+        </div>
+      ) : (
+        <div className="flex max-w-2xl flex-col gap-6">
+          <div className="flex items-center gap-3">
+            <TreeStatusIcon
+              status={TREE_ITEM_STATUS.SUCCESS}
+              className="size-6"
+            />
+            <h3 className="text-sm font-semibold">Accounts Connected!</h3>
+          </div>
+
+          <p className="text-text-neutral-secondary text-sm">
+            Your accounts are connected to Prowler and ready to Scan!
+          </p>
+
+          {createdProviderIds.length === 0 && (
+            <p className="text-text-error-primary text-sm">
+              No successfully connected accounts are available to launch scans.
+              Go back and retry connection tests.
+            </p>
+          )}
+
+          <div className="flex flex-col gap-4">
+            <p className="text-text-neutral-secondary text-sm">
+              Select a Prowler scan schedule for these accounts.
+            </p>
+            <Select
+              value={scheduleOption}
+              onValueChange={(value) =>
+                setScheduleOption(value as ScanScheduleOption)
+              }
+              disabled={isLaunching}
+            >
+              <SelectTrigger className="w-full max-w-[376px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={SCAN_SCHEDULE.DAILY}>
+                  Scan Daily (every 24 hours)
+                </SelectItem>
+                <SelectItem value={SCAN_SCHEDULE.SINGLE}>
+                  Run a single scan (no recurring schedule)
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/components/providers/organizations/org-setup-form.tsx
+++ b/ui/components/providers/organizations/org-setup-form.tsx
@@ -1,12 +1,51 @@
 "use client";
 
-import { useEffect } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Check, Copy, ExternalLink } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { FormEvent, useEffect, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { z } from "zod";
 
+import { AWSProviderBadge } from "@/components/icons/providers-badge";
 import {
   WIZARD_FOOTER_ACTION_TYPE,
   WizardFooterConfig,
 } from "@/components/providers/wizard/steps/footer-controls";
+import { Alert, AlertDescription } from "@/components/shadcn/alert";
+import { Button } from "@/components/shadcn/button/button";
+import { Checkbox } from "@/components/shadcn/checkbox/checkbox";
+import { Input } from "@/components/shadcn/input/input";
+import { TreeSpinner } from "@/components/shadcn/tree-view/tree-spinner";
+import { getAWSCredentialsTemplateLinks } from "@/lib";
 import { ORG_SETUP_PHASE, OrgSetupPhase } from "@/types/organizations";
+
+import { useOrgSetupSubmission } from "./hooks/use-org-setup-submission";
+
+const orgSetupSchema = z.object({
+  organizationName: z.string().trim().optional(),
+  awsOrgId: z
+    .string()
+    .trim()
+    .min(1, "Organization ID is required")
+    .regex(
+      /^o-[a-z0-9]{10,32}$/,
+      "Must be a valid AWS Organization ID (e.g., o-abc123def4)",
+    ),
+  roleArn: z
+    .string()
+    .trim()
+    .min(1, "Role ARN is required")
+    .regex(
+      /^arn:aws:iam::\d{12}:role\//,
+      "Must be a valid IAM Role ARN (e.g., arn:aws:iam::123456789012:role/ProwlerOrgRole)",
+    ),
+  stackSetDeployed: z.boolean().refine((value) => value, {
+    message: "You must confirm the StackSet deployment before continuing.",
+  }),
+});
+
+type OrgSetupFormData = z.infer<typeof orgSetupSchema>;
 
 interface OrgSetupFormProps {
   onBack: () => void;
@@ -23,29 +62,346 @@ export function OrgSetupForm({
   onPhaseChange,
   initialPhase = ORG_SETUP_PHASE.DETAILS,
 }: OrgSetupFormProps) {
-  useEffect(() => {
-    onPhaseChange(initialPhase);
-  }, [initialPhase, onPhaseChange]);
+  const { data: session } = useSession();
+  const [isExternalIdCopied, setIsExternalIdCopied] = useState(false);
+  const stackSetExternalId = session?.tenantId ?? "";
+  const [setupPhase, setSetupPhase] = useState<OrgSetupPhase>(initialPhase);
+  const formId = "org-wizard-setup-form";
+
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isValid },
+    setError,
+    watch,
+  } = useForm<OrgSetupFormData>({
+    resolver: zodResolver(orgSetupSchema),
+    mode: "onChange",
+    reValidateMode: "onChange",
+    defaultValues: {
+      organizationName: "",
+      awsOrgId: "",
+      roleArn: "",
+      stackSetDeployed: false,
+    },
+  });
+  const awsOrgIdField = register("awsOrgId", {
+    setValueAs: (value: unknown) =>
+      typeof value === "string" ? value.toLowerCase() : value,
+  });
+
+  const awsOrgId = watch("awsOrgId") || "";
+  const isOrgIdValid = /^o-[a-z0-9]{10,32}$/.test(awsOrgId.trim());
+  const stackSetQuickLink =
+    stackSetExternalId &&
+    getAWSCredentialsTemplateLinks(stackSetExternalId).cloudformationQuickLink;
+
+  const { apiError, setApiError, submitOrganizationSetup } =
+    useOrgSetupSubmission({
+      stackSetExternalId,
+      onNext,
+      setFieldError: (field, message) => {
+        setError(field, { message });
+      },
+    });
 
   useEffect(() => {
+    onPhaseChange(setupPhase);
+  }, [onPhaseChange, setupPhase]);
+
+  useEffect(() => {
+    if (setupPhase === ORG_SETUP_PHASE.DETAILS) {
+      onFooterChange({
+        showBack: true,
+        backLabel: "Back",
+        onBack,
+        showAction: true,
+        actionLabel: "Next",
+        actionDisabled: !isOrgIdValid,
+        actionType: WIZARD_FOOTER_ACTION_TYPE.SUBMIT,
+        actionFormId: formId,
+      });
+      return;
+    }
+
     onFooterChange({
       showBack: true,
       backLabel: "Back",
-      onBack,
+      backDisabled: isSubmitting,
+      onBack: () => setSetupPhase(ORG_SETUP_PHASE.DETAILS),
       showAction: true,
-      actionLabel: "Continue",
-      actionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
-      onAction: onNext,
+      actionLabel: "Authenticate",
+      actionDisabled: isSubmitting || !isValid || !stackSetExternalId,
+      actionType: WIZARD_FOOTER_ACTION_TYPE.SUBMIT,
+      actionFormId: formId,
     });
-  }, [onBack, onFooterChange, onNext]);
+  }, [
+    formId,
+    isOrgIdValid,
+    isSubmitting,
+    isValid,
+    onBack,
+    onFooterChange,
+    stackSetExternalId,
+    setupPhase,
+  ]);
+
+  const handleContinueToAccess = () => {
+    setApiError(null);
+
+    if (!isOrgIdValid) {
+      setError("awsOrgId", {
+        message: awsOrgId.trim()
+          ? "Must be a valid AWS Organization ID (e.g., o-abc123def4)"
+          : "Organization ID is required",
+      });
+      return;
+    }
+
+    setSetupPhase(ORG_SETUP_PHASE.ACCESS);
+  };
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (setupPhase === ORG_SETUP_PHASE.DETAILS) {
+      event.preventDefault();
+      handleContinueToAccess();
+      return;
+    }
+
+    void handleSubmit((data) => submitOrganizationSetup(data))(event);
+  };
+
+  useEffect(() => {
+    if (!apiError) return;
+    document
+      .getElementById(formId)
+      ?.scrollIntoView({ block: "start", behavior: "smooth" });
+  }, [apiError, formId]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col justify-center gap-2 py-6">
-      <h3 className="text-base font-semibold">AWS Organizations</h3>
-      <p className="text-muted-foreground text-sm">
-        The full AWS Organizations setup step is included in the next chained
-        PR.
-      </p>
-    </div>
+    <form
+      id={formId}
+      onSubmit={handleFormSubmit}
+      className="flex flex-col gap-5"
+    >
+      {setupPhase === ORG_SETUP_PHASE.DETAILS && (
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center gap-4">
+            <AWSProviderBadge size={32} />
+            <h3 className="text-base font-semibold">
+              Amazon Web Services (AWS) / Organization Details
+            </h3>
+          </div>
+
+          <p className="text-muted-foreground text-sm">
+            Enter the Organization ID for the accounts you want to add to
+            Prowler.
+          </p>
+        </div>
+      )}
+
+      {setupPhase === ORG_SETUP_PHASE.ACCESS && (
+        <div className="flex flex-col gap-8">
+          <div className="flex items-center gap-4">
+            <AWSProviderBadge size={32} />
+            <h3 className="text-base font-semibold">
+              Amazon Web Services (AWS) / Authentication Details
+            </h3>
+          </div>
+        </div>
+      )}
+
+      {setupPhase === ORG_SETUP_PHASE.ACCESS && isSubmitting && (
+        <div className="flex min-h-[220px] items-center justify-center">
+          <div className="flex items-center gap-3 py-2">
+            <TreeSpinner className="size-6" />
+            <p className="text-sm font-medium">Gathering AWS Accounts...</p>
+          </div>
+        </div>
+      )}
+
+      {apiError && (
+        <Alert variant="error">
+          <AlertDescription className="text-text-error-primary">
+            {apiError}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {setupPhase === ORG_SETUP_PHASE.DETAILS && (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="awsOrgId" className="text-sm font-medium">
+              Organization ID
+            </label>
+            <Input
+              id="awsOrgId"
+              placeholder="e.g. o-123456789-abcdefg"
+              required
+              aria-required="true"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+              {...awsOrgIdField}
+              onInput={(event) => {
+                const loweredValue = event.currentTarget.value.toLowerCase();
+                if (event.currentTarget.value !== loweredValue) {
+                  event.currentTarget.value = loweredValue;
+                }
+              }}
+            />
+            {errors.awsOrgId && (
+              <span className="text-text-error-primary text-xs">
+                {errors.awsOrgId.message}
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="organizationName" className="text-sm font-medium">
+              Name (optional)
+            </label>
+            <Input
+              id="organizationName"
+              placeholder=""
+              {...register("organizationName")}
+            />
+            {errors.organizationName && (
+              <span className="text-text-error-primary text-xs">
+                {errors.organizationName.message}
+              </span>
+            )}
+          </div>
+
+          <p className="text-muted-foreground text-sm">
+            If left blank, Prowler will use the Organization name stored in AWS.
+          </p>
+        </div>
+      )}
+
+      {setupPhase === ORG_SETUP_PHASE.ACCESS && !isSubmitting && (
+        <div className="flex flex-col gap-8">
+          <div className="flex flex-col gap-4">
+            <p className="text-text-neutral-primary text-sm leading-7 font-normal">
+              1) Launch the Prowler CloudFormation StackSet in your AWS Console.
+            </p>
+            <Button
+              variant="outline"
+              size="lg"
+              className="border-border-input-primary bg-bg-input-primary text-button-tertiary hover:bg-bg-input-primary active:bg-bg-input-primary h-12 w-full justify-start"
+              disabled={!stackSetQuickLink}
+              asChild
+            >
+              <a
+                href={stackSetQuickLink || "#"}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="size-5" />
+                <span>
+                  Prowler CloudFormation StackSet for AWS Organizations
+                </span>
+              </a>
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <p className="text-text-neutral-primary text-sm leading-7 font-normal">
+              2) Use the following Prowler External ID parameter in the
+              StackSet.
+            </p>
+            <div className="flex items-center gap-3">
+              <span className="text-text-neutral-tertiary text-xs">
+                External ID:
+              </span>
+              <div className="bg-bg-neutral-tertiary border-border-input-primary flex h-10 max-w-full items-center gap-3 rounded-full border px-4">
+                <span className="truncate text-xs font-medium">
+                  {stackSetExternalId || "Loading organization external ID..."}
+                </span>
+                <button
+                  type="button"
+                  disabled={!stackSetExternalId}
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(stackSetExternalId);
+                      setIsExternalIdCopied(true);
+                      setTimeout(() => setIsExternalIdCopied(false), 1500);
+                    } catch {
+                      // Ignore clipboard errors (e.g., unsupported browser context).
+                    }
+                  }}
+                  className="text-text-neutral-secondary hover:text-text-neutral-primary shrink-0 transition-colors"
+                  aria-label="Copy external ID"
+                >
+                  {isExternalIdCopied ? (
+                    <Check className="size-4" />
+                  ) : (
+                    <Copy className="size-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <p className="text-text-neutral-primary text-sm leading-7 font-normal">
+              3) Copy the Prowler IAM Role ARN from AWS and confirm the StackSet
+              is successfully deployed by clicking the checkbox below.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="roleArn" className="text-sm font-medium">
+              Role ARN
+            </label>
+            <Input
+              id="roleArn"
+              placeholder="e.g. arn:aws:iam::123456789012:role/ProwlerOrgRole"
+              {...register("roleArn")}
+            />
+            {errors.roleArn && (
+              <span className="text-text-error-primary text-xs">
+                {errors.roleArn.message}
+              </span>
+            )}
+          </div>
+
+          <p className="text-text-neutral-tertiary text-sm">
+            * It may take up to 60 seconds for AWS to generate the IAM Role ARN
+          </p>
+
+          <div className="flex items-start gap-4">
+            <Controller
+              name="stackSetDeployed"
+              control={control}
+              render={({ field }) => (
+                <>
+                  <Checkbox
+                    id="stackSetDeployed"
+                    className="mt-0.5"
+                    checked={field.value}
+                    onCheckedChange={(checked) =>
+                      field.onChange(Boolean(checked))
+                    }
+                  />
+                  <label
+                    htmlFor="stackSetDeployed"
+                    className="text-text-neutral-primary text-sm leading-7 font-normal"
+                  >
+                    The StackSet has been successfully deployed in AWS
+                  </label>
+                </>
+              )}
+            />
+          </div>
+          {errors.stackSetDeployed && (
+            <span className="text-text-error-primary text-xs">
+              {errors.stackSetDeployed.message}
+            </span>
+          )}
+        </div>
+      )}
+    </form>
   );
 }

--- a/ui/components/providers/wizard/steps/credentials-step.test.tsx
+++ b/ui/components/providers/wizard/steps/credentials-step.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useProviderWizardStore } from "@/store/provider-wizard/store";
+import { PROVIDER_WIZARD_MODE } from "@/types/provider-wizard";
+
+import { CredentialsStep } from "./credentials-step";
+
+vi.mock("../../workflow/forms", () => ({
+  AddViaCredentialsForm: () => <div>add-via-credentials-form</div>,
+  AddViaRoleForm: () => <div>add-via-role-form</div>,
+  UpdateViaCredentialsForm: () => <div>update-via-credentials-form</div>,
+  UpdateViaRoleForm: () => <div>update-via-role-form</div>,
+}));
+
+vi.mock("../../workflow/forms/select-credentials-type/aws", () => ({
+  SelectViaAWS: () => <div>select-via-aws</div>,
+}));
+
+vi.mock("../../workflow/forms/select-credentials-type/alibabacloud", () => ({
+  SelectViaAlibabaCloud: () => <div>select-via-alibabacloud</div>,
+}));
+
+vi.mock("../../workflow/forms/select-credentials-type/cloudflare", () => ({
+  SelectViaCloudflare: () => <div>select-via-cloudflare</div>,
+}));
+
+vi.mock("../../workflow/forms/select-credentials-type/gcp", () => ({
+  AddViaServiceAccountForm: () => <div>add-via-service-account-form</div>,
+  SelectViaGCP: () => <div>select-via-gcp</div>,
+}));
+
+vi.mock("../../workflow/forms/select-credentials-type/github", () => ({
+  SelectViaGitHub: () => <div>select-via-github</div>,
+}));
+
+vi.mock("../../workflow/forms/select-credentials-type/m365", () => ({
+  SelectViaM365: () => <div>select-via-m365</div>,
+}));
+
+vi.mock("../../workflow/forms/update-via-service-account-key-form", () => ({
+  UpdateViaServiceAccountForm: () => (
+    <div>update-via-service-account-form</div>
+  ),
+}));
+
+describe("CredentialsStep", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    useProviderWizardStore.getState().reset();
+  });
+
+  it("renders update role form when secret already exists in add mode", () => {
+    // Given
+    useProviderWizardStore.setState({
+      providerId: "provider-1",
+      providerType: "aws",
+      providerUid: "111111111111",
+      providerAlias: "Production",
+      via: "role",
+      secretId: "secret-1",
+      mode: PROVIDER_WIZARD_MODE.ADD,
+    });
+
+    // When
+    render(
+      <CredentialsStep
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+        onFooterChange={vi.fn()}
+      />,
+    );
+
+    // Then
+    expect(screen.getByText("update-via-role-form")).toBeInTheDocument();
+    expect(screen.queryByText("add-via-role-form")).not.toBeInTheDocument();
+  });
+});

--- a/ui/components/providers/wizard/steps/credentials-step.test.tsx
+++ b/ui/components/providers/wizard/steps/credentials-step.test.tsx
@@ -39,9 +39,7 @@ vi.mock("../../workflow/forms/select-credentials-type/m365", () => ({
 }));
 
 vi.mock("../../workflow/forms/update-via-service-account-key-form", () => ({
-  UpdateViaServiceAccountForm: () => (
-    <div>update-via-service-account-form</div>
-  ),
+  UpdateViaServiceAccountForm: () => <div>update-via-service-account-form</div>,
 }));
 
 describe("CredentialsStep", () => {

--- a/ui/components/providers/wizard/steps/credentials-step.tsx
+++ b/ui/components/providers/wizard/steps/credentials-step.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 
 import { getProviderFormType } from "@/lib/provider-helpers";
 import { useProviderWizardStore } from "@/store/provider-wizard/store";
-import { PROVIDER_WIZARD_MODE } from "@/types/provider-wizard";
 import { ProviderType } from "@/types/providers";
 
 import {
@@ -39,7 +38,7 @@ export function CredentialsStep({
   onBack,
   onFooterChange,
 }: CredentialsStepProps) {
-  const { providerId, providerType, providerUid, via, secretId, mode, setVia } =
+  const { providerId, providerType, providerUid, via, secretId, setVia } =
     useProviderWizardStore();
   const [isFormLoading, setIsFormLoading] = useState(false);
   const [isFormValid, setIsFormValid] = useState(false);
@@ -50,8 +49,7 @@ export function CredentialsStep({
     providerType && providerId
       ? getProviderFormType(providerType, via || undefined)
       : null;
-  const shouldUseUpdateForms =
-    mode === PROVIDER_WIZARD_MODE.UPDATE && Boolean(secretId);
+  const shouldUseUpdateForms = Boolean(secretId);
 
   const handleBack = () => {
     if (via) {

--- a/ui/components/providers/wizard/steps/test-connection-step.test.tsx
+++ b/ui/components/providers/wizard/steps/test-connection-step.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useProviderWizardStore } from "@/store/provider-wizard/store";
+import { PROVIDER_WIZARD_MODE } from "@/types/provider-wizard";
+
+import { TestConnectionStep } from "./test-connection-step";
+
+const { getProviderMock } = vi.hoisted(() => ({
+  getProviderMock: vi.fn(),
+}));
+
+vi.mock("@/actions/providers", () => ({
+  getProvider: getProviderMock,
+}));
+
+vi.mock("../../workflow/forms/test-connection-form", () => ({
+  TestConnectionForm: () => <div data-testid="test-connection-form" />,
+}));
+
+describe("TestConnectionStep", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    getProviderMock.mockReset();
+    useProviderWizardStore.getState().reset();
+  });
+
+  it("stores provider secret id after loading provider data", async () => {
+    // Given
+    useProviderWizardStore.setState({
+      providerId: "provider-1",
+      providerType: "aws",
+      mode: PROVIDER_WIZARD_MODE.ADD,
+    });
+    getProviderMock.mockResolvedValue({
+      data: {
+        id: "provider-1",
+        attributes: {
+          uid: "111111111111",
+          provider: "aws",
+          alias: "Production",
+          connection: { connected: false, last_checked_at: null },
+          scanner_args: {},
+        },
+        relationships: {
+          secret: { data: { type: "provider-secrets", id: "secret-1" } },
+        },
+      },
+    });
+
+    // When
+    render(
+      <TestConnectionStep
+        onSuccess={vi.fn()}
+        onResetCredentials={vi.fn()}
+        onFooterChange={vi.fn()}
+      />,
+    );
+
+    // Then
+    await waitFor(() => {
+      expect(screen.getByTestId("test-connection-form")).toBeInTheDocument();
+    });
+    expect(useProviderWizardStore.getState().secretId).toBe("secret-1");
+  });
+});

--- a/ui/components/providers/wizard/steps/test-connection-step.tsx
+++ b/ui/components/providers/wizard/steps/test-connection-step.tsx
@@ -27,7 +27,8 @@ export function TestConnectionStep({
   onResetCredentials,
   onFooterChange,
 }: TestConnectionStepProps) {
-  const { providerId, providerType, mode } = useProviderWizardStore();
+  const { providerId, providerType, mode, setSecretId } =
+    useProviderWizardStore();
   const [providerData, setProviderData] =
     useState<TestConnectionProviderData | null>(null);
   const [isLoadingProvider, setIsLoadingProvider] = useState(true);
@@ -62,11 +63,15 @@ export function TestConnectionStep({
         setErrorMessage(
           response.errors[0]?.detail || "Failed to load provider.",
         );
+        setSecretId(null);
         setProviderData(null);
         setIsLoadingProvider(false);
         return;
       }
 
+      const resolvedSecretId =
+        response?.data?.relationships?.secret?.data?.id ?? null;
+      setSecretId(resolvedSecretId);
       setProviderData(response as TestConnectionProviderData);
       setIsLoadingProvider(false);
     }
@@ -76,7 +81,7 @@ export function TestConnectionStep({
     return () => {
       isMounted = false;
     };
-  }, [providerId, providerType]);
+  }, [providerId, providerType, setSecretId]);
 
   useEffect(() => {
     const canSubmit = !isLoadingProvider && !errorMessage && !!providerData;


### PR DESCRIPTION
### Context

PROWLER-1091 — PR 5/6 in the provider wizard chain. Base: PR 4 (#10156).

### Description

- **OrgSetupForm** (`org-setup-form.tsx`): Two-phase form — Details (org ID + name) → Access (CloudFormation StackSet deploy, external ID copy, Role ARN paste). Zod validation with lowercase normalization for AWS Org IDs
- **useOrgSetupSubmission** hook: Idempotent org lookup/create, secret management, discovery trigger with AbortController-based polling (3s intervals, 60 retries). Server error mapping to form fields
- **OrgAccountSelection** (`org-account-selection.tsx`): TreeView with checkbox selection, connection status icons, error tooltips. Selection locking during connection test phase
- **useOrgAccountSelectionFlow** hook: Apply discovery → concurrent connection testing (with `runWithConcurrencyLimit`) → retry only failed providers → advance on full success
- **OrgAccountTreeItem**: Custom tree node renderer with status indicators and error tooltips
- **OrgLaunchScan**: Scan schedule selector (daily/single) with toast action link to providers page
- **Utils**: `buildAccountToProviderMap`, `canAdvanceToLaunchStep`, `getLaunchableProviderIds`, `pollConnectionTask`

### Steps to review

1. **Setup form** — `org-setup-form.tsx` + `use-org-setup-submission.ts` — verify Zod schema, polling cancellation, error mapping
2. **Account selection** — `org-account-selection.tsx` + `use-org-account-selection-flow.ts` — apply, concurrent testing, retry logic, selection locking
3. **Utils** — `org-account-selection.utils.ts` — concurrency limiter, connection polling, provider mapping
4. **Launch** — `org-launch-scan.tsx` — schedule selector, toast with action link
5. **Tests** — All hook, component, and utility tests

### Checklist

#### UI
- [x] Polling uses AbortController for cleanup on unmount
- [x] Connection testing respects concurrency limit
- [x] Retry only tests failed providers
- [x] Organizations flow gated behind `NEXT_PUBLIC_IS_CLOUD_ENV`
- [x] Tests cover apply success/failure, retry, and selection changes

### Chain

| PR | Description | Status |
|----|-------------|--------|
| PR 1 | shadcn primitives + shared components | #10153 |
| PR 2 | Organization and wizard types + stores | #10154 |
| PR 3 | Server actions and adapters | #10155 |
| PR 4 | Provider wizard modal | #10156 |
| **→ PR 5** | AWS Organizations flow | This PR |
| PR 6 | E2E test updates | Next |

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.