### PR TITLE
fix(api): exclude spurious retrieve from Jira docs and add known limitations

### DIFF
--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -6153,7 +6153,15 @@ class IntegrationViewSet(BaseRLSViewSet):
         tags=["Integration"],
         summary="Send findings to a Jira integration",
         description="Send a set of filtered findings to the given integration. At least one finding filter must be "
-        "provided.",
+        "provided.\n\n"
+        "## Known Limitations\n\n"
+        "### Issue Types with Required Custom Fields\n\n"
+        "Certain Jira issue types (such as Epic) may require mandatory custom fields that Prowler does not "
+        "currently populate when creating work items. If a selected issue type enforces required fields beyond "
+        'the standard set (e.g., "Team", "Epic Name"), the work item creation will fail.\n\n'
+        "To avoid this, select an issue type that does not require additional custom fields - **Task**, **Bug**, "
+        "or **Story** typically work without restrictions. If unsure which issue types are available for a project, "
+        'Prowler automatically fetches and displays them in the "Issue Type" selector when sending a finding.',
         responses={202: OpenApiResponse(response=TaskSerializer)},
         filters=True,
     )
@@ -6173,6 +6181,10 @@ class IntegrationJiraViewSet(BaseRLSViewSet):
 
     @extend_schema(exclude=True)
     def list(self, request, *args, **kwargs):
+        raise MethodNotAllowed(method="GET")
+
+    @extend_schema(exclude=True)
+    def retrieve(self, request, *args, **kwargs):
         raise MethodNotAllowed(method="GET")
 
     def get_serializer_class(self):


### PR DESCRIPTION
### Context

The Jira integration endpoints in the API documentation were showing a spurious `integrations_jira_retrieve` operation that doesn't exist and doesn't follow the naming convention of the rest of the API docs. Additionally, there was no documentation about Jira issue type limitations with required custom fields.

### Description

- Exclude the inherited `retrieve` action from `IntegrationJiraViewSet` OpenAPI schema, preventing it from appearing in the generated API docs.
- Add a "Known Limitations" section to the `dispatches` endpoint description documenting that certain Jira issue types (e.g., Epic) may fail if they require mandatory custom fields that Prowler does not populate.

<img width="631" height="369" alt="image" src="https://github.com/user-attachments/assets/311e8222-ce98-473e-9c94-ed2b9bc599cc" />

### Steps to review

1. Generate the OpenAPI schema and verify `integrations_jira_retrieve` no longer appears.
2. Check the `dispatches` endpoint description includes the known limitations note.
3. Confirm `issue_types` and `dispatches` actions still render correctly in the docs.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### API (if applicable)
- [x] All issue/task requirements work as expected on the API
- [x] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.