### PR TITLE
feat: CORS_ALLOWED_ORIGINS configurable via environment variable

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [1.22.0] (Prowler UNRELEASED)
+
+### 🚀 Added
+
+- `CORS_ALLOWED_ORIGINS` configurable via environment variable [(#10355)](https://github.com/prowler-cloud/prowler/pull/10355)
+
+---
+
 ## [1.21.0] (Prowler v5.20.0)
 
 ### 🔄 Changed

--- a/api/src/backend/config/django/production.py
+++ b/api/src/backend/config/django/production.py
@@ -3,6 +3,10 @@ from config.env import env
 
 DEBUG = env.bool("DJANGO_DEBUG", default=False)
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
+CORS_ALLOWED_ORIGINS = env.list(
+    "DJANGO_CORS_ALLOWED_ORIGINS",
+    default=["http://localhost", "http://127.0.0.1"],
+)
 
 # Database
 # TODO Use Django database routers https://docs.djangoproject.com/en/5.0/topics/db/multi-db/#automatic-database-routing


### PR DESCRIPTION
Fixes #10344

`CORS_ALLOWED_ORIGINS` in `api/src/backend/config/django/production.py` was hardcoded, preventing deployments from configuring allowed origins without modifying source code. Adds `CORS_ALLOWED_ORIGINS` as an env-configurable list via `DJANGO_CORS_ALLOWED_ORIGINS`, following the same pattern used by `DJANGO_ALLOWED_HOSTS`. Defaults to `["http://localhost", "http://127.0.0.1"]` to preserve existing local development behavior. Verified by confirming the env variable is read correctly using the existing `env.list()` utility from `config.env`.