### PR TITLE
feat(ui): make finding group delta indicator status-filter aware

### DIFF
--- a/ui/components/findings/table/column-finding-groups.tsx
+++ b/ui/components/findings/table/column-finding-groups.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/table";
 import { cn } from "@/lib";
 import {
-  getFindingGroupDelta,
+  getFilteredFindingGroupDelta,
   isFindingGroupMuted,
 } from "@/lib/findings-groups";
 import { FindingGroupRow, ProviderType } from "@/types";
@@ -29,6 +29,8 @@ interface GetColumnFindingGroupsOptions {
   expandedCheckId?: string | null;
   /** True when the expanded group has individually selected resources */
   hasResourceSelection?: boolean;
+  /** Active URL filters — used to make the delta indicator status-aware */
+  filters?: Record<string, string | string[] | undefined>;
 }
 
 const VISIBLE_DISABLED_CHECKBOX_CLASS =
@@ -40,6 +42,7 @@ export function getColumnFindingGroups({
   onDrillDown,
   expandedCheckId,
   hasResourceSelection = false,
+  filters = {},
 }: GetColumnFindingGroupsOptions): ColumnDef<FindingGroupRow>[] {
   const selectedCount = Object.values(rowSelection).filter(Boolean).length;
   const isAllSelected =
@@ -80,7 +83,7 @@ export function getColumnFindingGroups({
         const group = row.original;
         const allMuted = isFindingGroupMuted(group);
         const isExpanded = expandedCheckId === group.checkId;
-        const deltaKey = getFindingGroupDelta(group);
+        const deltaKey = getFilteredFindingGroupDelta(group, filters);
         const delta =
           deltaKey === "new"
             ? DeltaValues.NEW

--- a/ui/components/findings/table/findings-group-drill-down.tsx
+++ b/ui/components/findings/table/findings-group-drill-down.tsx
@@ -24,7 +24,7 @@ import { SeverityBadge, StatusFindingBadge } from "@/components/ui/table";
 import { useInfiniteResources } from "@/hooks/use-infinite-resources";
 import { cn, hasDateOrScanFilter } from "@/lib";
 import {
-  getFindingGroupDelta,
+  getFilteredFindingGroupDelta,
   isFindingGroupMuted,
 } from "@/lib/findings-groups";
 import { FindingGroupRow, FindingResourceRow } from "@/types";
@@ -156,7 +156,7 @@ export function FindingsGroupDrillDown({
   });
 
   // Delta for the sticky header
-  const deltaKey = getFindingGroupDelta(group);
+  const deltaKey = getFilteredFindingGroupDelta(group, filters);
   const delta =
     deltaKey === "new"
       ? DeltaValues.NEW

--- a/ui/components/findings/table/findings-group-table.tsx
+++ b/ui/components/findings/table/findings-group-table.tsx
@@ -173,6 +173,7 @@ export function FindingsGroupTable({
     onDrillDown: handleDrillDown,
     expandedCheckId,
     hasResourceSelection,
+    filters,
   });
 
   const renderAfterRow = (row: Row<FindingGroupRow>) => {

--- a/ui/lib/findings-groups.test.ts
+++ b/ui/lib/findings-groups.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import type { FindingGroupRow } from "@/types";
 
-import { getFindingGroupDelta, isFindingGroupMuted } from "./findings-groups";
+import {
+  getActiveStatusFilter,
+  getFilteredFindingGroupDelta,
+  getFindingGroupDelta,
+  isFindingGroupMuted,
+} from "./findings-groups";
 
 function makeGroup(overrides?: Partial<FindingGroupRow>): FindingGroupRow {
   return {
@@ -96,6 +101,137 @@ describe("getFindingGroupDelta", () => {
           newCount: 1,
           changedCount: 0,
         }),
+      ),
+    ).toBe("new");
+  });
+});
+
+describe("getActiveStatusFilter", () => {
+  it("returns null when no status filter is active", () => {
+    expect(getActiveStatusFilter({})).toBeNull();
+  });
+
+  it("returns the single value from filter[status]", () => {
+    const result = getActiveStatusFilter({ "filter[status]": "FAIL" });
+    expect(result).toEqual(new Set(["FAIL"]));
+  });
+
+  it("returns the parsed set from filter[status__in]", () => {
+    const result = getActiveStatusFilter({
+      "filter[status__in]": "FAIL,MANUAL",
+    });
+    expect(result).toEqual(new Set(["FAIL", "MANUAL"]));
+  });
+
+  it("prefers filter[status] over filter[status__in] when both are present", () => {
+    const result = getActiveStatusFilter({
+      "filter[status]": "PASS",
+      "filter[status__in]": "FAIL,MANUAL",
+    });
+    expect(result).toEqual(new Set(["PASS"]));
+  });
+
+  it("ignores unknown status values and returns null if nothing remains", () => {
+    expect(
+      getActiveStatusFilter({ "filter[status__in]": "UNKNOWN,FOO" }),
+    ).toBeNull();
+  });
+});
+
+describe("getFilteredFindingGroupDelta", () => {
+  it("falls back to the aggregate delta when no status filter is active", () => {
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newPassCount: 2,
+        }),
+        {},
+      ),
+    ).toBe("new");
+  });
+
+  it("ignores deltas that belong to filtered-out statuses", () => {
+    // Filter is FAIL, but the only delta is a new PASS → should be hidden.
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newPassCount: 3,
+        }),
+        { "filter[status__in]": "FAIL" },
+      ),
+    ).toBe("none");
+  });
+
+  it("surfaces FAIL deltas when the filter is FAIL", () => {
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newFailCount: 1,
+        }),
+        { "filter[status]": "FAIL" },
+      ),
+    ).toBe("new");
+  });
+
+  it("counts muted breakdown counters towards the filtered status", () => {
+    // A muted new FAIL still belongs to the FAIL bucket — a FAIL filter
+    // should still light up the "new" indicator.
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newFailMutedCount: 1,
+        }),
+        { "filter[status]": "FAIL" },
+      ),
+    ).toBe("new");
+  });
+
+  it("sums multiple filtered statuses from filter[status__in]", () => {
+    // Filter is FAIL+MANUAL, new delta is only in MANUAL → should still show.
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newManualCount: 1,
+        }),
+        { "filter[status__in]": "FAIL,MANUAL" },
+      ),
+    ).toBe("new");
+  });
+
+  it("prefers new over changed within the filtered status", () => {
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newFailCount: 1,
+          changedFailCount: 2,
+        }),
+        { "filter[status]": "FAIL" },
+      ),
+    ).toBe("new");
+  });
+
+  it("returns changed when only changed counters match the filtered status", () => {
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newPassCount: 2, // filtered out
+          changedFailCount: 1,
+        }),
+        { "filter[status]": "FAIL" },
+      ),
+    ).toBe("changed");
+  });
+
+  it("falls back to the aggregate delta when breakdowns are missing (legacy API)", () => {
+    // No breakdown fields populated but legacy newCount is set. With a FAIL
+    // filter active we cannot know which status bucket it belongs to, so we
+    // fall back to showing the delta rather than silently hiding it.
+    expect(
+      getFilteredFindingGroupDelta(
+        makeGroup({
+          newCount: 1,
+        }),
+        { "filter[status]": "FAIL" },
       ),
     ).toBe("new");
   });

