### PR TITLE
fix(security): Ignore cryptography vulnerability until we can upgrade it

### DIFF
--- a/.github/workflows/api-security.yml
+++ b/.github/workflows/api-security.yml
@@ -64,8 +64,9 @@ jobs:
 
       - name: Safety
         if: steps.check-changes.outputs.any_changed == 'true'
-        run: poetry run safety check --ignore 79023,79027
+        run: poetry run safety check --ignore 79023,79027,86217
         # TODO: 79023 & 79027 knack ReDoS until `azure-cli-core` (via `cartography`) allows `knack` >=0.13.0
+        # TODO: 86217 because `alibabacloud-tea-openapi == 0.4.3` don't let us upgrade `cryptography >= 46.0.0`
 
       - name: Vulture
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,7 +127,8 @@ repos:
         description: "Safety is a tool that checks your installed dependencies for known security vulnerabilities"
         # TODO: Botocore needs urllib3 1.X so we need to ignore these vulnerabilities 77744,77745. Remove this once we upgrade to urllib3 2.X
         # TODO: 79023 & 79027 knack ReDoS until `azure-cli-core` (via `cartography`) allows `knack` >=0.13.0
-        entry: bash -c 'safety check --ignore 70612,66963,74429,76352,76353,77744,77745,79023,79027'
+        # TODO: 86217 because `alibabacloud-tea-openapi == 0.4.3` don't let us upgrade `cryptography >= 46.0.0`
+        entry: bash -c 'safety check --ignore 70612,66963,74429,76352,76353,77744,77745,79023,79027,86217'
         language: system
 
       - id: vulture


### PR DESCRIPTION
### Context

The `cryptography` package has a known vulnerability (CVE / Safety ID 86217), but we can't upgrade past 44.0.3 right now. `alibabacloud-tea-openapi` (all versions up to the latest 0.4.3) pins `cryptography<45.0.0`, so pip refuses to resolve if we bump to 46.0.x.

This adds the Safety ignore so CI stops failing on a vulnerability we can't fix yet.

### Description

- Adds Safety ignore `86217` to `.github/workflows/api-security.yml` and `.pre-commit-config.yaml`
- Adds a TODO comment explaining the blocker (`alibabacloud-tea-openapi == 0.4.3` caps `cryptography < 45.0.0`)

We'll remove the ignore and upgrade `cryptography` once Alibaba releases a version that relaxes the upper bound.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.