### PR TITLE
chore(ui): update changelog for v1.20.0

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.20.0] (Prowler v5.20.0 UNRELEASED)
+
+### 🐞 Changed
+
+- Attack Paths: Improved error handling for server errors (5xx) and network failures with user-friendly messages instead of raw internal errors and layout changes. [(#10249)](https://github.com/prowler-cloud/prowler/pull/10249)
+- Refactor simple providers with new components and styles.[(#10259)](https://github.com/prowler-cloud/prowler/pull/10259)
 
 ## [1.19.1] (Prowler v5.19.1 UNRELEASED)
-
-### 🐞 Fixed
-
-- Attack Paths: Improved error handling for server errors (5xx) and network failures with user-friendly messages instead of raw internal errors
 
 ### 🔐 Security
 


### PR DESCRIPTION
### Context

Prepare the UI changelog for the upcoming v1.20.0 release by adding a new version section and reorganizing existing entries.

### Description

- Add new `[1.20.0]` section to `ui/CHANGELOG.md`
- Move attack paths layout improvements entry (#10249) under the new version with updated category (Changed)
- Add provider wizard migration entry (#10259) under v1.20.0

### Steps to review

1. Open `ui/CHANGELOG.md` and verify the new `[1.20.0]` section is correctly formatted
2. Confirm entries reference the correct PRs (#10249, #10259)
3. Verify the previous `[1.19.1]` section remains intact

### Checklist

- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.