### PR TITLE
chore: add prowler-openspec-opensource as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "openspec"]
+	path = openspec
+	url = https://github.com/prowler-cloud/prowler-openspec-opensource.git


### PR DESCRIPTION
## Summary
- Adds `prowler-openspec-opensource` as a git submodule at `openspec/`
- Used by SDD tooling to sync spec definitions across AI coding assistants

## Test plan
- [ ] Verify `git submodule update --init` initializes `openspec/` correctly after clone
- [ ] Verify worktree hooks pick up the submodule via `git submodule update --init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)