### PR TITLE
docs(tutorials): add note about latest scan results in Overview and Resources

### DIFF
--- a/docs/user-guide/tutorials/prowler-app.mdx
+++ b/docs/user-guide/tutorials/prowler-app.mdx
@@ -134,6 +134,18 @@ Track the progress of your scan in the `Scans` section:
 <img src="/images/scan-progress.png" alt="Scan Progress" width="700" />
 
 
+<Note>
+**How Dashboards Display Scan Data**
+
+Each dashboard handles scan data differently:
+
+* **Overview** displays aggregated metrics from the **latest completed scan per provider** only.
+* **Findings** displays results from the **latest completed scan per provider** by default. To access historical findings, apply a date or scan filter.
+* **Resources** lists **all discovered resources across all scans**. However, when selecting a resource, the Findings tab within the resource detail shows only findings from the **latest completed scan**. If the latest scan did not evaluate a particular resource, its Findings tab may appear empty.
+
+When a new scan completes or a new data ingestion is processed, the dashboards automatically reflect the updated results.
+</Note>
+
 ## **Step 8: Analyze the Findings**
 
 While the scan is running, start exploring the findings in these sections:


### PR DESCRIPTION
### Context

Clarify that both the Overview and Resources pages display findings from the most recent scan only.

### Description

Add a `<Note>` component in the **Step 8: Analyze the Findings** section of the Prowler Cloud tutorial (`docs/user-guide/tutorials/prowler-app.mdx`). The note informs that:

* Both the Overview and Resources pages display results from the most recent scan only.
* When navigating to findings from either page, only findings from the latest scan are shown.
* This behavior also applies when new data ingestions are added to a provider.

### Steps to review

1. Open the Prowler Cloud tutorial documentation.
2. Navigate to **Step 8: Analyze the Findings**.
3. Verify the note is visible and clearly communicates the latest-scan-only behavior.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.