### PR TITLE
feat(api): support sort=status on finding-groups endpoints

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the **Prowler API** are documented in this file.
 - `VALKEY_SCHEME`, `VALKEY_USERNAME`, and `VALKEY_PASSWORD` environment variables to configure Celery broker TLS/auth connection details for Valkey/ElastiCache [(#10420)](https://github.com/prowler-cloud/prowler/pull/10420)
 - `Vercel` provider support [(#10190)](https://github.com/prowler-cloud/prowler/pull/10190)
 - Finding groups list and latest endpoints support `sort=delta`, ordering by `new_count` then `changed_count` so groups with the most new findings rank highest [(#10606)](https://github.com/prowler-cloud/prowler/pull/10606)
+- Finding groups list and latest endpoints support `sort=status`, ordering by aggregated status with the FAIL > PASS > MUTED priority [(#10628)](https://github.com/prowler-cloud/prowler/pull/10628)
 
 ### 🔄 Changed
 

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -16872,6 +16872,68 @@ class TestFindingGroupViewSet:
         asc_keys = [delta_key(item) for item in response.json()["data"]]
         assert asc_keys == sorted(asc_keys)
 
+    @pytest.mark.parametrize(
+        "endpoint_name", ["finding-group-list", "finding-group-latest"]
+    )
+    def test_finding_groups_sort_by_status(
+        self,
+        authenticated_client,
+        finding_groups_fixture,
+        endpoint_name,
+    ):
+        """Sort by status orders by aggregated status (FAIL > PASS > MUTED)."""
+        status_order = {"FAIL": 3, "PASS": 2, "MUTED": 1}
+
+        # Descending: FAIL groups first, then PASS
+        params = {"sort": "-status"}
+        if endpoint_name == "finding-group-list":
+            params["filter[inserted_at]"] = TODAY
+
+        response = authenticated_client.get(reverse(endpoint_name), params)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert len(data) > 0
+
+        desc_statuses = [item["attributes"]["status"] for item in data]
+        desc_keys = [status_order[s] for s in desc_statuses]
+        assert desc_keys == sorted(desc_keys, reverse=True)
+
+        # Ascending: PASS groups first, then FAIL
+        params["sort"] = "status"
+        response = authenticated_client.get(reverse(endpoint_name), params)
+        assert response.status_code == status.HTTP_200_OK
+        asc_statuses = [
+            item["attributes"]["status"] for item in response.json()["data"]
+        ]
+        asc_keys = [status_order[s] for s in asc_statuses]
+        assert asc_keys == sorted(asc_keys)
+
+    @pytest.mark.parametrize(
+        "endpoint_name", ["finding-group-list", "finding-group-latest"]
+    )
+    def test_finding_groups_sort_by_status_includes_muted(
+        self,
+        authenticated_client,
+        finding_groups_fixture,
+        endpoint_name,
+    ):
+        """When include_muted is set, MUTED groups participate in status sort."""
+        status_order = {"FAIL": 3, "PASS": 2, "MUTED": 1}
+
+        params = {"sort": "status", "filter[include_muted]": "true"}
+        if endpoint_name == "finding-group-list":
+            params["filter[inserted_at]"] = TODAY
+
+        response = authenticated_client.get(reverse(endpoint_name), params)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+
+        statuses = [item["attributes"]["status"] for item in data]
+        assert "MUTED" in statuses
+        assert statuses[0] == "MUTED"
+        keys = [status_order[s] for s in statuses]
+        assert keys == sorted(keys)
+
     def test_finding_groups_latest_ignores_date_filters(
         self, authenticated_client, finding_groups_fixture
     ):

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -7219,6 +7219,7 @@ class FindingGroupViewSet(BaseRLSViewSet):
         "check_id": "check_id",
         "check_title": "check_title",
         "severity": "severity_order",
+        "status": "status_order",
         "delta": "delta_order",
         "fail_count": "fail_count",
         "pass_count": "pass_count",
@@ -7570,6 +7571,19 @@ class FindingGroupViewSet(BaseRLSViewSet):
                 sort_param, self._FINDING_GROUP_SORT_MAP
             )
             if ordering:
+                # status_order is annotated on demand so groups can be sorted
+                # by their aggregated status (FAIL > PASS > MUTED), mirroring
+                # the priority used in _post_process_aggregation.
+                if any(field.lstrip("-") == "status_order" for field in ordering):
+                    aggregated_queryset = aggregated_queryset.annotate(
+                        status_order=Case(
+                            When(fail_count__gt=0, then=Value(3)),
+                            When(pass_count__gt=0, then=Value(2)),
+                            default=Value(1),
+                            output_field=IntegerField(),
+                        )
+                    )
+
                 # delta_order is a virtual sort field: expand it to a
                 # lexicographic ordering by (new_count, changed_count) so groups
                 # with more new findings rank higher, with changed_count as the


### PR DESCRIPTION
### Context

Finding groups list and latest endpoints (`/api/v1/finding-groups` and `/api/v1/finding-groups/latest`) only allowed sorting by `severity`, `delta` and the raw counters, but not by the aggregated status (`FAIL` / `PASS` / `MUTED`). The UI needs to surface failing groups first when triaging, so the API needs a first-class `sort=status`.

### Description

Adds `status` as a sortable field to the finding groups list and latest endpoints. The aggregated status is derived from the existing counters with the same priority used in `_post_process_aggregation` (`FAIL > PASS > MUTED`):

- `fail_count > 0` → `FAIL` (order = 3)
- `pass_count > 0` → `PASS` (order = 2)
- otherwise         → `MUTED` (order = 1)

Implementation notes (consistency with the existing patterns in the same viewset):

- `_FINDING_GROUP_SORT_MAP` gets a new entry `"status": "status_order"`, mirroring the convention already used by `_RESOURCE_SORT_MAP` and the `severity_order` / `delta_order` virtual fields.
- The integer priority `FAIL=3 / PASS=2 / MUTED=1` matches the one already used in `_build_resource_aggregation`, so `-status` consistently puts FAIL first across both endpoints.
- The `status_order` annotation is added on demand in `_sorted_paginated_response` only when the user actually sorts by status. This is the same conditional-annotation pattern used by `_apply_aggregated_computed_filters` for the `aggregated_status` filter.
- Groups whose status would be `MUTED` are still excluded by default (existing `include_muted` behaviour). Passing `filter[include_muted]=true` makes them participate in the sort and they appear first in ascending order.

`new_count`/`changed_count` and the rest of the API contract are untouched, so this is a purely additive change with no breaking impact on existing clients.

### Steps to review

1. Hit `/api/v1/finding-groups?filter[inserted_at]=YYYY-MM-DD&sort=-status` and verify FAIL groups come first, then PASS.
2. Hit `/api/v1/finding-groups/latest?sort=status` and verify the inverse order.
3. Hit `/api/v1/finding-groups/latest?sort=status&filter[include_muted]=true` and verify MUTED groups participate and appear first.
4. Pass an invalid value (`?sort=foo`) and verify it still returns `400` with the existing error format.
5. Run the new tests:

   ```bash
   cd api
   poetry run pytest src/backend/api/tests/test_views.py \
     -k "test_finding_groups_sort_by_status" -x --tb=short
   ```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.