### PR TITLE
fix(ui): preserve query parameters in callbackUrl during

### DIFF
--- a/ui/auth.config.ts
+++ b/ui/auth.config.ts
@@ -289,7 +289,10 @@ export const authConfig = {
       // Return NextResponse.redirect to preserve callbackUrl for post-login redirect
       if (!isLoggedIn) {
         const signInUrl = new URL("/sign-in", nextUrl.origin);
-        signInUrl.searchParams.set("callbackUrl", nextUrl.pathname);
+        signInUrl.searchParams.set(
+          "callbackUrl",
+          nextUrl.pathname + nextUrl.search,
+        );
         // Include session error if present (e.g., RefreshAccessTokenError)
         if (sessionError) {
           signInUrl.searchParams.set("error", sessionError);

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -25,13 +25,13 @@ export default auth((req: NextRequest & { auth: any }) => {
   if (sessionError && !isPublicRoute(pathname)) {
     const signInUrl = new URL("/sign-in", req.url);
     signInUrl.searchParams.set("error", sessionError);
-    signInUrl.searchParams.set("callbackUrl", pathname);
+    signInUrl.searchParams.set("callbackUrl", pathname + req.nextUrl.search);
     return NextResponse.redirect(signInUrl);
   }
 
   if (!user && !isPublicRoute(pathname)) {
     const signInUrl = new URL("/sign-in", req.url);
-    signInUrl.searchParams.set("callbackUrl", pathname);
+    signInUrl.searchParams.set("callbackUrl", pathname + req.nextUrl.search);
     return NextResponse.redirect(signInUrl);
   }
 

--- a/ui/tests/auth/auth-session-errors.spec.ts
+++ b/ui/tests/auth/auth-session-errors.spec.ts
@@ -69,4 +69,19 @@ test.describe("Session Error Messages", () => {
       await signInPage.verifyRedirectWithCallback("/providers");
     },
   );
+
+  test(
+    "should preserve query parameters in callbackUrl",
+    { tag: ["@e2e", "@auth", "@session", "@AUTH-SESSION-E2E-005"] },
+    async ({ page, context }) => {
+      const signInPage = new SignInPage(page);
+      await context.clearCookies();
+
+      // Navigate to a protected route with query params and assert they are preserved.
+      await page.goto("/providers?ref=test", {
+        waitUntil: "commit",
+      });
+      await signInPage.verifyRedirectWithCallback("/providers?ref=test");
+    },
+  );
 });


### PR DESCRIPTION
  ### Context

  Query parameters (e.g., `?invitation_token=TOKEN`) are silently lost when unauthenticated users are redirected to `/sign-in`. Both `proxy.ts` and `auth.config.ts` only preserve `pathname` in the `callbackUrl`, discarding the search portion of
  the URL. This blocks the upcoming Invitation Flow Smart Routing feature (PROWLER-1298).

  Fix PROWLER-1299

  ### Description

  Both `proxy.ts` (lines 28, 34) and `auth.config.ts` (line 292) set `callbackUrl` to only `pathname`, losing any query parameters:

  `signInUrl.searchParams.set("callbackUrl", pathname)` — loses `?invitation_token=TOKEN`

  This PR appends `req.nextUrl.search` / `nextUrl.search` so the full URL is preserved through auth redirects:

  `signInUrl.searchParams.set("callbackUrl", pathname + req.nextUrl.search)`

  When there are no query params, `search` is `""`, so behavior is identical to before.

  **Security analysis:**
  - No open redirect risk: `callbackUrl` is always a relative path (starts with `/`)
  - No injection risk: `searchParams.set()` URL-encodes the value
  - No double-encoding: decoded correctly by `searchParams.get("callbackUrl")` on the sign-in page

  **Files changed:**
  - `ui/proxy.ts` — 2 lines changed (lines 28, 34)
  - `ui/auth.config.ts` — 1 line changed (line 292)
  - `ui/tests/auth/auth-session-errors.spec.ts` — new E2E test `AUTH-SESSION-E2E-005`

  ### Steps to review

  1. Review `proxy.ts` lines 28 and 34 — verify `req.nextUrl.search` is appended to `pathname`
  2. Review `auth.config.ts` line 292 — verify `nextUrl.search` is appended to `nextUrl.pathname`
  3. Review the new test in `auth-session-errors.spec.ts` — navigates to `/providers?ref=test` without auth and verifies the callbackUrl includes the query param
  4. Verify no other consumers of `callbackUrl` are affected — `sign-in-form.tsx:35` reads it with `searchParams.get("callbackUrl")` and passes it to `router.push()`, which handles relative URLs with query params correctly

  ### Checklist

  <details>

  <summary><b>Community Checklist</b></summary>

  - [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
  - [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

  </details>


  - [x] Review if the code is being covered by tests.
  - [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
  - [ ] Review if backport is needed.
  - [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
  - [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

  #### SDK/CLI
  - Are there new checks included in this PR? No

  #### UI
  - [x] All issue/task requirements work as expected on the UI
  - [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
  - [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
  - [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
  - [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

  #### API
  - N/A (no API changes)

  ### License

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.