### PR TITLE
chore(ui): move security changelog entry from v19.1 to v20

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -9,15 +9,15 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Attack Paths: Improved error handling for server errors (5xx) and network failures with user-friendly messages instead of raw internal errors and layout changes. [(#10249)](https://github.com/prowler-cloud/prowler/pull/10249)
 - Refactor simple providers with new components and styles.[(#10259)](https://github.com/prowler-cloud/prowler/pull/10259)
 
+### 🔐 Security
+
+- npm transitive dependencies patched to resolve 11 Dependabot alerts (6 HIGH, 4 MEDIUM, 1 LOW): hono, @hono/node-server, fast-xml-parser, serialize-javascript, minimatch [(#10267)](https://github.com/prowler-cloud/prowler/pull/10267)
+
 ## [1.19.1] (Prowler v5.19.1 UNRELEASED)
 
 ### 🐞 Fixed
 
 - Provider wizard now closes after updating credentials instead of incorrectly advancing to the Launch Scan step, which caused API errors for providers with existing scheduled scans [(#10278)](https://github.com/prowler-cloud/prowler/pull/10278)
-
-### 🔐 Security
-
-- npm transitive dependencies patched to resolve 11 Dependabot alerts (6 HIGH, 4 MEDIUM, 1 LOW): hono, @hono/node-server, fast-xml-parser, serialize-javascript, minimatch [(#10267)](https://github.com/prowler-cloud/prowler/pull/10267)
 
 ---
 


### PR DESCRIPTION
## Context

The npm security patching entry (#10267) was listed under v1.19.1 but should be released with v1.20.0.

## Description of Changes

- Moved the `🔐 Security` section (npm transitive dependencies patch for 11 Dependabot alerts) from `[1.19.1]` to `[1.20.0]` in the UI CHANGELOG.

## Steps to Review

1. Open `ui/CHANGELOG.md` and verify:
   - `[1.20.0]` now contains the `### 🔐 Security` section with #10267
   - `[1.19.1]` only has the `### 🐞 Fixed` section with #10278

## Checklist

- [x] Changes are limited to changelog reorganization
- [x] No code changes