### PR TITLE
feat(aws): add internet-exposed category to 13 checks

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### 🔄 Changed
 
+- Added `internet-exposed` category to 13 AWS checks (CloudFront, CodeArtifact, EC2, EFS, RDS, SageMaker, Shield, VPC) [(#10502)](https://github.com/prowler-cloud/prowler/pull/10502)
 - Minimum Python version from 3.9 to 3.10 and updated classifiers to reflect supported versions (3.10, 3.11, 3.12) [(#10464)](https://github.com/prowler-cloud/prowler/pull/10464)
 
 ### 🐞 Fixed

--- a/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_access_control/cloudfront_distributions_s3_origin_access_control.metadata.json
+++ b/prowler/providers/aws/services/cloudfront/cloudfront_distributions_s3_origin_access_control/cloudfront_distributions_s3_origin_access_control.metadata.json
@@ -35,7 +35,8 @@
     }
   },
   "Categories": [
-    "trust-boundaries"
+    "trust-boundaries",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.metadata.json
+++ b/prowler/providers/aws/services/codeartifact/codeartifact_packages_external_public_publishing_disabled/codeartifact_packages_external_public_publishing_disabled.metadata.json
@@ -34,7 +34,8 @@
     }
   },
   "Categories": [
-    "software-supply-chain"
+    "software-supply-chain",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic.metadata.json
+++ b/prowler/providers/aws/services/ec2/ec2_securitygroup_default_restrict_traffic/ec2_securitygroup_default_restrict_traffic.metadata.json
@@ -33,7 +33,8 @@
     }
   },
   "Categories": [
-    "trust-boundaries"
+    "trust-boundaries",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
+++ b/prowler/providers/aws/services/efs/efs_not_publicly_accessible/efs_not_publicly_accessible.metadata.json
@@ -32,7 +32,8 @@
     }
   },
   "Categories": [
-    "identity-access"
+    "identity-access",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/rds/rds_instance_inside_vpc/rds_instance_inside_vpc.metadata.json
+++ b/prowler/providers/aws/services/rds/rds_instance_inside_vpc/rds_instance_inside_vpc.metadata.json
@@ -33,7 +33,8 @@
     }
   },
   "Categories": [
-    "trust-boundaries"
+    "trust-boundaries",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/sagemaker/sagemaker_models_network_isolation_enabled/sagemaker_models_network_isolation_enabled.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_models_network_isolation_enabled/sagemaker_models_network_isolation_enabled.metadata.json
@@ -34,7 +34,8 @@
   "Categories": [
     "trust-boundaries",
     "container-security",
-    "gen-ai"
+    "gen-ai",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/sagemaker/sagemaker_models_vpc_settings_configured/sagemaker_models_vpc_settings_configured.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_models_vpc_settings_configured/sagemaker_models_vpc_settings_configured.metadata.json
@@ -31,8 +31,9 @@
     }
   },
   "Categories": [
-    "trust-boundaries", 
-    "gen-ai"
+    "trust-boundaries",
+    "gen-ai",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/sagemaker/sagemaker_training_jobs_network_isolation_enabled/sagemaker_training_jobs_network_isolation_enabled.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_training_jobs_network_isolation_enabled/sagemaker_training_jobs_network_isolation_enabled.metadata.json
@@ -33,7 +33,8 @@
   },
   "Categories": [
     "trust-boundaries",
-    "gen-ai"
+    "gen-ai",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/sagemaker/sagemaker_training_jobs_vpc_settings_configured/sagemaker_training_jobs_vpc_settings_configured.metadata.json
+++ b/prowler/providers/aws/services/sagemaker/sagemaker_training_jobs_vpc_settings_configured/sagemaker_training_jobs_vpc_settings_configured.metadata.json
@@ -33,7 +33,8 @@
   },
   "Categories": [
     "trust-boundaries",
-    "gen-ai"
+    "gen-ai",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips.metadata.json
+++ b/prowler/providers/aws/services/shield/shield_advanced_protection_in_associated_elastic_ips/shield_advanced_protection_in_associated_elastic_ips.metadata.json
@@ -32,7 +32,8 @@
     }
   },
   "Categories": [
-    "resilience"
+    "resilience",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/shield/shield_advanced_protection_in_classic_load_balancers/shield_advanced_protection_in_classic_load_balancers.metadata.json
+++ b/prowler/providers/aws/services/shield/shield_advanced_protection_in_classic_load_balancers/shield_advanced_protection_in_classic_load_balancers.metadata.json
@@ -31,7 +31,8 @@
     }
   },
   "Categories": [
-    "resilience"
+    "resilience",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/shield/shield_advanced_protection_in_cloudfront_distributions/shield_advanced_protection_in_cloudfront_distributions.metadata.json
+++ b/prowler/providers/aws/services/shield/shield_advanced_protection_in_cloudfront_distributions/shield_advanced_protection_in_cloudfront_distributions.metadata.json
@@ -31,7 +31,8 @@
     }
   },
   "Categories": [
-    "resilience"
+    "resilience",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],

--- a/prowler/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege.metadata.json
+++ b/prowler/providers/aws/services/vpc/vpc_peering_routing_tables_with_least_privilege/vpc_peering_routing_tables_with_least_privilege.metadata.json
@@ -34,7 +34,8 @@
     }
   },
   "Categories": [
-    "trust-boundaries"
+    "trust-boundaries",
+    "internet-exposed"
   ],
   "DependsOn": [],
   "RelatedTo": [],


### PR DESCRIPTION
Closes #6644

Adds `internet-exposed` category mapping to 13 existing AWS checks that evaluate public/internet accessibility of resources but were missing this category:

**EFS**
- `efs_not_publicly_accessible` - evaluates whether EFS allows unrestricted access

**CloudFront**
- `cloudfront_distributions_s3_origin_access_control` - without OAC, S3 origins are directly internet-accessible bypassing CloudFront

**EC2**
- `ec2_securitygroup_default_restrict_traffic` - default SG with open rules allows internet traffic to instances

**RDS**
- `rds_instance_inside_vpc` - instances outside a VPC can be directly internet-reachable

**SageMaker**
- `sagemaker_models_network_isolation_enabled` - without network isolation, models can reach/be reached from internet
- `sagemaker_models_vpc_settings_configured` - without VPC settings, models may be internet-accessible
- `sagemaker_training_jobs_network_isolation_enabled` - without network isolation, training jobs can reach internet
- `sagemaker_training_jobs_vpc_settings_configured` - without VPC settings, training jobs may be internet-accessible

**Shield Advanced** (protects internet-facing resources, consistent with existing `shield_advanced_protection_in_internet_facing_load_balancers` which already has this category)
- `shield_advanced_protection_in_associated_elastic_ips`
- `shield_advanced_protection_in_classic_load_balancers`
- `shield_advanced_protection_in_cloudfront_distributions`

**CodeArtifact**
- `codeartifact_packages_external_public_publishing_disabled` - public publishing exposes packages to the internet

**VPC**
- `vpc_peering_routing_tables_with_least_privilege` - routes with 0.0.0.0/0 through VPC peering can expose resources

All changes are metadata-only (adding `"internet-exposed"` to the `Categories` array), preserving existing categories.