### PR TITLE
fix(api): filter neo4j.io defunct connection logs in Sentry before_send

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 - Finding groups list/latest now apply computed status/severity filters and finding-level prefilters (delta, region, service, category, resource group, scan, resource type), plus `check_title` support for sort/filter consistency [(#10428)](https://github.com/prowler-cloud/prowler/pull/10428)
 - Populate compliance data inside `check_metadata` for findings, which was always returned as `null` [(#10449)](https://github.com/prowler-cloud/prowler/pull/10449)
+- Filter transient Neo4j defunct connection logs in Sentry `before_send` to suppress false-positive alerts handled by `RetryableSession` retries [(#10452)](https://github.com/prowler-cloud/prowler/pull/10452)
 
 ## [1.23.0] (Prowler v5.22.0)
 

--- a/api/src/backend/api/tests/test_sentry.py
+++ b/api/src/backend/api/tests/test_sentry.py
@@ -4,14 +4,25 @@ from unittest.mock import MagicMock
 from config.settings.sentry import before_send
 
 
+def _make_log_record(msg, level=logging.ERROR, name="test", args=None):
+    """Build a real LogRecord so getMessage() works like in production."""
+    record = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="",
+        lineno=0,
+        msg=msg,
+        args=args,
+        exc_info=None,
+    )
+    return record
+
+
 def test_before_send_ignores_log_with_ignored_exception():
     """Test that before_send ignores logs containing ignored exceptions."""
-    log_record = MagicMock()
-    log_record.msg = "Provider kubernetes is not connected"
-    log_record.levelno = logging.ERROR  # 40
+    log_record = _make_log_record("Provider kubernetes is not connected")
 
     hint = {"log_record": log_record}
-
     event = MagicMock()
 
     result = before_send(event, hint)
@@ -36,12 +47,9 @@ def test_before_send_ignores_exception_with_ignored_exception():
 
 def test_before_send_passes_through_non_ignored_log():
     """Test that before_send passes through logs that don't contain ignored exceptions."""
-    log_record = MagicMock()
-    log_record.msg = "Some other error message"
-    log_record.levelno = logging.ERROR  # 40
+    log_record = _make_log_record("Some other error message")
 
     hint = {"log_record": log_record}
-
     event = MagicMock()
 
     result = before_send(event, hint)
@@ -66,12 +74,11 @@ def test_before_send_passes_through_non_ignored_exception():
 
 def test_before_send_handles_warning_level():
     """Test that before_send handles warning level logs."""
-    log_record = MagicMock()
-    log_record.msg = "Provider kubernetes is not connected"
-    log_record.levelno = logging.WARNING  # 30
+    log_record = _make_log_record(
+        "Provider kubernetes is not connected", level=logging.WARNING
+    )
 
     hint = {"log_record": log_record}
-
     event = MagicMock()
 
     result = before_send(event, hint)
@@ -85,15 +92,20 @@ def test_before_send_ignores_neo4j_defunct_connection():
 
     The Neo4j driver logs transient connection errors at ERROR level
     before RetryableSession retries them. These are noise.
+
+    The driver uses %s formatting, so "defunct" is in the args, not
+    in the template. This test mirrors the real LogRecord structure.
     """
-    log_record = MagicMock()
-    log_record.name = "neo4j.io"
-    log_record.msg = (
-        "[#E5CC] _: <CONNECTION> error: Failed to read from defunct connection "
-        "IPv4Address(('cloud-neo4j.prowler.com', 7687)) "
-        "ConnectionResetError(104, 'Connection reset by peer')"
+    log_record = _make_log_record(
+        msg="[#%04X]  _: <CONNECTION> error: %s: %r",
+        name="neo4j.io",
+        args=(
+            0xE5CC,
+            "Failed to read from defunct connection "
+            "IPv4Address(('cloud-neo4j.prowler.com', 7687))",
+            ConnectionResetError(104, "Connection reset by peer"),
+        ),
     )
-    log_record.levelno = logging.ERROR
 
     hint = {"log_record": log_record}
     event = MagicMock()
@@ -103,10 +115,10 @@ def test_before_send_ignores_neo4j_defunct_connection():
 
 def test_before_send_passes_non_defunct_neo4j_log():
     """Test that before_send passes through neo4j.io logs that are not about defunct connections."""
-    log_record = MagicMock()
-    log_record.name = "neo4j.io"
-    log_record.msg = "Some other neo4j transport error"
-    log_record.levelno = logging.ERROR
+    log_record = _make_log_record(
+        msg="Some other neo4j transport error",
+        name="neo4j.io",
+    )
 
     hint = {"log_record": log_record}
     event = MagicMock()

--- a/api/src/backend/api/tests/test_sentry.py
+++ b/api/src/backend/api/tests/test_sentry.py
@@ -78,3 +78,37 @@ def test_before_send_handles_warning_level():
 
     # Assert that the event was dropped (None returned)
     assert result is None
+
+
+def test_before_send_ignores_neo4j_defunct_connection():
+    """Test that before_send drops neo4j.io defunct connection logs.
+
+    The Neo4j driver logs transient connection errors at ERROR level
+    before RetryableSession retries them. These are noise.
+    """
+    log_record = MagicMock()
+    log_record.name = "neo4j.io"
+    log_record.msg = (
+        "[#E5CC] _: <CONNECTION> error: Failed to read from defunct connection "
+        "IPv4Address(('cloud-neo4j.prowler.com', 7687)) "
+        "ConnectionResetError(104, 'Connection reset by peer')"
+    )
+    log_record.levelno = logging.ERROR
+
+    hint = {"log_record": log_record}
+    event = MagicMock()
+
+    assert before_send(event, hint) is None
+
+
+def test_before_send_passes_non_defunct_neo4j_log():
+    """Test that before_send passes through neo4j.io logs that are not about defunct connections."""
+    log_record = MagicMock()
+    log_record.name = "neo4j.io"
+    log_record.msg = "Some other neo4j transport error"
+    log_record.levelno = logging.ERROR
+
+    hint = {"log_record": log_record}
+    event = MagicMock()
+
+    assert before_send(event, hint) == event

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -1,4 +1,5 @@
 import sentry_sdk
+
 from config.env import env
 
 IGNORED_EXCEPTIONS = [
@@ -85,8 +86,20 @@ def before_send(event, hint):
     # Ignore logs with the ignored_exceptions
     # https://docs.python.org/3/library/logging.html#logrecord-objects
     if "log_record" in hint:
-        log_msg = hint["log_record"].msg
-        log_lvl = hint["log_record"].levelno
+        log_record = hint["log_record"]
+        log_msg = log_record.msg
+        log_lvl = log_record.levelno
+
+        # The Neo4j driver logs transient connection errors (defunct
+        # connections, resets) at ERROR level via the `neo4j.io` logger.
+        # `RetryableSession` handles these with retries. If all retries
+        # are exhausted, the exception propagates and Sentry captures
+        # it as a normal exception event.
+        if (
+            getattr(log_record, "name", "").startswith("neo4j.io")
+            and "defunct" in log_msg
+        ):
+            return None
 
         # Handle Error and Critical events and discard the rest
         if log_lvl <= 40 and any(ignored in log_msg for ignored in IGNORED_EXCEPTIONS):

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -87,7 +87,7 @@ def before_send(event, hint):
     # https://docs.python.org/3/library/logging.html#logrecord-objects
     if "log_record" in hint:
         log_record = hint["log_record"]
-        log_msg = log_record.msg
+        log_msg = log_record.getMessage()
         log_lvl = log_record.levelno
 
         # The Neo4j driver logs transient connection errors (defunct


### PR DESCRIPTION
### Context

Sentry fires false-positive alerts on transient Neo4j connection errors during attack paths scans. There are a few recent open issues of this pattern, 0 users impacted.                                                                                                                         
                                                                                                                                                         
The Neo4j Python driver logs defunct connection errors at `ERROR` level via its internal `neo4j.io` logger. Sentry captures these log records before the error reaches `RetryableSession`, which catches the exception, refreshes the session, and retries successfully. The scans complete fine but Sentry alerts on the driver's internal log.

### Description

Adds a targeted check in `before_send` that drops log records from the `neo4j.io` logger when the message contains `"defunct"`. This covers all three error subtypes seen in production:
- `ConnectionResetError(104, 'Connection reset by peer')`
- `OSError('No data')`
- `TimeoutError('timed out')`

If `RetryableSession` exhausts all retries, the exception propagates normally and Sentry captures it as an exception event (not a log record), so real failures are still reported.

#### Why not other approaches

- `ignore_logger("neo4j.io")` silences all logs from that logger, not just defunct connections
- Sentry server-side alert rules would work but aren't version-controlled and break if someone recreates the rule
- `before_send` is the existing pattern in this codebase for Sentry event filtering

#### Edit

Switched from `log_record.msg` to `log_record.getMessage()`. The neo4j driver uses `%s` formatting (`log.error("[#%04X] error: %s", port, message)`), so `.msg` is the template and doesn't contain `"defunct"`. `getMessage()` returns the formatted string. Tests now use real `LogRecord` objects instead of `MagicMock` to match production behavior.

### Steps to review

Run tests as specific tests for this has been added.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.