### PR TITLE
fix(ui): rename error text token to text-text-error-primary

### DIFF
--- a/ui/components/providers/radio-group-provider.tsx
+++ b/ui/components/providers/radio-group-provider.tsx
@@ -176,7 +176,7 @@ export const RadioGroupProvider: FC<RadioGroupProviderProps> = ({
           </div>
 
           {errorMessage && (
-            <FormMessage className="text-text-error">
+            <FormMessage className="text-text-error-primary">
               {errorMessage}
             </FormMessage>
           )}

--- a/ui/components/providers/workflow/forms/fields/wizard-input-field.tsx
+++ b/ui/components/providers/workflow/forms/fields/wizard-input-field.tsx
@@ -163,7 +163,7 @@ export const WizardInputField = <T extends FieldValues>({
                 )}
               </div>
             </FormControl>
-            <FormMessage className="text-text-error max-w-full text-xs" />
+            <FormMessage className="text-text-error-primary max-w-full text-xs" />
           </div>
         );
       }}

--- a/ui/components/providers/workflow/forms/fields/wizard-textarea-field.tsx
+++ b/ui/components/providers/workflow/forms/fields/wizard-textarea-field.tsx
@@ -87,7 +87,7 @@ export const WizardTextareaField = <T extends FieldValues>({
                 {description}
               </p>
             )}
-            <FormMessage className="text-text-error max-w-full text-xs" />
+            <FormMessage className="text-text-error-primary max-w-full text-xs" />
           </div>
         );
       }}

--- a/ui/components/providers/workflow/forms/select-credentials-type/alibabacloud/radio-group-alibabacloud-via-credentials-type-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/alibabacloud/radio-group-alibabacloud-via-credentials-type-form.tsx
@@ -50,7 +50,7 @@ export const RadioGroupAlibabaCloudViaCredentialsTypeForm = <
               </WizardRadioCard>
             </RadioGroup>
             {errorMessage && (
-              <FormMessage className="text-text-error">
+              <FormMessage className="text-text-error-primary">
                 {errorMessage}
               </FormMessage>
             )}

--- a/ui/components/providers/workflow/forms/select-credentials-type/aws/radio-group-aws-via-credentials-type-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/aws/radio-group-aws-via-credentials-type-form.tsx
@@ -43,7 +43,7 @@ export const RadioGroupAWSViaCredentialsTypeForm = ({
             </WizardRadioCard>
           </RadioGroup>
           {errorMessage && (
-            <FormMessage className="text-text-error">
+            <FormMessage className="text-text-error-primary">
               {errorMessage}
             </FormMessage>
           )}

--- a/ui/components/providers/workflow/forms/select-credentials-type/cloudflare/radio-group-cloudflare-via-credentials-type-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/cloudflare/radio-group-cloudflare-via-credentials-type-form.tsx
@@ -44,7 +44,7 @@ export const RadioGroupCloudflareViaCredentialsTypeForm = ({
             </WizardRadioCard>
           </RadioGroup>
           {errorMessage && (
-            <FormMessage className="text-text-error">
+            <FormMessage className="text-text-error-primary">
               {errorMessage}
             </FormMessage>
           )}

--- a/ui/components/providers/workflow/forms/select-credentials-type/gcp/radio-group-gcp-via-credentials-type-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/gcp/radio-group-gcp-via-credentials-type-form.tsx
@@ -47,7 +47,7 @@ export const RadioGroupGCPViaCredentialsTypeForm = ({
             </WizardRadioCard>
           </RadioGroup>
           {errorMessage && (
-            <FormMessage className="text-text-error">
+            <FormMessage className="text-text-error-primary">
               {errorMessage}
             </FormMessage>
           )}

--- a/ui/components/providers/workflow/forms/select-credentials-type/github/radio-group-github-via-credentials-type-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/github/radio-group-github-via-credentials-type-form.tsx
@@ -54,7 +54,7 @@ export const RadioGroupGitHubViaCredentialsTypeForm = ({
             </WizardRadioCard>
           </RadioGroup>
           {errorMessage && (
-            <FormMessage className="text-text-error">
+            <FormMessage className="text-text-error-primary">
               {errorMessage}
             </FormMessage>
           )}

--- a/ui/components/providers/workflow/forms/select-credentials-type/m365/radio-group-m365-via-credentials-type-form.tsx
+++ b/ui/components/providers/workflow/forms/select-credentials-type/m365/radio-group-m365-via-credentials-type-form.tsx
@@ -44,7 +44,7 @@ export const RadioGroupM365ViaCredentialsTypeForm = ({
             </WizardRadioCard>
           </RadioGroup>
           {errorMessage && (
-            <FormMessage className="text-text-error">
+            <FormMessage className="text-text-error-primary">
               {errorMessage}
             </FormMessage>
           )}

--- a/ui/components/ui/form/Form.test.tsx
+++ b/ui/components/ui/form/Form.test.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "./Form";
+
+interface TestValues {
+  providerUid: string;
+}
+
+function TestFormWithError() {
+  const form = useForm<TestValues>({
+    defaultValues: {
+      providerUid: "",
+    },
+  });
+
+  useEffect(() => {
+    form.setError("providerUid", {
+      type: "manual",
+      message: "Provider ID is required",
+    });
+  }, [form]);
+
+  return (
+    <Form {...form}>
+      <FormField
+        control={form.control}
+        name="providerUid"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Provider UID</FormLabel>
+            <FormControl>
+              <input {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </Form>
+  );
+}
+
+describe("Form", () => {
+  it("should use the existing error text token for labels and messages", async () => {
+    // Given
+    render(<TestFormWithError />);
+
+    // When
+    const label = await screen.findByText("Provider UID");
+    const message = await screen.findByText("Provider ID is required");
+
+    // Then
+    expect(label).toHaveClass("text-text-error-primary");
+    expect(message).toHaveClass("text-text-error-primary");
+  });
+});

--- a/ui/components/ui/form/Form.test.tsx
+++ b/ui/components/ui/form/Form.test.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import { render, screen } from "@testing-library/react";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 

--- a/ui/components/ui/form/Form.tsx
+++ b/ui/components/ui/form/Form.tsx
@@ -100,7 +100,10 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(error && "text-text-error max-w-full text-xs", className)}
+      className={cn(
+        error && "text-text-error-primary max-w-full text-xs",
+        className,
+      )}
       htmlFor={formItemId}
       {...props}
     />
@@ -164,7 +167,7 @@ const FormMessage = React.forwardRef<
       ref={ref}
       id={formMessageId}
       className={cn(
-        "text-text-error max-w-full text-xs font-medium",
+        "text-text-error-primary max-w-full text-xs font-medium",
         className,
       )}
       {...props}


### PR DESCRIPTION
### Context

The provider wizard error-text color bug was introduced after v1.19, during the v1.20 shadcn refactor. The key commits are 9cbc6d9a / 2d57ffee (Mar 4) and especially b1c5fa4c (#10259, Mar 6), which migrated form components to shadcn but left the old `text-text-error` token instead of the updated `text-text-error-primary`.

### Description

- Update `FormLabel` and `FormMessage` in `Form.tsx` to use `text-text-error-primary`
- Update all 9 provider credential radio group forms and wizard field components to use the new token
- Add a Vitest unit test (`Form.test.tsx`) verifying the correct error class is applied to both label and message elements

### Steps to review

1. Review `ui/components/ui/form/Form.tsx` — the core change in `FormLabel` and `FormMessage`
2. Verify the provider form files all have the same `text-text-error` → `text-text-error-primary` rename
3. Review the new test in `ui/components/ui/form/Form.test.tsx`

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.