### PR TITLE
fix(ci): remove setup-buildx-action from create-manifest jobs

### DIFF
--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -140,9 +140,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Create and push manifests for push event
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -140,9 +140,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Create and push manifests for push event
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -213,9 +213,6 @@ jobs:
         env:
           AWS_REGION: ${{ env.AWS_REGION }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Create and push manifests for push event
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -139,9 +139,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
       - name: Create and push manifests for push event
         if: github.event_name == 'push'
         run: |


### PR DESCRIPTION
## Context

The `create-manifest` jobs in container build-push workflows fail with "unauthorized" errors because `setup-buildx-action` creates a BuildKit container that cannot access the host's Docker credentials.

## Description

Remove `docker/setup-buildx-action` from `create-manifest` jobs in all 4 container workflows (SDK, API, UI, MCP). These jobs only run registry API calls (`imagetools create`, `regctl tag delete`) and don't need BuildKit. With the default `docker` driver (pre-installed on GitHub runners), buildx reads credentials directly from the host's `~/.docker/config.json`.

The `container-build-push` jobs are not affected — `build-push-action` handles credential forwarding to BuildKit internally.

## Steps to review

1. Verify that `setup-buildx-action` is removed only from `create-manifest` jobs, not from `container-build-push` jobs
2. Confirm no other steps in `create-manifest` depend on BuildKit

## Checklist

- [x] Review if backport is needed
- [x] Ensure new entries are added to CHANGELOG.md, if applicable

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.