### PR TITLE
refactor(m365): normalize CA platforms at model level

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - Added `internet-exposed` category to 13 AWS checks (CloudFront, CodeArtifact, EC2, EFS, RDS, SageMaker, Shield, VPC) [(#10502)](https://github.com/prowler-cloud/prowler/pull/10502)
 - Minimum Python version from 3.9 to 3.10 and updated classifiers to reflect supported versions (3.10, 3.11, 3.12) [(#10464)](https://github.com/prowler-cloud/prowler/pull/10464)
-- Platform normalization in Conditional Access checks moved to `PlatformConditions` model validator
+- Platform normalization in Conditional Access checks moved to `PlatformConditions` model validator [(#10614)](https://github.com/prowler-cloud/prowler/pull/10614)
 - Sensitive CLI flags now warn when values are passed directly, recommending environment variables instead [(#10532)](https://github.com/prowler-cloud/prowler/pull/10532)
 
 ### 🐞 Fixed

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - Added `internet-exposed` category to 13 AWS checks (CloudFront, CodeArtifact, EC2, EFS, RDS, SageMaker, Shield, VPC) [(#10502)](https://github.com/prowler-cloud/prowler/pull/10502)
 - Minimum Python version from 3.9 to 3.10 and updated classifiers to reflect supported versions (3.10, 3.11, 3.12) [(#10464)](https://github.com/prowler-cloud/prowler/pull/10464)
+- Platform normalization in Conditional Access checks moved to `PlatformConditions` model validator
 - Sensitive CLI flags now warn when values are passed directly, recommending environment variables instead [(#10532)](https://github.com/prowler-cloud/prowler/pull/10532)
 
 ### 🐞 Fixed

--- a/prowler/providers/m365/services/entra/entra_conditional_access_policy_approved_client_app_required_for_mobile/entra_conditional_access_policy_approved_client_app_required_for_mobile.py
+++ b/prowler/providers/m365/services/entra/entra_conditional_access_policy_approved_client_app_required_for_mobile/entra_conditional_access_policy_approved_client_app_required_for_mobile.py
@@ -1,10 +1,16 @@
 from prowler.lib.check.models import Check, CheckReportM365
 from prowler.providers.m365.services.entra.entra_client import entra_client
 from prowler.providers.m365.services.entra.entra_service import (
+    MOBILE_PLATFORMS,
     ConditionalAccessGrantControl,
     ConditionalAccessPolicyState,
     GrantControlOperator,
 )
+
+MOBILE_APP_GRANT_CONTROLS = {
+    ConditionalAccessGrantControl.APPROVED_APPLICATION,
+    ConditionalAccessGrantControl.COMPLIANT_APPLICATION,
+}
 
 
 class entra_conditional_access_policy_approved_client_app_required_for_mobile(Check):
@@ -16,19 +22,6 @@ class entra_conditional_access_policy_approved_client_app_required_for_mobile(Ch
     - PASS: An enabled policy requires approved client apps or app protection for iOS/Android.
     - FAIL: No policy restricts mobile app access to approved or protected apps.
     """
-
-    REQUIRED_MOBILE_PLATFORMS = {"android", "ios"}
-    MOBILE_APP_GRANT_CONTROLS = {
-        ConditionalAccessGrantControl.APPROVED_APPLICATION,
-        ConditionalAccessGrantControl.COMPLIANT_APPLICATION,
-    }
-
-    @staticmethod
-    def _normalize_platform(platform: object) -> str:
-        normalized_platform = getattr(platform, "value", platform)
-        return (
-            normalized_platform.lower() if isinstance(normalized_platform, str) else ""
-        )
 
     def execute(self) -> list[CheckReportM365]:
         """Execute the check logic.
@@ -54,43 +47,22 @@ class entra_conditional_access_policy_approved_client_app_required_for_mobile(Ch
             if not policy.conditions.platform_conditions:
                 continue
 
-            included_platforms = {
-                normalized_platform
-                for normalized_platform in map(
-                    self._normalize_platform,
-                    policy.conditions.platform_conditions.include_platforms,
-                )
-                if normalized_platform
-            }
-            excluded_platforms = {
-                normalized_platform
-                for normalized_platform in map(
-                    self._normalize_platform,
-                    policy.conditions.platform_conditions.exclude_platforms,
-                )
-                if normalized_platform
-            }
+            included = set(policy.conditions.platform_conditions.include_platforms)
+            excluded = set(policy.conditions.platform_conditions.exclude_platforms)
 
-            targets_mobile_platforms = (
-                "all" in included_platforms
-                or self.REQUIRED_MOBILE_PLATFORMS.issubset(included_platforms)
-            ) and not (
-                "all" in excluded_platforms
-                or self.REQUIRED_MOBILE_PLATFORMS.intersection(excluded_platforms)
-            )
-            if not targets_mobile_platforms:
+            targets_mobile = (
+                "all" in included or MOBILE_PLATFORMS.issubset(included)
+            ) and not ("all" in excluded or MOBILE_PLATFORMS.intersection(excluded))
+            if not targets_mobile:
                 continue
 
             built_in_controls = set(policy.grant_controls.built_in_controls)
-            has_mobile_app_control = bool(
-                self.MOBILE_APP_GRANT_CONTROLS.intersection(built_in_controls)
-            )
-            if not has_mobile_app_control:
+            if not MOBILE_APP_GRANT_CONTROLS.intersection(built_in_controls):
                 continue
 
             if (
                 policy.grant_controls.operator == GrantControlOperator.OR
-                and not built_in_controls.issubset(self.MOBILE_APP_GRANT_CONTROLS)
+                and not built_in_controls.issubset(MOBILE_APP_GRANT_CONTROLS)
             ):
                 continue
 

--- a/prowler/providers/m365/services/entra/entra_conditional_access_policy_unknown_device_blocked/entra_conditional_access_policy_unknown_device_blocked.py
+++ b/prowler/providers/m365/services/entra/entra_conditional_access_policy_unknown_device_blocked/entra_conditional_access_policy_unknown_device_blocked.py
@@ -19,13 +19,6 @@ class entra_conditional_access_policy_unknown_device_blocked(Check):
     - FAIL: No CA policy restricts access from unrecognized device platforms.
     """
 
-    @staticmethod
-    def _normalize_platform(platform: object) -> str:
-        normalized_platform = getattr(platform, "value", platform)
-        return (
-            normalized_platform.lower() if isinstance(normalized_platform, str) else ""
-        )
-
     def execute(self) -> list[CheckReportM365]:
         """Execute the check logic.
 
@@ -49,29 +42,13 @@ class entra_conditional_access_policy_unknown_device_blocked(Check):
             if not policy.conditions.platform_conditions:
                 continue
 
-            included_platforms = {
-                normalized_platform
-                for normalized_platform in map(
-                    self._normalize_platform,
-                    policy.conditions.platform_conditions.include_platforms,
-                )
-                if normalized_platform
-            }
-            excluded_platforms = {
-                normalized_platform
-                for normalized_platform in map(
-                    self._normalize_platform,
-                    policy.conditions.platform_conditions.exclude_platforms,
-                )
-                if normalized_platform
-            }
+            included = set(policy.conditions.platform_conditions.include_platforms)
+            excluded = set(policy.conditions.platform_conditions.exclude_platforms)
 
-            if "all" not in included_platforms:
+            if "all" not in included:
                 continue
 
-            if not {
-                self._normalize_platform(platform) for platform in KNOWN_PLATFORMS
-            }.issubset(excluded_platforms):
+            if not KNOWN_PLATFORMS.issubset(excluded):
                 continue
 
             if (

--- a/prowler/providers/m365/services/entra/entra_conditional_access_policy_unknown_device_blocked/entra_conditional_access_policy_unknown_device_blocked.py
+++ b/prowler/providers/m365/services/entra/entra_conditional_access_policy_unknown_device_blocked/entra_conditional_access_policy_unknown_device_blocked.py
@@ -66,10 +66,10 @@ class entra_conditional_access_policy_unknown_device_blocked(Check):
 
             if policy.state == ConditionalAccessPolicyState.ENABLED_FOR_REPORTING:
                 report.status = "FAIL"
-                report.status_extended = f"Conditional Access Policy '{policy.display_name}' is configured to block unknown device platforms but is only in report-only mode."
+                report.status_extended = f"Conditional Access Policy {policy.display_name} is configured to block unknown device platforms but is only in report-only mode."
             else:
                 report.status = "PASS"
-                report.status_extended = f"Conditional Access Policy '{policy.display_name}' blocks access from unknown or unsupported device platforms."
+                report.status_extended = f"Conditional Access Policy {policy.display_name} blocks access from unknown or unsupported device platforms."
                 break
 
         findings.append(report)

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -9,7 +9,7 @@ from msgraph.generated.models.o_data_errors.o_data_error import ODataError
 from msgraph.generated.security.microsoft_graph_security_run_hunting_query.run_hunting_query_post_request_body import (
     RunHuntingQueryPostRequestBody,
 )
-from pydantic.v1 import BaseModel, Field
+from pydantic.v1 import BaseModel, Field, validator
 
 from prowler.lib.logger import logger
 from prowler.providers.m365.lib.service.service import M365Service
@@ -1003,8 +1003,18 @@ class PlatformConditions(BaseModel):
     class Config:
         allow_population_by_field_name = True
 
+    @validator("include_platforms", "exclude_platforms", pre=True)
+    def normalize_platforms(cls, v):
+        normalized = []
+        for platform in v:
+            value = getattr(platform, "value", platform)
+            if isinstance(value, str) and value:
+                normalized.append(value.lower())
+        return normalized
+
 
 KNOWN_PLATFORMS = frozenset({"android", "ios", "windows", "macos", "linux"})
+MOBILE_PLATFORMS = frozenset({"android", "ios"})
 
 
 class TransferMethod(Enum):


### PR DESCRIPTION
### Context

Follows up on #10235. Both Conditional Access checks that inspect device platforms (`unknown_device_blocked` and `approved_client_app_required_for_mobile`) duplicated identical `_normalize_platform()` logic and platform-set comprehensions. This moves normalization to the data layer so checks can trust the model directly.

### Description

- Add a pydantic `validator` to `PlatformConditions` that lowercases platform values and extracts `.value` from enum objects at construction time
- Remove duplicated `_normalize_platform()` static method from both CA checks
- Export `MOBILE_PLATFORMS` frozenset from `entra_service` alongside `KNOWN_PLATFORMS`
- Simplify platform comparison logic in both checks (direct set operations, no per-check normalization)

### Steps to review

1. Review `entra_service.py` validator on `PlatformConditions`
2. Review simplified check logic in both CA checks
3. Run tests:
   ```bash
   poetry run pytest tests/providers/m365/services/entra/entra_conditional_access_policy_unknown_device_blocked/ tests/providers/m365/services/entra/entra_conditional_access_policy_approved_client_app_required_for_mobile/ -q
   ```

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md — N/A
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.