### PR TITLE
fix(sdk): pass registry arguments through init_global_provider

### DIFF
--- a/prowler/providers/common/provider.py
+++ b/prowler/providers/common/provider.py
@@ -307,6 +307,12 @@ class Provider(ABC):
                         timeout=arguments.timeout,
                         config_path=arguments.config_file,
                         fixer_config=fixer_config,
+                        registry=arguments.registry,
+                        image_filter=arguments.image_filter,
+                        tag_filter=arguments.tag_filter,
+                        max_images=arguments.max_images,
+                        registry_insecure=arguments.registry_insecure,
+                        registry_list_images=arguments.registry_list_images,
                     )
                 elif "mongodbatlas" in provider_class_name.lower():
                     provider_class(

--- a/tests/providers/image/image_provider_test.py
+++ b/tests/providers/image/image_provider_test.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from argparse import Namespace
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -1124,3 +1125,63 @@ class TestScanPerImage:
             list(provider.scan_per_image())
 
         mock_cleanup.assert_called_once()
+
+
+class TestInitGlobalProviderRegistryArgs:
+    """Regression test for registry arguments being passed through
+    init_global_provider to ImageProvider.
+
+    PR #9985 added registry scan support. PR #10128 accidentally removed
+    the registry kwargs from the init_global_provider call, so --registry
+    and related CLI flags were parsed but never forwarded to ImageProvider.
+    """
+
+    @patch("prowler.providers.common.provider.load_and_validate_config_file")
+    def test_registry_args_passed_to_image_provider(self, mock_load_config):
+        """Verify that init_global_provider passes registry-related arguments
+        to the ImageProvider constructor."""
+        mock_load_config.return_value = {}
+
+        # Simulate the parsed CLI arguments for `prowler image --registry ...`
+        arguments = Namespace(
+            provider="image",
+            config_file=None,
+            fixer_config=None,
+            images=None,
+            image_list_file=None,
+            scanners=["vuln"],
+            image_config_scanners=None,
+            trivy_severity=None,
+            ignore_unfixed=False,
+            timeout="5m",
+            registry="myregistry.example.com",
+            image_filter="myorg/",
+            tag_filter="latest",
+            max_images=100,
+            registry_insecure=True,
+            registry_list_images=False,
+        )
+
+        from prowler.providers.common.provider import Provider
+
+        # Ensure the isinstance check doesn't short-circuit
+        saved_global = Provider._global
+        Provider._global = None
+
+        try:
+            with patch.object(
+                ImageProvider, "__init__", return_value=None
+            ) as mock_init:
+                Provider.init_global_provider(arguments)
+
+                mock_init.assert_called_once()
+                call_kwargs = mock_init.call_args[1]
+
+                assert call_kwargs["registry"] == "myregistry.example.com"
+                assert call_kwargs["image_filter"] == "myorg/"
+                assert call_kwargs["tag_filter"] == "latest"
+                assert call_kwargs["max_images"] == 100
+                assert call_kwargs["registry_insecure"] is True
+                assert call_kwargs["registry_list_images"] is False
+        finally:
+            Provider._global = saved_global


### PR DESCRIPTION
**Please note, this is my first time contributing to Prowler**, I may have missed onboarding steps from CONTRIBUTING.md.

### Context

While deploying Prowler 5.22.0 as a weekly CronJob to scan my private OCI registry ([blumeops](https://forge.eblu.me/eblume/blumeops)), I discovered that `prowler image --registry <url>` always fails with `ImageNoImagesProvidedError[11000]: No images provided for scanning`, regardless of registry configuration.

Root cause: PR #9985 (merged 2026-02-19) correctly added registry kwargs (`registry`, `image_filter`, `tag_filter`, `max_images`, `registry_insecure`, `registry_list_images`) to the `init_global_provider` call. PR #10128 (merged 2026-02-24) accidentally removed them — likely a merge conflict resolution that took the older version of the `ImageProvider` constructor call.

My current workaround is an [init container that enumerates images via the registry's `/v2/_catalog` API](https://forge.eblu.me/eblume/blumeops/src/commit/75fd5b029d682e2f2a1337519bc6f3c5a1a210fc/argocd/manifests/prowler/cronjob-image-scan.yaml) and generates an `--image-list` file, bypassing `--registry` entirely.

### Description

Restores the six missing registry-related kwargs to the `init_global_provider` call for the image provider in `prowler/providers/common/provider.py`:

- `registry`
- `image_filter`
- `tag_filter`
- `max_images`
- `registry_insecure`
- `registry_list_images`

These are parsed by the CLI argument parser and accepted by `ImageProvider.__init__`, but were not being forwarded between the two.

Adds a regression test that mocks `ImageProvider.__init__` and verifies the registry kwargs are present in the constructor call.

### Steps to review

1. Compare the `elif "image"` block in `prowler/providers/common/provider.py` against `ImageProvider.__init__` signature in `prowler/providers/image/image_provider.py` — the six added kwargs match constructor parameters that were previously unreachable.
2. Run the regression test: `pytest tests/providers/image/image_provider_test.py::TestInitGlobalProviderRegistryArgs -xvs`
3. To verify the bug exists on master, revert the `provider.py` change and re-run the test — it fails with `KeyError: 'registry'`.
4. Run the full image provider test suite: `pytest tests/providers/image/image_provider_test.py` — all 116 tests pass.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
N/A

#### API
N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
