### PR TITLE
chore(mcp): bump MCP server version to 0.5.0

### DIFF
--- a/mcp_server/CHANGELOG.md
+++ b/mcp_server/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler MCP Server** are documented in this file.
 
-## [0.5.0] (Prowler v5.20.0 UNRELEASED)
+## [0.5.0] (Prowler v5.20.0)
 
 ### 🚀 Added
 

--- a/mcp_server/prowler_mcp_server/__init__.py
+++ b/mcp_server/prowler_mcp_server/__init__.py
@@ -5,7 +5,7 @@ This package provides MCP tools for accessing:
 - Prowler Hub: All security artifacts (detections, remediations and frameworks) supported by Prowler
 """
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __author__ = "Prowler Team"
 __email__ = "engineering@prowler.com"
 

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -11,7 +11,7 @@ description = "MCP server for Prowler ecosystem"
 name = "prowler-mcp"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.4.0"
+version = "0.5.0"
 
 [project.scripts]
 prowler-mcp = "prowler_mcp_server.main:main"

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -717,7 +717,7 @@ wheels = [
 
 [[package]]
 name = "prowler-mcp"
-version = "0.3.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
### Context

Bump the Prowler MCP Server version to 0.5.0 to align with the Prowler v5.20.0 release.

### Description

- Updates version from 0.4.0 to 0.5.0 in `pyproject.toml`, `__init__.py`, and `uv.lock`
- Marks CHANGELOG.md entry as released (removes UNRELEASED)

### Steps to review

1. Verify version strings are consistent across all files
2. Confirm CHANGELOG entry matches the release

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.