### PR TITLE
fix(docs): setting a couple of API PRs in the next release instead of 5.20

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,14 +2,21 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [1.22.0] (Prowler UNRELEASED)
+
+### 🔄 Changed
+
+- Attack Paths: Complete migration to private graph labels and properties, removing deprecated dual-write support [(#10268)](https://github.com/prowler-cloud/prowler/pull/10268)
+- Attack Paths: Added tenant and provider related labels to the nodes so they can be easily filtered on custom queries [(#10308)](https://github.com/prowler-cloud/prowler/pull/10308)
+
+---
+
 ## [1.21.0] (Prowler v5.20.0)
 
 ### 🔄 Changed
 
 - Attack Paths: Migrate network exposure queries from APOC to standard openCypher for Neo4j and Neptune compatibility [(#10266)](https://github.com/prowler-cloud/prowler/pull/10266)
-- Attack Paths: Complete migration to private graph labels and properties, removing deprecated dual-write support [(#10268)](https://github.com/prowler-cloud/prowler/pull/10268)
 - `POST /api/v1/providers` returns `409 Conflict` if already exists [(#10293)](https://github.com/prowler-cloud/prowler/pull/10293)
-- Attack Paths: Added tenant and provider related labels to the nodes so they can be easily filtered on custom queries [(#10308)](https://github.com/prowler-cloud/prowler/pull/10308)
 
 ### 🐞 Fixed
 


### PR DESCRIPTION
### Description

API PRs #10268 and #10308 were mistakingly added into 5.20 in `api/CHANGELOG.md`, so moving them to the next release.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.