### PR TITLE
fix(vercel): use canonical Hub URLs in check metadata

### DIFF
--- a/prowler/providers/vercel/services/authentication/authentication_no_stale_tokens/authentication_no_stale_tokens.metadata.json
+++ b/prowler/providers/vercel/services/authentication/authentication_no_stale_tokens/authentication_no_stale_tokens.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Regularly audit API tokens and revoke any that have not been used within 90 days. Implement a token lifecycle management process that includes periodic reviews, automatic expiration dates, and documentation of each token's purpose and owner.",
-      "Url": "https://hub.prowler.com/checks/vercel/authentication_no_stale_tokens"
+      "Url": "https://hub.prowler.com/check/authentication_no_stale_tokens"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/authentication/authentication_token_not_expired/authentication_token_not_expired.metadata.json
+++ b/prowler/providers/vercel/services/authentication/authentication_token_not_expired/authentication_token_not_expired.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Remove expired tokens and create new ones with appropriate expiration dates. Implement a token rotation schedule to ensure tokens are refreshed before they expire. Update all integrations and automation that depend on the replaced tokens.",
-      "Url": "https://hub.prowler.com/checks/vercel/authentication_token_not_expired"
+      "Url": "https://hub.prowler.com/check/authentication_token_not_expired"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/deployment/deployment_production_uses_stable_target/deployment_production_uses_stable_target.metadata.json
+++ b/prowler/providers/vercel/services/deployment/deployment_production_uses_stable_target/deployment_production_uses_stable_target.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Configure the production branch to main or master and ensure all production deployments go through the standard merge workflow. Use branch protection rules in your Git provider to prevent direct pushes to the production branch.",
-      "Url": "https://hub.prowler.com/checks/vercel/deployment_production_uses_stable_target"
+      "Url": "https://hub.prowler.com/check/deployment_production_uses_stable_target"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/domain/domain_dns_properly_configured/domain_dns_properly_configured.metadata.json
+++ b/prowler/providers/vercel/services/domain/domain_dns_properly_configured/domain_dns_properly_configured.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Update DNS records at your domain registrar to correctly point to Vercel. Use a CNAME record for subdomains or an A record for apex domains. Verify the configuration in the Vercel dashboard after making changes.",
-      "Url": "https://hub.prowler.com/checks/vercel/domain_dns_properly_configured"
+      "Url": "https://hub.prowler.com/check/domain_dns_properly_configured"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/domain/domain_ssl_certificate_valid/domain_ssl_certificate_valid.metadata.json
+++ b/prowler/providers/vercel/services/domain/domain_ssl_certificate_valid/domain_ssl_certificate_valid.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Ensure domain DNS records are properly configured to point to Vercel. Once DNS is validated, Vercel automatically provisions and renews SSL/TLS certificates. Check the domain configuration in the Vercel dashboard if the certificate is not being issued.",
-      "Url": "https://hub.prowler.com/checks/vercel/domain_ssl_certificate_valid"
+      "Url": "https://hub.prowler.com/check/domain_ssl_certificate_valid"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/domain/domain_verified/domain_verified.metadata.json
+++ b/prowler/providers/vercel/services/domain/domain_verified/domain_verified.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Complete domain verification by configuring the required DNS records at your domain registrar. Remove any domains that are no longer needed to reduce the attack surface. Regularly audit domain configurations to ensure all domains remain verified.",
-      "Url": "https://hub.prowler.com/checks/vercel/domain_verified"
+      "Url": "https://hub.prowler.com/check/domain_verified"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_auto_expose_system_env_disabled/project_auto_expose_system_env_disabled.metadata.json
+++ b/prowler/providers/vercel/services/project/project_auto_expose_system_env_disabled/project_auto_expose_system_env_disabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Disable automatic exposure of system environment variables and explicitly define only the variables required by your application. This follows the principle of least privilege and reduces the risk of leaking internal infrastructure details through client-side code.",
-      "Url": "https://hub.prowler.com/checks/vercel/project_auto_expose_system_env_disabled"
+      "Url": "https://hub.prowler.com/check/project_auto_expose_system_env_disabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_deployment_protection_enabled/project_deployment_protection_enabled.metadata.json
+++ b/prowler/providers/vercel/services/project/project_deployment_protection_enabled/project_deployment_protection_enabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Enable deployment protection on preview deployments to require authentication before visitors can access preview URLs. Use 'Standard Protection' for Vercel Authentication or configure trusted IP ranges for more granular control.",
-      "Url": "https://hub.prowler.com/checks/vercel/project_deployment_protection_enabled"
+      "Url": "https://hub.prowler.com/check/project_deployment_protection_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_directory_listing_disabled/project_directory_listing_disabled.metadata.json
+++ b/prowler/providers/vercel/services/project/project_directory_listing_disabled/project_directory_listing_disabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Disable directory listing to prevent visitors from browsing the file structure of your deployments. Ensure that all directories either contain an index file or return a 404 response when accessed directly.",
-      "Url": "https://hub.prowler.com/checks/vercel/project_directory_listing_disabled"
+      "Url": "https://hub.prowler.com/check/project_directory_listing_disabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_environment_no_overly_broad_target/project_environment_no_overly_broad_target.metadata.json
+++ b/prowler/providers/vercel/services/project/project_environment_no_overly_broad_target/project_environment_no_overly_broad_target.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Follow the **principle of least privilege** for environment variable targeting.\n- Assign each variable to only the environments where it is actually needed\n- Use different credentials for production, preview, and development environments\n- Non-sensitive configuration (e.g. feature flags, public URLs) may be acceptable in multiple environments but should still be reviewed\n- Regularly audit environment variable targets to prevent scope creep",
-      "Url": "https://hub.prowler.com/checks/vercel/project_environment_no_overly_broad_target"
+      "Url": "https://hub.prowler.com/check/project_environment_no_overly_broad_target"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_environment_no_secrets_in_plain_type/project_environment_no_secrets_in_plain_type.metadata.json
+++ b/prowler/providers/vercel/services/project/project_environment_no_secrets_in_plain_type/project_environment_no_secrets_in_plain_type.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Use the **Sensitive** type for all environment variables that contain secrets, keys, tokens, or passwords.\n- Sensitive variables are never exposed in the dashboard or API responses after creation\n- Rotate all credentials that were previously stored as plain text\n- Implement naming conventions that make it easy to identify secret variables",
-      "Url": "https://hub.prowler.com/checks/vercel/project_environment_no_secrets_in_plain_type"
+      "Url": "https://hub.prowler.com/check/project_environment_no_secrets_in_plain_type"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_environment_production_vars_not_in_preview/project_environment_production_vars_not_in_preview.metadata.json
+++ b/prowler/providers/vercel/services/project/project_environment_production_vars_not_in_preview/project_environment_production_vars_not_in_preview.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Maintain strict **environment separation** between production and preview deployments.\n- Use dedicated, limited-scope credentials for preview environments\n- Never share production database credentials, API keys, or signing keys with preview builds\n- Enable Vercel's deployment protection features to further restrict access to preview deployments\n- Regularly audit which environment variables target multiple environments",
-      "Url": "https://hub.prowler.com/checks/vercel/project_environment_production_vars_not_in_preview"
+      "Url": "https://hub.prowler.com/check/project_environment_production_vars_not_in_preview"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_git_fork_protection_enabled/project_git_fork_protection_enabled.metadata.json
+++ b/prowler/providers/vercel/services/project/project_git_fork_protection_enabled/project_git_fork_protection_enabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Enable Git fork protection to require explicit authorization before pull requests from forked repositories can trigger deployments. This prevents untrusted contributors from accessing environment variables and secrets through the build process. For open-source projects, review fork PRs manually before allowing builds.",
-      "Url": "https://hub.prowler.com/checks/vercel/project_git_fork_protection_enabled"
+      "Url": "https://hub.prowler.com/check/project_git_fork_protection_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_password_protection_enabled/project_password_protection_enabled.metadata.json
+++ b/prowler/providers/vercel/services/project/project_password_protection_enabled/project_password_protection_enabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Enable password protection to add a shared-password gate to your deployments. This is especially recommended for preview deployments shared with external clients or stakeholders who do not have Vercel accounts. Combine with Vercel Authentication for defense-in-depth.",
-      "Url": "https://hub.prowler.com/checks/vercel/project_password_protection_enabled"
+      "Url": "https://hub.prowler.com/check/project_password_protection_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_production_deployment_protection_enabled/project_production_deployment_protection_enabled.metadata.json
+++ b/prowler/providers/vercel/services/project/project_production_deployment_protection_enabled/project_production_deployment_protection_enabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Enable deployment protection on production deployments for applications that should not be publicly accessible. This is critical for internal tools, admin dashboards, and pre-launch applications where unauthorized access could lead to data exposure or system compromise.",
-      "Url": "https://hub.prowler.com/checks/vercel/project_production_deployment_protection_enabled"
+      "Url": "https://hub.prowler.com/check/project_production_deployment_protection_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/project/project_skew_protection_enabled/project_skew_protection_enabled.metadata.json
+++ b/prowler/providers/vercel/services/project/project_skew_protection_enabled/project_skew_protection_enabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Enable skew protection to ensure that all client requests during a deployment rollout are routed to the same deployment version that served the initial page. This prevents version mismatch errors and ensures a consistent user experience during deployments.",
-      "Url": "https://hub.prowler.com/checks/vercel/project_skew_protection_enabled"
+      "Url": "https://hub.prowler.com/check/project_skew_protection_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/security/security_custom_rules_configured/security_custom_rules_configured.metadata.json
+++ b/prowler/providers/vercel/services/security/security_custom_rules_configured/security_custom_rules_configured.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Configure custom firewall rules to protect application-specific endpoints and enforce security policies. Focus on protecting admin panels, API routes, authentication endpoints, and any paths that handle sensitive data.",
-      "Url": "https://hub.prowler.com/checks/vercel/security_custom_rules_configured"
+      "Url": "https://hub.prowler.com/check/security_custom_rules_configured"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/security/security_ip_blocking_rules_configured/security_ip_blocking_rules_configured.metadata.json
+++ b/prowler/providers/vercel/services/security/security_ip_blocking_rules_configured/security_ip_blocking_rules_configured.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Configure IP blocking rules to deny traffic from known malicious sources. Maintain a blocklist of IPs identified through security monitoring, threat intelligence feeds, or incident investigation. Regularly review and update the blocklist.",
-      "Url": "https://hub.prowler.com/checks/vercel/security_ip_blocking_rules_configured"
+      "Url": "https://hub.prowler.com/check/security_ip_blocking_rules_configured"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/security/security_managed_rulesets_enabled/security_managed_rulesets_enabled.metadata.json
+++ b/prowler/providers/vercel/services/security/security_managed_rulesets_enabled/security_managed_rulesets_enabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Enable managed WAF rulesets to benefit from Vercel-curated protection against common attack patterns. If you are on a plan that does not support managed rulesets, consider upgrading to the Enterprise plan for enhanced security features.",
-      "Url": "https://hub.prowler.com/checks/vercel/security_managed_rulesets_enabled"
+      "Url": "https://hub.prowler.com/check/security_managed_rulesets_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/security/security_rate_limiting_configured/security_rate_limiting_configured.metadata.json
+++ b/prowler/providers/vercel/services/security/security_rate_limiting_configured/security_rate_limiting_configured.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Configure rate limiting rules to protect critical endpoints such as authentication, API routes, and form submissions. Start with conservative thresholds and adjust based on traffic patterns to avoid blocking legitimate users.",
-      "Url": "https://hub.prowler.com/checks/vercel/security_rate_limiting_configured"
+      "Url": "https://hub.prowler.com/check/security_rate_limiting_configured"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/security/security_waf_enabled/security_waf_enabled.metadata.json
+++ b/prowler/providers/vercel/services/security/security_waf_enabled/security_waf_enabled.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Enable the Vercel Web Application Firewall to protect your application against common web attacks. Start with managed rulesets for baseline protection and add custom rules as needed based on your application's threat model.",
-      "Url": "https://hub.prowler.com/checks/vercel/security_waf_enabled"
+      "Url": "https://hub.prowler.com/check/security_waf_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/team/team_directory_sync_enabled/team_directory_sync_enabled.metadata.json
+++ b/prowler/providers/vercel/services/team/team_directory_sync_enabled/team_directory_sync_enabled.metadata.json
@@ -25,7 +25,7 @@
     },
     "Recommendation": {
       "Text": "Enable directory sync (SCIM) to automate user lifecycle management. This ensures that team membership stays synchronized with your identity provider, automatically provisioning new members and revoking access when employees leave or change roles.",
-      "Url": "https://hub.prowler.com/checks/vercel/team_directory_sync_enabled"
+      "Url": "https://hub.prowler.com/check/team_directory_sync_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/team/team_member_role_least_privilege/team_member_role_least_privilege.metadata.json
+++ b/prowler/providers/vercel/services/team/team_member_role_least_privilege/team_member_role_least_privilege.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Limit the number of team owners to the minimum required for administration. Assign the least privileged role necessary for each member's responsibilities. Use MEMBER, DEVELOPER, or VIEWER roles for non-administrative team members.",
-      "Url": "https://hub.prowler.com/checks/vercel/team_member_role_least_privilege"
+      "Url": "https://hub.prowler.com/check/team_member_role_least_privilege"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/team/team_no_stale_invitations/team_no_stale_invitations.metadata.json
+++ b/prowler/providers/vercel/services/team/team_no_stale_invitations/team_no_stale_invitations.metadata.json
@@ -24,7 +24,7 @@
     },
     "Recommendation": {
       "Text": "Regularly review and revoke stale team invitations. Establish a process to follow up on pending invitations within a reasonable timeframe and revoke those that are no longer needed to reduce the risk of unauthorized access.",
-      "Url": "https://hub.prowler.com/checks/vercel/team_no_stale_invitations"
+      "Url": "https://hub.prowler.com/check/team_no_stale_invitations"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/team/team_saml_sso_enabled/team_saml_sso_enabled.metadata.json
+++ b/prowler/providers/vercel/services/team/team_saml_sso_enabled/team_saml_sso_enabled.metadata.json
@@ -25,7 +25,7 @@
     },
     "Recommendation": {
       "Text": "Enable SAML SSO for the Vercel team to centralize authentication through your organization's identity provider. This ensures consistent security policies, simplifies user lifecycle management, and enables enforcement of MFA and other access controls.",
-      "Url": "https://hub.prowler.com/checks/vercel/team_saml_sso_enabled"
+      "Url": "https://hub.prowler.com/check/team_saml_sso_enabled"
     }
   },
   "Categories": [

--- a/prowler/providers/vercel/services/team/team_saml_sso_enforced/team_saml_sso_enforced.metadata.json
+++ b/prowler/providers/vercel/services/team/team_saml_sso_enforced/team_saml_sso_enforced.metadata.json
@@ -25,7 +25,7 @@
     },
     "Recommendation": {
       "Text": "Enforce SAML SSO for all team members to ensure authentication is managed exclusively through your identity provider. This prevents credential bypass, enforces MFA policies, and provides centralized access control and audit capabilities.",
-      "Url": "https://hub.prowler.com/checks/vercel/team_saml_sso_enforced"
+      "Url": "https://hub.prowler.com/check/team_saml_sso_enforced"
     }
   },
   "Categories": [

--- a/tests/lib/check/check_test.py
+++ b/tests/lib/check/check_test.py
@@ -1048,6 +1048,34 @@ class TestCheck:
         )
         self.verify_metadata_check_id(base_directory)
 
