### PR TITLE
fix(sdk): scope scan_id by provider and account

### DIFF
--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -57,8 +57,14 @@ class OCSF(Output):
             if not findings:
                 return
 
-            scan_id = _uuid7_from_timestamp(findings[0].timestamp)
+            scan_ids_by_provider = {}
             for finding in findings:
+                provider = finding.metadata.Provider
+                if provider not in scan_ids_by_provider:
+                    scan_ids_by_provider[provider] = _uuid7_from_timestamp(
+                        finding.timestamp
+                    )
+                scan_id = scan_ids_by_provider[provider]
                 finding_activity = ActivityID.Create
                 cloud_account_type = self.get_account_type_id_by_provider(
                     finding.metadata.Provider

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -57,14 +57,16 @@ class OCSF(Output):
             if not findings:
                 return
 
-            scan_ids_by_provider = {}
+            scan_ids_by_provider_account = {}
             for finding in findings:
                 provider = finding.metadata.Provider
-                if provider not in scan_ids_by_provider:
-                    scan_ids_by_provider[provider] = _uuid7_from_timestamp(
+                account_uid = finding.account_uid
+                scan_key = (provider, account_uid)
+                if scan_key not in scan_ids_by_provider_account:
+                    scan_ids_by_provider_account[scan_key] = _uuid7_from_timestamp(
                         finding.timestamp
                     )
-                scan_id = scan_ids_by_provider[provider]
+                scan_id = scan_ids_by_provider_account[scan_key]
                 finding_activity = ActivityID.Create
                 cloud_account_type = self.get_account_type_id_by_provider(
                     finding.metadata.Provider

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -123,6 +123,23 @@ class TestOCSF:
             1619600000, tz=timezone.utc
         )
 
+    def test_scan_id_is_unique_per_provider(self):
+        findings = [
+            generate_finding_output(provider="aws"),
+            generate_finding_output(provider="azure"),
+            generate_finding_output(provider="aws"),
+        ]
+
+        ocsf = OCSF(findings)
+
+        scan_ids = [finding.unmapped["scan_id"] for finding in ocsf.data]
+
+        assert UUID(scan_ids[0])
+        assert UUID(scan_ids[1])
+        assert UUID(scan_ids[2])
+        assert scan_ids[0] == scan_ids[2]
+        assert scan_ids[0] != scan_ids[1]
+
     def test_validate_ocsf(self):
         mock_file = StringIO()
         findings = [

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -123,11 +123,11 @@ class TestOCSF:
             1619600000, tz=timezone.utc
         )
 
-    def test_scan_id_is_unique_per_provider(self):
+    def test_scan_id_is_unique_per_provider_and_account(self):
         findings = [
-            generate_finding_output(provider="aws"),
-            generate_finding_output(provider="azure"),
-            generate_finding_output(provider="aws"),
+            generate_finding_output(provider="aws", account_uid="111111111111"),
+            generate_finding_output(provider="aws", account_uid="222222222222"),
+            generate_finding_output(provider="aws", account_uid="111111111111"),
         ]
 
         ocsf = OCSF(findings)


### PR DESCRIPTION
### Context
OCSF ingestion needs a distinct `scan_id` per provider account; multiple accounts under the same provider should not share a scan ID.

### Description
- Scope `scan_id` generation to `(provider, account_uid)`.
- Add test coverage for repeated accounts vs different accounts.

### Steps to review
- Run `poetry run pytest tests/lib/outputs/ocsf/ocsf_test.py -v`.
- Generate an OCSF export with multiple accounts under one provider and confirm `unmapped.scan_id` differs per `cloud.account.uid`.

### Checklist
<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI (if applicable)
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [ ] Ensure new entries are added to ui/CHANGELOG.md

#### API (if applicable)
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.