### PR TITLE
chore: update Python version references from 3.9 to 3.10

### DIFF
--- a/.github/workflows/sdk-code-quality.yml
+++ b/.github/workflows/sdk-code-quality.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ Prowler is an open-source cloud security assessment tool supporting AWS, Azure, 
 
 | Component | Location | Tech Stack |
 |-----------|----------|------------|
-| SDK | `prowler/` | Python 3.9+, Poetry |
+| SDK | `prowler/` | Python 3.10+, Poetry |
 | API | `api/` | Django 5.1, DRF, Celery |
 | UI | `ui/` | Next.js 15, React 19, Tailwind 4 |
 | MCP Server | `mcp_server/` | FastMCP, Python 3.12+ |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ pnpm start
 
 ## Prowler CLI
 ### Pip package
-Prowler CLI is available as a project in [PyPI](https://pypi.org/project/prowler-cloud/). Consequently, it can be installed using pip with Python >3.9.1, <3.13:
+Prowler CLI is available as a project in [PyPI](https://pypi.org/project/prowler-cloud/). Consequently, it can be installed using pip with Python >=3.10, <3.13:
 
 ```console
 pip install prowler
@@ -273,7 +273,7 @@ The container images are available here:
 
 ### From GitHub
 
-Python >3.9.1, <3.13 is required with pip and Poetry:
+Python >=3.10, <3.13 is required with pip and Poetry:
 
 ``` console
 git clone https://github.com/prowler-cloud/prowler

--- a/docs/developer-guide/introduction.mdx
+++ b/docs/developer-guide/introduction.mdx
@@ -79,7 +79,7 @@ Remember, our community is here to help! If you need guidance, do not hesitate t
 Before proceeding, ensure the following:
 
 - Git is installed.
-- Python 3.9 or higher is installed.
+- Python 3.10 or higher is installed.
 - `poetry` is installed to manage dependencies.
 
 ### Forking the Prowler Repository

--- a/docs/developer-guide/provider.mdx
+++ b/docs/developer-guide/provider.mdx
@@ -1249,7 +1249,7 @@ Dependencies ensure that your provider's required libraries are available when P
 
 ```toml
 [tool.poetry.dependencies]
-python = "^3.9"
+python = ">=3.10,<3.13"
 # ... other dependencies
 your-sdk-library = "^1.0.0"  # Add your SDK dependency
 ```

--- a/docs/getting-started/installation/prowler-cli.mdx
+++ b/docs/getting-started/installation/prowler-cli.mdx
@@ -4,7 +4,7 @@ title: 'Installation'
 
 ## Installation
 
-To install Prowler as a Python package, use `Python >= 3.9, <= 3.12`. Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/):
+To install Prowler as a Python package, use `Python >= 3.10, <= 3.12`. Prowler is available as a project in [PyPI](https://pypi.org/project/prowler/):
 
 <Tabs>
   <Tab title="pipx">
@@ -12,7 +12,7 @@ To install Prowler as a Python package, use `Python >= 3.9, <= 3.12`. Prowler is
 
     _Requirements_:
 
-    * `Python >= 3.9, <= 3.12`
+    * `Python >= 3.10, <= 3.12`
     * `pipx` installed: [pipx installation](https://pipx.pypa.io/stable/installation/).
     * AWS, GCP, Azure and/or Kubernetes credentials
 
@@ -30,7 +30,7 @@ To install Prowler as a Python package, use `Python >= 3.9, <= 3.12`. Prowler is
 
     _Requirements_:
 
-    * `Python >= 3.9, <= 3.12`
+    * `Python >= 3.10, <= 3.12`
     * `Python pip >= 21.0.0`
     * AWS, GCP, Azure, M365 and/or Kubernetes credentials
 
@@ -87,7 +87,7 @@ To install Prowler as a Python package, use `Python >= 3.9, <= 3.12`. Prowler is
   <Tab title="Amazon Linux 2">
     _Requirements_:
 
-    * `Python >= 3.9, <= 3.12`
+    * `Python >= 3.10, <= 3.12`
     * AWS, GCP, Azure and/or Kubernetes credentials
 
     _Commands_:
@@ -102,8 +102,8 @@ To install Prowler as a Python package, use `Python >= 3.9, <= 3.12`. Prowler is
   <Tab title="Ubuntu">
     _Requirements_:
 
-    * `Ubuntu 23.04` or above. For older Ubuntu versions, check [pipx installation](https://docs.prowler.com/projects/prowler-open-source/en/latest/#__tabbed_1_1) and ensure `Python >= 3.9, <= 3.12` is installed.
-    * `Python >= 3.9, <= 3.12`
+    * `Ubuntu 23.04` or above. For older Ubuntu versions, check [pipx installation](https://docs.prowler.com/projects/prowler-open-source/en/latest/#__tabbed_1_1) and ensure `Python >= 3.10, <= 3.12` is installed.
+    * `Python >= 3.10, <= 3.12`
     * AWS, GCP, Azure and/or Kubernetes credentials
 
     _Commands_:

--- a/prowler/AGENTS.md
+++ b/prowler/AGENTS.md
@@ -81,7 +81,7 @@ class {check_name}(Check):
 
 ## TECH STACK
 
-Python 3.9+ | Poetry 2+ | pytest | moto (AWS mocking) | Pre-commit hooks (black, flake8, pylint, bandit)
+Python 3.10+ | Poetry 2+ | pytest | moto (AWS mocking) | Pre-commit hooks (black, flake8, pylint, bandit)
 
 ---
 

--- a/skills/prowler/SKILL.md
+++ b/skills/prowler/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch, WebSearch, Task
 
 | Component | Stack | Location |
 |-----------|-------|----------|
-| SDK | Python 3.9+, Poetry | `prowler/` |
+| SDK | Python 3.10+, Poetry | `prowler/` |
 | API | Django 5.1, DRF, Celery | `api/` |
 | UI | Next.js 15, React 19, Tailwind 4 | `ui/` |
 | MCP | FastMCP 2.13.1 | `mcp_server/` |


### PR DESCRIPTION
### Context

Python 3.9 is no longer supported (`pyproject.toml` defines `requires-python = ">=3.10,<3.13"`), but multiple documentation files and CI workflows still referenced it.

### Description

- Updated all documentation and agent config files that incorrectly referenced Python 3.9 as the minimum supported version to 3.10
- Removed Python 3.9 from the CI test matrix in `sdk-code-quality.yml` and `sdk-tests.yml`
- 9 files updated across docs, AGENTS.md, README.md, skills, and GitHub Actions workflows

**Not changed (intentionally):**
- `poetry.lock` / `uv.lock` — third-party package requirements
- `prowler/CHANGELOG.md` — historical entries
- `contrib/` — legacy deployment scripts (v2/v3)
- Test files with `python3.9` Lambda runtime — valid AWS runtime
- Compliance JSON mentioning `python3.9` — AWS Lambda supported runtimes
- CloudShell docs — factual reference to AL2023 environment

### Steps to review

1. Verify all updated files now reference Python 3.10 instead of 3.9
2. Confirm CI matrix no longer includes 3.9
3. Confirm no other tracked files still claim 3.9 support

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.