### PR TITLE
fix(sdk): add missing __init__.py for codebuild GitHub orgs check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - `return` statements in `finally` blocks replaced across IAM, Organizations, GCP provider, and custom checks metadata to stop silently swallowing exceptions [(#10102)](https://github.com/prowler-cloud/prowler/pull/10102)
 - `JiraConnection` now includes issue types per project fetched during `test_connection`, fixing `JiraInvalidIssueTypeError` on non-English Jira instances [(#10534)](https://github.com/prowler-cloud/prowler/pull/10534)
+- Missing `__init__.py` in `codebuild_project_uses_allowed_github_organizations` check preventing discovery by `--list-checks` [(#10584)](https://github.com/prowler-cloud/prowler/pull/10584)
 
 ### 🔐 Security
 


### PR DESCRIPTION
### Context

The `codebuild_project_uses_allowed_github_organizations` check directory was missing its `__init__.py` file. Python's `pkgutil.walk_packages` requires `__init__.py` to discover subpackages, so this check was invisible to `--list-checks` and could not be executed.

### Description

Add the missing `__init__.py` to `prowler/providers/aws/services/codebuild/codebuild_project_uses_allowed_github_organizations/`. Without it, `walk_packages` skips the directory and reports 585 AWS checks instead of 586.

### Steps to review

1. Verify the check is now discoverable:
   ```bash
   poetry run python prowler-cli.py aws --list-checks | grep codebuild_project_uses_allowed_github_organizations
   ```
2. Confirm `--list-checks` now reports 586 AWS checks instead of 585

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
N/A — no UI changes.

#### API
N/A — no API changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.