### PR TITLE
feat(api): support sort by delta on finding-groups endpoints

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - Filter RBAC role lookup by `tenant_id` to prevent cross-tenant privilege leak [(#10491)](https://github.com/prowler-cloud/prowler/pull/10491)
 - `VALKEY_SCHEME`, `VALKEY_USERNAME`, and `VALKEY_PASSWORD` environment variables to configure Celery broker TLS/auth connection details for Valkey/ElastiCache [(#10420)](https://github.com/prowler-cloud/prowler/pull/10420)
 - `Vercel` provider support [(#10190)](https://github.com/prowler-cloud/prowler/pull/10190)
+- Finding groups list and latest endpoints support `sort=delta`, ordering by `new_count` then `changed_count` so groups with the most new findings rank highest [(#10606)](https://github.com/prowler-cloud/prowler/pull/10606)
 
 ### 🔄 Changed
 

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -16839,6 +16839,39 @@ class TestFindingGroupViewSet:
         data = response.json()["data"]
         assert len(data) > 0
 
+    @pytest.mark.parametrize(
+        "endpoint_name", ["finding-group-list", "finding-group-latest"]
+    )
+    def test_finding_groups_sort_by_delta(
+        self,
+        authenticated_client,
+        finding_groups_fixture,
+        endpoint_name,
+    ):
+        """Sort by delta orders by new_count then changed_count (lexicographic)."""
+        params = {"sort": "-delta"}
+        if endpoint_name == "finding-group-list":
+            params["filter[inserted_at]"] = TODAY
+
+        response = authenticated_client.get(reverse(endpoint_name), params)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert len(data) > 0
+
+        def delta_key(item):
+            attrs = item["attributes"]
+            return (attrs.get("new_count", 0), attrs.get("changed_count", 0))
+
+        desc_keys = [delta_key(item) for item in data]
+        assert desc_keys == sorted(desc_keys, reverse=True)
+
+        # Ascending order produces the inverse arrangement
+        params["sort"] = "delta"
+        response = authenticated_client.get(reverse(endpoint_name), params)
+        assert response.status_code == status.HTTP_200_OK
+        asc_keys = [delta_key(item) for item in response.json()["data"]]
+        assert asc_keys == sorted(asc_keys)
+
     def test_finding_groups_latest_ignores_date_filters(
         self, authenticated_client, finding_groups_fixture
     ):

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -7219,6 +7219,7 @@ class FindingGroupViewSet(BaseRLSViewSet):
         "check_id": "check_id",
         "check_title": "check_title",
         "severity": "severity_order",
+        "delta": "delta_order",
         "fail_count": "fail_count",
         "pass_count": "pass_count",
         "muted_count": "muted_count",
@@ -7569,7 +7570,20 @@ class FindingGroupViewSet(BaseRLSViewSet):
                 sort_param, self._FINDING_GROUP_SORT_MAP
             )
             if ordering:
-                aggregated_queryset = aggregated_queryset.order_by(*ordering)
+                # delta_order is a virtual sort field: expand it to a
+                # lexicographic ordering by (new_count, changed_count) so groups
+                # with more new findings rank higher, with changed_count as the
+                # tie-breaker (preserves the "new > changed" priority used by
+                # the resources endpoint, but driven by the actual counters).
+                expanded_ordering = []
+                for field in ordering:
+                    if field.lstrip("-") == "delta_order":
+                        sign = "-" if field.startswith("-") else ""
+                        expanded_ordering.append(f"{sign}new_count")
+                        expanded_ordering.append(f"{sign}changed_count")
+                    else:
+                        expanded_ordering.append(field)
+                aggregated_queryset = aggregated_queryset.order_by(*expanded_ordering)
         else:
             aggregated_queryset = aggregated_queryset.order_by(
                 "-fail_count", "-severity_order", "check_id"


### PR DESCRIPTION
### Context

The `/api/v1/finding-groups` and `/api/v1/finding-groups/latest` endpoints did not accept `sort=delta` even though the nested resources endpoint (`/api/v1/finding-groups/latest/<check_id>/resources?sort=-delta`) already supports it. This made it impossible to surface checks with the most recent activity (new or changed findings) at the top of the list view.

### Description

Adds `delta` to the allowed sort fields on the finding-groups list and latest endpoints. Because finding groups are aggregations and already expose `new_count` / `changed_count` per group (computed by both `_aggregate_findings` and `_aggregate_daily_summaries`), `delta` is implemented as a virtual sort field that expands to a lexicographic ordering by `(new_count, changed_count)` with the same sign:

- `sort=-delta` → `ORDER BY new_count DESC, changed_count DESC`
- `sort=delta`  → `ORDER BY new_count ASC, changed_count ASC`

This preserves the convention used in the resources endpoint (`new` outranks `changed` outranks none) but lets the actual counters drive the ordering. For example, a group with `new=1, changed=100` ranks above a group with `new=0, changed=500` because the primary key (`new_count`) wins regardless of the tie-breaker.

No annotation is added to the queryset (the columns are already there), no new field is exposed in the response, and behavior for any other sort field is unchanged.

### Steps to review

1. Default behavior unchanged:
   ```
   GET /api/v1/finding-groups/latest
   ```
   Should still return groups ordered by `-fail_count, -severity_order, check_id`.

2. Sort descending by delta — groups with most `new` findings appear first, ties broken by `changed_count`:
   ```
   GET /api/v1/finding-groups/latest?sort=-delta
   ```

3. Sort ascending by delta — groups with no delta appear first, then groups with `changed` only, then groups with `new`:
   ```
   GET /api/v1/finding-groups/latest?sort=delta
   ```

4. Same behavior on the dated list endpoint:
   ```
   GET /api/v1/finding-groups?filter[inserted_at]=YYYY-MM-DD&sort=-delta
   ```

5. Combined with other sorts (e.g. tie-break by check title):
   ```
   GET /api/v1/finding-groups/latest?sort=-delta,check_title
   ```

6. Run the new parametrized test:
   ```
   poetry run pytest src/backend/api/tests/test_views.py::TestFindingGroupViewSet::test_finding_groups_sort_by_delta -x
   ```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - N/A — no SDK changes.

#### API (if applicable)
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable) — response shape is unchanged; only ordering is affected.
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — N/A, no new query, only an additional `ORDER BY` over already-projected columns.
- [ ] Performance test results (if applicable) — N/A.
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.