### PR TITLE
fix(ui): refine filter clear and undo behavior in Findings page

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Findings filters now use a batch-apply pattern with an Apply Filters button, filter summary strip, and independent filter options instead of triggering API calls on every selection [(#10388)](https://github.com/prowler-cloud/prowler/pull/10388)
 
+### 🐞 Fixed
+
+- Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button
+
 ---
 
 ## [1.21.0] (Prowler v5.21.0)

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🐞 Fixed
 
-- Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button
+- Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button [(#10446)](https://github.com/prowler-cloud/prowler/pull/10446)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.23.0] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button [(#10446)](https://github.com/prowler-cloud/prowler/pull/10446)
+
+---
+
 ## [1.22.0] (Prowler v5.22.0)
 
 ### 🚀 Added
@@ -11,10 +19,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Findings filters now use a batch-apply pattern with an Apply Filters button, filter summary strip, and independent filter options instead of triggering API calls on every selection [(#10388)](https://github.com/prowler-cloud/prowler/pull/10388)
-
-### 🐞 Fixed
-
-- Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button [(#10446)](https://github.com/prowler-cloud/prowler/pull/10446)
 
 ---
 

--- a/ui/components/filters/apply-filters-button.test.tsx
+++ b/ui/components/filters/apply-filters-button.test.tsx
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from "vitest";
 // Mock lucide-react to avoid SVG rendering issues in jsdom
 vi.mock("lucide-react", () => ({
   Check: () => <svg data-testid="check-icon" />,
-  X: () => <svg data-testid="x-icon" />,
 }));
 
 // Mock @/components/shadcn to avoid next-auth import chain
@@ -74,7 +73,7 @@ describe("ApplyFiltersButton", () => {
       expect(applyButton).toBeDisabled();
     });
 
-    it("should NOT render the discard (X) button when there are no changes", () => {
+    it("should NOT render the Undo button when there are no changes", () => {
       // Given / When
       render(
         <ApplyFiltersButton
@@ -88,7 +87,7 @@ describe("ApplyFiltersButton", () => {
       // Then
       expect(
         screen.queryByRole("button", {
-          name: /discard/i,
+          name: /undo/i,
         }),
       ).not.toBeInTheDocument();
     });
@@ -166,7 +165,7 @@ describe("ApplyFiltersButton", () => {
       ).toBeInTheDocument();
     });
 
-    it("should render the discard (X) button", () => {
+    it("should render the Undo button", () => {
       // Given / When
       render(
         <ApplyFiltersButton
@@ -179,7 +178,7 @@ describe("ApplyFiltersButton", () => {
 
       // Then
       expect(
-        screen.getByRole("button", { name: /discard pending filter changes/i }),
+        screen.getByRole("button", { name: /undo pending filter changes/i }),
       ).toBeInTheDocument();
     });
   });
@@ -237,7 +236,7 @@ describe("ApplyFiltersButton", () => {
   // ── onDiscard interaction ────────────────────────────────────────────────
 
   describe("onDiscard", () => {
-    it("should call onDiscard when the Discard button is clicked", async () => {
+    it("should call onDiscard when the Undo button is clicked", async () => {
       // Given
       const user = userEvent.setup();
       const onApply = vi.fn();
@@ -254,7 +253,7 @@ describe("ApplyFiltersButton", () => {
 
       // When
       await user.click(
-        screen.getByRole("button", { name: /discard pending filter changes/i }),
+        screen.getByRole("button", { name: /undo pending filter changes/i }),
       );
 
       // Then

--- a/ui/components/filters/apply-filters-button.tsx
+++ b/ui/components/filters/apply-filters-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, X } from "lucide-react";
+import { Check } from "lucide-react";
 
 import { Button } from "@/components/shadcn";
 import { cn } from "@/lib/utils";
@@ -12,7 +12,7 @@ export interface ApplyFiltersButtonProps {
   changeCount: number;
   /** Called when the user clicks "Apply Filters" */
   onApply: () => void;
-  /** Called when the user clicks the discard (X) action */
+  /** Called when the user clicks the discard (Undo) action */
   onDiscard: () => void;
   /** Optional extra class names for the outer wrapper */
   className?: string;
@@ -50,13 +50,8 @@ export const ApplyFiltersButton = ({
       </Button>
 
       {hasChanges && (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={onDiscard}
-          aria-label="Discard pending filter changes"
-        >
-          <X className="size-4" />
+        <Button variant="ghost" size="sm" onClick={onDiscard}>
+          Undo
         </Button>
       )}
     </div>

--- a/ui/components/filters/apply-filters-button.tsx
+++ b/ui/components/filters/apply-filters-button.tsx
@@ -50,7 +50,12 @@ export const ApplyFiltersButton = ({
       </Button>
 
       {hasChanges && (
-        <Button variant="ghost" size="sm" onClick={onDiscard} aria-label="Undo pending filter changes">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onDiscard}
+          aria-label="Undo pending filter changes"
+        >
           Undo
         </Button>
       )}

--- a/ui/components/filters/apply-filters-button.tsx
+++ b/ui/components/filters/apply-filters-button.tsx
@@ -50,7 +50,7 @@ export const ApplyFiltersButton = ({
       </Button>
 
       {hasChanges && (
-        <Button variant="ghost" size="sm" onClick={onDiscard}>
+        <Button variant="ghost" size="sm" onClick={onDiscard} aria-label="Undo pending filter changes">
           Undo
         </Button>
       )}

--- a/ui/components/filters/apply-filters-button.tsx
+++ b/ui/components/filters/apply-filters-button.tsx
@@ -23,7 +23,7 @@ export interface ApplyFiltersButtonProps {
  *
  * - Shows the count of pending changes when `hasChanges` is true.
  * - The apply button is disabled (and visually muted) when there are no changes.
- * - The discard (X) button only appears when there are pending changes.
+ * - The Undo button only appears when there are pending changes.
  * - Uses Prowler's shadcn `Button` component.
  */
 export const ApplyFiltersButton = ({

--- a/ui/components/filters/clear-filters-button.tsx
+++ b/ui/components/filters/clear-filters-button.tsx
@@ -2,7 +2,6 @@
 
 import { XCircle } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback } from "react";
 
 import { Button } from "../shadcn";
 
@@ -52,7 +51,7 @@ export const ClearFiltersButton = ({
   const filterCount = activeFilters.length;
 
   // Clear all filters except excluded ones (muted, search)
-  const clearFiltersPreservingExcluded = useCallback(() => {
+  const clearFiltersPreservingExcluded = () => {
     const params = new URLSearchParams(searchParams.toString());
     Array.from(params.keys()).forEach((key) => {
       if (
@@ -64,7 +63,7 @@ export const ClearFiltersButton = ({
     });
     params.delete("page");
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
-  }, [router, searchParams, pathname]);
+  };
 
   // In batch mode: use pendingCount if provided; otherwise fall back to URL count.
   // In instant mode: always use URL count.

--- a/ui/components/findings/findings-filters.tsx
+++ b/ui/components/findings/findings-filters.tsx
@@ -118,7 +118,8 @@ export const FindingsFilters = ({
     setPending,
     applyAll,
     discardAll,
-    clearAll,
+    clearAndApply,
+    clearKeys,
     hasChanges,
     changeCount,
     getFilterValue,
@@ -252,7 +253,7 @@ export const FindingsFilters = ({
         )}
         <ClearFiltersButton
           showCount
-          onClear={clearAll}
+          onClear={clearAndApply}
           pendingCount={
             Object.entries(pendingFilters).filter(([key, values]) => {
               if (!values || values.length === 0) return false;
@@ -279,7 +280,13 @@ export const FindingsFilters = ({
       <FilterSummaryStrip
         chips={filterChips}
         onRemove={handleChipRemove}
-        onClearAll={clearAll}
+        onClearAll={() => {
+          // Collect the unique filter keys that are currently visible as chips.
+          // This intentionally excludes provider_type__in and provider_id__in
+          // (they never produce chips) so "Clear all" does not touch the selectors.
+          const chipKeys = Array.from(new Set(filterChips.map((c) => c.key)));
+          clearKeys(chipKeys);
+        }}
       />
 
       {/* Expandable filters section */}

--- a/ui/components/findings/findings-filters.tsx
+++ b/ui/components/findings/findings-filters.tsx
@@ -201,8 +201,15 @@ export const FindingsFilters = ({
 
   // Handler for clearing all chips: clears only the filter keys visible as chips,
   // without touching provider/account selectors.
+  const PROVIDER_KEYS = new Set([
+    "filter[provider_type__in]",
+    "filter[provider_id__in]",
+  ]);
+
   const handleClearAllChips = () => {
-    const chipKeys = Array.from(new Set(filterChips.map((c) => c.key)));
+    const chipKeys = Array.from(new Set(filterChips.map((c) => c.key))).filter(
+      (k) => !PROVIDER_KEYS.has(k),
+    );
     clearKeys(chipKeys);
   };
 

--- a/ui/components/findings/findings-filters.tsx
+++ b/ui/components/findings/findings-filters.tsx
@@ -199,6 +199,13 @@ export const FindingsFilters = ({
     setPending(filterKey, nextValues);
   };
 
+  // Handler for clearing all chips: clears only the filter keys visible as chips,
+  // without touching provider/account selectors.
+  const handleClearAllChips = () => {
+    const chipKeys = Array.from(new Set(filterChips.map((c) => c.key)));
+    clearKeys(chipKeys);
+  };
+
   // Derive pending muted state for the checkbox.
   // Note: "filter[muted]" participates in batch mode — applyAll includes it
   // when present in pending state, and the defaultParams option ensures
@@ -280,13 +287,7 @@ export const FindingsFilters = ({
       <FilterSummaryStrip
         chips={filterChips}
         onRemove={handleChipRemove}
-        onClearAll={() => {
-          // Collect the unique filter keys that are currently visible as chips.
-          // This intentionally excludes provider_type__in and provider_id__in
-          // (they never produce chips) so "Clear all" does not touch the selectors.
-          const chipKeys = Array.from(new Set(filterChips.map((c) => c.key)));
-          clearKeys(chipKeys);
-        }}
+        onClearAll={handleClearAllChips}
       />
 
       {/* Expandable filters section */}

--- a/ui/hooks/use-filter-batch.test.ts
+++ b/ui/hooks/use-filter-batch.test.ts
@@ -585,4 +585,264 @@ describe("useFilterBatch", () => {
       ]);
     });
   });
+
+  // ── clearAndApply ──────────────────────────────────────────────────────────
+
+  describe("clearAndApply", () => {
+    it("should clear all batch-managed filters and push URL immediately", () => {
+      // Given
+      setSearchParams({
+        "filter[severity__in]": "critical",
+        "filter[status__in]": "FAIL",
+      });
+      const { result } = renderHook(() => useFilterBatch());
+
+      // Pre-condition — pending is loaded from URL
+      expect(result.current.pendingFilters["filter[severity__in]"]).toEqual([
+        "critical",
+      ]);
+      expect(result.current.pendingFilters["filter[status__in]"]).toEqual([
+        "FAIL",
+      ]);
+
+      // When
+      act(() => {
+        result.current.clearAndApply();
+      });
+
+      // Then — pending is empty
+      expect(result.current.pendingFilters).toEqual({});
+
+      // And router.push was called
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+
+      // The pushed URL must NOT contain severity or status
+      expect(calledUrl).not.toContain("severity");
+      expect(calledUrl).not.toContain("status");
+    });
+
+    it("should apply defaultParams when clearing", () => {
+      // Given
+      setSearchParams({ "filter[severity__in]": "critical" });
+      const { result } = renderHook(() =>
+        useFilterBatch({ defaultParams: { "filter[muted]": "false" } }),
+      );
+
+      // When
+      act(() => {
+        result.current.clearAndApply();
+      });
+
+      // Then — pushed URL contains the defaultParam
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("filter%5Bmuted%5D=false");
+    });
+
+    it("should preserve filter[search] (excluded from batch)", () => {
+      // Given — URL has both a search param (excluded) and a batch filter
+      mockSearchParamsValue = new URLSearchParams({
+        "filter[search]": "test",
+        "filter[severity__in]": "critical",
+      });
+      const { result } = renderHook(() => useFilterBatch());
+
+      // When
+      act(() => {
+        result.current.clearAndApply();
+      });
+
+      // Then — search param is preserved; severity is gone
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("filter%5Bsearch%5D=test");
+      expect(calledUrl).not.toContain("severity");
+    });
+
+    it("should reset pagination to page 1", () => {
+      // Given — URL already has a page param
+      mockSearchParamsValue = new URLSearchParams({
+        "filter[severity__in]": "critical",
+        page: "3",
+      });
+      const { result } = renderHook(() => useFilterBatch());
+
+      // When
+      act(() => {
+        result.current.clearAndApply();
+      });
+
+      // Then — page is reset to 1
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("page=1");
+    });
+  });
+
+  // ── clearKeys ─────────────────────────────────────────────────────────────
+
+  describe("clearKeys", () => {
+    it("should remove only specified keys and push URL", () => {
+      // Given
+      setSearchParams({});
+      const { result } = renderHook(() => useFilterBatch());
+
+      act(() => {
+        result.current.setPending("filter[severity__in]", ["critical"]);
+        result.current.setPending("filter[status__in]", ["FAIL"]);
+        result.current.setPending("filter[region__in]", ["us-east-1"]);
+      });
+
+      // When
+      act(() => {
+        result.current.clearKeys(["filter[severity__in]"]);
+      });
+
+      // Then — severity is gone; status and region remain
+      expect(
+        result.current.pendingFilters["filter[severity__in]"],
+      ).toBeUndefined();
+      expect(result.current.pendingFilters["filter[status__in]"]).toEqual([
+        "FAIL",
+      ]);
+      expect(result.current.pendingFilters["filter[region__in]"]).toEqual([
+        "us-east-1",
+      ]);
+
+      // And the pushed URL contains the remaining keys but not severity
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("status");
+      expect(calledUrl).toContain("region");
+      expect(calledUrl).not.toContain("severity");
+    });
+
+    it("should accept keys without 'filter[' prefix", () => {
+      // Given
+      setSearchParams({});
+      const { result } = renderHook(() => useFilterBatch());
+
+      act(() => {
+        result.current.setPending("filter[severity__in]", ["critical"]);
+      });
+
+      // When — pass key without filter[] wrapper
+      act(() => {
+        result.current.clearKeys(["severity__in"]);
+      });
+
+      // Then — severity is cleared
+      expect(
+        result.current.pendingFilters["filter[severity__in]"],
+      ).toBeUndefined();
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).not.toContain("severity");
+    });
+
+    it("should preserve provider/account keys not in the cleared list", () => {
+      // Given
+      setSearchParams({});
+      const { result } = renderHook(() => useFilterBatch());
+
+      act(() => {
+        result.current.setPending("filter[provider_type__in]", ["aws"]);
+        result.current.setPending("filter[severity__in]", ["critical"]);
+        result.current.setPending("filter[status__in]", ["FAIL"]);
+      });
+
+      // When — clear only severity and status; leave provider untouched
+      act(() => {
+        result.current.clearKeys([
+          "filter[severity__in]",
+          "filter[status__in]",
+        ]);
+      });
+
+      // Then — provider_type__in is still in pending
+      expect(
+        result.current.pendingFilters["filter[provider_type__in]"],
+      ).toEqual(["aws"]);
+      expect(
+        result.current.pendingFilters["filter[severity__in]"],
+      ).toBeUndefined();
+      expect(
+        result.current.pendingFilters["filter[status__in]"],
+      ).toBeUndefined();
+
+      // And the pushed URL retains provider but not severity/status
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("provider_type__in");
+      expect(calledUrl).not.toContain("severity");
+      expect(calledUrl).not.toContain("status__in");
+    });
+
+    it("should apply defaultParams after clearing", () => {
+      // Given
+      setSearchParams({});
+      const { result } = renderHook(() =>
+        useFilterBatch({ defaultParams: { "filter[muted]": "false" } }),
+      );
+
+      act(() => {
+        result.current.setPending("filter[severity__in]", ["critical"]);
+      });
+
+      // When
+      act(() => {
+        result.current.clearKeys(["filter[severity__in]"]);
+      });
+
+      // Then — defaultParam is present in the pushed URL
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("filter%5Bmuted%5D=false");
+    });
+
+    it("should reset pagination to page 1", () => {
+      // Given — URL already has a page param
+      mockSearchParamsValue = new URLSearchParams({
+        "filter[severity__in]": "critical",
+        page: "5",
+      });
+      const { result } = renderHook(() => useFilterBatch());
+
+      // When
+      act(() => {
+        result.current.clearKeys(["filter[severity__in]"]);
+      });
+
+      // Then — page is reset to 1
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("page=1");
+    });
+
+    it("should handle empty keys array gracefully", () => {
+      // Given
+      setSearchParams({});
+      const { result } = renderHook(() => useFilterBatch());
+
+      act(() => {
+        result.current.setPending("filter[severity__in]", ["critical"]);
+      });
+
+      // When — clear no keys at all
+      act(() => {
+        result.current.clearKeys([]);
+      });
+
+      // Then — pending is unchanged
+      expect(result.current.pendingFilters["filter[severity__in]"]).toEqual([
+        "critical",
+      ]);
+
+      // And router.push was still called (navigates with current state)
+      expect(mockPush).toHaveBeenCalledTimes(1);
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      expect(calledUrl).toContain("severity");
+    });
+  });
 });

--- a/ui/hooks/use-filter-batch.ts
+++ b/ui/hooks/use-filter-batch.ts
@@ -32,6 +32,19 @@ export interface UseFilterBatchReturn {
    * Includes provider/account keys and all batch-managed filter keys.
    */
   clearAll: () => void;
+  /**
+   * Clear all batch-managed filters and immediately navigate (router.push)
+   * with defaultParams applied. Equivalent to clearAll() + applyAll() but
+   * avoids the async state gap between the two calls.
+   */
+  clearAndApply: () => void;
+  /**
+   * Clear only the specified filter keys from pending state and immediately
+   * navigate (router.push) with the remaining pending filters + defaultParams.
+   * Used by "Clear all" in the pills strip to remove only pill-visible filters
+   * without touching provider/account selectors.
+   */
+  clearKeys: (keys: string[]) => void;
   /** Remove a single filter key from pending state */
   removePending: (key: string) => void;
   /** Whether pending state differs from the current URL */
@@ -230,6 +243,106 @@ export const useFilterBatch = (
     setPendingFilters({});
   };
 
+  /**
+   * Clears ALL batch-managed filters and immediately navigates (router.push).
+   *
+   * Works around the async gap between clearAll() + applyAll(): instead of
+   * setting pending to `{}` and then calling applyAll() (which would still
+   * read the old pendingFilters from the closure), this function builds the
+   * target URL directly from an empty pending state and pushes it in one step.
+   * defaultParams (e.g. filter[muted]=false) are applied as usual.
+   */
+  const clearAndApply = () => {
+    // Build params starting from the current URL (preserves non-batch params like filter[search])
+    const params = new URLSearchParams(searchParams.toString());
+
+    // Remove all batch-managed filter params
+    Array.from(params.keys()).forEach((key) => {
+      if (key.startsWith("filter[") && !EXCLUDED_FROM_BATCH.includes(key)) {
+        params.delete(key);
+      }
+    });
+
+    // Apply caller-supplied defaults for any params not already set
+    if (options?.defaultParams) {
+      Object.entries(options.defaultParams).forEach(([key, value]) => {
+        if (!params.has(key)) {
+          params.set(key, value);
+        }
+      });
+    }
+
+    // Reset pagination
+    if (params.has("page")) {
+      params.set("page", "1");
+    }
+
+    // Clear pending state so the UI updates immediately
+    setPendingFilters({});
+
+    const queryString = params.toString();
+    const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
+    router.push(targetUrl, { scroll: false });
+  };
+
+  /**
+   * Removes only the specified filter keys from pending state and immediately
+   * navigates (router.push) with the remaining filters + defaultParams.
+   *
+   * Used by the pills strip "Clear all" to remove pill-visible filters (severity,
+   * status, delta, region, service, etc.) without touching provider/account selectors.
+   */
+  const clearKeys = (keys: string[]) => {
+    const normalizedKeys = keys.map((k) =>
+      k.startsWith("filter[") ? k : `filter[${k}]`,
+    );
+
+    // Build the next pending state by removing the specified keys
+    const nextPending: PendingFilters = { ...pendingFilters };
+    normalizedKeys.forEach((k) => {
+      delete nextPending[k];
+    });
+
+    // Update local state so the UI reflects the cleared filters immediately
+    setPendingFilters(nextPending);
+
+    // Build the target URL from the updated pending state
+    const params = new URLSearchParams(searchParams.toString());
+
+    // Remove all batch-managed filter params from the URL first
+    Array.from(params.keys()).forEach((key) => {
+      if (key.startsWith("filter[") && !EXCLUDED_FROM_BATCH.includes(key)) {
+        params.delete(key);
+      }
+    });
+
+    // Re-apply the remaining (non-cleared) pending filters
+    Object.entries(nextPending).forEach(([key, values]) => {
+      const nonEmpty = values.filter(Boolean);
+      if (nonEmpty.length > 0) {
+        params.set(key, nonEmpty.join(","));
+      }
+    });
+
+    // Apply caller-supplied defaults for any params not already set
+    if (options?.defaultParams) {
+      Object.entries(options.defaultParams).forEach(([key, value]) => {
+        if (!params.has(key)) {
+          params.set(key, value);
+        }
+      });
+    }
+
+    // Reset pagination
+    if (params.has("page")) {
+      params.set("page", "1");
+    }
+
+    const queryString = params.toString();
+    const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
+    router.push(targetUrl, { scroll: false });
+  };
+
   const getFilterValue = (key: string): string[] => {
     const filterKey = key.startsWith("filter[") ? key : `filter[${key}]`;
     return pendingFilters[filterKey] ?? [];
@@ -249,6 +362,8 @@ export const useFilterBatch = (
     applyAll,
     discardAll,
     clearAll,
+    clearAndApply,
+    clearKeys,
     removePending,
     hasChanges,
     changeCount,

--- a/ui/hooks/use-filter-batch.ts
+++ b/ui/hooks/use-filter-batch.ts
@@ -177,20 +177,19 @@ export const useFilterBatch = (
     });
   };
 
-  const applyAll = () => {
-    // Start from the current URL params to preserve non-batch params.
-    // Only filter[search] is excluded from batch management and preserved from the URL as-is.
+  /** Private helper — builds URLSearchParams from a pending state and pushes. */
+  const buildAndPush = (nextPending: PendingFilters) => {
     const params = new URLSearchParams(searchParams.toString());
 
-    // Remove all existing batch-managed filter params
+    // Remove all batch-managed filter params
     Array.from(params.keys()).forEach((key) => {
       if (key.startsWith("filter[") && !EXCLUDED_FROM_BATCH.includes(key)) {
         params.delete(key);
       }
     });
 
-    // Write the pending state
-    Object.entries(pendingFilters).forEach(([key, values]) => {
+    // Re-apply the given pending filters
+    Object.entries(nextPending).forEach(([key, values]) => {
       const nonEmpty = values.filter(Boolean);
       if (nonEmpty.length > 0) {
         params.set(key, nonEmpty.join(","));
@@ -214,6 +213,10 @@ export const useFilterBatch = (
     const queryString = params.toString();
     const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
     router.push(targetUrl, { scroll: false });
+  };
+
+  const applyAll = () => {
+    buildAndPush(pendingFilters);
   };
 
   const discardAll = () => {
@@ -253,36 +256,8 @@ export const useFilterBatch = (
    * defaultParams (e.g. filter[muted]=false) are applied as usual.
    */
   const clearAndApply = () => {
-    // Build params starting from the current URL (preserves non-batch params like filter[search])
-    const params = new URLSearchParams(searchParams.toString());
-
-    // Remove all batch-managed filter params
-    Array.from(params.keys()).forEach((key) => {
-      if (key.startsWith("filter[") && !EXCLUDED_FROM_BATCH.includes(key)) {
-        params.delete(key);
-      }
-    });
-
-    // Apply caller-supplied defaults for any params not already set
-    if (options?.defaultParams) {
-      Object.entries(options.defaultParams).forEach(([key, value]) => {
-        if (!params.has(key)) {
-          params.set(key, value);
-        }
-      });
-    }
-
-    // Reset pagination
-    if (params.has("page")) {
-      params.set("page", "1");
-    }
-
-    // Clear pending state so the UI updates immediately
     setPendingFilters({});
-
-    const queryString = params.toString();
-    const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
-    router.push(targetUrl, { scroll: false });
+    buildAndPush({});
   };
 
   /**
@@ -296,51 +271,12 @@ export const useFilterBatch = (
     const normalizedKeys = keys.map((k) =>
       k.startsWith("filter[") ? k : `filter[${k}]`,
     );
-
-    // Build the next pending state by removing the specified keys
     const nextPending: PendingFilters = { ...pendingFilters };
     normalizedKeys.forEach((k) => {
       delete nextPending[k];
     });
-
-    // Update local state so the UI reflects the cleared filters immediately
     setPendingFilters(nextPending);
-
-    // Build the target URL from the updated pending state
-    const params = new URLSearchParams(searchParams.toString());
-
-    // Remove all batch-managed filter params from the URL first
-    Array.from(params.keys()).forEach((key) => {
-      if (key.startsWith("filter[") && !EXCLUDED_FROM_BATCH.includes(key)) {
-        params.delete(key);
-      }
-    });
-
-    // Re-apply the remaining (non-cleared) pending filters
-    Object.entries(nextPending).forEach(([key, values]) => {
-      const nonEmpty = values.filter(Boolean);
-      if (nonEmpty.length > 0) {
-        params.set(key, nonEmpty.join(","));
-      }
-    });
-
-    // Apply caller-supplied defaults for any params not already set
-    if (options?.defaultParams) {
-      Object.entries(options.defaultParams).forEach(([key, value]) => {
-        if (!params.has(key)) {
-          params.set(key, value);
-        }
-      });
-    }
-
-    // Reset pagination
-    if (params.has("page")) {
-      params.set("page", "1");
-    }
-
-    const queryString = params.toString();
-    const targetUrl = queryString ? `${pathname}?${queryString}` : pathname;
-    router.push(targetUrl, { scroll: false });
+    buildAndPush(nextPending);
   };
 
   const getFilterValue = (key: string): string[] => {


### PR DESCRIPTION
### Context

Follow-up refinements to the batch-apply filter pattern introduced in #10388. The Clear Filters, Clear all (pills), and discard button behaviors needed adjustments based on UX feedback.

### Description

- **Clear Filters** now resets **all** filters including "Include muted findings" and auto-applies immediately (`router.push`), instead of only staging the change
- **Discard button** (next to Apply Filters) replaced the `X` icon with an **"Undo"** text button for better discoverability
- **Clear all** in the pills strip now only removes pill-visible sub-filters (severity, status, delta, region, etc.) **without** touching provider/account selectors, and auto-applies
- Added `clearAndApply()` and `clearKeys(keys[])` methods to `useFilterBatch` hook to support atomic clear+navigate operations, avoiding React state batching issues

### Steps to review

1. Navigate to **Findings** page
2. Select some filters (provider, account, severity, muted, etc.)
3. Click **Apply Filters** to apply them
4. Verify **Clear Filters** resets everything (including muted checkbox) and navigates immediately
5. Re-apply some filters, verify **"Undo"** text button (next to Apply Filters) reverts pending changes
6. Apply filters with pills visible, verify **"Clear all"** in pills only removes sub-filters (not provider/account) and auto-applies
7. Verify provider and account selectors are preserved after "Clear all" in pills

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.