### PR TITLE
refactor(m365): rename conditional access policy checks to include policy prefix

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - `entra_default_app_management_policy_enabled` check for M365 provider [(#9898)](https://github.com/prowler-cloud/prowler/pull/9898)
 - `Google Workspace` provider support with Directory service including 1 security check [(#10022)](https://github.com/prowler-cloud/prowler/pull/10022)
-- `entra_app_enforced_restrictions` check for M365 provider [(#10058)](https://github.com/prowler-cloud/prowler/pull/10058)
+- `entra_conditional_access_policy_app_enforced_restrictions` check for M365 provider [(#10058)](https://github.com/prowler-cloud/prowler/pull/10058)
 - `entra_app_registration_no_unused_privileged_permissions` check for m365 provider [(#10080)](https://github.com/prowler-cloud/prowler/pull/10080)
 - `defenderidentity_health_issues_no_open` check for M365 provider [(#10087)](https://github.com/prowler-cloud/prowler/pull/10087)
 - `organization_verified_badge` check for GitHub provider [(#10033)](https://github.com/prowler-cloud/prowler/pull/10033)
@@ -34,7 +34,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Add file descriptor limits (`ulimits`) to Docker Compose worker services to prevent `Too many open files` errors [(#10107)](https://github.com/prowler-cloud/prowler/pull/10107)
 - SecNumCloud compliance framework for the AWS provider [(#10117)](https://github.com/prowler-cloud/prowler/pull/10117)
 - CIS 6.0 for the AWS provider [(#10127)](https://github.com/prowler-cloud/prowler/pull/10127)
-- `entra_require_mfa_for_management_api` check for m365 provider [(#10150)](https://github.com/prowler-cloud/prowler/pull/10150)
+- `entra_conditional_access_policy_require_mfa_for_management_api` check for m365 provider [(#10150)](https://github.com/prowler-cloud/prowler/pull/10150)
 - OpenStack provider multiple regions support [(#10135)](https://github.com/prowler-cloud/prowler/pull/10135)
 
 ### 🔄 Changed

--- a/prowler/compliance/azure/c5_azure.json
+++ b/prowler/compliance/azure/c5_azure.json
@@ -74,7 +74,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_invite_only_for_admin_roles",
         "iam_custom_role_has_permissions_to_administer_resource_locks",
         "iam_role_user_access_admin_restricted",
@@ -94,7 +94,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_default_users_cannot_create_security_groups",
         "iam_custom_role_has_permissions_to_administer_resource_locks",
         "iam_role_user_access_admin_restricted",
@@ -286,7 +286,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_default_users_cannot_create_security_groups",
         "entra_policy_guest_invite_only_for_admin_roles",
         "entra_policy_user_consent_for_verified_apps",
@@ -709,7 +709,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_users_access_restrictions",
         "entra_user_with_vm_access_has_mfa",
         "iam_custom_role_has_permissions_to_administer_resource_locks",
@@ -2122,7 +2122,7 @@
         "monitor_alert_delete_public_ip_address_rule",
         "aks_clusters_public_access_disabled",
         "app_function_access_keys_configured",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_users_access_restrictions",
         "entra_user_with_vm_access_has_mfa",
         "iam_role_user_access_admin_restricted",
@@ -3497,7 +3497,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_user_with_vm_access_has_mfa",
         "iam_custom_role_has_permissions_to_administer_resource_locks",
         "iam_role_user_access_admin_restricted",
@@ -4522,7 +4522,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_invite_only_for_admin_roles",
         "entra_policy_guest_users_access_restrictions",
         "entra_user_with_vm_access_has_mfa",
@@ -4894,7 +4894,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_users_access_restrictions",
         "entra_user_with_vm_access_has_mfa",
         "iam_custom_role_has_permissions_to_administer_resource_locks",
@@ -4917,7 +4917,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_users_access_restrictions",
         "entra_user_with_vm_access_has_mfa",
         "iam_custom_role_has_permissions_to_administer_resource_locks",
@@ -5053,7 +5053,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"
       ]
@@ -5298,7 +5298,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa",
         "iam_role_user_access_admin_restricted",
@@ -5346,7 +5346,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_users_access_restrictions",
         "entra_policy_user_consent_for_verified_apps",
         "entra_user_with_vm_access_has_mfa",
@@ -5429,7 +5429,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_user_with_vm_access_has_mfa"
       ]
     },
@@ -5518,7 +5518,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"
       ]
@@ -5557,7 +5557,7 @@
         "app_function_not_publicly_accessible",
         "containerregistry_not_publicly_accessible",
         "containerregistry_uses_private_link",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_users_access_restrictions",
         "entra_user_with_vm_access_has_mfa",
         "iam_role_user_access_admin_restricted",
@@ -5598,7 +5598,7 @@
         "app_function_not_publicly_accessible",
         "containerregistry_not_publicly_accessible",
         "containerregistry_uses_private_link",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_users_access_restrictions",
         "entra_user_with_vm_access_has_mfa",
         "iam_role_user_access_admin_restricted",
@@ -9010,7 +9010,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"
@@ -9029,7 +9029,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_privileged_user_has_mfa"
       ]
     },
@@ -9240,7 +9240,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_policy_guest_invite_only_for_admin_roles",
         "entra_policy_guest_users_access_restrictions",
         "iam_custom_role_has_permissions_to_administer_resource_locks",

--- a/prowler/compliance/azure/ccc_azure.json
+++ b/prowler/compliance/azure/ccc_azure.json
@@ -1414,7 +1414,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_privileged_user_has_mfa",
         "iam_role_user_access_admin_restricted",
@@ -5135,7 +5135,7 @@
       "Checks": [
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_security_defaults_enabled",
         "entra_user_with_vm_access_has_mfa"
       ]
@@ -5201,7 +5201,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_security_defaults_enabled"
@@ -5266,7 +5266,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_security_defaults_enabled"
@@ -5331,7 +5331,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"
@@ -5411,7 +5411,7 @@
         "keyvault_rbac_enabled",
         "keyvault_private_endpoints",
         "keyvault_access_only_through_private_endpoints",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_security_defaults_enabled",
@@ -5506,7 +5506,7 @@
         "aks_clusters_public_access_disabled",
         "app_function_not_publicly_accessible",
         "entra_global_admin_in_less_than_five_users",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_trusted_named_locations_exists",
@@ -5571,7 +5571,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "iam_role_user_access_admin_restricted",
@@ -5681,7 +5681,7 @@
         "network_ssh_internet_access_restricted",
         "network_udp_internet_access_restricted",
         "vm_jit_access_enabled",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
@@ -5845,7 +5845,7 @@
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "keyvault_rbac_enabled",
         "vm_jit_access_enabled",
         "vm_linux_enforce_ssh_authentication"

--- a/prowler/compliance/azure/cis_2.1_azure.json
+++ b/prowler/compliance/azure/cis_2.1_azure.json
@@ -688,7 +688,7 @@
       "Id": "1.2.6",
       "Description": "Ensure Multifactor Authentication is Required for Windows Azure Service Management API",
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ],
       "Attributes": [
         {

--- a/prowler/compliance/azure/cis_3.0_azure.json
+++ b/prowler/compliance/azure/cis_3.0_azure.json
@@ -729,7 +729,7 @@
       "Id": "2.2.7",
       "Description": "Ensure Multi-factor Authentication is Required for Windows Azure Service Management API",
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ],
       "Attributes": [
         {

--- a/prowler/compliance/azure/cis_4.0_azure.json
+++ b/prowler/compliance/azure/cis_4.0_azure.json
@@ -1013,7 +1013,7 @@
       "Id": "6.2.6",
       "Description": "Ensure that multifactor authentication is required for Windows Azure Service Management API",
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ],
       "Attributes": [
         {

--- a/prowler/compliance/azure/cis_5.0_azure.json
+++ b/prowler/compliance/azure/cis_5.0_azure.json
@@ -449,7 +449,7 @@
       "Id": "5.2.6",
       "Description": "Ensure that multifactor authentication is required for Windows Azure Service Management API",
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ],
       "Attributes": [
         {

--- a/prowler/compliance/azure/csa_ccm_4.0_azure.json
+++ b/prowler/compliance/azure/csa_ccm_4.0_azure.json
@@ -3703,7 +3703,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_user_with_vm_access_has_mfa",
         "iam_role_user_access_admin_restricted",
@@ -3921,7 +3921,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_security_defaults_enabled",

--- a/prowler/compliance/azure/ens_rd2022_azure.json
+++ b/prowler/compliance/azure/ens_rd2022_azure.json
@@ -279,7 +279,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ]
     },
     {
@@ -329,7 +329,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ]
     },
     {
@@ -484,7 +484,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ]
     },
     {

--- a/prowler/compliance/azure/fedramp_20x_ksi_low_azure.json
+++ b/prowler/compliance/azure/fedramp_20x_ksi_low_azure.json
@@ -89,7 +89,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_policy_default_users_cannot_create_security_groups",

--- a/prowler/compliance/azure/hipaa_azure.json
+++ b/prowler/compliance/azure/hipaa_azure.json
@@ -142,7 +142,7 @@
         "entra_privileged_user_has_mfa",
         "entra_non_privileged_user_has_mfa",
         "entra_security_defaults_enabled",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_user_with_vm_access_has_mfa",
         "network_flow_log_captured_sent",
         "app_http_logs_enabled"
@@ -730,7 +730,7 @@
         "entra_security_defaults_enabled",
         "entra_privileged_user_has_mfa",
         "entra_non_privileged_user_has_mfa",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_user_with_vm_access_has_mfa",
         "entra_trusted_named_locations_exists",
         "sqlserver_azuread_administrator_enabled",

--- a/prowler/compliance/azure/iso27001_2022_azure.json
+++ b/prowler/compliance/azure/iso27001_2022_azure.json
@@ -35,7 +35,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_policy_default_users_cannot_create_security_groups",
@@ -307,7 +307,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"

--- a/prowler/compliance/azure/mitre_attack_azure.json
+++ b/prowler/compliance/azure/mitre_attack_azure.json
@@ -212,7 +212,7 @@
       "Description": "Adversaries may obtain and abuse credentials of existing accounts as a means of gaining Initial Access, Persistence, Privilege Escalation, or Defense Evasion. Compromised credentials may be used to bypass access controls placed on various resources on systems within the network and may even be used for persistent access to remote systems and externally available services, such as VPNs, Outlook Web Access, network devices, and remote desktop.[1] Compromised credentials may also grant an adversary increased privilege to specific systems or access to restricted areas of the network. Adversaries may choose not to use malware or tools in conjunction with the legitimate access those credentials provide to make it harder to detect their presence.",
       "TechniqueURL": "https://attack.mitre.org/techniques/T1078/",
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_policy_default_users_cannot_create_security_groups",
@@ -489,7 +489,7 @@
       "Description": "Adversaries may manipulate accounts to maintain access to victim systems. Account manipulation may consist of any action that preserves adversary access to a compromised account, such as modifying credentials or permission groups. These actions could also include account activity designed to subvert security policies, such as performing iterative password updates to bypass password duration policies and preserve the life of compromised credentials.",
       "TechniqueURL": "https://attack.mitre.org/techniques/T1098/",
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_policy_default_users_cannot_create_security_groups",
@@ -804,7 +804,7 @@
       "Description": "Adversaries may modify authentication mechanisms and processes to access user credentials or enable otherwise unwarranted access to accounts. The authentication process is handled by mechanisms, such as the Local Security Authentication Server (LSASS) process and the Security Accounts Manager (SAM) on Windows, pluggable authentication modules (PAM) on Unix-based systems, and authorization plugins on MacOS systems, responsible for gathering, storing, and validating credentials. By modifying an authentication process, an adversary may be able to authenticate to a service or system without using Valid Accounts.",
       "TechniqueURL": "https://attack.mitre.org/techniques/T1556/",
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
@@ -1279,7 +1279,7 @@
       "Description": "Adversaries may sniff network traffic to capture information about an environment, including authentication material passed over the network. Network sniffing refers to using the network interface on a system to monitor or capture information sent over a wired or wireless connection. An adversary may place a network interface into promiscuous mode to passively access data in transit over the network, or use span ports to capture a larger amount of data.",
       "TechniqueURL": "https://attack.mitre.org/techniques/T1040/",
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_policy_default_users_cannot_create_security_groups",

--- a/prowler/compliance/azure/nis2_azure.json
+++ b/prowler/compliance/azure/nis2_azure.json
@@ -1603,7 +1603,7 @@
       "Id": "11.3.2.a",
       "Description": "establish strong identification, authentication such as multi-factor authentication, and authorisation procedures for privileged accounts and system administration accounts;",
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"
@@ -1692,7 +1692,7 @@
       "Checks": [
         "entra_trusted_named_locations_exists",
         "entra_user_with_vm_access_has_mfa",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_privileged_user_has_mfa"
       ],
       "Attributes": [
@@ -1762,7 +1762,7 @@
       "Id": "11.6.2.a",
       "Description": "ensure the strength of authentication is appropriate to the classification of the asset to be accessed;",
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"
@@ -1794,7 +1794,7 @@
       "Id": "11.7.2",
       "Description": "The relevant entities shall ensure that the strength of authentication is appropriate for the classification of the asset to be accessed.",
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_non_privileged_user_has_mfa",
         "entra_privileged_user_has_mfa",
         "entra_user_with_vm_access_has_mfa"

--- a/prowler/compliance/azure/prowler_threatscore_azure.json
+++ b/prowler/compliance/azure/prowler_threatscore_azure.json
@@ -45,7 +45,7 @@
       "Id": "1.1.3",
       "Description": "Ensure Multi-factor Authentication is Required for Windows Azure Service Management API",
       "Checks": [
-        "entra_require_mfa_for_management_api"
+        "entra_conditional_access_policy_require_mfa_for_management_api"
       ],
       "Attributes": [
         {

--- a/prowler/compliance/azure/rbi_cyber_security_framework_azure.json
+++ b/prowler/compliance/azure/rbi_cyber_security_framework_azure.json
@@ -160,7 +160,7 @@
         "entra_policy_restricts_user_consent_for_apps",
         "entra_user_with_vm_access_has_mfa",
         "entra_security_defaults_enabled",
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_trusted_named_locations_exists",
         "sqlserver_azuread_administrator_enabled",
         "postgresql_flexible_server_entra_id_authentication_enabled",

--- a/prowler/compliance/azure/soc2_azure.json
+++ b/prowler/compliance/azure/soc2_azure.json
@@ -18,7 +18,7 @@
         }
       ],
       "Checks": [
-        "entra_require_mfa_for_management_api",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
         "entra_global_admin_in_less_than_five_users",
         "entra_non_privileged_user_has_mfa",
         "entra_policy_default_users_cannot_create_security_groups",

--- a/prowler/compliance/m365/iso27001_2022_m365.json
+++ b/prowler/compliance/m365/iso27001_2022_m365.json
@@ -174,7 +174,7 @@
         }
       ],
       "Checks": [
-        "entra_app_enforced_restrictions",
+        "entra_conditional_access_policy_app_enforced_restrictions",
         "exchange_transport_config_smtp_auth_disabled",
         "exchange_transport_rules_mail_forwarding_disabled",
         "exchange_transport_rules_whitelist_disabled",
@@ -615,7 +615,7 @@
       "Checks": [
         "defenderxdr_endpoint_privileged_user_exposed_credentials",
         "entra_admin_users_phishing_resistant_mfa_enabled",
-        "entra_app_enforced_restrictions",
+        "entra_conditional_access_policy_app_enforced_restrictions",
         "entra_managed_device_required_for_authentication",
         "entra_managed_device_required_for_mfa_registration",
         "entra_users_mfa_capable",
@@ -669,7 +669,7 @@
       ],
       "Checks": [
         "entra_admin_portals_access_restriction",
-        "entra_app_enforced_restrictions",
+        "entra_conditional_access_policy_app_enforced_restrictions",
         "entra_policy_guest_users_access_restrictions",
         "sharepoint_external_sharing_restricted"
       ]
@@ -755,7 +755,7 @@
         "defender_antiphishing_policy_configured",
         "defender_safelinks_policy_enabled",
         "entra_admin_users_phishing_resistant_mfa_enabled",
-        "entra_app_enforced_restrictions"
+        "entra_conditional_access_policy_app_enforced_restrictions"
       ]
     },
     {

--- a/prowler/compliance/m365/prowler_threatscore_m365.json
+++ b/prowler/compliance/m365/prowler_threatscore_m365.json
@@ -823,7 +823,7 @@
       "Id": "1.3.9",
       "Description": "Ensure OneDrive sync is restricted for unmanaged devices",
       "Checks": [
-        "entra_app_enforced_restrictions",
+        "entra_conditional_access_policy_app_enforced_restrictions",
         "sharepoint_onedrive_sync_restricted_unmanaged_devices"
       ],
       "Attributes": [

--- a/prowler/providers/m365/services/entra/entra_conditional_access_policy_app_enforced_restrictions/entra_conditional_access_policy_app_enforced_restrictions.metadata.json
+++ b/prowler/providers/m365/services/entra/entra_conditional_access_policy_app_enforced_restrictions/entra_conditional_access_policy_app_enforced_restrictions.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "m365",
-  "CheckID": "entra_app_enforced_restrictions",
+  "CheckID": "entra_conditional_access_policy_app_enforced_restrictions",
   "CheckTitle": "Conditional Access policy enforces application restrictions for unmanaged devices",
   "CheckType": [],
   "ServiceName": "entra",
@@ -25,7 +25,7 @@
     },
     "Recommendation": {
       "Text": "Configure Conditional Access policies with **application enforced restrictions** to control access from unmanaged devices. Apply this to Office 365 applications (SharePoint, OneDrive, Exchange) to limit download, print, and sync operations.\n\nCombine with SharePoint access control settings for comprehensive protection.",
-      "Url": "https://hub.prowler.com/check/entra_app_enforced_restrictions"
+      "Url": "https://hub.prowler.com/check/entra_conditional_access_policy_app_enforced_restrictions"
     }
   },
   "Categories": [

--- a/prowler/providers/m365/services/entra/entra_conditional_access_policy_app_enforced_restrictions/entra_conditional_access_policy_app_enforced_restrictions.py
+++ b/prowler/providers/m365/services/entra/entra_conditional_access_policy_app_enforced_restrictions/entra_conditional_access_policy_app_enforced_restrictions.py
@@ -6,7 +6,7 @@ from prowler.providers.m365.services.entra.entra_service import (
 )
 
 
-class entra_app_enforced_restrictions(Check):
+class entra_conditional_access_policy_app_enforced_restrictions(Check):
     """Check if at least one Conditional Access policy enforces application restrictions.
 
     This check verifies that the tenant has at least one enabled Conditional Access policy

--- a/prowler/providers/m365/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.metadata.json
+++ b/prowler/providers/m365/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.metadata.json
@@ -1,6 +1,6 @@
 {
   "Provider": "m365",
-  "CheckID": "entra_require_mfa_for_management_api",
+  "CheckID": "entra_conditional_access_policy_require_mfa_for_management_api",
   "CheckTitle": "Conditional Access Policy enforces MFA for Azure Management API access",
   "CheckType": [],
   "ServiceName": "entra",
@@ -25,7 +25,7 @@
     },
     "Recommendation": {
       "Text": "Enforce **MFA** via Conditional Access for the Windows Azure Service Management API scoped to all users. Prefer **phishing-resistant** methods, apply **least privilege**, and monitor sign-ins for anomalous activity. Only exclude dedicated break-glass accounts.",
-      "Url": "https://hub.prowler.com/check/entra_require_mfa_for_management_api"
+      "Url": "https://hub.prowler.com/check/entra_conditional_access_policy_require_mfa_for_management_api"
     }
   },
   "Categories": [

--- a/prowler/providers/m365/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
+++ b/prowler/providers/m365/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/entra_conditional_access_policy_require_mfa_for_management_api.py
@@ -9,7 +9,7 @@ from prowler.providers.m365.services.entra.entra_service import (
 AZURE_MANAGEMENT_API_APP_ID = "797f4846-ba00-4fd7-ba43-dac1f8f63013"
 
 
-class entra_require_mfa_for_management_api(Check):
+class entra_conditional_access_policy_require_mfa_for_management_api(Check):
     """Check if at least one enabled Conditional Access policy requires MFA for Azure Management API.
 
     This check verifies that at least one enabled Conditional Access policy

--- a/tests/providers/m365/services/entra/entra_conditional_access_policy_app_enforced_restrictions/entra_conditional_access_policy_app_enforced_restrictions_test.py
+++ b/tests/providers/m365/services/entra/entra_conditional_access_policy_app_enforced_restrictions/entra_conditional_access_policy_app_enforced_restrictions_test.py
@@ -19,7 +19,7 @@ from prowler.providers.m365.services.entra.entra_service import (
 from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
 
 
-class Test_entra_app_enforced_restrictions:
+class Test_entra_conditional_access_policy_app_enforced_restrictions:
     def test_entra_no_conditional_access_policies(self):
         """Test FAIL when no conditional access policies exist."""
         entra_client = mock.MagicMock
@@ -32,17 +32,17 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
 
             entra_client.conditional_access_policies = {}
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -56,7 +56,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == "conditionalAccessPolicies"
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_policy_disabled(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_policy_disabled(
+        self,
+    ):
         """Test FAIL when policy with app enforced restrictions is disabled."""
         id = str(uuid4())
         display_name = "App Enforced Restrictions Policy"
@@ -70,12 +72,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -125,7 +127,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -139,7 +141,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == "conditionalAccessPolicies"
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_enabled_for_reporting(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_enabled_for_reporting(
+        self,
+    ):
         """Test FAIL when policy is enabled for reporting but not enforcing."""
         id = str(uuid4())
         display_name = "App Enforced Restrictions Reporting"
@@ -153,12 +157,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -208,7 +212,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -225,7 +229,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == id
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_not_enabled(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_not_enabled(
+        self,
+    ):
         """Test FAIL when policy exists but app enforced restrictions is not enabled."""
         id = str(uuid4())
         display_name = "Policy Without App Restrictions"
@@ -239,12 +245,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -294,7 +300,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -308,7 +314,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == "conditionalAccessPolicies"
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_missing_all_users(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_missing_all_users(
+        self,
+    ):
         """Test FAIL when policy does not include all users."""
         id = str(uuid4())
         display_name = "Policy Missing All Users"
@@ -322,12 +330,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -377,7 +385,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -391,7 +399,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == "conditionalAccessPolicies"
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_missing_all_client_apps(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_missing_all_client_apps(
+        self,
+    ):
         """Test FAIL when policy does not include all client app types."""
         id = str(uuid4())
         display_name = "Policy Missing All Client Apps"
@@ -405,12 +415,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -460,7 +470,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -474,7 +484,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == "conditionalAccessPolicies"
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_missing_required_apps(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_missing_required_apps(
+        self,
+    ):
         """Test FAIL when policy does not include Office365 or the required individual apps."""
         id = str(uuid4())
         display_name = "Policy Missing Required Apps"
@@ -488,12 +500,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -543,7 +555,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -557,7 +569,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == "conditionalAccessPolicies"
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_individual_apps_pass(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_individual_apps_pass(
+        self,
+    ):
         """Test PASS when policy targets SharePoint and Exchange individually."""
         id = str(uuid4())
         display_name = "Individual Apps Policy"
@@ -571,12 +585,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -629,7 +643,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -646,7 +660,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == id
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_only_sharepoint_fail(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_only_sharepoint_fail(
+        self,
+    ):
         """Test FAIL when policy targets only SharePoint but not Exchange."""
         id = str(uuid4())
         display_name = "Only SharePoint Policy"
@@ -660,12 +676,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -717,7 +733,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -731,7 +747,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == "conditionalAccessPolicies"
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_browser_and_mobile_pass(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_browser_and_mobile_pass(
+        self,
+    ):
         """Test PASS when policy uses browser + mobile apps instead of ALL."""
         id = str(uuid4())
         display_name = "Browser and Mobile Apps Policy"
@@ -745,12 +763,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -803,7 +821,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -820,7 +838,7 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == id
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_enabled(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_enabled(self):
         """Test PASS when a compliant policy with app enforced restrictions is enabled."""
         id = str(uuid4())
         display_name = "App Enforced Restrictions Enabled"
@@ -834,12 +852,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -889,7 +907,7 @@ class Test_entra_app_enforced_restrictions:
                 )
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1
@@ -906,7 +924,9 @@ class Test_entra_app_enforced_restrictions:
             assert result[0].resource_id == id
             assert result[0].location == "global"
 
-    def test_entra_app_enforced_restrictions_multiple_policies_one_compliant(self):
+    def test_entra_conditional_access_policy_app_enforced_restrictions_multiple_policies_one_compliant(
+        self,
+    ):
         """Test PASS when multiple policies exist and at least one is compliant."""
         id1 = str(uuid4())
         id2 = str(uuid4())
@@ -922,12 +942,12 @@ class Test_entra_app_enforced_restrictions:
                 return_value=set_mocked_m365_provider(),
             ),
             mock.patch(
-                "prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions.entra_client",
+                "prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions.entra_client",
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_app_enforced_restrictions.entra_app_enforced_restrictions import (
-                entra_app_enforced_restrictions,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_app_enforced_restrictions.entra_conditional_access_policy_app_enforced_restrictions import (
+                entra_conditional_access_policy_app_enforced_restrictions,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -1018,7 +1038,7 @@ class Test_entra_app_enforced_restrictions:
                 ),
             }
 
-            check = entra_app_enforced_restrictions()
+            check = entra_conditional_access_policy_app_enforced_restrictions()
             result = check.execute()
 
             assert len(result) == 1

--- a/tests/providers/m365/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/m365_entra_conditional_access_policy_require_mfa_for_management_api_test.py
+++ b/tests/providers/m365/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/m365_entra_conditional_access_policy_require_mfa_for_management_api_test.py
@@ -18,10 +18,10 @@ from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
 
 AZURE_MANAGEMENT_API_APP_ID = "797f4846-ba00-4fd7-ba43-dac1f8f63013"
 
-CHECK_MODULE_PATH = "prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api"
+CHECK_MODULE_PATH = "prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api"
 
 
-class Test_m365_entra_require_mfa_for_management_api:
+class Test_m365_entra_conditional_access_policy_require_mfa_for_management_api:
     def test_no_conditional_access_policies(self):
         """Test FAIL when there are no Conditional Access policies."""
         entra_client = mock.MagicMock
@@ -37,13 +37,13 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
 
             entra_client.conditional_access_policies = {}
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -74,8 +74,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -122,7 +122,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -153,8 +153,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -201,7 +201,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -235,8 +235,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -279,7 +279,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -310,8 +310,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -358,7 +358,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -389,8 +389,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -439,7 +439,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -470,8 +470,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -518,7 +518,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "FAIL"
@@ -549,8 +549,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -597,7 +597,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"
@@ -631,8 +631,8 @@ class Test_m365_entra_require_mfa_for_management_api:
                 new=entra_client,
             ),
         ):
-            from prowler.providers.m365.services.entra.entra_require_mfa_for_management_api.entra_require_mfa_for_management_api import (
-                entra_require_mfa_for_management_api,
+            from prowler.providers.m365.services.entra.entra_conditional_access_policy_require_mfa_for_management_api.entra_conditional_access_policy_require_mfa_for_management_api import (
+                entra_conditional_access_policy_require_mfa_for_management_api,
             )
             from prowler.providers.m365.services.entra.entra_service import (
                 ConditionalAccessPolicy,
@@ -679,7 +679,7 @@ class Test_m365_entra_require_mfa_for_management_api:
                 )
             }
 
-            check = entra_require_mfa_for_management_api()
+            check = entra_conditional_access_policy_require_mfa_for_management_api()
             result = check.execute()
             assert len(result) == 1
             assert result[0].status == "PASS"


### PR DESCRIPTION
### Context

Rename M365 Entra conditional access policy checks to follow a consistent naming convention that includes `conditional_access_policy` in the check name prefix.

### Description

Renames two checks:
- `entra_app_enforced_restrictions` → `entra_conditional_access_policy_app_enforced_restrictions`
- `entra_require_mfa_for_management_api` → `entra_conditional_access_policy_require_mfa_for_management_api`

Updates all references across:
- Check source files (directories, `.py`, `.metadata.json`)
- Test files
- 16 Azure compliance frameworks
- 2 M365 compliance frameworks
- SDK CHANGELOG

### Steps to review

1. Verify all old check name references are gone: `grep -r "entra_app_enforced_restrictions\|entra_require_mfa_for_management_api" prowler/ tests/` should return nothing
2. Run the renamed checks: `poetry run python prowler-cli.py m365 --check entra_conditional_access_policy_app_enforced_restrictions`
3. Run tests: `poetry run pytest tests/providers/m365/services/entra/entra_conditional_access_policy_app_enforced_restrictions/ tests/providers/m365/services/entra/entra_conditional_access_policy_require_mfa_for_management_api/ -v`

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.