### PR TITLE
fix(ci): prevent grep exit code 1 from failing empty dir check

### DIFF
--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -242,7 +242,7 @@ jobs:
                 echo "Skipping empty test directory: $p"
               fi
             done <<< "$TEST_PATHS"
-            VALID_PATHS=$(echo "$VALID_PATHS" | grep -v '^$')
+            VALID_PATHS=$(echo "$VALID_PATHS" | grep -v '^$' || true)
             if [[ -z "$VALID_PATHS" ]]; then
               echo "No test files found in any resolved paths — skipping E2E"
               exit 0


### PR DESCRIPTION
## Context

The empty directory check added in #10311 fails with exit code 1 when ALL resolved test directories are empty (for example, `ui/tests/findings/**` or `ui/tests/attack-paths/**`).

Failing run: https://github.com/prowler-cloud/prowler/actions/runs/22996873117/job/66771299065?pr=10314

**Root cause:** GitHub Actions bash runs with `set -eo pipefail`. When `VALID_PATHS` is empty, `grep -v '^$'` has no output and returns exit code 1, which kills the script before reaching the graceful `exit 0`.

## Description of Changes

One-line fix: add `|| true` to the grep command so it returns 0 even when there are no matches.

```bash
# Before (fails with exit 1 when VALID_PATHS is empty)
VALID_PATHS=$(echo "$VALID_PATHS" | grep -v '^$')

# After (returns 0 even with no matches)
VALID_PATHS=$(echo "$VALID_PATHS" | grep -v '^$' || true)
```

## Related

Follow-up to #10311, #10304