### PR TITLE
fix(ui): show active organization ID in profile page

### DIFF
--- a/ui/app/(prowler)/profile/page.tsx
+++ b/ui/app/(prowler)/profile/page.tsx
@@ -77,11 +77,7 @@ const SSRDataUser = async ({
     {},
   );
 
-  const firstUserMembership = membershipsIncluded.find(
-    (m) => m.relationships?.user?.data?.id === userData.id,
-  );
-
-  const userTenantId = firstUserMembership?.relationships?.tenant?.data?.id;
+  const userTenantId = session?.tenantId;
 
   const userRoleIds =
     userData.relationships?.roles?.data?.map((r) => r.id) || [];


### PR DESCRIPTION
### Context

The profile page (`/profile`) displayed the Organization ID from the user's first membership instead of the currently active tenant. After the organization switching feature was introduced, this caused the Organization ID to remain static regardless of which organization the user switched to.

### Description

Replaced the logic that extracted the tenant ID from the first membership relationship with `session.tenantId`, which already contains the active tenant ID decoded from the JWT token. This value is already used correctly in `MembershipsCard` to mark the active tenant.

### Steps to review

1. Log in with a user that belongs to multiple organizations
2. Navigate to `/profile`
3. Verify the Organization ID matches the currently active organization
4. Switch to a different organization
5. Navigate to `/profile` again
6. Verify the Organization ID now reflects the switched organization

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [ ] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.