### PR TITLE
Make VM name comparison case-insensitive in azure vm_backup_enabled check

### DIFF
--- a/prowler/providers/azure/services/vm/vm_backup_enabled/vm_backup_enabled.py
+++ b/prowler/providers/azure/services/vm/vm_backup_enabled/vm_backup_enabled.py
@@ -31,7 +31,7 @@ class vm_backup_enabled(Check):
                     for backup_item in vault.backup_protected_items.values():
                         if (
                             backup_item.workload_type == DataSourceType.VM
-                            and backup_item.name.split(";")[-1] == vm.resource_name
+                            and backup_item.name.split(";")[-1].lower() == vm.resource_name.lower()
                         ):
                             found = True
                             found_vault_name = vault.name


### PR DESCRIPTION
### Context

FIX #10372

### Description

This makes the vm comparison case insensitive 

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.



### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
