### PR TITLE
fix(ci): remove DOCKER_HUB_REPOSITORY secret and add toniblyx mirror push

### DIFF
--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -270,7 +270,6 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_LATEST_TAG} \
-            -t ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_LATEST_TAG} \
             -t ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_LATEST_TAG} \
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_LATEST_TAG}-amd64 \
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_LATEST_TAG}-arm64
@@ -281,12 +280,10 @@ jobs:
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         run: |
           docker buildx imagetools create \
-            -t ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${NEEDS_SETUP_OUTPUTS_PROWLER_VERSION} \
-            -t ${{ secrets.DOCKER_HUB_REPOSITORY }}/${{ env.IMAGE_NAME }}:${NEEDS_SETUP_OUTPUTS_STABLE_TAG} \
-            -t ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${NEEDS_SETUP_OUTPUTS_PROWLER_VERSION} \
-            -t ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${NEEDS_SETUP_OUTPUTS_STABLE_TAG} \
             -t ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_PROWLER_VERSION} \
             -t ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_STABLE_TAG} \
+            -t ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${NEEDS_SETUP_OUTPUTS_PROWLER_VERSION} \
+            -t ${{ secrets.PUBLIC_ECR_REPOSITORY }}/${{ env.IMAGE_NAME }}:${NEEDS_SETUP_OUTPUTS_STABLE_TAG} \
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_LATEST_TAG}-amd64 \
             ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_LATEST_TAG}-arm64
         env:

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -42,6 +42,7 @@ env:
   # Container registries
   PROWLERCLOUD_DOCKERHUB_REPOSITORY: prowlercloud
   PROWLERCLOUD_DOCKERHUB_IMAGE: prowler
+  TONIBLYX_DOCKERHUB_REPOSITORY: toniblyx
 
   # AWS configuration (for ECR)
   AWS_REGION: us-east-1
@@ -290,6 +291,39 @@ jobs:
           NEEDS_SETUP_OUTPUTS_PROWLER_VERSION: ${{ needs.setup.outputs.prowler_version }}
           NEEDS_SETUP_OUTPUTS_STABLE_TAG: ${{ needs.setup.outputs.stable_tag }}
           NEEDS_SETUP_OUTPUTS_LATEST_TAG: ${{ needs.setup.outputs.latest_tag }}
+
+      # Push to toniblyx/prowler only for current version (latest/stable/release tags)
+      - name: Login to DockerHub (toniblyx)
+        if: needs.setup.outputs.latest_tag == 'latest'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.TONIBLYX_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.TONIBLYX_DOCKERHUB_PASSWORD }}
+
+      - name: Push manifests to toniblyx for push event
+        if: needs.setup.outputs.latest_tag == 'latest' && github.event_name == 'push'
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.TONIBLYX_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:latest \
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:latest
+
+      - name: Push manifests to toniblyx for release event
+        if: needs.setup.outputs.latest_tag == 'latest' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.TONIBLYX_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:${NEEDS_SETUP_OUTPUTS_PROWLER_VERSION} \
+            -t ${{ env.TONIBLYX_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:stable \
+            ${{ env.PROWLERCLOUD_DOCKERHUB_REPOSITORY }}/${{ env.PROWLERCLOUD_DOCKERHUB_IMAGE }}:stable
+        env:
+          NEEDS_SETUP_OUTPUTS_PROWLER_VERSION: ${{ needs.setup.outputs.prowler_version }}
+
+      # Re-login as prowlercloud for cleanup of intermediate tags
+      - name: Login to DockerHub (prowlercloud)
+        if: always()
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install regctl
         if: always()


### PR DESCRIPTION
### Context

The `sdk-container-build-push` workflow was referencing a `DOCKER_HUB_REPOSITORY` secret that is no longer needed since the repository name is now hardcoded as an env var. Additionally, we need to mirror images to the legacy `toniblyx/prowler` DockerHub repository for backward compatibility.

### Description

- **Commit 1:** Remove the `DOCKER_HUB_REPOSITORY` secret reference and replace it with the existing `PROWLERCLOUD_DOCKERHUB_REPOSITORY` env var.
- **Commit 2:** Add steps to push manifests to `toniblyx/prowler` using `docker buildx imagetools create` from the `prowlercloud/prowler` source images. Only triggers for current version builds (`latest_tag == 'latest'`). Re-login as `prowlercloud` after toniblyx push to preserve cleanup behavior.

### Steps to review

1. Verify the `TONIBLYX_DOCKERHUB_REPOSITORY` env var is correctly defined.
2. Check the conditional logic: toniblyx push only happens when `latest_tag == 'latest'`.
3. Confirm the `imagetools create` commands correctly re-tag from prowlercloud to toniblyx for both push and release events.
4. Verify the re-login step ensures regctl cleanup still works with prowlercloud credentials.

### Checklist

- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.