### PR TITLE
fix(ui): fix pre-commit hook skipping lint, tests, and build

### DIFF
--- a/ui/.husky/pre-commit
+++ b/ui/.husky/pre-commit
@@ -38,7 +38,8 @@ echo -e "${BLUE}ℹ️  Code Review Status: ${CODE_REVIEW_ENABLED}${NC}"
 echo ""
 
 # Get staged files in the UI folder only (what will be committed)
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM -- 'ui/**' | grep -E '\.(tsx?|jsx?)$' || true)
+# Always use GIT_ROOT-relative pathspecs so detection works regardless of cwd
+STAGED_FILES=$(git -C "$GIT_ROOT" diff --cached --name-only --diff-filter=ACM -- 'ui/' | grep -E '\.(tsx?|jsx?)$' || true)
 
 if [ "$CODE_REVIEW_ENABLED" = "true" ]; then
   if [ -z "$STAGED_FILES" ]; then
@@ -135,18 +136,17 @@ else
   echo ""
 fi
 
-# Check if there are any UI files to validate
-if [ -z "$STAGED_FILES" ] && [ "$CODE_REVIEW_ENABLED" = "true" ]; then
-  echo -e "${YELLOW}⏭️  No UI files to validate, skipping healthcheck${NC}"
+# Run healthcheck (typecheck and lint check) only if there are UI changes
+if [ -z "$STAGED_FILES" ]; then
+  echo -e "${YELLOW}⏭️  No UI files staged, skipping healthcheck/tests/build${NC}"
   echo ""
   exit 0
 fi
 
-# Run healthcheck (typecheck and lint check) only if there are UI changes
 echo -e "${BLUE}🏥 Running healthcheck...${NC}"
 echo ""
 
-cd ui || cd .
+cd "$GIT_ROOT/ui"
 if pnpm run healthcheck; then
   echo ""
   echo -e "${GREEN}✅ Healthcheck passed${NC}"
@@ -164,11 +164,11 @@ echo -e "${BLUE}🧪 Running unit tests...${NC}"
 echo ""
 
 # Get staged source files (exclude test files)
-# Note: we already cd'd into ui/, so pathspecs are relative (no ui/ prefix)
-STAGED_SOURCE_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.ts' '*.tsx' | grep -v '\.test\.\|\.spec\.\|vitest\.config\|vitest\.setup' || true)
+# Use GIT_ROOT so pathspecs are always correct regardless of cwd
+STAGED_SOURCE_FILES=$(git -C "$GIT_ROOT" diff --cached --name-only --diff-filter=ACM -- 'ui/*.ts' 'ui/*.tsx' | sed 's|^ui/||' | grep -v '\.test\.\|\.spec\.\|vitest\.config\|vitest\.setup' || true)
 
 # Check if critical paths changed (lib/, types/, config/)
-CRITICAL_PATHS_CHANGED=$(git diff --cached --name-only -- 'lib/**' 'types/**' 'config/**' 'middleware.ts' 'vitest.config.ts' 'vitest.setup.ts' || true)
+CRITICAL_PATHS_CHANGED=$(git -C "$GIT_ROOT" diff --cached --name-only -- 'ui/lib/' 'ui/types/' 'ui/config/' 'ui/middleware.ts' 'ui/vitest.config.ts' 'ui/vitest.setup.ts' || true)
 
 if [ -n "$CRITICAL_PATHS_CHANGED" ]; then
   echo -e "${YELLOW}Critical paths changed - running ALL unit tests${NC}"


### PR DESCRIPTION
### Context

The UI pre-commit hook (`ui/.husky/pre-commit`) was silently skipping **all quality gates** (healthcheck, lint, unit tests, build) due to two bugs in path resolution and control flow. This means UI changes could be committed locally without any validation.

Discovered while investigating CI failures on #10481 — the same prettier errors that CI caught should have been caught locally by the pre-commit hook.

### Description

**Bug 1 — Wrong pathspecs for staged file detection (line 41)**

The hook is invoked via `.pre-commit-config.yaml` with `cd ui && .husky/pre-commit`, so it runs from inside `ui/`. However, `git diff --cached -- 'ui/**'` looks for paths starting with `ui/` — which never matches because git reports paths relative to repo root (`ui/components/...`) but the glob `ui/**` from inside `ui/` doesn't resolve correctly. `STAGED_FILES` was **always empty**.

**Fix**: Use `git -C "$GIT_ROOT"` to always run git from repo root, making pathspecs predictable regardless of cwd.

**Bug 2 — Early exit skipping all quality gates (lines 139-142)**

When `CODE_REVIEW_ENABLED=true` and `STAGED_FILES` was empty (which was always, due to Bug 1), the hook hit an `exit 0` **before** reaching healthcheck, tests, and build. The early exit was only meant to skip Claude Code review but was placed after the review block, gating everything.

**Fix**: Move the "no UI files" early exit to a single check that correctly skips all gates only when there are genuinely no UI files staged.

**Bug 3 — Same pathspec issue for test targeting (lines 168, 171)**

`STAGED_SOURCE_FILES` and `CRITICAL_PATHS_CHANGED` used bare pathspecs (`lib/**`, `*.ts`) that also depended on cwd. Fixed to use `git -C "$GIT_ROOT"` with `ui/` prefixed paths, then `sed 's|^ui/||'` to strip the prefix for vitest.

### Steps to review

1. Read the diff — it's a single file, small changes
2. Verify the logic: `git -C "$GIT_ROOT"` ensures all `git diff` calls are cwd-independent
3. Verify the early exit now only triggers when `STAGED_FILES` is genuinely empty (no longer gated by `CODE_REVIEW_ENABLED`)

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- N/A Screenshots/Video — no UI changes visible to the user
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- N/A — no API changes

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.