### PR TITLE
chore(ui): add pnpm supply chain security protections

### DIFF
--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -165,7 +165,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
-          version: 10
+          package_json_file: ui/package.json
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -98,7 +98,7 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
-          version: 10
+          package_json_file: ui/package.json
           run_install: false
 
       - name: Get pnpm store directory

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY scripts ./scripts
 RUN pnpm install --frozen-lockfile
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,7 +3,7 @@ FROM node:24.13.0-alpine@sha256:cd6fb7efa6490f039f3471a189214d5f548c11df1ff9e5b1
 LABEL maintainer="https://github.com/prowler-cloud"
 
 # Enable corepack for pnpm
-RUN corepack enable && corepack prepare pnpm@10 --activate
+RUN corepack enable
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -15,7 +15,7 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY scripts ./scripts
-RUN pnpm install --frozen-lockfile
+RUN corepack install && pnpm install --frozen-lockfile
 
 
 # Rebuild the source code only when needed

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -23,6 +23,10 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# Install pinned pnpm so build uses the exact version from package.json.
+# Alternative: move COPY package.json + corepack install to base stage to avoid
+# re-downloading, at the cost of invalidating all stages on any package.json change.
+RUN corepack install
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry

--- a/ui/package.json
+++ b/ui/package.json
@@ -195,5 +195,5 @@
     }
   },
   "version": "0.0.1",
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a"
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -7,6 +7,11 @@ packages: []
 # Prevents installing compromised packages during the detection window.
 minimumReleaseAge: 1440
 
+# Bypasses the minimum release age for specific packages.
+# Use ONLY for emergency patches (e.g., critical CVE fixes) that cannot wait 24h.
+# This should be ephemeral — remove the entry once the package meets the age threshold.
+# minimumReleaseAgeExclude:
+
 # --- Level 2: Explicit Build Script Allow-list ---
 # Only these packages may run install/postinstall lifecycle scripts.
 # Any unlisted package with lifecycle scripts will have them silently skipped.

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -11,12 +11,16 @@ minimumReleaseAge: 1440
 # Only these packages may run install/postinstall lifecycle scripts.
 # Any unlisted package with lifecycle scripts will have them silently skipped.
 onlyBuiltDependencies:
+  # sharp: Native image processing (libvips). Installs platform-specific pre-built binary or compiles from source.
   - sharp
+  # @sentry/cli: Downloads the sentry-cli native binary for the current platform. Validates integrity via SHA256.
   - "@sentry/cli"
+  # esbuild: Go binary. Downloads the pre-compiled binary matching the current platform/architecture.
   - esbuild
+  # @heroui/shared-utils: Demi pattern — detects React/Next.js version at install time and copies the compatible bundle (React 18 vs 19).
   - "@heroui/shared-utils"
+  # unrs-resolver: Rust module resolver (NAPI-RS). Verifies the correct native binding is available for the platform.
   - unrs-resolver
-  - msw
 
 # --- Level 3: Trust Policy + Exotic Subdeps ---
 # Fail when a package's trust evidence is downgraded (e.g., new publisher).

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,0 +1,27 @@
+# Reference: https://pnpm.io/supply-chain-security
+
+packages: []
+
+# --- Level 1: Minimum Release Age ---
+# Packages must be published for at least 1 day before they can be installed.
+# Prevents installing compromised packages during the detection window.
+minimumReleaseAge: 1440
+
+# --- Level 2: Explicit Build Script Allow-list ---
+# Only these packages may run install/postinstall lifecycle scripts.
+# Any unlisted package with lifecycle scripts will have them silently skipped.
+onlyBuiltDependencies:
+  - sharp
+  - "@sentry/cli"
+  - esbuild
+  - "@heroui/shared-utils"
+  - unrs-resolver
+  - msw
+
+# --- Level 3: Trust Policy + Exotic Subdeps ---
+# Fail when a package's trust evidence is downgraded (e.g., new publisher).
+trustPolicy: no-downgrade
+trustPolicyExclude: []
+
+# Block transitive dependencies from using exotic specifiers (git URLs, tarballs).
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

- Add `pnpm-workspace.yaml` with layered supply chain protections
  per https://pnpm.io/supply-chain-security
- Bump pnpm from 10.24.0 to 10.33.0 (required for
  `blockExoticSubdeps` and `trustPolicy`)
- Fix CI workflows to read exact pnpm version from
  `ui/package.json` instead of floating `version: 10`

## Supply chain protections added

| Protection | Setting | What it does |
  |---|---|---|
| Minimum release age | `minimumReleaseAge: 1440` | Blocks
  packages published < 24h ago |
| Build script allow-list | `onlyBuiltDependencies` | Only 6
  explicitly trusted packages may run postinstall scripts |
| Trust policy | `trustPolicy: no-downgrade` | Fails install if a
  package's trust evidence degrades (e.g., account takeover) |
| Block exotic subdeps | `blockExoticSubdeps: true` | Prevents
  transitive deps from using git/tarball URLs |

## CI fix

`pnpm/action-setup` was configured with `version: 10`, which
installs the latest 10.x ignoring the pinned version in
`packageManager`. Since `package.json` lives in `ui/` (not repo
root), the action never found it. Now uses `package_json_file:
  ui/package.json` to read the exact SHA512-verified version.

## Test plan

- [x] Clean install (`rm -rf node_modules && pnpm install`) — no
  trust violations or exotic subdep issues
- [x] All 6 allowed packages run build scripts successfully
- [x] 123/123 unit tests pass
- [x] Healthcheck (typecheck + ESLint) passes
- [x] Production build succeeds
- [ ] CI workflows pass with `package_json_file: ui/package.json`