### PR TITLE
fix(ui): exclude service filter from finding group resources endpoint

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Deleting the active organization now switches to the target org before deleting, preventing JWT rejection from the backend [(#10491)](https://github.com/prowler-cloud/prowler/pull/10491)
 - Clear Filters now resets all filters including muted findings and auto-applies, Clear all in pills only removes pill-visible sub-filters, and the discard icon is now an Undo text button [(#10446)](https://github.com/prowler-cloud/prowler/pull/10446)
 - Send to Jira modal now dynamically fetches and displays available issue types per project instead of hardcoding `"Task"`, fixing failures on non-English Jira instances [(#10534)](https://github.com/prowler-cloud/prowler/pull/10534)
+- Exclude service filter from finding group resources endpoint to prevent empty results when a service filter is active [(#10652)](https://github.com/prowler-cloud/prowler/pull/10652)
 
 ---
 

--- a/ui/actions/finding-groups/finding-groups.ts
+++ b/ui/actions/finding-groups/finding-groups.ts
@@ -41,10 +41,25 @@ function splitCsvFilterValues(value: string | string[] | undefined): string[] {
   return [];
 }
 
+/**
+ * Filters that belong to finding-groups but are NOT valid for the
+ * finding-group resources sub-endpoint. These must be stripped before
+ * calling the resources API to avoid empty results.
+ */
+const FINDING_GROUP_ONLY_FILTERS = ["filter[service__in]"] as const;
+
 function normalizeFindingGroupResourceFilters(
   filters: Record<string, string | string[] | undefined>,
 ): Record<string, string | string[] | undefined> {
-  const normalized = { ...filters };
+  const normalized = Object.fromEntries(
+    Object.entries(filters).filter(
+      ([key]) =>
+        !FINDING_GROUP_ONLY_FILTERS.includes(
+          key as (typeof FINDING_GROUP_ONLY_FILTERS)[number],
+        ),
+    ),
+  );
+
   const exactStatusFilter = normalized["filter[status]"];
 
   if (exactStatusFilter !== undefined) {

--- a/ui/components/findings/table/findings-group-drill-down.tsx
+++ b/ui/components/findings/table/findings-group-drill-down.tsx
@@ -270,7 +270,9 @@ export function FindingsGroupDrillDown({
                     colSpan={columns.length}
                     className="h-24 text-center"
                   >
-                    No resources found.
+                    {Object.keys(filters).length > 0
+                      ? "No resources found for the selected filters."
+                      : "No resources found."}
                   </TableCell>
                 </TableRow>
               ) : null}

--- a/ui/components/findings/table/inline-resource-container.tsx
+++ b/ui/components/findings/table/inline-resource-container.tsx
@@ -363,7 +363,9 @@ export function InlineResourceContainer({
                             colSpan={columns.length}
                             className="h-24 text-center"
                           >
-                            No resources found.
+                            {Object.keys(filters).length > 0
+                              ? "No resources found for the selected filters."
+                              : "No resources found."}
                           </TableCell>
                         </TableRow>
                       )}


### PR DESCRIPTION
### Context

When a service filter (e.g. "account") was active on the finding groups page and a group row was expanded to show its resources, the `filter[service__in]` parameter was being forwarded to the finding group resources sub-endpoint. This filter is not valid for the resources endpoint, causing it to return empty results ("No resources found").

### Description

Strip `filter[service__in]` from the filters passed to the finding group resources endpoint in `normalizeFindingGroupResourceFilters`. Uses a declarative `FINDING_GROUP_ONLY_FILTERS` constant so additional finding-group-only filters can be added easily if needed.

### Steps to review

1. Navigate to findings page with finding groups view
2. Apply a **Services** filter (e.g. "account")
3. Expand a finding group row
4. Verify resources load correctly instead of showing "No resources found"

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.