### PR TITLE
fix(api): use raw FK ids in membership `post_delete` signal to avoid cascade lookup failures

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - `MANAGE_ACCOUNT` permission no longer required for listing and creating tenants [(#10468)](https://github.com/prowler-cloud/prowler/pull/10468)
 - Finding groups muted filter, counters, metadata extraction and mute reaggregation [(#10477)](https://github.com/prowler-cloud/prowler/pull/10477)
 - Finding groups `check_title__icontains` resolution, `name__icontains` resource filter and `resource_group` field in `/resources` response [(#10486)](https://github.com/prowler-cloud/prowler/pull/10486)
-- Membership `post_delete` signal using raw FK ids to avoid `DoesNotExist` during cascade deletions [(#10496)](https://github.com/prowler-cloud/prowler/pull/10496)
+- Membership `post_delete` signal using raw FK ids to avoid `DoesNotExist` during cascade deletions [(#10497)](https://github.com/prowler-cloud/prowler/pull/10497)
 
 ### 🔐 Security
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - `MANAGE_ACCOUNT` permission no longer required for listing and creating tenants [(#10468)](https://github.com/prowler-cloud/prowler/pull/10468)
 - Finding groups muted filter, counters, metadata extraction and mute reaggregation [(#10477)](https://github.com/prowler-cloud/prowler/pull/10477)
 - Finding groups `check_title__icontains` resolution, `name__icontains` resource filter and `resource_group` field in `/resources` response [(#10486)](https://github.com/prowler-cloud/prowler/pull/10486)
+- Membership `post_delete` signal using raw FK ids to avoid `DoesNotExist` during cascade deletions [(#10496)](https://github.com/prowler-cloud/prowler/pull/10496)
 
 ### 🔐 Security
 

--- a/api/src/backend/api/signals.py
+++ b/api/src/backend/api/signals.py
@@ -61,7 +61,7 @@ def revoke_membership_api_keys(sender, instance, **kwargs):  # noqa: F841
     in that tenant should be revoked to prevent further access.
     """
     TenantAPIKey.objects.filter(
-        entity=instance.user, tenant_id=instance.tenant.id
+        entity_id=instance.user_id, tenant_id=instance.tenant_id
     ).update(revoked=True)
 
 

--- a/api/src/backend/conftest.py
+++ b/api/src/backend/conftest.py
@@ -111,8 +111,9 @@ def disable_logging():
     logging.disable(logging.CRITICAL)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def create_test_user(django_db_setup, django_db_blocker):
+@pytest.fixture(scope="session")
+def _session_test_user(django_db_setup, django_db_blocker):
+    """Create the test user once per session. Internal; use create_test_user instead."""
     with django_db_blocker.unblock():
         user = User.objects.create_user(
             name="testing",
@@ -120,6 +121,21 @@ def create_test_user(django_db_setup, django_db_blocker):
             password=TEST_PASSWORD,
         )
     return user
+
+
+@pytest.fixture(autouse=True)
+def create_test_user(_session_test_user, django_db_blocker):
+    """Re-create the session-scoped test user when a TransactionTestCase
+    has truncated the users table."""
+    with django_db_blocker.unblock():
+        if not User.objects.filter(pk=_session_test_user.pk).exists():
+            User.objects.create_user(
+                id=_session_test_user.pk,
+                name="testing",
+                email=TEST_USER,
+                password=TEST_PASSWORD,
+            )
+    return _session_test_user
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
### Description

The membership `post_delete` signal crashes during cascade deletions because it queries the DB for related objects that may already be deleted.
- Use `instance.user_id` / `instance.tenant_id` instead of `instance.user` / `instance.tenant.id` in the signal handler
- Split `create_test_user` fixture into a session-scoped creator and a function-scoped guard that re-creates the user if a `transaction=True` test flushed the DB

### Steps to review

Run the API tests.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.