### PR TITLE
feat(m365): enhance entra_legacy_authentication_blocked security check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - CIS 6.0 for the AWS provider [(#10127)](https://github.com/prowler-cloud/prowler/pull/10127)
 - `entra_require_mfa_for_management_api` check for m365 provider [(#10150)](https://github.com/prowler-cloud/prowler/pull/10150)
 - OpenStack provider multiple regions support [(#10135)](https://github.com/prowler-cloud/prowler/pull/10135)
+- `entra_legacy_authentication_blocked` check for m365 provider [(#10196)](https://github.com/prowler-cloud/prowler/pull/10196)
 
 ### 🔄 Changed
 

--- a/prowler/providers/m365/services/entra/entra_legacy_authentication_blocked/entra_legacy_authentication_blocked.metadata.json
+++ b/prowler/providers/m365/services/entra/entra_legacy_authentication_blocked/entra_legacy_authentication_blocked.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "m365",
   "CheckID": "entra_legacy_authentication_blocked",
-  "CheckTitle": "Ensure that Conditional Access policy blocks legacy authentication",
+  "CheckTitle": "Conditional Access policy blocks legacy authentication for all users and cloud apps",
   "CheckType": [],
   "ServiceName": "entra",
   "SubServiceName": "",
@@ -9,23 +9,28 @@
   "Severity": "critical",
   "ResourceType": "Conditional Access Policy",
   "ResourceGroup": "IAM",
-  "Description": "Ensure that Conditional Access policy blocks legacy authentication in Microsoft Entra ID to enforce modern authentication methods and protect against credential-stuffing and brute-force attacks.",
-  "Risk": "Legacy authentication protocols do not support MFA, making them vulnerable to credential-stuffing and brute-force attacks. Attackers commonly exploit these protocols to bypass security controls and gain unauthorized access.",
-  "RelatedUrl": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-block-legacy-authentication",
+  "Description": "A Conditional Access policy in Microsoft Entra ID blocks **legacy authentication** protocols (IMAP, POP3, SMTP, MAPI) by targeting `exchangeActiveSync` and `other` client app types for all users and all cloud apps.\n\nThe policy must be in an **enabled** state with a **block** grant control to be effective.",
+  "Risk": "Legacy authentication protocols do not support **MFA**, making them the primary vector for **password spray attacks** (99%+ use legacy auth). Attackers exploit protocols like IMAP, POP3, and SMTP to bypass Conditional Access controls and gain unauthorized access to user accounts.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-block-legacy-authentication",
+    "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication"
+  ],
   "Remediation": {
     "Code": {
       "CLI": "",
       "NativeIaC": "",
-      "Other": "1. Navigate to the Microsoft Entra admin center https://entra.microsoft.com. 2. Click expand Protection > Conditional Access select Policies. 3. Create a new policy by selecting New policy. Under Users include All users. Under Target resources include All cloud apps and do not create any exclusions. Under Conditions select Client apps and check the boxes for Exchange ActiveSync clients and Other clients. Under Grant select Block Access. Click Select. 4. Set the policy On and click Create.",
+      "Other": "1. Navigate to the Microsoft Entra admin center (https://entra.microsoft.com)\n2. Go to **Protection** > **Conditional Access** > **Policies**\n3. Select **New policy**\n4. Under **Users**, include **All users**\n5. Under **Target resources**, include **All cloud apps**\n6. Under **Conditions** > **Client apps**, check **Exchange ActiveSync clients** and **Other clients**\n7. Under **Grant**, select **Block access**\n8. Set the policy to **On** and click **Create**",
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Enforce Conditional Access policies to block legacy authentication across all users in Microsoft Entra ID. Ensure all applications and devices use modern authentication methods such as OAuth 2.0. For necessary exceptions (e.g., multifunction printers), configure secure alternatives following Microsoft's mail flow best practices.",
-      "Url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/policy-block-legacy-authentication"
+      "Text": "Block legacy authentication protocols using a Conditional Access policy targeting all users and all cloud apps. Apply the **zero trust** principle by enforcing modern authentication methods (OAuth 2.0) and disabling legacy protocols that cannot support MFA.",
+      "Url": "https://hub.prowler.com/check/entra_legacy_authentication_blocked"
     }
   },
   "Categories": [
-    "e3"
+    "e3",
+    "identity-access"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/m365/services/entra/entra_legacy_authentication_blocked/entra_legacy_authentication_blocked.py
+++ b/prowler/providers/m365/services/entra/entra_legacy_authentication_blocked/entra_legacy_authentication_blocked.py
@@ -8,16 +8,20 @@ from prowler.providers.m365.services.entra.entra_service import (
 
 
 class entra_legacy_authentication_blocked(Check):
-    """Check if at least one Conditional Access policy blocks legacy authentication.
+    """Check if a Conditional Access policy blocks legacy authentication for all users and cloud apps.
 
-    This check ensures that at least one Conditional Access policy blocks legacy authentication.
+    This check verifies that an enabled Conditional Access policy exists that blocks
+    legacy authentication protocols (Exchange ActiveSync and other legacy clients)
+    targeting all users and all cloud applications.
+    - PASS: An enabled policy blocks legacy authentication for all users and cloud apps.
+    - FAIL: No enabled policy blocks legacy authentication, or the policy is in report-only mode.
     """
 
     def execute(self) -> list[CheckReportM365]:
-        """Execute the check to ensure that at least one Conditional Access policy blocks legacy authentication.
+        """Execute the legacy authentication blocking check.
 
         Returns:
-            list[CheckReportM365]: A list containing the results of the check.
+            A list of reports containing the result of the check.
         """
         findings = []
         report = CheckReportM365(
@@ -47,7 +51,8 @@ class entra_legacy_authentication_blocked(Check):
             if (
                 ClientAppType.EXCHANGE_ACTIVE_SYNC
                 not in policy.conditions.client_app_types
-                or ClientAppType.OTHER_CLIENTS not in policy.conditions.client_app_types
+                or ClientAppType.OTHER_CLIENTS
+                not in policy.conditions.client_app_types
             ):
                 continue
 

--- a/tests/providers/m365/services/entra/entra_legacy_authentication_blocked/entra_legacy_authentication_blocked_test.py
+++ b/tests/providers/m365/services/entra/entra_legacy_authentication_blocked/entra_legacy_authentication_blocked_test.py
@@ -18,6 +18,17 @@ from prowler.providers.m365.services.entra.entra_service import (
 )
 from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
 
+DEFAULT_SESSION_CONTROLS = SessionControls(
+    persistent_browser=PersistentBrowser(is_enabled=False, mode="always"),
+    sign_in_frequency=SignInFrequency(
+        is_enabled=False,
+        frequency=None,
+        type=None,
+        interval=SignInFrequencyInterval.EVERY_TIME,
+    ),
+    application_enforced_restrictions=ApplicationEnforcedRestrictions(is_enabled=False),
+)
+
 
 class Test_entra_legacy_authentication_blocked:
     def test_entra_no_conditional_access_policies(self):
@@ -107,20 +118,7 @@ class Test_entra_legacy_authentication_blocked:
                         ],
                         operator=GrantControlOperator.AND,
                     ),
-                    session_controls=SessionControls(
-                        persistent_browser=PersistentBrowser(
-                            is_enabled=False, mode="always"
-                        ),
-                        sign_in_frequency=SignInFrequency(
-                            is_enabled=False,
-                            frequency=None,
-                            type=None,
-                            interval=SignInFrequencyInterval.EVERY_TIME,
-                        ),
-                        application_enforced_restrictions=ApplicationEnforcedRestrictions(
-                            is_enabled=False
-                        ),
-                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
                     state=ConditionalAccessPolicyState.DISABLED,
                 )
             }
@@ -192,20 +190,7 @@ class Test_entra_legacy_authentication_blocked:
                         ],
                         operator=GrantControlOperator.AND,
                     ),
-                    session_controls=SessionControls(
-                        persistent_browser=PersistentBrowser(
-                            is_enabled=False, mode="always"
-                        ),
-                        sign_in_frequency=SignInFrequency(
-                            is_enabled=False,
-                            frequency=None,
-                            type=None,
-                            interval=SignInFrequencyInterval.EVERY_TIME,
-                        ),
-                        application_enforced_restrictions=ApplicationEnforcedRestrictions(
-                            is_enabled=False
-                        ),
-                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
                     state=ConditionalAccessPolicyState.ENABLED_FOR_REPORTING,
                 )
             }
@@ -280,20 +265,7 @@ class Test_entra_legacy_authentication_blocked:
                         ],
                         operator=GrantControlOperator.AND,
                     ),
-                    session_controls=SessionControls(
-                        persistent_browser=PersistentBrowser(
-                            is_enabled=False, mode="always"
-                        ),
-                        sign_in_frequency=SignInFrequency(
-                            is_enabled=False,
-                            frequency=None,
-                            type=None,
-                            interval=SignInFrequencyInterval.EVERY_TIME,
-                        ),
-                        application_enforced_restrictions=ApplicationEnforcedRestrictions(
-                            is_enabled=False
-                        ),
-                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
                     state=ConditionalAccessPolicyState.ENABLED,
                 )
             }
@@ -312,4 +284,466 @@ class Test_entra_legacy_authentication_blocked:
             )
             assert result[0].resource_name == display_name
             assert result[0].resource_id == id
