### PR TITLE
chore(ui): unset GIT_WORK_TREE in pre-commit hook

### DIFF
--- a/ui/.husky/pre-commit
+++ b/ui/.husky/pre-commit
@@ -6,6 +6,9 @@
 
 set -e
 
+# Ensure git resolves the real repo root, not a pre-commit framework override
+unset GIT_WORK_TREE
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/ui/.husky/pre-commit
+++ b/ui/.husky/pre-commit
@@ -6,8 +6,11 @@
 
 set -e
 
-# Ensure git resolves the real repo root, not a pre-commit framework override
-unset GIT_WORK_TREE
+# The Python pre-commit framework (see .pre-commit-config.yaml, hook "ui-checks")
+# exports GIT_WORK_TREE, GIT_DIR, and GIT_INDEX_FILE pointing to its temp staging
+# area. Unset them so git commands below resolve against the real repo and index.
+# See: https://github.com/prowler-cloud/prowler/pull/10574
+unset GIT_WORK_TREE GIT_DIR GIT_INDEX_FILE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY
 
 # Colors
 RED='\033[0;31m'

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -21,7 +21,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Deleting the active organization now switches to the target org before deleting, preventing JWT rejection from the backend [(#10491)](https://github.com/prowler-cloud/prowler/pull/10491)
 - Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button [(#10446)](https://github.com/prowler-cloud/prowler/pull/10446)
 - Send to Jira modal now dynamically fetches and displays available issue types per project instead of hardcoding `"Task"`, fixing failures on non-English Jira instances [(#10534)](https://github.com/prowler-cloud/prowler/pull/10534)
-- Pre-commit hook now unsets `GIT_WORK_TREE` to fix path resolution when the variable is inherited from parent processes [(#10574)](https://github.com/prowler-cloud/prowler/pull/10574)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Deleting the active organization now switches to the target org before deleting, preventing JWT rejection from the backend [(#10491)](https://github.com/prowler-cloud/prowler/pull/10491)
 - Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button [(#10446)](https://github.com/prowler-cloud/prowler/pull/10446)
 - Send to Jira modal now dynamically fetches and displays available issue types per project instead of hardcoding `"Task"`, fixing failures on non-English Jira instances [(#10534)](https://github.com/prowler-cloud/prowler/pull/10534)
+- Pre-commit hook now unsets `GIT_WORK_TREE` to fix path resolution when the variable is inherited from parent processes [(#10574)](https://github.com/prowler-cloud/prowler/pull/10574)
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes pre-commit hook path resolution when Python `pre-commit` framework sets `GIT_WORK_TREE`, `GIT_DIR`, and `GIT_INDEX_FILE` to a temp staging area
- `git rev-parse --show-toplevel` was returning `prowler/ui` instead of `prowler`, causing `cd "$GIT_ROOT/ui"` to resolve to `prowler/ui/ui` (non-existent)
- `git -C "$GIT_ROOT" diff --cached` was reading the wrong index, so quality gates could silently pass against the wrong staged file set
- Unsetting all `GIT_*` env vars (`GIT_WORK_TREE`, `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_PREFIX`, `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`) after `set -e` restores correct behavior without side effects

## Test plan

- [ ] Reproduce the full failure mode the Python pre-commit framework creates:
  ```bash
  env GIT_WORK_TREE=/tmp/fake GIT_DIR=/tmp/fake/.git GIT_INDEX_FILE=/tmp/fake/index \
    bash ui/.husky/pre-commit
  ```
- [ ] Or run the actual framework hook: `pre-commit run ui-checks --verbose --all-files`
- [ ] Commit a UI file change and verify the husky pre-commit hook completes successfully
- [ ] Verify healthcheck, tests, and build steps still run from the correct directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)