### PR TITLE
chore(ui): improve provider wizard docs link labels

### DIFF
--- a/ui/components/providers/wizard/provider-wizard-modal.tsx
+++ b/ui/components/providers/wizard/provider-wizard-modal.tsx
@@ -84,7 +84,7 @@ export function ProviderWizardModal({
           <Button variant="link" size="link-sm" className="h-auto p-0" asChild>
             <a href={docsLink} target="_blank" rel="noopener noreferrer">
               <ExternalLink className="size-3.5 shrink-0" />
-              <span>{`Prowler Docs (${docsDestination})`}</span>
+              <span>{`${docsDestination} documentation`}</span>
             </a>
           </Button>
         </div>

--- a/ui/components/providers/wizard/provider-wizard-modal.utils.test.ts
+++ b/ui/components/providers/wizard/provider-wizard-modal.utils.test.ts
@@ -58,7 +58,7 @@ describe("getProviderWizardDocsDestination", () => {
       "https://goto.prowler.com/provider-aws",
     );
 
-    expect(destination).toBe("aws");
+    expect(destination).toBe("AWS");
   });
 
   it("returns a compact destination label for long docs links", () => {
@@ -66,6 +66,6 @@ describe("getProviderWizardDocsDestination", () => {
       "https://docs.prowler.com/user-guide/tutorials/prowler-cloud-aws-organizations",
     );
 
-    expect(destination).toBe("aws-organizations");
+    expect(destination).toBe("AWS Organizations");
   });
 });

--- a/ui/components/providers/wizard/provider-wizard-modal.utils.ts
+++ b/ui/components/providers/wizard/provider-wizard-modal.utils.ts
@@ -29,6 +29,24 @@ export function getProviderWizardModalTitle(mode: ProviderWizardMode) {
 }
 
 export function getProviderWizardDocsDestination(docsLink: string) {
+  const destinationLabelMap: Record<string, string> = {
+    "aws-organizations": "AWS Organizations",
+    aws: "AWS",
+    azure: "Azure",
+    m365: "Microsoft 365",
+    gcp: "GCP",
+    k8s: "Kubernetes",
+    kubernetes: "Kubernetes",
+    github: "GitHub",
+    iac: "IaC",
+    oraclecloud: "Oracle Cloud",
+    mongodbatlas: "MongoDB Atlas",
+    alibabacloud: "Alibaba Cloud",
+    cloudflare: "Cloudflare",
+    openstack: "OpenStack",
+    help: "Cloud Provider",
+  };
+
   try {
     const parsed = new URL(docsLink);
     const pathSegments = parsed.pathname
@@ -40,7 +58,21 @@ export function getProviderWizardDocsDestination(docsLink: string) {
       return parsed.hostname;
     }
 
-    return lastSegment.replace(/^provider-/, "").replace(/^prowler-cloud-/, "");
+    const compactDestination = lastSegment
+      .replace(/^provider-/, "")
+      .replace(/^prowler-cloud-/, "");
+    const mappedDestination = destinationLabelMap[compactDestination];
+
+    if (mappedDestination) {
+      return mappedDestination;
+    }
+
+    return compactDestination
+      .split("-")
+      .map((word) =>
+        word.length === 0 ? word : word[0].toUpperCase() + word.slice(1),
+      )
+      .join(" ");
   } catch {
     return docsLink;
   }


### PR DESCRIPTION
### Context

Improve docs link labels in the provider wizard to show human-readable provider names instead of raw URL slugs.

<img width="930" height="207" alt="Screenshot 2026-03-04 at 09 17 30" src="https://github.com/user-attachments/assets/819e9d88-2430-4665-9f6e-c6ec2e554697" />
<img width="787" height="194" alt="Screenshot 2026-03-04 at 09 17 21" src="https://github.com/user-attachments/assets/d190c7da-28db-4500-8803-5c00eed333c2" />


### Description

- Map provider slugs (e.g., `aws`, `m365`, `k8s`) to human-readable labels (e.g., "AWS", "Microsoft 365", "Kubernetes") via a lookup table
- Add a capitalization fallback for unmapped slugs
- Change docs link format from `"Prowler Docs (aws)"` to `"AWS documentation"`
- Update tests to match new expected labels

### Steps to review

1. Review the label mapping in `ui/components/providers/wizard/provider-wizard-modal.utils.ts` — verify all providers are covered and the capitalization fallback works
2. Check the docs link text change in `ui/components/providers/wizard/provider-wizard-modal.tsx:87`
3. Verify test expectations in `ui/components/providers/wizard/provider-wizard-modal.utils.test.ts`

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.