--- a/ui/lib/findings-groups.ts
+++ b/ui/lib/findings-groups.ts
@@ -75,3 +75,127 @@ export function getFindingGroupDelta(
 
   return "none";
 }
+
+const FINDING_GROUP_STATUSES = ["FAIL", "PASS", "MANUAL"] as const;
+type FindingGroupStatus = (typeof FINDING_GROUP_STATUSES)[number];
+
+type FindingGroupFiltersRecord = Record<string, string | string[] | undefined>;
+
+function parseStatusFilterValue(
+  rawValue: string | string[] | undefined,
+): FindingGroupStatus[] {
+  if (!rawValue) {
+    return [];
+  }
+
+  const joined = Array.isArray(rawValue) ? rawValue.join(",") : rawValue;
+
+  return joined
+    .split(",")
+    .map((status) => status.trim().toUpperCase())
+    .filter((status): status is FindingGroupStatus =>
+      (FINDING_GROUP_STATUSES as readonly string[]).includes(status),
+    );
+}
+
+/**
+ * Returns the set of statuses the user has explicitly narrowed the findings
+ * view to, or null when no status filter is active (→ all statuses should be
+ * considered). Supports both `filter[status]` (single value) and
+ * `filter[status__in]` (comma-separated values).
+ */
+export function getActiveStatusFilter(
+  filters: FindingGroupFiltersRecord,
+): Set<FindingGroupStatus> | null {
+  const direct = parseStatusFilterValue(filters["filter[status]"]);
+  if (direct.length > 0) {
+    return new Set(direct);
+  }
+
+  const multi = parseStatusFilterValue(filters["filter[status__in]"]);
+  if (multi.length > 0) {
+    return new Set(multi);
+  }
+
+  return null;
+}
+
+function hasAnyDeltaBreakdown(group: FindingGroupDeltaState): boolean {
+  return (
+    (group.newFailCount ?? 0) > 0 ||
+    (group.newFailMutedCount ?? 0) > 0 ||
+    (group.newPassCount ?? 0) > 0 ||
+    (group.newPassMutedCount ?? 0) > 0 ||
+    (group.newManualCount ?? 0) > 0 ||
+    (group.newManualMutedCount ?? 0) > 0 ||
+    (group.changedFailCount ?? 0) > 0 ||
+    (group.changedFailMutedCount ?? 0) > 0 ||
+    (group.changedPassCount ?? 0) > 0 ||
+    (group.changedPassMutedCount ?? 0) > 0 ||
+    (group.changedManualCount ?? 0) > 0 ||
+    (group.changedManualMutedCount ?? 0) > 0
+  );
+}
+
+function getNewDeltaForStatuses(
+  group: FindingGroupDeltaState,
+  statuses: Set<FindingGroupStatus>,
+): number {
+  let total = 0;
+  if (statuses.has("FAIL")) {
+    total += (group.newFailCount ?? 0) + (group.newFailMutedCount ?? 0);
+  }
+  if (statuses.has("PASS")) {
+    total += (group.newPassCount ?? 0) + (group.newPassMutedCount ?? 0);
+  }
+  if (statuses.has("MANUAL")) {
+    total += (group.newManualCount ?? 0) + (group.newManualMutedCount ?? 0);
+  }
+  return total;
+}
+
+function getChangedDeltaForStatuses(
+  group: FindingGroupDeltaState,
+  statuses: Set<FindingGroupStatus>,
+): number {
+  let total = 0;
+  if (statuses.has("FAIL")) {
+    total += (group.changedFailCount ?? 0) + (group.changedFailMutedCount ?? 0);
+  }
+  if (statuses.has("PASS")) {
+    total += (group.changedPassCount ?? 0) + (group.changedPassMutedCount ?? 0);
+  }
+  if (statuses.has("MANUAL")) {
+    total +=
+      (group.changedManualCount ?? 0) + (group.changedManualMutedCount ?? 0);
+  }
+  return total;
+}
+
+/**
+ * Filter-aware variant of {@link getFindingGroupDelta}. When a status filter
+ * is active, only delta counters belonging to the filtered statuses contribute
+ * to the indicator. When no status filter is active, or when the API response
+ * lacks breakdown counters (legacy shape), this falls back to the aggregate
+ * delta so rows still surface deltas correctly.
+ */
+export function getFilteredFindingGroupDelta(
+  group: FindingGroupDeltaState,
+  filters: FindingGroupFiltersRecord,
+): "new" | "changed" | "none" {
+  const activeStatuses = getActiveStatusFilter(filters);
+
+  if (!activeStatuses || !hasAnyDeltaBreakdown(group)) {
+    return getFindingGroupDelta(group);
+  }
+
+  if (getNewDeltaForStatuses(group, activeStatuses) > 0) {
+    return "new";
+  }
+
+  if (getChangedDeltaForStatuses(group, activeStatuses) > 0) {
+    return "changed";
+  }
+
+  return "none";
+}


