### PR TITLE
fix(ci): remove broken resolved_reference step from setup-python-poetry

### DIFF
--- a/.github/actions/setup-python-poetry/action.yml
+++ b/.github/actions/setup-python-poetry/action.yml
@@ -64,19 +64,6 @@ runs:
         echo "Updated resolved_reference:"
         grep -A2 -B2 "resolved_reference" poetry.lock
 
-    - name: Update SDK resolved_reference to latest commit (prowler repo on push)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'prowler-cloud/prowler'
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      run: |
-        LATEST_COMMIT=$(curl -s "https://api.github.com/repos/prowler-cloud/prowler/commits/master" | jq -r '.sha')
-        echo "Latest commit hash: $LATEST_COMMIT"
-        sed -i '/url = "https:\/\/github\.com\/prowler-cloud\/prowler\.git"/,/resolved_reference = / {
-          s/resolved_reference = "[a-f0-9]\{40\}"/resolved_reference = "'"$LATEST_COMMIT"'"/
-        }' poetry.lock
-        echo "Updated resolved_reference:"
-        grep -A2 -B2 "resolved_reference" poetry.lock
-
     - name: Update poetry.lock (prowler repo only)
       if: github.repository == 'prowler-cloud/prowler' && inputs.update-lock == 'true'
       shell: bash


### PR DESCRIPTION
### Context

The composite action `.github/actions/setup-python-poetry/action.yml` contains a step named "Update SDK resolved_reference to latest commit (prowler repo on push)" that runs on pushes to `master` in `prowler-cloud/prowler`. That step ends with:

```bash
grep -A2 -B2 "resolved_reference" poetry.lock
```

However, the root `poetry.lock` of this repository has no `resolved_reference` entries — the repo does not self-reference itself via `git+https`. As a consequence, `grep` exits with status 1 and fails the step on every push to `master`.

This has been breaking `.github/workflows/sdk-container-build-push.yml` on every push to `master` since PR #10681 migrated that workflow to use this composite action.

### Description

Remove the broken step from the composite action. The sibling step "Update SDK resolved_reference to latest commit (downstream repos)" remains untouched, since it operates on downstream repositories where `poetry.lock` does contain the expected `resolved_reference` entries.

### Steps to review

1. Inspect `.github/actions/setup-python-poetry/action.yml` and confirm only the broken "prowler repo on push" step is removed.
2. Confirm the downstream-repos sibling step is preserved.
3. Confirm the root `poetry.lock` contains no `resolved_reference` entries, validating that the removed step could never succeed in this repo.
4. After merge, verify that `sdk-container-build-push.yml` succeeds on the next push to `master`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
Not applicable — CI-only change.

#### API
Not applicable — CI-only change.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.