### PR TITLE
docs: document required permissions for mutelist features

### DIFF
--- a/docs/user-guide/tutorials/prowler-app-mute-findings.mdx
+++ b/docs/user-guide/tutorials/prowler-app-mute-findings.mdx
@@ -24,6 +24,11 @@ Advanced Mutelist enables users to create powerful, pattern-based muting rules u
 
 ## Prerequisites
 
+<Note>
+Advanced Mutelist requires the **Manage Account** permission. See [RBAC Administrative Permissions](/user-guide/tutorials/prowler-app-rbac#rbac-administrative-permissions) for details.
+
+</Note>
+
 Before muting findings, ensure:
 
 - Valid access to Prowler App with appropriate permissions

--- a/docs/user-guide/tutorials/prowler-app-simple-mutelist.mdx
+++ b/docs/user-guide/tutorials/prowler-app-simple-mutelist.mdx
@@ -23,6 +23,11 @@ Simple Mutelist creates rules based on the finding's unique identifier (UID). Fo
 
 </Note>
 
+<Note>
+Simple Mutelist requires the **Manage Scans** permission. See [RBAC Administrative Permissions](/user-guide/tutorials/prowler-app-rbac#rbac-administrative-permissions) for details.
+
+</Note>
+
 ## Accessing the Mutelist Page
 
 To access the Mutelist page:


### PR DESCRIPTION
### Context

The Simple Mutelist and Advanced Mutelist features require different RBAC permissions (`Manage Scans` and `Manage Account` respectively), but this was not documented anywhere in the user-facing documentation.

### Description

Add permission requirement notes to both mutelist documentation pages:

- **Simple Mutelist** (`prowler-app-simple-mutelist.mdx`): Added a `<Note>` block indicating the **Manage Scans** permission is required, with a link to the RBAC page.
- **Advanced Mutelist** (`prowler-app-mute-findings.mdx`): Added a `<Note>` block indicating the **Manage Account** permission is required, with a link to the RBAC page.

Both notes follow the same style for consistency.

### Steps to review

1. Review the two modified `.mdx` files for content accuracy and style consistency.
2. Optionally run `mint dev` locally to preview the rendered pages.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.