### PR TITLE
feat(ui): Invitation link backward compatibility

### DIFF
--- a/ui/auth.config.ts
+++ b/ui/auth.config.ts
@@ -281,9 +281,10 @@ export const authConfig = {
       const sessionError = auth?.error;
       const isSignUpPage = nextUrl.pathname === "/sign-up";
       const isSignInPage = nextUrl.pathname === "/sign-in";
+      const isInvitationPage = nextUrl.pathname.startsWith("/invitation");
 
-      // Allow access to sign-up and sign-in pages
-      if (isSignUpPage || isSignInPage) return true;
+      // Allow access to sign-up, sign-in, and invitation pages
+      if (isSignUpPage || isSignInPage || isInvitationPage) return true;
 
       // For all other routes, require authentication
       // Return NextResponse.redirect to preserve callbackUrl for post-login redirect

--- a/ui/proxy.ts
+++ b/ui/proxy.ts
@@ -5,6 +5,7 @@ import { auth } from "@/auth.config";
 const publicRoutes = [
   "/sign-in",
   "/sign-up",
+  "/invitation",
   // In Cloud uncomment the following lines:
   // "/reset-password",
   // "/email-verification",
@@ -18,6 +19,20 @@ const isPublicRoute = (pathname: string): boolean => {
 // NextAuth's auth() wrapper - renamed from middleware to proxy
 export default auth((req: NextRequest & { auth: any }) => {
   const { pathname } = req.nextUrl;
+
+  // Backward compatibility: redirect old invitation links to new smart router
+  if (
+    pathname === "/sign-up" &&
+    req.nextUrl.searchParams.has("invitation_token")
+  ) {
+    const acceptUrl = new URL("/invitation/accept", req.url);
+    acceptUrl.searchParams.set(
+      "invitation_token",
+      req.nextUrl.searchParams.get("invitation_token")!,
+    );
+    return NextResponse.redirect(acceptUrl);
+  }
+
   const user = req.auth?.user;
   const sessionError = req.auth?.error;
 


### PR DESCRIPTION
## Context

  Part of the invitation flow smart routing epic (PROWLER-1298). Old invitation emails contain links to `/sign-up?invitation_token=TOKEN`, which break in two scenarios:
  - **Logged-in users**: The `(auth)` layout redirects to `/`, silently discarding the invitation token.
  - **Existing users (not logged in)**: They land on the sign-up form but already have an account — dead end.

  ### Description

  Adds backward compatibility for old invitation links by redirecting `/sign-up?invitation_token=TOKEN` to `/invitation/accept?invitation_token=TOKEN` at the middleware level.

  Changes:
  - **`proxy.ts`**: Added redirect from `/sign-up?invitation_token=` to `/invitation/accept?invitation_token=` before any auth logic runs. Added `/invitation` to `publicRoutes`.
  - **`auth.config.ts`**: Added `/invitation` to the `authorized` callback allowlist so both authenticated and unauthenticated users can access the route.

  The redirect lives in the middleware because it must execute before the `(auth)` layout's `redirect("/")` for logged-in users.

  ### Steps to review

  1. Review `proxy.ts` — the redirect is placed before auth checks intentionally so it runs before the `(auth)` layout can swallow the token
  2. Review `auth.config.ts` — `/invitation` is allowed for all users (both authenticated and unauthenticated)
  3. Verify that `/sign-up` without `invitation_token` still works normally (no redirect)
  4. Verify that `/sign-up?invitation_token=abc` redirects to `/invitation/accept?invitation_token=abc`
  5. Verify the redirect works for both logged-in and logged-out users

  ### Checklist

  <details>

  <summary><b>Community Checklist</b></summary>

  - [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
  - [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

  </details>


  - [x] Review if the code is being covered by tests.
  - [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
  - [ ] Review if backport is needed.
  - [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
  - [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

  #### SDK/CLI
  - Are there new checks included in this PR? No

  #### UI
  - [x] All issue/task requirements work as expected on the UI
  - [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
  - [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
  - [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
  - [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

  #### API
  - [ ] All issue/task requirements work as expected on the API
  - [ ] Endpoint response output (if applicable)
  - [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
  - [ ] Performance test results (if applicable)
  - [ ] Any other relevant evidence of the implementation (if applicable)
  - [ ] Verify if API specs need to be regenerated.
  - [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
  - [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

  ### License

  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.