### PR DESCRIPTION
### Context

Follow-up polish on the finding groups feature merged in #10633. When the user narrows the findings table by status (e.g. filter by FAIL), the delta indicator on each finding group row was still computed against the aggregate new/changed counters — so a row could light up the "new" dot because of a new PASS finding that the user could not even see in the expanded drill-down. This PR makes the indicator honour the active status filter so it only surfaces deltas that belong to the filtered status bucket(s).

### Description

- New helpers in `ui/lib/findings-groups.ts`:
  - `getActiveStatusFilter(filters)` returns the `Set<"FAIL" | "PASS" | "MANUAL">` the user has explicitly selected, or `null` when no status filter is active. Supports both `filter[status]` and `filter[status__in]` (comma-separated).
  - `getFilteredFindingGroupDelta(group, filters)` sums only the breakdown counters belonging to the active statuses (`newFailCount + newFailMutedCount`, etc.) to decide `new` / `changed` / `none`. Falls back to the existing aggregate `getFindingGroupDelta` when no status filter is active or when the API response lacks breakdown counters (legacy shape) — so rows with only `newCount`/`changedCount` still surface a delta instead of silently hiding it.
- Wired the filter-aware helper into the two call sites that render the group delta indicator:
  - `column-finding-groups.tsx` — `getColumnFindingGroups` now accepts an optional `filters` option and uses it for the indicator cell. `findings-group-table.tsx` passes the URL filters through.
  - `findings-group-drill-down.tsx` — the sticky header already had `filters` in scope, switched to the filter-aware call.
