### PR TITLE
feat(ui): add attack paths tools to Lighthouse allowed list

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - PDF report available for the CSA CCM compliance framework [(#10088)](https://github.com/prowler-cloud/prowler/pull/10088)
 - Cloudflare provider support [(#9910)](https://github.com/prowler-cloud/prowler/pull/9910)
 - CSV and PDF download buttons in compliance views [(#10093)](https://github.com/prowler-cloud/prowler/pull/10093)
+- Attack Paths tools added to Lighthouse AI workflow allowed list [(#10175)](https://github.com/prowler-cloud/prowler/pull/10175)
 
 ### 🔄 Changed
 

--- a/ui/lib/lighthouse/workflow.ts
+++ b/ui/lib/lighthouse/workflow.ts
@@ -80,6 +80,10 @@ const ALLOWED_TOOLS = new Set([
   "prowler_app_list_resources",
   "prowler_app_get_resource",
   "prowler_app_get_resources_overview",
+  // Attack Paths
+  "prowler_app_list_attack_paths_queries",
+  "prowler_app_list_attack_paths_scans",
+  "prowler_app_run_attack_paths_query",
 ]);
 
 /**


### PR DESCRIPTION
### Context

Enable the Lighthouse AI workflow to use Attack Paths MCP tools, allowing users to query and analyze attack paths directly through the AI assistant.

### Description

Added three Attack Paths tools to the `ALLOWED_TOOLS` set in the Lighthouse workflow configuration:
- `prowler_app_list_attack_paths_queries` - List available attack path queries
- `prowler_app_list_attack_paths_scans` - List attack path scans
- `prowler_app_run_attack_paths_query` - Execute an attack path query

### Steps to review

1. Review `ui/lib/lighthouse/workflow.ts` — the three new entries in `ALLOWED_TOOLS`
2. Verify the tool names match the MCP server tool definitions

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented.
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.