### PR TITLE
chore(ui): add changelog entry for org dropdown actions (#10317)

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.21.0] (Prowler UNRELEASED)
+
+### 🚀 Added
+
+- Organization and organizational unit row actions (Edit Name, Update Credentials, Test Connections, Delete) in providers table dropdown [(#10317)](https://github.com/prowler-cloud/prowler/pull/10317)
+
+---
+
 ## [1.20.0] (Prowler v5.20.0)
 
 ### 🚀 Added


### PR DESCRIPTION
### Context

PR #10317 (`feat(ui): add organization-specific actions to providers table dropdown`) was merged without a changelog entry. This PR adds the missing entry under `[1.21.0] (Prowler UNRELEASED)`.

### Description

- Add `🚀 Added` changelog entry for organization and organizational unit row actions in providers table dropdown

### Steps to review

1. Open `ui/CHANGELOG.md` — verify the new `[1.21.0] (Prowler UNRELEASED)` section with the Added entry for #10317
2. Confirm the entry follows keepachangelog format with emoji prefix and PR link

### Checklist

- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.