- 12 new unit tests in `ui/lib/findings-groups.test.ts` covering both helpers: `filter[status]` vs `filter[status__in]`, single vs composite statuses (`FAIL,MANUAL`), muted breakdown counters, precedence of `new` over `changed`, and the legacy-API fallback.

### Steps to review

1. **Helper logic and fallbacks** — Review `ui/lib/findings-groups.ts`, especially `getFilteredFindingGroupDelta`. Key checks:
   - Muted breakdown counters (e.g. `newFailMutedCount`) are counted under their status bucket — a muted new FAIL still belongs to the FAIL filter.
   - When `hasAnyDeltaBreakdown(group)` is `false` but the legacy `newCount`/`changedCount` are set, the function falls back to `getFindingGroupDelta(group)` rather than silently returning `"none"`. Confirm this is the right trade-off (showing a possibly-misattributed delta vs hiding a real one).
   - `getActiveStatusFilter` ignores unknown status values and returns `null` if nothing remains, avoiding stray UPPERCASE typos silently filtering everything out.
2. **Tests** — `ui/lib/findings-groups.test.ts` — 12 new cases plus the pre-existing suite (19 tests total). Skim the test names in `describe("getFilteredFindingGroupDelta", …)` — they describe the intended behaviour in one line each.
3. **Call-site wiring** — `ui/components/findings/table/column-finding-groups.tsx` (new `filters` option, default `{}`) and `ui/components/findings/table/findings-group-table.tsx` (passes `filters` through). Then `ui/components/findings/table/findings-group-drill-down.tsx` where the sticky header's delta dot is computed.
4. **Manual QA** — With a real scan that has mixed PASS/FAIL/MANUAL deltas:
   - Apply the status filter `FAIL`. Groups whose only delta is in PASS/MANUAL should lose the new/changed dot. Groups with new FAIL deltas should keep it.
   - Switch the filter to `PASS`. The behaviour should flip.
   - Clear the filter. All rows should go back to the aggregate behaviour (same as before this PR).
5. **Regressions** — Confirm the existing `column-finding-groups.test.tsx` still passes (it mocks `NotificationIndicator` and asserts the `delta` prop; default `filters = {}` keeps the existing assertions green).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.