### PR TITLE
feat(api): block attack-paths-scans custom queries and schema endpoints

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - OpenStack provider support [(#10003)](https://github.com/prowler-cloud/prowler/pull/10003)
 - PDF report for the CSA CCM compliance framework [(#10088)](https://github.com/prowler-cloud/prowler/pull/10088)
 - `image` provider support for container image scanning [(#10128)](https://github.com/prowler-cloud/prowler/pull/10128)
-- Attack Paths: Custom query and Cartography schema endpoints [(#10149)](https://github.com/prowler-cloud/prowler/pull/10149)
+- Attack Paths: Custom query and Cartography schema endpoints (temporarily blocked) [(#10149)](https://github.com/prowler-cloud/prowler/pull/10149)
 
 ### 🔄 Changed
 

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -4280,6 +4280,8 @@ class TestAttackPathsScanViewSet:
             }
         }
 
+    # TODO: Remove skip once queries/custom and schema endpoints are unblocked
+    @pytest.mark.skip(reason="Endpoint temporarily blocked")
     def test_run_custom_query_returns_graph(
         self,
         authenticated_client,
@@ -4337,6 +4339,7 @@ class TestAttackPathsScanViewSet:
         assert attributes["total_nodes"] == 1
         assert attributes["truncated"] is False
 
+    @pytest.mark.skip(reason="Endpoint temporarily blocked")
     def test_run_custom_query_returns_404_when_no_nodes(
         self,
         authenticated_client,
@@ -4378,6 +4381,7 @@ class TestAttackPathsScanViewSet:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    @pytest.mark.skip(reason="Endpoint temporarily blocked")
     def test_run_custom_query_returns_400_when_graph_not_ready(
         self,
         authenticated_client,
@@ -4404,6 +4408,7 @@ class TestAttackPathsScanViewSet:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "not available" in response.json()["errors"][0]["detail"]
 
+    @pytest.mark.skip(reason="Endpoint temporarily blocked")
     def test_run_custom_query_returns_403_for_write_query(
         self,
         authenticated_client,
@@ -4443,6 +4448,7 @@ class TestAttackPathsScanViewSet:
 
     # -- cartography_schema action ------------------------------------------------
 
+    @pytest.mark.skip(reason="Endpoint temporarily blocked")
     def test_cartography_schema_returns_urls(
         self,
         authenticated_client,
@@ -4492,6 +4498,7 @@ class TestAttackPathsScanViewSet:
         assert "schema.md" in attributes["schema_url"]
         assert "raw.githubusercontent.com" in attributes["raw_schema_url"]
 
+    @pytest.mark.skip(reason="Endpoint temporarily blocked")
     def test_cartography_schema_returns_404_when_no_metadata(
         self,
         authenticated_client,
@@ -4526,6 +4533,7 @@ class TestAttackPathsScanViewSet:
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert "No cartography schema metadata" in str(response.json())
 
+    @pytest.mark.skip(reason="Endpoint temporarily blocked")
     def test_cartography_schema_returns_400_when_graph_not_ready(
         self,
         authenticated_client,

--- a/api/src/backend/api/v1/urls.py
+++ b/api/src/backend/api/v1/urls.py
@@ -1,5 +1,7 @@
 from allauth.socialaccount.providers.saml.views import ACSView, MetadataView, SLSView
+from django.http import JsonResponse
 from django.urls import include, path
+from django.views.decorators.csrf import csrf_exempt
 from drf_spectacular.views import SpectacularRedocView
 from rest_framework_nested import routers
 
@@ -47,6 +49,16 @@ from api.v1.views import (
     UserRoleRelationshipView,
     UserViewSet,
 )
+
+
+@csrf_exempt
+def _blocked_endpoint(request, *args, **kwargs):
+    return JsonResponse(
+        {"errors": [{"detail": "This endpoint is not available."}]},
+        status=405,
+        content_type="application/vnd.api+json",
+    )
+
 
 router = routers.DefaultRouter(trailing_slash=False)
 
@@ -197,6 +209,17 @@ urlpatterns = [
     path("tokens/saml", SAMLTokenValidateView.as_view(), name="token-saml"),
     path("tokens/google", GoogleSocialLoginView.as_view(), name="token-google"),
     path("tokens/github", GithubSocialLoginView.as_view(), name="token-github"),
+    # TODO: Remove these blocked endpoints once they are properly tested
+    path(
+        "attack-paths-scans/<uuid:pk>/queries/custom",
+        _blocked_endpoint,
+        name="attack-paths-scans-queries-custom-blocked",
+    ),
+    path(
+        "attack-paths-scans/<uuid:pk>/schema",
+        _blocked_endpoint,
+        name="attack-paths-scans-schema-blocked",
+    ),
     path("", include(router.urls)),
     path("", include(tenants_router.urls)),
     path("", include(users_router.urls)),


### PR DESCRIPTION
### Context

We need to temporarily disable the `/api/v1/attack-paths-scans/{id}/queries/custom` and `/api/v1/attack-paths-scans/{id}/schema` endpoints until they are properly tested. All other attack-paths-scans endpoints remain fully functional.

### Description

Added two explicit URL path entries in `api/v1/urls.py` that intercept requests to the `queries/custom` and `schema` sub-routes **before** they reach the DRF router, returning a `405 Method Not Allowed` response with a JSON:API-compliant body.

These are temporary overrides — once the endpoints are properly tested, the blocked paths (and the helper function) will be removed to restore the original router behavior.

**Changes:**
- Added a `_blocked_endpoint` CSRF-exempt view that returns a 405 JSON:API response
- Registered explicit paths for `queries/custom` and `schema` before `router.urls` so they take priority
- Added a `TODO` comment documenting the intent to remove these overrides after testing

### Steps to review

1. Verify the blocked endpoints return 405:
   ```bash
   curl -X POST /api/v1/attack-paths-scans/<uuid>/queries/custom
   curl -X GET /api/v1/attack-paths-scans/<uuid>/schema
   ```
2. Verify the remaining attack-paths-scans endpoints still work normally:
   - `GET /api/v1/attack-paths-scans` (list)
   - `GET /api/v1/attack-paths-scans/<uuid>` (detail)
   - `GET /api/v1/attack-paths-scans/<uuid>/queries` (list queries)
   - `POST /api/v1/attack-paths-scans/<uuid>/queries/run` (run query)

<img width="500" height="236" alt="image" src="https://github.com/user-attachments/assets/325cf1c8-d7f7-4e48-872c-c8155ef59d1e" />

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### API (if applicable)
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.