+            assert result[0].location == "global"
+
+    def test_entra_block_legacy_authentication_missing_client_app_types(self):
+        id = str(uuid4())
+        display_name = "Test"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked import (
+                entra_legacy_authentication_blocked,
+            )
+            from prowler.providers.m365.services.entra.entra_service import (
+                ConditionalAccessPolicy,
+            )
+
+            entra_client.conditional_access_policies = {
+                id: ConditionalAccessPolicy(
+                    id=id,
+                    display_name=display_name,
+                    conditions=Conditions(
+                        application_conditions=ApplicationsConditions(
+                            included_applications=["All"],
+                            excluded_applications=[],
+                            included_user_actions=[],
+                        ),
+                        user_conditions=UsersConditions(
+                            included_groups=[],
+                            excluded_groups=[],
+                            included_users=["All"],
+                            excluded_users=[],
+                            included_roles=[],
+                            excluded_roles=[],
+                        ),
+                        client_app_types=[
+                            ClientAppType.EXCHANGE_ACTIVE_SYNC,
+                        ],
+                        user_risk_levels=[],
+                    ),
+                    grant_controls=GrantControls(
+                        built_in_controls=[
+                            ConditionalAccessGrantControl.BLOCK,
+                        ],
+                        operator=GrantControlOperator.AND,
+                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
+                    state=ConditionalAccessPolicyState.ENABLED,
+                )
+            }
+
+            check = entra_legacy_authentication_blocked()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "No Conditional Access Policy blocks legacy authentication."
+            )
+            assert result[0].resource == {}
+            assert result[0].resource_name == "Conditional Access Policies"
+            assert result[0].resource_id == "conditionalAccessPolicies"
+
+    def test_entra_block_legacy_authentication_missing_exchange_active_sync(self):
+        id = str(uuid4())
+        display_name = "Test"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked import (
+                entra_legacy_authentication_blocked,
+            )
+            from prowler.providers.m365.services.entra.entra_service import (
+                ConditionalAccessPolicy,
+            )
+
+            entra_client.conditional_access_policies = {
+                id: ConditionalAccessPolicy(
+                    id=id,
+                    display_name=display_name,
+                    conditions=Conditions(
+                        application_conditions=ApplicationsConditions(
+                            included_applications=["All"],
+                            excluded_applications=[],
+                            included_user_actions=[],
+                        ),
+                        user_conditions=UsersConditions(
+                            included_groups=[],
+                            excluded_groups=[],
+                            included_users=["All"],
+                            excluded_users=[],
+                            included_roles=[],
+                            excluded_roles=[],
+                        ),
+                        client_app_types=[
+                            ClientAppType.OTHER_CLIENTS,
+                        ],
+                        user_risk_levels=[],
+                    ),
+                    grant_controls=GrantControls(
+                        built_in_controls=[
+                            ConditionalAccessGrantControl.BLOCK,
+                        ],
+                        operator=GrantControlOperator.AND,
+                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
+                    state=ConditionalAccessPolicyState.ENABLED,
+                )
+            }
+
+            check = entra_legacy_authentication_blocked()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "No Conditional Access Policy blocks legacy authentication."
+            )
+            assert result[0].resource == {}
+            assert result[0].resource_name == "Conditional Access Policies"
+            assert result[0].resource_id == "conditionalAccessPolicies"
+
+    def test_entra_block_legacy_authentication_not_all_users(self):
+        id = str(uuid4())
+        display_name = "Test"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked import (
+                entra_legacy_authentication_blocked,
+            )
+            from prowler.providers.m365.services.entra.entra_service import (
+                ConditionalAccessPolicy,
+            )
+
+            entra_client.conditional_access_policies = {
+                id: ConditionalAccessPolicy(
+                    id=id,
+                    display_name=display_name,
+                    conditions=Conditions(
+                        application_conditions=ApplicationsConditions(
+                            included_applications=["All"],
+                            excluded_applications=[],
+                            included_user_actions=[],
+                        ),
+                        user_conditions=UsersConditions(
+                            included_groups=[],
+                            excluded_groups=[],
+                            included_users=["user-id-123"],
+                            excluded_users=[],
+                            included_roles=[],
+                            excluded_roles=[],
+                        ),
+                        client_app_types=[
+                            ClientAppType.EXCHANGE_ACTIVE_SYNC,
+                            ClientAppType.OTHER_CLIENTS,
+                        ],
+                        user_risk_levels=[],
+                    ),
+                    grant_controls=GrantControls(
+                        built_in_controls=[
+                            ConditionalAccessGrantControl.BLOCK,
+                        ],
+                        operator=GrantControlOperator.AND,
+                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
+                    state=ConditionalAccessPolicyState.ENABLED,
+                )
+            }
+
+            check = entra_legacy_authentication_blocked()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "No Conditional Access Policy blocks legacy authentication."
+            )
+            assert result[0].resource == {}
+            assert result[0].resource_name == "Conditional Access Policies"
+            assert result[0].resource_id == "conditionalAccessPolicies"
+
+    def test_entra_block_legacy_authentication_not_all_apps(self):
+        id = str(uuid4())
+        display_name = "Test"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked import (
+                entra_legacy_authentication_blocked,
+            )
+            from prowler.providers.m365.services.entra.entra_service import (
+                ConditionalAccessPolicy,
+            )
+
+            entra_client.conditional_access_policies = {
+                id: ConditionalAccessPolicy(
+                    id=id,
+                    display_name=display_name,
+                    conditions=Conditions(
+                        application_conditions=ApplicationsConditions(
+                            included_applications=["app-id-123"],
+                            excluded_applications=[],
+                            included_user_actions=[],
+                        ),
+                        user_conditions=UsersConditions(
+                            included_groups=[],
+                            excluded_groups=[],
+                            included_users=["All"],
+                            excluded_users=[],
+                            included_roles=[],
+                            excluded_roles=[],
+                        ),
+                        client_app_types=[
+                            ClientAppType.EXCHANGE_ACTIVE_SYNC,
+                            ClientAppType.OTHER_CLIENTS,
+                        ],
+                        user_risk_levels=[],
+                    ),
+                    grant_controls=GrantControls(
+                        built_in_controls=[
+                            ConditionalAccessGrantControl.BLOCK,
+                        ],
+                        operator=GrantControlOperator.AND,
+                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
+                    state=ConditionalAccessPolicyState.ENABLED,
+                )
+            }
+
+            check = entra_legacy_authentication_blocked()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "No Conditional Access Policy blocks legacy authentication."
+            )
+            assert result[0].resource == {}
+            assert result[0].resource_name == "Conditional Access Policies"
+            assert result[0].resource_id == "conditionalAccessPolicies"
+
+    def test_entra_block_legacy_authentication_no_block_grant(self):
+        id = str(uuid4())
+        display_name = "Test"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked import (
+                entra_legacy_authentication_blocked,
+            )
+            from prowler.providers.m365.services.entra.entra_service import (
+                ConditionalAccessPolicy,
+            )
+
+            entra_client.conditional_access_policies = {
+                id: ConditionalAccessPolicy(
+                    id=id,
+                    display_name=display_name,
+                    conditions=Conditions(
+                        application_conditions=ApplicationsConditions(
+                            included_applications=["All"],
+                            excluded_applications=[],
+                            included_user_actions=[],
+                        ),
+                        user_conditions=UsersConditions(
+                            included_groups=[],
+                            excluded_groups=[],
+                            included_users=["All"],
+                            excluded_users=[],
+                            included_roles=[],
+                            excluded_roles=[],
+                        ),
+                        client_app_types=[
+                            ClientAppType.EXCHANGE_ACTIVE_SYNC,
+                            ClientAppType.OTHER_CLIENTS,
+                        ],
+                        user_risk_levels=[],
+                    ),
+                    grant_controls=GrantControls(
+                        built_in_controls=[
+                            ConditionalAccessGrantControl.MFA,
+                        ],
+                        operator=GrantControlOperator.AND,
+                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
+                    state=ConditionalAccessPolicyState.ENABLED,
+                )
+            }
+
+            check = entra_legacy_authentication_blocked()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == "No Conditional Access Policy blocks legacy authentication."
+            )
+            assert result[0].resource == {}
+            assert result[0].resource_name == "Conditional Access Policies"
+            assert result[0].resource_id == "conditionalAccessPolicies"
+
+    def test_entra_block_legacy_authentication_multiple_policies_report_only_and_enabled(
+        self,
+    ):
+        report_only_id = str(uuid4())
+        enabled_id = str(uuid4())
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_legacy_authentication_blocked.entra_legacy_authentication_blocked import (
+                entra_legacy_authentication_blocked,
+            )
+            from prowler.providers.m365.services.entra.entra_service import (
+                ConditionalAccessPolicy,
+            )
+
+            entra_client.conditional_access_policies = {
+                report_only_id: ConditionalAccessPolicy(
+                    id=report_only_id,
+                    display_name="Report Only Policy",
+                    conditions=Conditions(
+                        application_conditions=ApplicationsConditions(
+                            included_applications=["All"],
+                            excluded_applications=[],
+                            included_user_actions=[],
+                        ),
+                        user_conditions=UsersConditions(
+                            included_groups=[],
+                            excluded_groups=[],
+                            included_users=["All"],
+                            excluded_users=[],
+                            included_roles=[],
+                            excluded_roles=[],
+                        ),
+                        client_app_types=[
+                            ClientAppType.EXCHANGE_ACTIVE_SYNC,
+                            ClientAppType.OTHER_CLIENTS,
+                        ],
+                        user_risk_levels=[],
+                    ),
+                    grant_controls=GrantControls(
+                        built_in_controls=[
+                            ConditionalAccessGrantControl.BLOCK,
+                        ],
+                        operator=GrantControlOperator.AND,
+                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
+                    state=ConditionalAccessPolicyState.ENABLED_FOR_REPORTING,
+                ),
+                enabled_id: ConditionalAccessPolicy(
+                    id=enabled_id,
+                    display_name="Enabled Block Policy",
+                    conditions=Conditions(
+                        application_conditions=ApplicationsConditions(
+                            included_applications=["All"],
+                            excluded_applications=[],
+                            included_user_actions=[],
+                        ),
+                        user_conditions=UsersConditions(
+                            included_groups=[],
+                            excluded_groups=[],
+                            included_users=["All"],
+                            excluded_users=[],
+                            included_roles=[],
+                            excluded_roles=[],
+                        ),
+                        client_app_types=[
+                            ClientAppType.EXCHANGE_ACTIVE_SYNC,
+                            ClientAppType.OTHER_CLIENTS,
+                        ],
+                        user_risk_levels=[],
+                    ),
+                    grant_controls=GrantControls(
+                        built_in_controls=[
+                            ConditionalAccessGrantControl.BLOCK,
+                        ],
+                        operator=GrantControlOperator.AND,
+                    ),
+                    session_controls=DEFAULT_SESSION_CONTROLS,
+                    state=ConditionalAccessPolicyState.ENABLED,
+                ),
+            }
+
+            check = entra_legacy_authentication_blocked()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == "Conditional Access Policy 'Enabled Block Policy' blocks legacy authentication."
+            )
+            assert (
+                result[0].resource
+                == entra_client.conditional_access_policies[enabled_id].dict()
+            )
+            assert result[0].resource_name == "Enabled Block Policy"
+            assert result[0].resource_id == enabled_id
             assert result[0].location == "global"


