### PR TITLE
refactor(api): remove dead `cleanup_findings` no-op from `attack-paths` module

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🔄 Changed
 
 - Bump Poetry to `2.3.4` in Dockerfile and pre-commit hooks. Regenerate `api/poetry.lock` [(#10681)](https://github.com/prowler-cloud/prowler/pull/10681)
+- Attack Paths: Remove dead `cleanup_findings` no-op and its supporting `prowler_finding_lastupdated` index [(#10684)](https://github.com/prowler-cloud/prowler/pull/10684)
 
 ### 🔐 Security
 

--- a/api/src/backend/tasks/jobs/attack_paths/findings.py
+++ b/api/src/backend/tasks/jobs/attack_paths/findings.py
@@ -5,7 +5,6 @@ This module handles:
 - Adding resource labels to Cartography nodes for efficient lookups
 - Loading Prowler findings into the graph
 - Linking findings to resources
-- Cleaning up stale findings
 """
 
 from collections import defaultdict
@@ -24,7 +23,6 @@ from tasks.jobs.attack_paths.config import (
 )
 from tasks.jobs.attack_paths.queries import (
     ADD_RESOURCE_LABEL_TEMPLATE,
-    CLEANUP_FINDINGS_TEMPLATE,
     INSERT_FINDING_TEMPLATE,
     render_cypher_template,
 )
@@ -92,14 +90,13 @@ def analysis(
     """
     Main entry point for Prowler findings analysis.
 
-    Adds resource labels, loads findings, and cleans up stale data.
+    Adds resource labels and loads findings.
     """
     add_resource_label(
         neo4j_session, prowler_api_provider.provider, str(prowler_api_provider.uid)
     )
     findings_data = stream_findings_with_resources(prowler_api_provider, scan_id)
     load_findings(neo4j_session, findings_data, prowler_api_provider, config)
-    cleanup_findings(neo4j_session, prowler_api_provider, config)
 
 
 def add_resource_label(
@@ -181,28 +178,6 @@ def load_findings(
         neo4j_session.run(query, parameters)
 
     logger.info(f"Finished loading {total_records} records in {batch_num} batches")
-
-
-def cleanup_findings(
-    neo4j_session: neo4j.Session,
-    prowler_api_provider: Provider,
-    config: CartographyConfig,
-) -> None:
-    """Remove stale findings (classic Cartography behaviour)."""
-    parameters = {
-        "last_updated": config.update_tag,
-        "batch_size": BATCH_SIZE,
-    }
-
-    batch = 1
-    deleted_count = 1
-    while deleted_count > 0:
-        logger.info(f"Cleaning findings batch {batch}")
-
-        result = neo4j_session.run(CLEANUP_FINDINGS_TEMPLATE, parameters)
-
-        deleted_count = result.single().get("deleted_findings_count", 0)
-        batch += 1
 
 
 # Findings Streaming (Generator-based)

--- a/api/src/backend/tasks/jobs/attack_paths/indexes.py
+++ b/api/src/backend/tasks/jobs/attack_paths/indexes.py
@@ -13,14 +13,13 @@ from tasks.jobs.attack_paths.config import (
 logger = get_task_logger(__name__)
 
 
-# Indexes for Prowler findings and resource lookups
+# Indexes for Prowler Findings and resource lookups
 FINDINGS_INDEX_STATEMENTS = [
     # Resource indexes for Prowler Finding lookups
     "CREATE INDEX aws_resource_arn IF NOT EXISTS FOR (n:_AWSResource) ON (n.arn);",
     "CREATE INDEX aws_resource_id IF NOT EXISTS FOR (n:_AWSResource) ON (n.id);",
     # Prowler Finding indexes
     f"CREATE INDEX prowler_finding_id IF NOT EXISTS FOR (n:{PROWLER_FINDING_LABEL}) ON (n.id);",
-    f"CREATE INDEX prowler_finding_lastupdated IF NOT EXISTS FOR (n:{PROWLER_FINDING_LABEL}) ON (n.lastupdated);",
     f"CREATE INDEX prowler_finding_status IF NOT EXISTS FOR (n:{PROWLER_FINDING_LABEL}) ON (n.status);",
     # Internet node index for MERGE lookups
     f"CREATE INDEX internet_id IF NOT EXISTS FOR (n:{INTERNET_NODE_LABEL}) ON (n.id);",

--- a/api/src/backend/tasks/jobs/attack_paths/queries.py
+++ b/api/src/backend/tasks/jobs/attack_paths/queries.py
@@ -80,17 +80,6 @@ INSERT_FINDING_TEMPLATE = f"""
             rel.lastupdated = $last_updated
 """
 
-CLEANUP_FINDINGS_TEMPLATE = f"""
-    MATCH (finding:{PROWLER_FINDING_LABEL})
-        WHERE finding.lastupdated < $last_updated
-
-    WITH finding LIMIT $batch_size
-
-    DETACH DELETE finding
-
-    RETURN COUNT(finding) AS deleted_findings_count
-"""
-
 # Internet queries (used by internet.py)
 # ---------------------------------------
 

--- a/api/src/backend/tasks/tests/test_attack_paths_scan.py
+++ b/api/src/backend/tasks/tests/test_attack_paths_scan.py
@@ -1298,23 +1298,6 @@ class TestAttackPathsFindingsHelpers:
             assert params["last_updated"] == config.update_tag
             assert "findings_data" in params
 
-    def test_cleanup_findings_runs_batches(self, providers_fixture):
-        provider = providers_fixture[0]
-        config = SimpleNamespace(update_tag=1024)
-        mock_session = MagicMock()
-
-        first_batch = MagicMock()
-        first_batch.single.return_value = {"deleted_findings_count": 3}
-        second_batch = MagicMock()
-        second_batch.single.return_value = {"deleted_findings_count": 0}
-        mock_session.run.side_effect = [first_batch, second_batch]
-
-        findings_module.cleanup_findings(mock_session, provider, config)
-
-        assert mock_session.run.call_count == 2
-        params = mock_session.run.call_args.args[1]
-        assert params["last_updated"] == config.update_tag
-
     def test_stream_findings_with_resources_returns_latest_scan_data(
         self,
         tenants_fixture,


### PR DESCRIPTION
### Description

Remove `cleanup_findings` from the attack-paths module. It's a no-op: runs against the per-scan temp DB where every finding shares the same `update_tag`, so `WHERE lastupdated < $update_tag` never matches.

Also drops the `prowler_finding_lastupdated` index (only the cleanup query read it) and the matching test.

### Steps to review

Run tests and a local Attack Paths scan.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.