### PR TITLE
fix(ci): prevent E2E auth setups from running on broad path matches

### DIFF
--- a/.github/test-impact.yml
+++ b/.github/test-impact.yml
@@ -224,8 +224,24 @@ modules:
     tests:
       - api/src/backend/api/tests/test_views.py
     e2e:
-      # API view changes can break UI
-      - ui/tests/**
+      # All E2E test suites (explicit to avoid triggering auth setups in tests/setups/)
+      - ui/tests/auth/**
+      - ui/tests/sign-in/**
+      - ui/tests/sign-up/**
+      - ui/tests/sign-in-base/**
+      - ui/tests/scans/**
+      - ui/tests/providers/**
+      - ui/tests/findings/**
+      - ui/tests/compliance/**
+      - ui/tests/invitations/**
+      - ui/tests/roles/**
+      - ui/tests/users/**
+      - ui/tests/integrations/**
+      - ui/tests/resources/**
+      - ui/tests/profile/**
+      - ui/tests/lighthouse/**
+      - ui/tests/home/**
+      - ui/tests/attack-paths/**
 
   - name: api-serializers
     match:
@@ -234,8 +250,24 @@ modules:
     tests:
       - api/src/backend/api/tests/**
     e2e:
-      # Serializer changes affect API responses → UI
-      - ui/tests/**
+      # All E2E test suites (explicit to avoid triggering auth setups in tests/setups/)
+      - ui/tests/auth/**
+      - ui/tests/sign-in/**
+      - ui/tests/sign-up/**
+      - ui/tests/sign-in-base/**
+      - ui/tests/scans/**
+      - ui/tests/providers/**
+      - ui/tests/findings/**
+      - ui/tests/compliance/**
+      - ui/tests/invitations/**
+      - ui/tests/roles/**
+      - ui/tests/users/**
+      - ui/tests/integrations/**
+      - ui/tests/resources/**
+      - ui/tests/profile/**
+      - ui/tests/lighthouse/**
+      - ui/tests/home/**
+      - ui/tests/attack-paths/**
 
   - name: api-filters
     match:
@@ -407,8 +439,24 @@ modules:
       - ui/components/ui/**
     tests: []
     e2e:
-      # Shared components can affect any E2E
-      - ui/tests/**
+      # All E2E test suites (explicit to avoid triggering auth setups in tests/setups/)
+      - ui/tests/auth/**
+      - ui/tests/sign-in/**
+      - ui/tests/sign-up/**
+      - ui/tests/sign-in-base/**
+      - ui/tests/scans/**
+      - ui/tests/providers/**
+      - ui/tests/findings/**
+      - ui/tests/compliance/**
+      - ui/tests/invitations/**
+      - ui/tests/roles/**
+      - ui/tests/users/**
+      - ui/tests/integrations/**
+      - ui/tests/resources/**
+      - ui/tests/profile/**
+      - ui/tests/lighthouse/**
+      - ui/tests/home/**
+      - ui/tests/attack-paths/**
 
   - name: ui-attack-paths
     match:

--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -214,6 +214,20 @@ jobs:
             TEST_PATHS=$(echo "$TEST_PATHS" | sed 's|ui/||g' | sed 's|\*\*||g' | tr ' ' '\n' | sort -u)
             # Drop auth setup helpers (not runnable test suites)
             TEST_PATHS=$(echo "$TEST_PATHS" | grep -v '^tests/setups/')
+            # Safety net: if bare "tests/" appears (from broad patterns like ui/tests/**),
+            # expand to specific subdirs to avoid Playwright discovering setup files
+            if echo "$TEST_PATHS" | grep -qx 'tests/'; then
+              echo "Expanding bare 'tests/' to specific subdirs (excluding setups)..."
+              SPECIFIC_DIRS=""
+              for dir in tests/*/; do
+                [[ "$dir" == "tests/setups/" ]] && continue
+                SPECIFIC_DIRS="${SPECIFIC_DIRS}${dir}"$'\n'
+              done
+              # Replace "tests/" with specific dirs, keep other paths
+              TEST_PATHS=$(echo "$TEST_PATHS" | grep -vx 'tests/')
+              TEST_PATHS="${TEST_PATHS}"$'\n'"${SPECIFIC_DIRS}"
+              TEST_PATHS=$(echo "$TEST_PATHS" | grep -v '^$' | sort -u)
+            fi
             if [[ -z "$TEST_PATHS" ]]; then
               echo "No runnable E2E test paths after filtering setups"
               exit 0


### PR DESCRIPTION
## Context

The `ui-e2e-tests-v2.yml` workflow was triggering all E2E auth setup projects (requesting env vars like `E2E_MANAGE_SCANS_USER`, `E2E_INVITE_AND_MANAGE_USERS_USER`, etc.) when they shouldn't have been running.

**Root cause:** Three modules in `test-impact.yml` (`api-views`, `api-serializers`, `ui-shadcn`) used `ui/tests/**` as their e2e pattern. After the workflow's `sed` transformation, this became bare `tests/` which caused Playwright to scan the entire test directory — including `tests/setups/` — discovering all auth setup files and failing on missing env vars.

## Description of Changes

### `test-impact.yml`
- Replaced `ui/tests/**` with 17 explicit test directory patterns in `api-views`, `api-serializers`, and `ui-shadcn` modules
- This prevents the `sed` transformation from ever producing a bare `tests/` path

### `ui-e2e-tests-v2.yml`
- Added safety net: if a bare `tests/` path somehow makes it through (defense in depth), it expands to all subdirectories except `tests/setups/`

## Testing

### Local validation (test-impact.py simulations)

| # | Test | Result |
|---|------|--------|
| 1 | `api-views` trigger outputs explicit paths, not `ui/tests/**` | PASS |
| 2 | `api-serializers` trigger outputs explicit paths | PASS |
| 3 | `ui-shadcn` trigger outputs explicit paths | PASS |
| 4 | Normal UI module (`ui-scans`) still works correctly (regression) | PASS |
| 5 | Setup files in ignored list still don't trigger tests | PASS |
| 6 | Safety net catches bare `tests/` and expands excluding setups | PASS |
| 7 | Targeted paths (`scans/`, `providers/`) don't trigger safety net | PASS |
| 8 | All 17 explicit paths resolve cleanly, no `tests/` or `setups` | PASS |

### CI validation (GitHub Actions)

| # | Test | Mode | Result |
|---|------|------|--------|
| 1 | This PR (#10304) — changes `.github/` files (critical path) | `run-all` | ALL GREEN — full E2E suite passed in 12m23s |
| 2 | Test PR (#10305) — touched only `ui/components/shadcn/` to trigger `ui-shadcn` module | `targeted` (else branch) | 25/25 passed — NO auth setup env var errors. 1 pre-existing AWS AssumeRole failure + 1 flaky GitHub provider timeout (unrelated to this fix). Test PR closed after validation. |

The second CI test was critical because this PR's own CI used the `run-all` branch (`pnpm run test:e2e`) which bypasses the path transformation logic entirely. The test PR confirmed the `else` branch (targeted paths + sed transforms + safety net) works correctly.

## Related

Follow-up to #10176 which added E2E test paths to module match blocks.