### PR TITLE
chore(mcp_server): bump MCP Server package version to 0.4.0

### DIFF
--- a/mcp_server/prowler_mcp_server/__init__.py
+++ b/mcp_server/prowler_mcp_server/__init__.py
@@ -5,7 +5,7 @@ This package provides MCP tools for accessing:
 - Prowler Hub: All security artifacts (detections, remediations and frameworks) supported by Prowler
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __author__ = "Prowler Team"
 __email__ = "engineering@prowler.com"
 

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -11,7 +11,7 @@ description = "MCP server for Prowler ecosystem"
 name = "prowler-mcp"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.3.0"
+version = "0.4.0"
 
 [project.scripts]
 prowler-mcp = "prowler_mcp_server.main:main"


### PR DESCRIPTION
### Context

Bump the MCP Server package version to `0.4.0` to match the latest CHANGELOG.md entry, which includes the new Attack Paths tools added in #10145.

### Description

Updates the hardcoded version from `0.3.0` to `0.4.0` in:
- `mcp_server/pyproject.toml`
- `mcp_server/prowler_mcp_server/__init__.py`

### Steps to review

1. Verify version in `pyproject.toml` matches `0.4.0`
2. Verify `__version__` in `__init__.py` matches `0.4.0`
3. Confirm both align with the `[0.4.0]` entry in `mcp_server/CHANGELOG.md`

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.