### PR TITLE
fix(ui): skip launch step when updating provider credentials

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ## [1.19.1] (Prowler v5.19.1 UNRELEASED)
 
+### 🐞 Fixed
+
+- Provider wizard now closes after updating credentials instead of incorrectly advancing to the Launch Scan step, which caused API errors for providers with existing scheduled scans [(#10278)](https://github.com/prowler-cloud/prowler/pull/10278)
+
 ### 🔐 Security
 
 - npm transitive dependencies patched to resolve 11 Dependabot alerts (6 HIGH, 4 MEDIUM, 1 LOW): hono, @hono/node-server, fast-xml-parser, serialize-javascript, minimatch [(#10267)](https://github.com/prowler-cloud/prowler/pull/10267)

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
@@ -121,7 +121,7 @@ describe("useProviderWizardController", () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it("moves to launch step after a successful connection test in update mode", async () => {
+  it("closes the modal after a successful connection test in update mode", async () => {
     // Given
     const onOpenChange = vi.fn();
     const { result } = renderHook(() =>
@@ -149,9 +149,8 @@ describe("useProviderWizardController", () => {
       result.current.handleTestSuccess();
     });
 
-    // Then
-    expect(result.current.currentStep).toBe(PROVIDER_WIZARD_STEP.LAUNCH);
-    expect(onOpenChange).not.toHaveBeenCalled();
+    // Then — update mode should close the modal, not advance to launch
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("does not override launch footer config in the controller", () => {

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
@@ -173,6 +173,10 @@ export function useProviderWizardController({
   };
 
   const handleTestSuccess = () => {
+    if (mode === PROVIDER_WIZARD_MODE.UPDATE) {
+      handleClose();
+      return;
+    }
     setCurrentStep(PROVIDER_WIZARD_STEP.LAUNCH);
   };
 


### PR DESCRIPTION
### Context

Fix PROWLER-1180

When updating existing provider credentials from the providers table, the wizard incorrectly advanced to the Launch Scan step. This caused API errors because scans were already scheduled for the provider.

### Description

- In `handleTestSuccess` (wizard controller), check the wizard mode before deciding the next step
- In **UPDATE** mode: close the modal after a successful connection test (credentials updated, scans already exist)
- In **ADD** mode: advance to the Launch Scan step as before (new provider needs its first scan)
- Updated the unit test to verify the modal closes in update mode instead of advancing to launch

### Steps to review

1. Review `ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts` — the 4-line change in `handleTestSuccess`
2. Review the updated test in `use-provider-wizard-controller.test.tsx` — now asserts `onOpenChange(false)` instead of expecting LAUNCH step
3. **Manual test (update flow)**: From providers table → click actions on a provider with existing credentials → "Update Credentials" → fill new credentials → test connection → verify modal closes (does NOT show Launch Scan step)
4. **Manual test (add flow)**: From providers table → click actions on a provider without credentials → "Add Credentials" → fill credentials → test connection → verify it advances to Launch Scan step as usual

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.