### PR DESCRIPTION
### Context

Legacy authentication protocols (IMAP, POP3, SMTP, MAPI) do not support multi-factor authentication, making them the primary attack vector for password spray attacks — over 99% of which exploit legacy auth. Attackers routinely target these protocols to bypass Conditional Access controls and gain unauthorized access to user accounts, leading to data exfiltration, lateral movement, and full tenant compromise.

### Description

This PR enhances the existing `entra_legacy_authentication_blocked` check to validate that a Conditional Access policy in Microsoft Entra ID effectively blocks legacy authentication. The check verifies that an **enabled** policy targets **all users** and **all cloud apps**, includes both `exchangeActiveSync` and `other` client app types, and applies a **block** grant control. Policies in report-only mode are flagged as FAIL since they do not actively enforce the block. The metadata has been updated with detailed risk context, step-by-step remediation guidance, and relevant Microsoft documentation links. Unit tests have been expanded to cover all pass/fail scenarios including report-only policies.

### Steps to review

1. Review the check implementation at `prowler/providers/m365/services/entra/entra_legacy_authentication_blocked/`
2. Review the metadata file for correct severity, remediation, and compliance mappings
3. Review compliance framework mappings in `prowler/compliance/m365/` to ensure the check is correctly mapped to relevant requirements
4. Run the check tests: `poetry run pytest tests/providers/m365/services/entra/entra_legacy_authentication_blocked/ -v`
5. **Run the check against a real environment** (if possible):
   ```bash
   prowler m365 --check entra_legacy_authentication_blocked
   ```

### Related Issues

https://prowlerpro.atlassian.net/browse/PROWLER-1140

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **Yes**
    - If so, do we need to update permissions for the provider? Please review this carefully.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.