### PR TITLE
fix(ci): include E2E test paths in impact analysis module matching

### DIFF
--- a/.github/test-impact.yml
+++ b/.github/test-impact.yml
@@ -27,7 +27,7 @@ ignored:
     # IDE/Editor configs
     - .vscode/**
     - .idea/**
-    
+
     # Examples and contrib (not production code)
     - examples/**
     - contrib/**
@@ -272,6 +272,7 @@ modules:
       - ui/components/providers/**
       - ui/actions/providers/**
       - ui/app/**/providers/**
+      - ui/tests/providers/**
     tests: []
     e2e:
       - ui/tests/providers/**
@@ -281,6 +282,7 @@ modules:
       - ui/components/findings/**
       - ui/actions/findings/**
       - ui/app/**/findings/**
+      - ui/tests/findings/**
     tests: []
     e2e:
       - ui/tests/findings/**
@@ -290,6 +292,7 @@ modules:
       - ui/components/scans/**
       - ui/actions/scans/**
       - ui/app/**/scans/**
+      - ui/tests/scans/**
     tests: []
     e2e:
       - ui/tests/scans/**
@@ -299,6 +302,7 @@ modules:
       - ui/components/compliance/**
       - ui/actions/compliances/**
       - ui/app/**/compliance/**
+      - ui/tests/compliance/**
     tests: []
     e2e:
       - ui/tests/compliance/**
@@ -308,6 +312,8 @@ modules:
       - ui/components/auth/**
       - ui/actions/auth/**
       - ui/app/(auth)/**
+      - ui/tests/sign-in/**
+      - ui/tests/sign-up/**
     tests: []
     e2e:
       - ui/tests/sign-in/**
@@ -318,6 +324,7 @@ modules:
       - ui/components/invitations/**
       - ui/actions/invitations/**
       - ui/app/**/invitations/**
+      - ui/tests/invitations/**
     tests: []
     e2e:
       - ui/tests/invitations/**
@@ -327,6 +334,7 @@ modules:
       - ui/components/roles/**
       - ui/actions/roles/**
       - ui/app/**/roles/**
+      - ui/tests/roles/**
     tests: []
     e2e:
       - ui/tests/roles/**
@@ -336,6 +344,7 @@ modules:
       - ui/components/users/**
       - ui/actions/users/**
       - ui/app/**/users/**
+      - ui/tests/users/**
     tests: []
     e2e:
       - ui/tests/users/**
@@ -345,6 +354,7 @@ modules:
       - ui/components/integrations/**
       - ui/actions/integrations/**
       - ui/app/**/integrations/**
+      - ui/tests/integrations/**
     tests: []
     e2e:
       - ui/tests/integrations/**
@@ -354,6 +364,7 @@ modules:
       - ui/components/resources/**
       - ui/actions/resources/**
       - ui/app/**/resources/**
+      - ui/tests/resources/**
     tests: []
     e2e:
       - ui/tests/resources/**
@@ -361,6 +372,7 @@ modules:
   - name: ui-profile
     match:
       - ui/app/**/profile/**
+      - ui/tests/profile/**
     tests: []
     e2e:
       - ui/tests/profile/**
@@ -371,6 +383,7 @@ modules:
       - ui/actions/lighthouse/**
       - ui/app/**/lighthouse/**
       - ui/lib/lighthouse/**
+      - ui/tests/lighthouse/**
     tests: []
     e2e:
       - ui/tests/lighthouse/**
@@ -379,6 +392,7 @@ modules:
     match:
       - ui/components/overview/**
       - ui/actions/overview/**
+      - ui/tests/home/**
     tests: []
     e2e:
       - ui/tests/home/**
@@ -397,6 +411,7 @@ modules:
       - ui/components/attack-paths/**
       - ui/actions/attack-paths/**
       - ui/app/**/attack-paths/**
+      - ui/tests/attack-paths/**
     tests: []
     e2e:
       - ui/tests/attack-paths/**

--- a/.github/test-impact.yml
+++ b/.github/test-impact.yml
@@ -61,6 +61,8 @@ critical:
     - ui/types/**
     - ui/config/**
     - ui/middleware.ts
+    - ui/tsconfig.json
+    - ui/playwright.config.ts
 
     # CI/CD changes
     - .github/workflows/**
@@ -312,10 +314,12 @@ modules:
       - ui/components/auth/**
       - ui/actions/auth/**
       - ui/app/(auth)/**
+      - ui/tests/auth/**
       - ui/tests/sign-in/**
       - ui/tests/sign-up/**
     tests: []
     e2e:
+      - ui/tests/auth/**
       - ui/tests/sign-in/**
       - ui/tests/sign-up/**
 


### PR DESCRIPTION
### Context

The optimized E2E workflow (`ui-e2e-tests-v2.yml`) uses test impact analysis to run only the relevant E2E tests based on changed files. However, when **only test files** were modified (e.g., `ui/tests/providers/providers-page.ts`), the impact analysis found no matching module and silently skipped all E2E tests.

Real-world example: [this CI run](https://github.com/prowler-cloud/prowler/actions/runs/22396760585/job/64832311555) changed files in `ui/tests/auth/`, `ui/tests/invitations/`, and `ui/tests/providers/` — all E2E tests were skipped.

### Description

Each UI module in `test-impact.yml` had `match` patterns only for source code (`ui/components/**`, `ui/actions/**`, `ui/app/**`) but not for the test files themselves (`ui/tests/**`). This meant a PR that only modifies test files would match zero modules → `has-tests=false` → E2E job skipped entirely.

The fix adds each module's E2E test directory to its own `match` block, so changing a test file triggers the corresponding E2E suite. This is the most precise approach — a test change only runs its own module's tests, not all E2E.

### Steps to review

1. Review the `match` additions in `.github/test-impact.yml` — each UI module now includes its own `ui/tests/<feature>/**` path
2. Verify the mapping is correct (e.g., `ui-providers` matches `ui/tests/providers/**`, `ui-auth` matches `ui/tests/sign-in/**` and `ui/tests/sign-up/**`)
3. To validate locally:
   ```bash
   pip install pyyaml
   python .github/scripts/test-impact.py ui/tests/providers/some-test.spec.ts
   # Should output: ui-e2e=ui/tests/providers/**
   ```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.