### PR TITLE
fix(ui): allow selecting failed scans when graph data is available

### DIFF
--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/scan-list-table.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/scan-list-table.test.tsx
@@ -162,4 +162,45 @@ describe("ScanListTable", () => {
       "/attack-paths?scanPage=1&scanPageSize=5&scanId=scan-1",
     );
   });
+
+  it("enables the select button for a failed scan when graph data is ready", async () => {
+    const user = userEvent.setup();
+    const failedScan: AttackPathScan = {
+      ...createScan(1),
+      attributes: {
+        ...createScan(1).attributes,
+        state: "failed",
+        graph_data_ready: true,
+      },
+    };
+
+    render(<ScanListTable scans={[failedScan]} />);
+
+    const button = screen.getByRole("button", { name: "Select scan" });
+    expect(button).toBeEnabled();
+    expect(button).toHaveTextContent("Select");
+
+    await user.click(button);
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/attack-paths?scanPage=1&scanPageSize=5&scanId=scan-1",
+    );
+  });
+
+  it("disables the select button for a failed scan when graph data is not ready", () => {
+    const failedScan: AttackPathScan = {
+      ...createScan(1),
+      attributes: {
+        ...createScan(1).attributes,
+        state: "failed",
+        graph_data_ready: false,
+      },
+    };
+
+    render(<ScanListTable scans={[failedScan]} />);
+
+    const button = screen.getByRole("button", { name: "Select scan" });
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent("Failed");
+  });
 });

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/scan-list-table.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/scan-list-table.tsx
@@ -42,11 +42,7 @@ const isSelectDisabled = (
   scan: AttackPathScan,
   selectedScanId: string | null,
 ) => {
-  return (
-    !scan.attributes.graph_data_ready ||
-    scan.attributes.state === SCAN_STATES.FAILED ||
-    selectedScanId === scan.id
-  );
+  return !scan.attributes.graph_data_ready || selectedScanId === scan.id;
 };
 
 const getSelectButtonLabel = (

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/scan-status-badge.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/scan-status-badge.tsx
@@ -38,7 +38,7 @@ const BADGE_CONFIG: Record<
   [SCAN_STATES.FAILED]: {
     className: "bg-bg-fail-secondary text-text-error-primary",
     label: "Failed",
-    showGraphDot: false,
+    showGraphDot: true,
   },
 };
 


### PR DESCRIPTION
### Description

Scans with `graph_data_ready=true` were not selectable when the scan state was `FAILED`. The button showed "Select" but was disabled, which was contradictory.                                                                                                                                         

Now the select button is enabled whenever graph data is available, regardless of scan state. The `FAILED` badge also shows a green dot to indicate graph data availability, matching the behavior of `SCHEDULED` and `QUEUED` badges.

### Steps to review

Run Attack Paths scans on the UI checking the status label.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.