### PR TITLE
feat(sdk): add provider_uid to OCSF unmapped output

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - OpenStack block storage service with 7 security checks [(#10120)](https://github.com/prowler-cloud/prowler/pull/10120)
 - OpenStack compute service with 7 security checks [(#9944)](https://github.com/prowler-cloud/prowler/pull/9944)
 - OpenStack image service with 6 security checks [(#10096)](https://github.com/prowler-cloud/prowler/pull/10096)
+- `provider_uid` field in OCSF `unmapped` output for provider identification
 
 ### 🔄 Changed
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - OpenStack block storage service with 7 security checks [(#10120)](https://github.com/prowler-cloud/prowler/pull/10120)
 - OpenStack compute service with 7 security checks [(#9944)](https://github.com/prowler-cloud/prowler/pull/9944)
 - OpenStack image service with 6 security checks [(#10096)](https://github.com/prowler-cloud/prowler/pull/10096)
-- `provider_uid` field in OCSF `unmapped` output for provider identification
+- `provider_uid` field in OCSF `unmapped` output for provider identification [(#10231)](https://github.com/prowler-cloud/prowler/pull/10231)
 
 ### 🔄 Changed
 

--- a/prowler/lib/outputs/finding.py
+++ b/prowler/lib/outputs/finding.py
@@ -34,6 +34,7 @@ class Finding(BaseModel):
     auth_method: str
     timestamp: Union[int, datetime]
     account_uid: str
+    provider_uid: Optional[str] = None
     account_name: Optional[str] = None
     account_email: Optional[str] = None
     account_organization_uid: Optional[str] = None
@@ -244,6 +245,7 @@ class Finding(BaseModel):
                 output_data["account_uid"] = get_nested_attribute(
                     provider, "identity.cluster"
                 )
+                output_data["provider_uid"] = provider.identity.context
                 output_data["region"] = f"namespace: {check_output.namespace}"
 
             elif provider.type == "github":

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -178,7 +178,7 @@ class OCSF(Output):
                         "notes": finding.metadata.Notes,
                         "compliance": finding.compliance,
                         "scan_id": str(scan_id),
-                        "provider_uid": finding.account_uid,
+                        "provider_uid": finding.provider_uid or finding.account_uid,
                     },
                 )
                 if finding.provider != "kubernetes":

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -178,7 +178,7 @@ class OCSF(Output):
                         "notes": finding.metadata.Notes,
                         "compliance": finding.compliance,
                         "scan_id": str(scan_id),
-                        "provider_id": finding.account_uid,
+                        "provider_uid": finding.account_uid,
                     },
                 )
                 if finding.provider != "kubernetes":

--- a/prowler/lib/outputs/ocsf/ocsf.py
+++ b/prowler/lib/outputs/ocsf/ocsf.py
@@ -178,6 +178,7 @@ class OCSF(Output):
                         "notes": finding.metadata.Notes,
                         "compliance": finding.compliance,
                         "scan_id": str(scan_id),
+                        "provider_id": finding.account_uid,
                     },
                 )
                 if finding.provider != "kubernetes":

--- a/tests/lib/outputs/finding_test.py
+++ b/tests/lib/outputs/finding_test.py
@@ -514,6 +514,7 @@ class TestFinding:
         assert finding_output.resource_tags == {}
         assert finding_output.partition is None
         assert finding_output.account_uid == "test_cluster"
+        assert finding_output.provider_uid == "In-Cluster"
         assert finding_output.account_name == "context: In-Cluster"
         assert finding_output.account_email is None
         assert finding_output.account_organization_uid is None

--- a/tests/lib/outputs/fixtures/fixtures.py
+++ b/tests/lib/outputs/fixtures/fixtures.py
@@ -44,11 +44,13 @@ def generate_finding_output(
     check_id: str = "service_test_check_id",
     check_title: str = "service_test_check_id",
     check_type: list[str] = ["test-type"],
+    provider_uid: str = None,
 ) -> Finding:
     return Finding(
         auth_method="profile: default",
         timestamp=timestamp if timestamp else datetime.now(),
         account_uid=account_uid,
+        provider_uid=provider_uid,
         account_name=account_name,
         account_email="",
         account_organization_uid="test-organization-id",

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -113,7 +113,7 @@ class TestOCSF:
             "additional_urls": findings[0].metadata.AdditionalURLs,
             "notes": findings[0].metadata.Notes,
             "compliance": findings[0].compliance,
-            "provider_id": findings[0].account_uid,
+            "provider_uid": findings[0].account_uid,
         }
 
         # Test with int timestamp (UNIX timestamp)
@@ -220,7 +220,7 @@ class TestOCSF:
                     ],
                     "notes": "test-notes",
                     "compliance": {"test-compliance": "test-compliance"},
-                    "provider_id": "123456789012",
+                    "provider_uid": "123456789012",
                 },
                 "activity_name": "Create",
                 "activity_id": 1,
@@ -356,7 +356,7 @@ class TestOCSF:
             "additional_urls": finding_output.metadata.AdditionalURLs,
             "notes": finding_output.metadata.Notes,
             "compliance": finding_output.compliance,
-            "provider_id": finding_output.account_uid,
+            "provider_uid": finding_output.account_uid,
         }
 
         # ResourceDetails

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -427,6 +427,7 @@ class TestOCSF:
             muted=True,
             region=AWS_REGION_EU_WEST_1,
             provider="kubernetes",
+            provider_uid="test-k8s-context",
         )
 
         finding_ocsf = OCSF([finding_output])
@@ -436,6 +437,7 @@ class TestOCSF:
         assert finding_ocsf.resources[0].namespace == finding_output.region.replace(
             "namespace: ", ""
         )
+        assert finding_ocsf.unmapped["provider_uid"] == "test-k8s-context"
 
     def test_finding_output_cloud_fail_low_not_muted(self):
         finding_output = generate_finding_output(

--- a/tests/lib/outputs/ocsf/ocsf_test.py
+++ b/tests/lib/outputs/ocsf/ocsf_test.py
@@ -113,6 +113,7 @@ class TestOCSF:
             "additional_urls": findings[0].metadata.AdditionalURLs,
             "notes": findings[0].metadata.Notes,
             "compliance": findings[0].compliance,
+            "provider_id": findings[0].account_uid,
         }
 
         # Test with int timestamp (UNIX timestamp)
@@ -219,6 +220,7 @@ class TestOCSF:
                     ],
                     "notes": "test-notes",
                     "compliance": {"test-compliance": "test-compliance"},
+                    "provider_id": "123456789012",
                 },
                 "activity_name": "Create",
                 "activity_id": 1,
@@ -354,6 +356,7 @@ class TestOCSF:
             "additional_urls": finding_output.metadata.AdditionalURLs,
             "notes": finding_output.metadata.Notes,
             "compliance": finding_output.compliance,
+            "provider_id": finding_output.account_uid,
         }
 
         # ResourceDetails


### PR DESCRIPTION
### Context

The API needs a way to match CLI scan results with API provider entities during OCSF ingestion. Currently, there is no direct link between the OCSF output from the CLI and the provider records in the API.

### Description

Add a `provider_uid` field to the OCSF `DetectionFinding` unmapped dict, using the existing `finding.account_uid` value (the same value already used for `cloud.account.uid`). This allows the API ingestion process to look up the corresponding provider entity without additional mapping logic.

### Steps to review

1. Review `prowler/lib/outputs/ocsf/ocsf.py` — single line added to the `unmapped` dict
2. Review `tests/lib/outputs/ocsf/ocsf_test.py` — three test assertions updated
3. Run OCSF tests: `pytest -vv tests/lib/outputs/ocsf/ocsf_test.py`

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.