### PR TITLE
fix(ui): stabilize provider wizard modal and DataTable rendering

### DIFF
--- a/ui/app/(prowler)/providers/page.test.ts
+++ b/ui/app/(prowler)/providers/page.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+describe("providers page", () => {
+  it("does not use unstable Date.now keys for the providers DataTable", () => {
+    const currentDir = path.dirname(fileURLToPath(import.meta.url));
+    const pagePath = path.join(currentDir, "page.tsx");
+    const source = readFileSync(pagePath, "utf8");
+
+    expect(source).not.toContain("key={`providers-${Date.now()}`}");
+  });
+});

--- a/ui/app/(prowler)/providers/page.tsx
+++ b/ui/app/(prowler)/providers/page.tsx
@@ -104,7 +104,6 @@ const ProvidersTable = async ({
       <div className="grid grid-cols-12 gap-4">
         <div className="col-span-12">
           <DataTable
-            key={`providers-${Date.now()}`}
             columns={ColumnProviders}
             data={enrichedProviders || []}
             metadata={providersData?.meta}

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
@@ -188,4 +188,69 @@ describe("useProviderWizardController", () => {
     expect(result.current.wizardVariant).toBe("organizations");
     expect(result.current.orgCurrentStep).toBe(ORG_WIZARD_STEP.VALIDATE);
   });
+
+  it("does not rehydrate wizard state when initial data changes while modal remains open", async () => {
+    // Given
+    const onOpenChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({
+        open,
+        initialData,
+      }: {
+        open: boolean;
+        initialData?: {
+          providerId: string;
+          providerType: "gcp";
+          providerUid: string;
+          providerAlias: string;
+          secretId: string | null;
+          mode: "add" | "update";
+        };
+      }) =>
+        useProviderWizardController({
+          open,
+          onOpenChange,
+          initialData,
+        }),
+      {
+        initialProps: {
+          open: true,
+          initialData: {
+            providerId: "provider-1",
+            providerType: "gcp",
+            providerUid: "project-123",
+            providerAlias: "gcp-main",
+            secretId: null,
+            mode: PROVIDER_WIZARD_MODE.ADD,
+          },
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.currentStep).toBe(PROVIDER_WIZARD_STEP.CREDENTIALS);
+    });
+
+    act(() => {
+      useProviderWizardStore.getState().setVia("service-account");
+      result.current.setCurrentStep(PROVIDER_WIZARD_STEP.TEST);
+    });
+
+    // When: provider data refreshes while modal is still open
+    rerender({
+      open: true,
+      initialData: {
+        providerId: "provider-1",
+        providerType: "gcp",
+        providerUid: "project-123",
+        providerAlias: "gcp-main",
+        secretId: "secret-1",
+        mode: PROVIDER_WIZARD_MODE.UPDATE,
+      },
+    });
+
+    // Then: keep user progress in the current flow
+    expect(result.current.currentStep).toBe(PROVIDER_WIZARD_STEP.TEST);
+    expect(useProviderWizardStore.getState().via).toBe("service-account");
+  });
 });

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
@@ -11,16 +11,6 @@ import {
 
 import { useProviderWizardController } from "./use-provider-wizard-controller";
 
-const { pushMock } = vi.hoisted(() => ({
-  pushMock: vi.fn(),
-}));
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: pushMock,
-  }),
-}));
-
 vi.mock("next-auth/react", () => ({
   useSession: () => ({
     data: null,
@@ -30,9 +20,9 @@ vi.mock("next-auth/react", () => ({
 
 describe("useProviderWizardController", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     sessionStorage.clear();
     localStorage.clear();
-    pushMock.mockReset();
     useProviderWizardStore.getState().reset();
     useOrgSetupStore.getState().reset();
   });
@@ -131,7 +121,7 @@ describe("useProviderWizardController", () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it("closes and navigates when launch footer action is triggered", () => {
+  it("does not override launch footer config in the controller", () => {
     // Given
     const onOpenChange = vi.fn();
     const { result } = renderHook(() =>
@@ -146,15 +136,10 @@ describe("useProviderWizardController", () => {
       result.current.setCurrentStep(PROVIDER_WIZARD_STEP.LAUNCH);
     });
 
-    const { resolvedFooterConfig } = result.current;
-    act(() => {
-      resolvedFooterConfig.onAction?.();
-    });
-
     // Then
-    expect(pushMock).toHaveBeenCalledWith("/scans");
-    expect(onOpenChange).toHaveBeenCalledWith(false);
-    expect(result.current.currentStep).toBe(PROVIDER_WIZARD_STEP.CONNECT);
+    expect(result.current.resolvedFooterConfig.showAction).toBe(false);
+    expect(result.current.resolvedFooterConfig.showBack).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("does not reset organizations step when org store updates while modal is open", () => {

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { DOCS_URLS, getProviderHelpText } from "@/lib/external-urls";
 import { useOrgSetupStore } from "@/store/organizations/store";
@@ -64,6 +64,7 @@ export function useProviderWizardController({
   const initialVia = initialData?.via ?? null;
   const initialMode = initialData?.mode ?? null;
   const router = useRouter();
+  const hasHydratedForCurrentOpenRef = useRef(false);
   const [wizardVariant, setWizardVariant] = useState<WizardVariant>(
     WIZARD_VARIANT.PROVIDER,
   );
@@ -95,8 +96,14 @@ export function useProviderWizardController({
 
   useEffect(() => {
     if (!open) {
+      hasHydratedForCurrentOpenRef.current = false;
       return;
     }
+
+    if (hasHydratedForCurrentOpenRef.current) {
+      return;
+    }
+    hasHydratedForCurrentOpenRef.current = true;
 
     if (initialProviderId && initialProviderType && initialProviderUid) {
       setWizardVariant(WIZARD_VARIANT.PROVIDER);

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 import { DOCS_URLS, getProviderHelpText } from "@/lib/external-urls";
@@ -63,7 +62,6 @@ export function useProviderWizardController({
   const initialSecretId = initialData?.secretId ?? null;
   const initialVia = initialData?.via ?? null;
   const initialMode = initialData?.mode ?? null;
-  const router = useRouter();
   const hasHydratedForCurrentOpenRef = useRef(false);
   const [wizardVariant, setWizardVariant] = useState<WizardVariant>(
     WIZARD_VARIANT.PROVIDER,
@@ -205,25 +203,7 @@ export function useProviderWizardController({
   const docsLink = isProviderFlow
     ? getProviderHelpText(providerTypeHint ?? providerType ?? "").link
     : DOCS_URLS.AWS_ORGANIZATIONS;
-  const resolvedFooterConfig: WizardFooterConfig =
-    isProviderFlow && currentStep === PROVIDER_WIZARD_STEP.LAUNCH
-      ? {
-          showBack: true,
-          backLabel: "Back",
-          onBack: () => setCurrentStep(PROVIDER_WIZARD_STEP.TEST),
-          showSecondaryAction: false,
-          secondaryActionLabel: "",
-          secondaryActionVariant: "outline",
-          secondaryActionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
-          showAction: true,
-          actionLabel: "Go to scans",
-          actionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
-          onAction: () => {
-            handleClose();
-            router.push("/scans");
-          },
-        }
-      : footerConfig;
+  const resolvedFooterConfig: WizardFooterConfig = footerConfig;
   const modalTitle = getProviderWizardModalTitle(mode);
 
   return {

--- a/ui/components/providers/wizard/provider-wizard-modal.tsx
+++ b/ui/components/providers/wizard/provider-wizard-modal.tsx
@@ -13,7 +13,10 @@ import { ORG_SETUP_PHASE, ORG_WIZARD_STEP } from "@/types/organizations";
 import { PROVIDER_WIZARD_STEP } from "@/types/provider-wizard";
 
 import { useProviderWizardController } from "./hooks/use-provider-wizard-controller";
-import { getOrganizationsStepperOffset } from "./provider-wizard-modal.utils";
+import {
+  getOrganizationsStepperOffset,
+  getProviderWizardDocsDestination,
+} from "./provider-wizard-modal.utils";
 import { ConnectStep } from "./steps/connect-step";
 import { CredentialsStep } from "./steps/credentials-step";
 import { WIZARD_FOOTER_ACTION_TYPE } from "./steps/footer-controls";
@@ -62,6 +65,7 @@ export function ProviderWizardModal({
     enabled: open,
     refreshToken: scrollHintRefreshToken,
   });
+  const docsDestination = getProviderWizardDocsDestination(docsLink);
 
   return (
     <Modal
@@ -80,7 +84,7 @@ export function ProviderWizardModal({
           <Button variant="link" size="link-sm" className="h-auto p-0" asChild>
             <a href={docsLink} target="_blank" rel="noopener noreferrer">
               <ExternalLink className="size-3.5 shrink-0" />
-              <span>Prowler Docs</span>
+              <span>{`Prowler Docs (${docsDestination})`}</span>
             </a>
           </Button>
         </div>
@@ -136,7 +140,11 @@ export function ProviderWizardModal({
             )}
 
             {isProviderFlow && currentStep === PROVIDER_WIZARD_STEP.LAUNCH && (
-              <LaunchStep />
+              <LaunchStep
+                onBack={() => setCurrentStep(PROVIDER_WIZARD_STEP.TEST)}
+                onClose={handleClose}
+                onFooterChange={setFooterConfig}
+              />
             )}
 
             {!isProviderFlow && orgCurrentStep === ORG_WIZARD_STEP.SETUP && (

--- a/ui/components/providers/wizard/provider-wizard-modal.utils.test.ts
+++ b/ui/components/providers/wizard/provider-wizard-modal.utils.test.ts
@@ -4,6 +4,7 @@ import { ORG_SETUP_PHASE, ORG_WIZARD_STEP } from "@/types/organizations";
 import { PROVIDER_WIZARD_MODE } from "@/types/provider-wizard";
 
 import {
+  getProviderWizardDocsDestination,
   getOrganizationsStepperOffset,
   getProviderWizardModalTitle,
 } from "./provider-wizard-modal.utils";
@@ -48,5 +49,23 @@ describe("getProviderWizardModalTitle", () => {
     const title = getProviderWizardModalTitle(PROVIDER_WIZARD_MODE.UPDATE);
 
     expect(title).toBe("Update Provider Credentials");
+  });
+});
+
+describe("getProviderWizardDocsDestination", () => {
+  it("returns a compact provider label for short provider docs links", () => {
+    const destination = getProviderWizardDocsDestination(
+      "https://goto.prowler.com/provider-aws",
+    );
+
+    expect(destination).toBe("aws");
+  });
+
+  it("returns a compact destination label for long docs links", () => {
+    const destination = getProviderWizardDocsDestination(
+      "https://docs.prowler.com/user-guide/tutorials/prowler-cloud-aws-organizations",
+    );
+
+    expect(destination).toBe("aws-organizations");
   });
 });

--- a/ui/components/providers/wizard/provider-wizard-modal.utils.test.ts
+++ b/ui/components/providers/wizard/provider-wizard-modal.utils.test.ts
@@ -4,8 +4,8 @@ import { ORG_SETUP_PHASE, ORG_WIZARD_STEP } from "@/types/organizations";
 import { PROVIDER_WIZARD_MODE } from "@/types/provider-wizard";
 
 import {
-  getProviderWizardDocsDestination,
   getOrganizationsStepperOffset,
+  getProviderWizardDocsDestination,
   getProviderWizardModalTitle,
 } from "./provider-wizard-modal.utils";
 

--- a/ui/components/providers/wizard/provider-wizard-modal.utils.ts
+++ b/ui/components/providers/wizard/provider-wizard-modal.utils.ts
@@ -27,3 +27,23 @@ export function getProviderWizardModalTitle(mode: ProviderWizardMode) {
 
   return "Adding A Cloud Provider";
 }
+
+export function getProviderWizardDocsDestination(docsLink: string) {
+  try {
+    const parsed = new URL(docsLink);
+    const pathSegments = parsed.pathname
+      .split("/")
+      .filter((segment) => segment.length > 0);
+    const lastSegment = pathSegments.at(-1);
+
+    if (!lastSegment) {
+      return parsed.hostname;
+    }
+
+    return lastSegment
+      .replace(/^provider-/, "")
+      .replace(/^prowler-cloud-/, "");
+  } catch {
+    return docsLink;
+  }
+}

--- a/ui/components/providers/wizard/provider-wizard-modal.utils.ts
+++ b/ui/components/providers/wizard/provider-wizard-modal.utils.ts
@@ -40,9 +40,7 @@ export function getProviderWizardDocsDestination(docsLink: string) {
       return parsed.hostname;
     }
 
-    return lastSegment
-      .replace(/^provider-/, "")
-      .replace(/^prowler-cloud-/, "");
+    return lastSegment.replace(/^provider-/, "").replace(/^prowler-cloud-/, "");
   } catch {
     return docsLink;
   }

--- a/ui/components/providers/wizard/steps/launch-step.test.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.test.tsx
@@ -50,7 +50,11 @@ describe("LaunchStep", () => {
     scheduleDailyMock.mockResolvedValue({ data: { id: "scan-1" } });
 
     render(
-      <LaunchStep onBack={vi.fn()} onClose={onClose} onFooterChange={onFooterChange} />,
+      <LaunchStep
+        onBack={vi.fn()}
+        onClose={onClose}
+        onFooterChange={onFooterChange}
+      />,
     );
 
     await waitFor(() => {

--- a/ui/components/providers/wizard/steps/launch-step.test.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.test.tsx
@@ -1,0 +1,81 @@
+import { act, render, waitFor } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useProviderWizardStore } from "@/store/provider-wizard/store";
+
+import { LaunchStep } from "./launch-step";
+
+const { scheduleDailyMock, scanOnDemandMock, toastMock } = vi.hoisted(() => ({
+  scheduleDailyMock: vi.fn(),
+  scanOnDemandMock: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock("@/actions/scans", () => ({
+  scheduleDaily: scheduleDailyMock,
+  scanOnDemand: scanOnDemandMock,
+}));
+
+vi.mock("@/components/ui", () => ({
+  ToastAction: ({ children, ...props }: ComponentProps<"button">) => (
+    <button {...props}>{children}</button>
+  ),
+  useToast: () => ({
+    toast: toastMock,
+  }),
+}));
+
+describe("LaunchStep", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    scheduleDailyMock.mockReset();
+    scanOnDemandMock.mockReset();
+    toastMock.mockReset();
+    useProviderWizardStore.getState().reset();
+  });
+
+  it("launches a daily scan and shows toast", async () => {
+    // Given
+    const onClose = vi.fn();
+    const onFooterChange = vi.fn();
+    useProviderWizardStore.setState({
+      providerId: "provider-1",
+      providerType: "gcp",
+      providerUid: "project-123",
+      mode: "add",
+    });
+
+    scheduleDailyMock.mockResolvedValue({ data: { id: "scan-1" } });
+
+    render(
+      <LaunchStep onBack={vi.fn()} onClose={onClose} onFooterChange={onFooterChange} />,
+    );
+
+    await waitFor(() => {
+      expect(onFooterChange).toHaveBeenCalled();
+    });
+
+    // When
+    const initialFooterConfig = onFooterChange.mock.calls.at(-1)?.[0];
+    await act(async () => {
+      initialFooterConfig.onAction?.();
+    });
+
+    // Then
+    await waitFor(() => {
+      expect(scheduleDailyMock).toHaveBeenCalledTimes(1);
+    });
+
+    const sentFormData = scheduleDailyMock.mock.calls[0]?.[0] as FormData;
+    expect(sentFormData.get("providerId")).toBe("provider-1");
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(scanOnDemandMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Scan Launched",
+      }),
+    );
+  });
+});

--- a/ui/components/providers/wizard/steps/launch-step.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.tsx
@@ -4,8 +4,6 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 
 import { scanOnDemand, scheduleDaily } from "@/actions/scans";
-import { TreeSpinner } from "@/components/shadcn/tree-view/tree-spinner";
-import { TreeStatusIcon } from "@/components/shadcn/tree-view/tree-status-icon";
 import {
   Select,
   SelectContent,
@@ -13,6 +11,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/shadcn/select/select";
+import { TreeSpinner } from "@/components/shadcn/tree-view/tree-spinner";
+import { TreeStatusIcon } from "@/components/shadcn/tree-view/tree-status-icon";
 import { ToastAction, useToast } from "@/components/ui";
 import { useProviderWizardStore } from "@/store/provider-wizard/store";
 import { TREE_ITEM_STATUS } from "@/types/tree";
@@ -35,7 +35,11 @@ interface LaunchStepProps {
   onFooterChange: (config: WizardFooterConfig) => void;
 }
 
-export function LaunchStep({ onBack, onClose, onFooterChange }: LaunchStepProps) {
+export function LaunchStep({
+  onBack,
+  onClose,
+  onFooterChange,
+}: LaunchStepProps) {
   const { toast } = useToast();
   const { providerId } = useProviderWizardStore();
   const [isLaunching, setIsLaunching] = useState(false);
@@ -135,7 +139,9 @@ export function LaunchStep({ onBack, onClose, onFooterChange }: LaunchStepProps)
         <p className="text-text-neutral-secondary text-sm">Scan schedule</p>
         <Select
           value={scheduleOption}
-          onValueChange={(value) => setScheduleOption(value as ScanScheduleOption)}
+          onValueChange={(value) =>
+            setScheduleOption(value as ScanScheduleOption)
+          }
           disabled={isLaunching || !providerId}
         >
           <SelectTrigger className="w-full max-w-[376px]">

--- a/ui/components/providers/wizard/steps/launch-step.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.tsx
@@ -1,15 +1,156 @@
 "use client";
 
-import { CheckCircle2 } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 
-export function LaunchStep() {
+import { scanOnDemand, scheduleDaily } from "@/actions/scans";
+import { TreeSpinner } from "@/components/shadcn/tree-view/tree-spinner";
+import { TreeStatusIcon } from "@/components/shadcn/tree-view/tree-status-icon";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/shadcn/select/select";
+import { ToastAction, useToast } from "@/components/ui";
+import { useProviderWizardStore } from "@/store/provider-wizard/store";
+import { TREE_ITEM_STATUS } from "@/types/tree";
+
+import {
+  WIZARD_FOOTER_ACTION_TYPE,
+  WizardFooterConfig,
+} from "./footer-controls";
+
+const SCAN_SCHEDULE = {
+  DAILY: "daily",
+  SINGLE: "single",
+} as const;
+
+type ScanScheduleOption = (typeof SCAN_SCHEDULE)[keyof typeof SCAN_SCHEDULE];
+
+interface LaunchStepProps {
+  onBack: () => void;
+  onClose: () => void;
+  onFooterChange: (config: WizardFooterConfig) => void;
+}
+
+export function LaunchStep({ onBack, onClose, onFooterChange }: LaunchStepProps) {
+  const { toast } = useToast();
+  const { providerId } = useProviderWizardStore();
+  const [isLaunching, setIsLaunching] = useState(false);
+  const [scheduleOption, setScheduleOption] = useState<ScanScheduleOption>(
+    SCAN_SCHEDULE.DAILY,
+  );
+  const launchActionRef = useRef<() => void>(() => {});
+
+  const handleLaunchScan = async () => {
+    if (!providerId) {
+      return;
+    }
+
+    setIsLaunching(true);
+    const formData = new FormData();
+    formData.set("providerId", providerId);
+    const result =
+      scheduleOption === SCAN_SCHEDULE.DAILY
+        ? await scheduleDaily(formData)
+        : await scanOnDemand(formData);
+
+    if (result?.error) {
+      setIsLaunching(false);
+      toast({
+        variant: "destructive",
+        title: "Unable to launch scan",
+        description: String(result.error),
+      });
+      return;
+    }
+
+    setIsLaunching(false);
+    onClose();
+    toast({
+      title: "Scan Launched",
+      description:
+        scheduleOption === SCAN_SCHEDULE.DAILY
+          ? "Daily scan scheduled successfully."
+          : "Single scan launched successfully.",
+      action: (
+        <ToastAction altText="Go to scans" asChild>
+          <Link href="/scans">Go to scans</Link>
+        </ToastAction>
+      ),
+    });
+  };
+
+  launchActionRef.current = () => {
+    void handleLaunchScan();
+  };
+
+  useEffect(() => {
+    onFooterChange({
+      showBack: true,
+      backLabel: "Back",
+      backDisabled: isLaunching,
+      onBack,
+      showAction: true,
+      actionLabel: isLaunching ? "Launching scans..." : "Launch scan",
+      actionDisabled: isLaunching || !providerId,
+      actionType: WIZARD_FOOTER_ACTION_TYPE.BUTTON,
+      onAction: () => {
+        launchActionRef.current();
+      },
+    });
+  }, [isLaunching, onBack, onFooterChange, providerId]);
+
+  if (isLaunching) {
+    return (
+      <div className="flex min-h-[320px] items-center justify-center">
+        <div className="flex items-center gap-3 py-2">
+          <TreeSpinner className="size-6" />
+          <p className="text-sm font-medium">Launching scans...</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex min-h-[320px] flex-col items-center justify-center gap-4 text-center">
-      <CheckCircle2 className="text-success size-12" />
-      <h3 className="text-xl font-semibold">Provider connected successfully</h3>
-      <p className="text-muted-foreground text-sm">
-        Continue with the action button to go to scans.
+    <div className="flex min-h-0 flex-1 flex-col gap-6">
+      <div className="flex items-center gap-3">
+        <TreeStatusIcon status={TREE_ITEM_STATUS.SUCCESS} className="size-6" />
+        <h3 className="text-sm font-semibold">Connection validated!</h3>
+      </div>
+
+      <p className="text-text-neutral-secondary text-sm">
+        Choose how you want to launch scans for this provider.
       </p>
+
+      {!providerId && (
+        <p className="text-text-error-primary text-sm">
+          Provider data is missing. Go back and test the connection again.
+        </p>
+      )}
+
+      <div className="flex flex-col gap-4">
+        <p className="text-text-neutral-secondary text-sm">Scan schedule</p>
+        <Select
+          value={scheduleOption}
+          onValueChange={(value) => setScheduleOption(value as ScanScheduleOption)}
+          disabled={isLaunching || !providerId}
+        >
+          <SelectTrigger className="w-full max-w-[376px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={SCAN_SCHEDULE.DAILY}>
+              Scan Daily (every 24 hours)
+            </SelectItem>
+            <SelectItem value={SCAN_SCHEDULE.SINGLE}>
+              Run a single scan (no recurring schedule)
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
     </div>
   );
 }

--- a/ui/components/providers/wizard/steps/test-connection-step.tsx
+++ b/ui/components/providers/wizard/steps/test-connection-step.tsx
@@ -92,7 +92,9 @@ export function TestConnectionStep({
       backDisabled: isFormLoading,
       onBack: onResetCredentials,
       showAction: canSubmit,
-      actionLabel: isFormLoading ? "Checking connection..." : "Check connection",
+      actionLabel: isFormLoading
+        ? "Checking connection..."
+        : "Check connection",
       actionDisabled: isFormLoading,
       actionType: WIZARD_FOOTER_ACTION_TYPE.SUBMIT,
       actionFormId: formId,

--- a/ui/components/providers/wizard/steps/test-connection-step.tsx
+++ b/ui/components/providers/wizard/steps/test-connection-step.tsx
@@ -92,10 +92,7 @@ export function TestConnectionStep({
       backDisabled: isFormLoading,
       onBack: onResetCredentials,
       showAction: canSubmit,
-      actionLabel:
-        mode === PROVIDER_WIZARD_MODE.UPDATE
-          ? "Check connection"
-          : "Launch scan",
+      actionLabel: isFormLoading ? "Checking connection..." : "Check connection",
       actionDisabled: isFormLoading,
       actionType: WIZARD_FOOTER_ACTION_TYPE.SUBMIT,
       actionFormId: formId,

--- a/ui/components/providers/workflow/forms/test-connection-form.tsx
+++ b/ui/components/providers/workflow/forms/test-connection-form.tsx
@@ -207,9 +207,7 @@ export const TestConnectionForm = ({
         className="flex flex-col gap-4"
       >
         <div className="text-left">
-          <div className="mb-2 text-xl font-medium">
-            Check connection
-          </div>
+          <div className="mb-2 text-xl font-medium">Check connection</div>
           <p className="text-small text-default-500 py-2">
             {!isUpdated
               ? "After a successful connection, continue to the launch step to configure and start your scan."

--- a/ui/components/providers/workflow/forms/test-connection-form.tsx
+++ b/ui/components/providers/workflow/forms/test-connection-form.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Checkbox } from "@heroui/checkbox";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Icon } from "@iconify/react";
 import { Loader2 } from "lucide-react";
@@ -14,9 +13,8 @@ import {
   checkConnectionProvider,
   deleteCredentials,
 } from "@/actions/providers";
-import { scanOnDemand, scheduleDaily } from "@/actions/scans";
 import { getTask } from "@/actions/task/tasks";
-import { CheckIcon, RocketIcon } from "@/components/icons";
+import { CheckIcon } from "@/components/icons";
 import { Button } from "@/components/shadcn";
 import { useToast } from "@/components/ui";
 import { Form } from "@/components/ui/form";
@@ -83,7 +81,6 @@ export const TestConnectionForm = ({
     error: string | null;
   } | null>(null);
   const [isResettingCredentials, setIsResettingCredentials] = useState(false);
-  const [isRedirecting, setIsRedirecting] = useState(false);
 
   const formSchema = testConnectionFormSchema;
 
@@ -91,7 +88,6 @@ export const TestConnectionForm = ({
     resolver: zodResolver(formSchema),
     defaultValues: {
       providerId,
-      runOnce: false,
     },
   });
 
@@ -149,44 +145,12 @@ export const TestConnectionForm = ({
         }
 
         if (connected && !isUpdated) {
-          try {
-            // Check if the runOnce checkbox is checked
-            const runOnce = form.watch("runOnce");
-
-            let data;
-
-            if (runOnce) {
-              data = await scanOnDemand(formData);
-            } else {
-              data = await scheduleDaily(formData);
-            }
-
-            if (data.error) {
-              setApiErrorMessage(data.error);
-              form.setError("providerId", {
-                type: "server",
-                message: data.error,
-              });
-              toast({
-                variant: "destructive",
-                title: "Oops! Something went wrong",
-                description: data.error,
-              });
-            } else {
-              if (onSuccess) {
-                onSuccess();
-                return;
-              }
-
-              setIsRedirecting(true);
-              router.push("/scans");
-            }
-          } catch (_error) {
-            form.setError("providerId", {
-              type: "server",
-              message: "An unexpected error occurred. Please try again.",
-            });
+          if (onSuccess) {
+            onSuccess();
+            return;
           }
+
+          return router.push("/providers");
         } else {
           setConnectionStatus({
             connected: false,
@@ -235,25 +199,6 @@ export const TestConnectionForm = ({
     }
   };
 
-  if (isRedirecting) {
-    return (
-      <div className="flex flex-col items-center justify-center gap-6 py-12">
-        <div className="relative">
-          <div className="bg-primary/20 h-24 w-24 animate-pulse rounded-full" />
-          <div className="border-primary absolute inset-0 h-24 w-24 animate-spin rounded-full border-4 border-t-transparent" />
-        </div>
-        <div className="text-center">
-          <p className="text-primary text-xl font-medium">
-            Scan initiated successfully
-          </p>
-          <p className="text-small mt-2 font-bold text-gray-500">
-            Redirecting to scans job details...
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <Form {...form}>
       <form
@@ -263,13 +208,11 @@ export const TestConnectionForm = ({
       >
         <div className="text-left">
           <div className="mb-2 text-xl font-medium">
-            {!isUpdated
-              ? "Check connection and launch scan"
-              : "Check connection"}
+            Check connection
           </div>
           <p className="text-small text-default-500 py-2">
             {!isUpdated
-              ? "After a successful connection, a scan will automatically run every 24 hours. To run a single scan instead, select the checkbox below."
+              ? "After a successful connection, continue to the launch step to configure and start your scan."
               : "A successful connection will redirect you to the providers page."}
           </p>
         </div>
@@ -308,20 +251,6 @@ export const TestConnectionForm = ({
           providerAlias={providerData.data.attributes.alias}
           providerUID={providerData.data.attributes.uid}
         />
-
-        {!isUpdated && !connectionStatus?.error && (
-          <Checkbox
-            {...form.register("runOnce")}
-            isSelected={!!form.watch("runOnce")}
-            classNames={{
-              label: "text-small",
-              wrapper: "checkbox-update",
-            }}
-            color="default"
-          >
-            Run a single scan (no recurring schedule).
-          </Checkbox>
-        )}
 
         {isUpdated && !connectionStatus?.error && (
           <p className="text-small text-default-500 py-2">
@@ -372,13 +301,13 @@ export const TestConnectionForm = ({
                 {isLoading ? (
                   <Loader2 className="animate-spin" />
                 ) : (
-                  !isUpdated && <RocketIcon size={24} />
+                  <CheckIcon size={24} />
                 )}
                 {isLoading
-                  ? "Loading"
+                  ? "Checking"
                   : isUpdated
                     ? "Check connection"
-                    : "Launch scan"}
+                    : "Continue"}
               </Button>
             )}
           </div>

--- a/ui/tests/scans/scans-page.ts
+++ b/ui/tests/scans/scans-page.ts
@@ -38,6 +38,9 @@ export class ScansPage extends BasePage {
 
   async verifyPageLoaded(): Promise<void> {
     // Verify the scans page is loaded
+    if (!this.page.url().includes("/scans")) {
+      await this.goto();
+    }
 
     await expect(this.page).toHaveTitle(/Prowler/);
     await expect(this.scanTable).toBeVisible();


### PR DESCRIPTION
### Context

Fixes two stability issues in the providers page introduced with the provider wizard modal feature:
1. The providers DataTable was using `Date.now()` as a React key, forcing a full re-mount on every render cycle.
2. The wizard controller hook re-hydrated wizard state whenever props changed—even while the modal was open—resetting user progress mid-flow.

### Description

- **Remove unstable `Date.now()` key from providers DataTable**: This key caused the table to destroy and recreate its DOM on every render, losing scroll position, selection state, and triggering unnecessary work. React's default keying is correct here since there's a single DataTable instance.
- **Add hydration guard to `useProviderWizardController`**: Introduced a `hasHydratedForCurrentOpenRef` ref that ensures initial data is applied only once per modal open cycle. When the modal closes, the ref resets. This prevents background data refreshes (e.g., SWR revalidation, Server Component re-renders) from overwriting the user's in-progress wizard state.
- **Added regression tests** for both fixes: a source-level assertion against the `Date.now()` anti-pattern and a `renderHook` test proving wizard state survives prop changes while the modal remains open.

### Steps to review

1. Review `ui/app/(prowler)/providers/page.tsx` — confirm `key` prop removal from DataTable (line ~107)
2. Review `ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts` — check the `hasHydratedForCurrentOpenRef` guard logic (lines 67, 99-104)
3. Review `ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx` — verify the new "does not rehydrate" test case
4. Review `ui/app/(prowler)/providers/page.test.ts` — verify the regression test for `Date.now()` key

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.