### PR TITLE
chore: update CODEOWNERS for new team hierarchy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,15 @@
 # SDK
-/* @prowler-cloud/sdk
-/prowler/ @prowler-cloud/sdk @prowler-cloud/detection-and-remediation
-/tests/ @prowler-cloud/sdk @prowler-cloud/detection-and-remediation
-/dashboard/ @prowler-cloud/sdk
-/docs/ @prowler-cloud/sdk
-/examples/ @prowler-cloud/sdk
-/util/ @prowler-cloud/sdk
-/contrib/ @prowler-cloud/sdk
-/permissions/ @prowler-cloud/sdk
-/codecov.yml @prowler-cloud/sdk @prowler-cloud/api
+/* @prowler-cloud/detection-remediation
+/prowler/ @prowler-cloud/detection-remediation
+/prowler/compliance/ @prowler-cloud/compliance
+/tests/ @prowler-cloud/detection-remediation
+/dashboard/ @prowler-cloud/detection-remediation
+/docs/ @prowler-cloud/detection-remediation
+/examples/ @prowler-cloud/detection-remediation
+/util/ @prowler-cloud/detection-remediation
+/contrib/ @prowler-cloud/detection-remediation
+/permissions/ @prowler-cloud/detection-remediation
+/codecov.yml @prowler-cloud/detection-remediation @prowler-cloud/api
 
 # API
 /api/ @prowler-cloud/api
@@ -17,7 +18,7 @@
 /ui/ @prowler-cloud/ui
 
 # AI
-/mcp_server/ @prowler-cloud/ai
+/mcp_server/ @prowler-cloud/detection-remediation
 
 # Platform
 /.github/ @prowler-cloud/platform


### PR DESCRIPTION
### Context

Realign CODEOWNERS references to match the new team hierarchy defined in the `github-org` Terraform stack. The previous teams (`sdk`, `detection-and-remediation`, `ai`) no longer reflect the current org structure (application/api/ui, detection-remediation/compliance, platform).

### Description

Update `.github/CODEOWNERS` so path ownership maps to the current teams:

- `sdk` and `detection-and-remediation` consolidated into `detection-remediation`.
- New `/prowler/compliance/` path owned by the `compliance` team.
- `ai` replaced by `detection-remediation` for `/mcp_server/`.
- `api`, `ui`, and `platform` ownership unchanged.

Plain-text CODEOWNERS-only change; no code, config, or behavior is affected.

### Steps to review

1. Diff `.github/CODEOWNERS` against master.
2. Confirm each team slug exists under `prowler-cloud` and matches the `github-org` Terraform hierarchy.

### Checklist

- [x] Review if the code is being covered by tests. (N/A — metadata only)
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings (N/A)
- [x] Review if backport is needed. (No)
- [x] Review if is needed to change the Readme.md (No)
- [x] Ensure new entries are added to CHANGELOG.md, if applicable. (N/A)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.