### PR TITLE
docs(mcp_server): add Attack Paths MCP tools documentation

### DIFF
--- a/docs/getting-started/basic-usage/prowler-mcp-tools.mdx
+++ b/docs/getting-started/basic-usage/prowler-mcp-tools.mdx
@@ -10,7 +10,7 @@ Complete reference guide for all tools available in the Prowler MCP Server. Tool
 |----------|------------|------------------------|
 | Prowler Hub | 10 tools | No |
 | Prowler Documentation | 2 tools | No |
-| Prowler Cloud/App | 24 tools | Yes |
+| Prowler Cloud/App | 27 tools | Yes |
 
 ## Tool Naming Convention
 
@@ -79,6 +79,14 @@ Tools for managing finding muting, including pattern-based bulk muting (mutelist
 - **`prowler_app_create_mute_rule`** - Create a new mute rule to mute specific findings with documentation and audit trail
 - **`prowler_app_update_mute_rule`** - Update a mute rule's name, reason, or enabled status
 - **`prowler_app_delete_mute_rule`** - Delete a mute rule from the system
+
+### Attack Paths Analysis
+
+Tools for analyzing privilege escalation chains and security misconfigurations using graph-based analysis. Attack Paths maps relationships between cloud resources, permissions, and security findings to detect how privileges can be escalated and how misconfigurations can be exploited.
+
+- **`prowler_app_list_attack_paths_scans`** - List Attack Paths scans with filtering by provider, provider type, and scan state (available, scheduled, executing, completed, failed, cancelled)
+- **`prowler_app_list_attack_paths_queries`** - Discover available Attack Paths queries for a completed scan, including query names, descriptions, and required parameters
+- **`prowler_app_run_attack_paths_query`** - Execute an Attack Paths query against a completed scan and retrieve graph results with nodes (cloud resources, findings, virtual nodes) and relationships (access paths, role assumptions, security group memberships)
 
 ### Compliance Management
 

--- a/docs/getting-started/products/prowler-mcp.mdx
+++ b/docs/getting-started/products/prowler-mcp.mdx
@@ -24,6 +24,7 @@ Full access to Prowler Cloud platform and self-managed Prowler App for:
 - **Scan Orchestration**: Trigger on-demand scans and schedule recurring security assessments
 - **Resource Inventory**: Search and view detailed information about your audited resources
 - **Muting Management**: Create and manage muting lists/rules to suppress non-relevant findings
+- **Attack Paths Analysis**: Analyze privilege escalation chains and security misconfigurations through graph-based analysis of cloud resource relationships
 
 ### 2. Prowler Hub
 
@@ -61,6 +62,7 @@ The Prowler MCP Server enables powerful workflows through AI assistants:
 - "Show me all critical findings from my AWS production accounts"
 - "Register my new AWS account in Prowler and run a scheduled scan every day"
 - "List all muted findings and detect what findgings are muted by a not enough good reason in relation to their severity"
+- "Run an attack paths query to find EC2 instances exposed to the Internet with access to sensitive S3 buckets"
 
 **Security Research**
 - "Explain what the S3 bucket public access Prowler check does"

--- a/docs/user-guide/tutorials/prowler-app-attack-paths.mdx
+++ b/docs/user-guide/tutorials/prowler-app-attack-paths.mdx
@@ -201,3 +201,20 @@ To expand the graph for detailed exploration, click the fullscreen icon in the g
   alt="Attack Paths fullscreen mode with graph and node detail side panel"
   width="700"
 />
+
+## Using Attack Paths with the MCP Server
+
+Attack Paths capabilities are also available through the [Prowler MCP Server](/getting-started/products/prowler-mcp), enabling interaction with Attack Paths data via AI assistants like Claude Desktop, Cursor, and other MCP clients.
+
+The following MCP tools are available for Attack Paths:
+
+- **`prowler_app_list_attack_paths_scans`** - List and filter Attack Paths scans
+- **`prowler_app_list_attack_paths_queries`** - Discover available queries for a completed scan
+- **`prowler_app_run_attack_paths_query`** - Execute a query and retrieve graph results with nodes and relationships
+
+These tools enable workflows such as:
+- Asking an AI assistant to identify privilege escalation paths in a specific AWS account
+- Automating attack path analysis across multiple scans
+- Combining attack path data with findings and compliance information for comprehensive security reports
+
+For the complete list of MCP tools, see the [Tools Reference](/getting-started/basic-usage/prowler-mcp-tools#attack-paths-analysis).


### PR DESCRIPTION
### Context

Add documentation for the three new Attack Paths MCP tools introduced in the Prowler MCP Server, updating the tool count from 24 to 27.

### Description

This PR documents the new Attack Paths Analysis MCP tools across three documentation pages:

- **MCP Tools Reference** (`prowler-mcp-tools.mdx`): Added "Attack Paths Analysis" section with the three new tools (`prowler_app_list_attack_paths_scans`, `prowler_app_list_attack_paths_queries`, `prowler_app_run_attack_paths_query`) and updated the Prowler Cloud/App tool count from 24 to 27.
- **MCP Product Page** (`prowler-mcp.mdx`): Added Attack Paths Analysis to the Prowler Cloud capabilities list and included an example workflow prompt.
- **Attack Paths Tutorial** (`prowler-app-attack-paths.mdx`): Added a new section explaining how to use Attack Paths through the MCP Server, including available tools and example workflows.

### Steps to review

1. Review the new "Attack Paths Analysis" section in the MCP tools reference for accuracy and completeness.
2. Verify the tool count update (24 → 27) is correct.
3. Check the new MCP Server section in the Attack Paths tutorial for clarity.
4. Confirm links between pages are correct.

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.