### PR TITLE
fix(api): make CORS_ALLOWED_ORIGINS configurable via env variable

### DIFF
--- a/api/src/backend/config/django/production.py
+++ b/api/src/backend/config/django/production.py
@@ -3,6 +3,10 @@ from config.env import env
 
 DEBUG = env.bool("DJANGO_DEBUG", default=False)
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["localhost", "127.0.0.1"])
+CORS_ALLOWED_ORIGINS = env.list(
+    "DJANGO_CORS_ALLOWED_ORIGINS",
+    default=["http://localhost", "http://127.0.0.1"],
+)
 
 # Database
 # TODO Use Django database routers https://docs.djangoproject.com/en/5.0/topics/db/multi-db/#automatic-database-routing


### PR DESCRIPTION
Closes #10344

## Summary

- Added `DJANGO_CORS_ALLOWED_ORIGINS` env var support in `production.py`
- Uses `env.list()` with same defaults as `base.py` (`http://localhost`, `http://127.0.0.1`)
- Follows the existing pattern used by `DJANGO_ALLOWED_HOSTS` on the line above

## Usage

```bash
DJANGO_CORS_ALLOWED_ORIGINS=https://prowler.example.com,https://prowler.internal.local
```

## Test plan

- [ ] Verify default behavior unchanged when env var is not set
- [ ] Set `DJANGO_CORS_ALLOWED_ORIGINS` to a custom origin, confirm CORS headers are returned
- [ ] Confirm `ALLOWED_HOSTS` and `CORS_ALLOWED_ORIGINS` can be configured independently