+    def test_vercel_checks_metadata_is_valid(self):
+        base_directory = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "../../../",
+                "prowler/providers/vercel/services",
+            )
+        )
+        self.verify_metadata_check_id(base_directory)
+
+    def test_vercel_checks_metadata_use_canonical_hub_urls(self):
+        base_directory = pathlib.Path(__file__).resolve().parents[3] / "prowler"
+        provider_path = base_directory / "providers" / "vercel" / "services"
+
+        invalid_urls = []
+
+        for metadata_file_path in provider_path.rglob("*.metadata.json"):
+            with metadata_file_path.open("r") as metadata_file:
+                data = json.load(metadata_file)
+
+            recommendation = data.get("Remediation", {}).get("Recommendation", {})
+            url = recommendation.get("Url", "")
+
+            if url.startswith("https://hub.prowler.com/checks/vercel/"):
+                invalid_urls.append(f"{metadata_file_path}: {url}")
+
+        assert not invalid_urls, "\n".join(invalid_urls)
+
     def verify_metadata_check_id(self, provider_path):
         errors = []
         # Walk through the base directory to find all service directories


### PR DESCRIPTION
### Context

The Vercel check metadata files used the wrong URL pattern for Prowler Hub links (`/checks/vercel/<check_name>` instead of `/check/<check_name>`), resulting in broken recommendation URLs.

### Description

- Updated all 26 Vercel check metadata files to use the canonical Hub URL format (`https://hub.prowler.com/check/<check_name>`)
- Added `test_vercel_checks_metadata_is_valid` to validate Vercel metadata structure
- Added `test_vercel_checks_metadata_use_canonical_hub_urls` to prevent regressions on Hub URL format

### Steps to review

1. Check any metadata file diff — each changes only the `Recommendation.Url` field from `/checks/vercel/X` to `/check/X`
2. Review the two new tests in `tests/lib/check/check_test.py` — they follow the same pattern as existing provider tests
3. Verify a sample URL resolves correctly: https://hub.prowler.com/check/authentication_no_stale_tokens

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.