### PR TITLE
test(ci): validate targeted E2E path resolution for shadcn module

### DIFF
--- a/.github/test-impact.yml
+++ b/.github/test-impact.yml
@@ -224,8 +224,24 @@ modules:
     tests:
       - api/src/backend/api/tests/test_views.py
     e2e:
-      # API view changes can break UI
-      - ui/tests/**
+      # All E2E test suites (explicit to avoid triggering auth setups in tests/setups/)
+      - ui/tests/auth/**
+      - ui/tests/sign-in/**
+      - ui/tests/sign-up/**
+      - ui/tests/sign-in-base/**
+      - ui/tests/scans/**
+      - ui/tests/providers/**
+      - ui/tests/findings/**
+      - ui/tests/compliance/**
+      - ui/tests/invitations/**
+      - ui/tests/roles/**
+      - ui/tests/users/**
+      - ui/tests/integrations/**
+      - ui/tests/resources/**
+      - ui/tests/profile/**
+      - ui/tests/lighthouse/**
+      - ui/tests/home/**
+      - ui/tests/attack-paths/**
 
   - name: api-serializers
     match:
@@ -234,8 +250,24 @@ modules:
     tests:
       - api/src/backend/api/tests/**
     e2e:
-      # Serializer changes affect API responses → UI
-      - ui/tests/**
+      # All E2E test suites (explicit to avoid triggering auth setups in tests/setups/)
+      - ui/tests/auth/**
+      - ui/tests/sign-in/**
+      - ui/tests/sign-up/**
+      - ui/tests/sign-in-base/**
+      - ui/tests/scans/**
+      - ui/tests/providers/**
+      - ui/tests/findings/**
+      - ui/tests/compliance/**
+      - ui/tests/invitations/**
+      - ui/tests/roles/**
+      - ui/tests/users/**
+      - ui/tests/integrations/**
+      - ui/tests/resources/**
+      - ui/tests/profile/**
+      - ui/tests/lighthouse/**
+      - ui/tests/home/**
+      - ui/tests/attack-paths/**
 
   - name: api-filters
     match:
@@ -407,8 +439,24 @@ modules:
       - ui/components/ui/**
     tests: []
     e2e:
-      # Shared components can affect any E2E
-      - ui/tests/**
+      # All E2E test suites (explicit to avoid triggering auth setups in tests/setups/)
+      - ui/tests/auth/**
+      - ui/tests/sign-in/**
+      - ui/tests/sign-up/**
+      - ui/tests/sign-in-base/**
+      - ui/tests/scans/**
+      - ui/tests/providers/**
+      - ui/tests/findings/**
+      - ui/tests/compliance/**
+      - ui/tests/invitations/**
+      - ui/tests/roles/**
+      - ui/tests/users/**
+      - ui/tests/integrations/**
+      - ui/tests/resources/**
+      - ui/tests/profile/**
+      - ui/tests/lighthouse/**
+      - ui/tests/home/**
+      - ui/tests/attack-paths/**
 
   - name: ui-attack-paths
     match:

--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -214,6 +214,20 @@ jobs:
             TEST_PATHS=$(echo "$TEST_PATHS" | sed 's|ui/||g' | sed 's|\*\*||g' | tr ' ' '\n' | sort -u)
             # Drop auth setup helpers (not runnable test suites)
             TEST_PATHS=$(echo "$TEST_PATHS" | grep -v '^tests/setups/')
+            # Safety net: if bare "tests/" appears (from broad patterns like ui/tests/**),
+            # expand to specific subdirs to avoid Playwright discovering setup files
+            if echo "$TEST_PATHS" | grep -qx 'tests/'; then
+              echo "Expanding bare 'tests/' to specific subdirs (excluding setups)..."
+              SPECIFIC_DIRS=""
+              for dir in tests/*/; do
+                [[ "$dir" == "tests/setups/" ]] && continue
+                SPECIFIC_DIRS="${SPECIFIC_DIRS}${dir}"$'\n'
+              done
+              # Replace "tests/" with specific dirs, keep other paths
+              TEST_PATHS=$(echo "$TEST_PATHS" | grep -vx 'tests/')
+              TEST_PATHS="${TEST_PATHS}"$'\n'"${SPECIFIC_DIRS}"
+              TEST_PATHS=$(echo "$TEST_PATHS" | grep -v '^$' | sort -u)
+            fi
             if [[ -z "$TEST_PATHS" ]]; then
               echo "No runnable E2E test paths after filtering setups"
               exit 0

--- a/ui/components/shadcn/select/multiselect.tsx
+++ b/ui/components/shadcn/select/multiselect.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// CI test: trigger ui-shadcn module to validate targeted E2E path resolution
 import { CheckIcon, ChevronDown, XIcon } from "lucide-react";
 import {
   type ComponentPropsWithoutRef,


### PR DESCRIPTION
## Context

Test PR to validate that the fix from #10304 works correctly when the `ui-shadcn` module is triggered through the **targeted path branch** (not `run-all`).

The previous PR's CI passed because it hit critical paths and used `pnpm run test:e2e` (run-all mode). This PR only touches a shadcn component to exercise the `else` branch with the path transformation + safety net logic.

**Will be closed after CI validation.**

## Expected behavior

- Impact analysis detects `ui-shadcn` module
- E2E paths resolve to 17 explicit test directories (not bare `tests/`)
- Auth setups in `tests/setups/` are NOT discovered by Playwright
- No `E2E_MANAGE_SCANS_USER` or similar env var errors