### PR TITLE
docs: rename Prowler App to Prowler Cloud in provider headers

### DIFF
--- a/docs/user-guide/providers/alibabacloud/getting-started-alibabacloud.mdx
+++ b/docs/user-guide/providers/alibabacloud/getting-started-alibabacloud.mdx
@@ -37,7 +37,7 @@ Before you begin, make sure you have:
 
 ![Get Account ID](/images/providers/alibaba-account-id.png)
 
-### Step 2: Access Prowler Cloud or Prowler App
+### Step 2: Access Prowler Cloud
 
 1. Navigate to [Prowler Cloud](https://cloud.prowler.com/) or launch [Prowler App](/user-guide/tutorials/prowler-app)
 2. Go to "Configuration" > "Cloud Providers"

--- a/docs/user-guide/providers/aws/getting-started-aws.mdx
+++ b/docs/user-guide/providers/aws/getting-started-aws.mdx
@@ -2,7 +2,7 @@
 title: 'Getting Started With AWS on Prowler'
 ---
 
-## Prowler App
+## Prowler Cloud
 
 <iframe width="560" height="380" src="https://www.youtube-nocookie.com/embed/RPgIWOCERzY" title="Prowler Cloud Onboarding AWS" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
 
@@ -16,7 +16,7 @@ title: 'Getting Started With AWS on Prowler'
 ![Account ID detail](/images/providers/aws-account-id.png)
 
 
-### Step 2: Access Prowler Cloud or Prowler App
+### Step 2: Access Prowler Cloud
 
 1. Navigate to [Prowler Cloud](https://cloud.prowler.com/) or launch [Prowler App](/user-guide/tutorials/prowler-app)
 2. Go to "Configuration" > "Cloud Providers"

--- a/docs/user-guide/providers/azure/getting-started-azure.mdx
+++ b/docs/user-guide/providers/azure/getting-started-azure.mdx
@@ -2,7 +2,7 @@
 title: 'Getting Started With Azure on Prowler'
 ---
 
-## Prowler App
+## Prowler Cloud
 
 <iframe width="560" height="380" src="https://www.youtube-nocookie.com/embed/v1as8vTFlMg" title="Prowler Cloud Onboarding Azure" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="1"></iframe>
 > Walkthrough video onboarding an Azure Subscription using Service Principal.
@@ -32,7 +32,7 @@ For detailed instructions on how to create the Service Principal and configure p
 
 ---
 
-### Step 2: Access Prowler App
+### Step 2: Access Prowler Cloud
 
 1. Navigate to [Prowler Cloud](https://cloud.prowler.com/) or launch [Prowler App](/user-guide/tutorials/prowler-app)
 2. Navigate to `Configuration` > `Cloud Providers`
@@ -51,7 +51,7 @@ For detailed instructions on how to create the Service Principal and configure p
 
     ![Add Subscription ID](/images/providers/add-subscription-id.png)
 
-### Step 3: Add Credentials to Prowler App
+### Step 3: Add Credentials to Prowler Cloud
 
 For Azure, Prowler App uses a service principal application to authenticate. For more information about the process of creating and adding permissions to a service principal refer to this [section](/user-guide/providers/azure/authentication). When you finish creating and adding the [Entra](/user-guide/providers/azure/create-prowler-service-principal#assigning-proper-permissions) and [Subscription](/user-guide/providers/azure/subscriptions) scope permissions to the service principal, enter the `Tenant ID`, `Client ID` and `Client Secret` of the service principal application.
 

--- a/docs/user-guide/providers/gcp/getting-started-gcp.mdx
+++ b/docs/user-guide/providers/gcp/getting-started-gcp.mdx
@@ -2,7 +2,7 @@
 title: 'Getting Started With GCP on Prowler'
 ---
 
-## Prowler App
+## Prowler Cloud
 
 ### Step 1: Get the GCP Project ID
 
@@ -11,7 +11,7 @@ title: 'Getting Started With GCP on Prowler'
 
 ![Get the Project ID](/images/providers/project-id-console.png)
 
-### Step 2: Access Prowler Cloud or Prowler App
+### Step 2: Access Prowler Cloud
 
 1. Navigate to [Prowler Cloud](https://cloud.prowler.com/) or launch [Prowler App](/user-guide/tutorials/prowler-app)
 2. Go to "Configuration" > "Cloud Providers"

--- a/docs/user-guide/providers/iac/getting-started-iac.mdx
+++ b/docs/user-guide/providers/iac/getting-started-iac.mdx
@@ -31,7 +31,7 @@ Prowler IaC provider scans the following Infrastructure as Code configurations f
 - Mutelist logic ([filtering](https://trivy.dev/latest/docs/configuration/filtering/)) is handled by Trivy, not Prowler.
 - Results are output in the same formats as other Prowler providers (CSV, JSON, HTML, etc.).
 
-## Prowler App
+## Prowler Cloud
 
 <VersionBadge version="5.14.0" />
 

--- a/docs/user-guide/providers/kubernetes/getting-started-k8s.mdx
+++ b/docs/user-guide/providers/kubernetes/getting-started-k8s.mdx
@@ -2,7 +2,7 @@
 title: 'Getting Started with Kubernetes'
 ---
 
-## Prowler App
+## Prowler Cloud
 
 ### Step 1: Access Prowler Cloud/App
 

--- a/docs/user-guide/providers/oci/getting-started-oci.mdx
+++ b/docs/user-guide/providers/oci/getting-started-oci.mdx
@@ -14,7 +14,7 @@ The following steps apply to Prowler Cloud and the self-hosted Prowler App.
 3. Generate or locate the API key fingerprint and private key for that user. Follow the [Config File Authentication steps](/user-guide/providers/oci/authentication#config-file-authentication-manual-api-key-setup) to create or rotate the key pair and copy the fingerprint.
 4. Note the **Region** identifier to scan (for example, `us-ashburn-1`).
 
-### Step 2: Access Prowler Cloud or Prowler App
+### Step 2: Access Prowler Cloud
 1. Navigate to [Prowler Cloud](https://cloud.prowler.com/) or launch [Prowler App](/user-guide/tutorials/prowler-app).
 2. Go to **Configuration** → **Cloud Providers** and click **Add Cloud Provider**.
 ![Add OCI Cloud Provider](./images/oci-add-cloud-provider.png)


### PR DESCRIPTION
## Summary
- Rename "Prowler App" to "Prowler Cloud" in all provider getting-started page headers
- Standardize sub-headers (e.g., "Access Prowler Cloud or Prowler App" → "Access Prowler Cloud")

## Affected Providers
- AWS
- Azure
- GCP
- Kubernetes
- IaC
- Alibaba Cloud
- OCI

## Test Plan
- [ ] Verify Mintlify docs build successfully
- [ ] Confirm all provider getting-started pages render correct headers