### PR TITLE
docs: add missing pre-commit hooks setup for TruffleHog, Safety and Hadolint

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Some pre-commit hooks require tools installed on your system:
     pip install safety
     ```
 
+3. **Install [Hadolint](https://github.com/hadolint/hadolint#install)** (Dockerfile linting) — see the [official installation options](https://github.com/hadolint/hadolint#install).
+
 ## Prowler CLI
 ### Pip package
 Prowler CLI is available as a project in [PyPI](https://pypi.org/project/prowler-cloud/). Consequently, it can be installed using pip with Python >3.9.1, <3.13:

--- a/README.md
+++ b/README.md
@@ -239,6 +239,27 @@ pnpm start
 
 > Once configured, access the Prowler App at http://localhost:3000. Sign up using your email and password to get started.
 
+**Pre-commit Hooks Setup**
+
+Some pre-commit hooks require tools installed on your system:
+
+1. **Install [TruffleHog](https://github.com/trufflesecurity/trufflehog)** (secret scanning):
+
+    ```console
+    # Homebrew (macOS / Linux)
+    brew install trufflehog
+
+    # Or via install script
+    curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+    ```
+
+2. **Install [Safety](https://github.com/pyupio/safety)** (dependency vulnerability checking):
+
+    ```console
+    # Requires a Python environment (e.g. via pyenv)
+    pip install safety
+    ```
+
 ## Prowler CLI
 ### Pip package
 Prowler CLI is available as a project in [PyPI](https://pypi.org/project/prowler-cloud/). Consequently, it can be installed using pip with Python >3.9.1, <3.13:

--- a/README.md
+++ b/README.md
@@ -243,15 +243,7 @@ pnpm start
 
 Some pre-commit hooks require tools installed on your system:
 
-1. **Install [TruffleHog](https://github.com/trufflesecurity/trufflehog)** (secret scanning):
-
-    ```console
-    # Homebrew (macOS / Linux)
-    brew install trufflehog
-
-    # Or via install script
-    curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-    ```
+1. **Install [TruffleHog](https://github.com/trufflesecurity/trufflehog#install)** (secret scanning) — see the [official installation options](https://github.com/trufflesecurity/trufflehog#install).
 
 2. **Install [Safety](https://github.com/pyupio/safety)** (dependency vulnerability checking):
 


### PR DESCRIPTION
## Summary

- Document installation steps for TruffleHog, Safety and Hadolint, required by pre-commit hooks but missing from the developer setup guide

## Context

Following the current "From GitHub" setup instructions, the first `git commit` fails with `exit code 127` (command not found) for `trufflehog`, `safety` and `hadolint`. These are configured as `language: system` hooks in `.pre-commit-config.yaml`, so they need to be installed manually but this was not documented.

## Feedback requested

The Safety installation approach documented here (`pip install safety` via a pyenv-managed Python environment) is one working solution. Open to suggestions if there's a preferred alternative for the team.

## Test plan

- [ ] Fresh clone following the README setup instructions can pass all pre-commit hooks