### PR TITLE
fix: replace bare except with except Exception in prowler-wrapper

### DIFF
--- a/contrib/wazuh/prowler-wrapper.py
+++ b/contrib/wazuh/prowler-wrapper.py
@@ -220,7 +220,7 @@ def _send_prowler_results(prowler_results, _prowler_version, options):
         try:
             _debug("RESULT MSG --- {0}".format(_check_result), 2)
             _check_result = json.loads(TEMPLATE_CHECK.format(_check_result))
-        except:
+        except Exception:
             _debug(
                 "INVALID JSON --- {0}".format(TEMPLATE_CHECK.format(_check_result)), 1
             )


### PR DESCRIPTION
## Summary

Replace bare `except:` with `except Exception:` in `contrib/wazuh/prowler-wrapper.py`.

PEP 8 recommends against bare `except:` as it catches system-exiting exceptions. Using `except Exception:` catches all program errors while letting `KeyboardInterrupt` and `SystemExit` propagate normally.

**Change:**
```python
# Before
except:

# After
except Exception:
```

## Testing
No behavior change — style/correctness fix only.