### PR TITLE
chore: update dependencies

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -5827,14 +5827,14 @@ files = [
 
 [[package]]
 name = "nltk"
-version = "3.9.2"
+version = "3.9.4"
 description = "Natural Language Toolkit"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a"},
-    {file = "nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419"},
+    {file = "nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f"},
+    {file = "nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -3964,14 +3964,14 @@ test-extras = ["pytest-mpl", "pytest-randomly"]
 
 [[package]]
 name = "nltk"
-version = "3.9.2"
+version = "3.9.4"
 description = "Natural Language Toolkit"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a"},
-    {file = "nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419"},
+    {file = "nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f"},
+    {file = "nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
### Context

Update the `nltk` dependency from version 3.9.2 to 3.9.4 in both the root and API lock files.

### Description

Bumps `nltk` from 3.9.2 to 3.9.4 in both `poetry.lock` and `api/poetry.lock`. This update also raises the minimum Python version requirement for `nltk` from 3.9 to 3.10, which aligns with the project's supported Python versions.

### Steps to review

1. Verify the lock file changes are consistent across both `poetry.lock` and `api/poetry.lock`.
2. Confirm the updated hashes match the official `nltk` 3.9.4 release.
3. Ensure no breaking changes are introduced by the version bump.

### Checklist

- [x] Review if backport is needed.
- [x] No new checks, no documentation changes, no changelog entry needed (dependency update only).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.