### PR TITLE
fix(sdk): allow account-scoped tokens in Cloudflare connection test

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
+## [5.26.0] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Cloudflare account-scoped API tokens failing connection test in the App with `CloudflareUserTokenRequiredError` [(#10723)](https://github.com/prowler-cloud/prowler/pull/10723)
+
+---
+
 ## [5.24.0] (Prowler v5.24.0)
 
 ### 🚀 Added

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
-## [5.26.0] (Prowler UNRELEASED)
+## [5.25.0] (Prowler UNRELEASED)
 
 ### 🐞 Fixed
 

--- a/prowler/providers/cloudflare/cloudflare_provider.py
+++ b/prowler/providers/cloudflare/cloudflare_provider.py
@@ -338,10 +338,7 @@ class CloudflareProvider(Provider):
                 raise CloudflareInvalidAPIKeyError(
                     file=os.path.basename(__file__),
                 )
-            # For permission errors (including 9109 account-scoped tokens),
-            # try accounts.list() as fallback before failing.
-            # Error 9109 means the token is account-scoped, not user-level,
-            # which is valid for scanning — only fail if accounts.list() also fails.
+            # For other permission errors (including 9109), try accounts.list() as fallback
             logger.warning(
                 f"Unable to retrieve Cloudflare user info: {error}. "
                 "Trying accounts.list() as fallback."

--- a/prowler/providers/cloudflare/cloudflare_provider.py
+++ b/prowler/providers/cloudflare/cloudflare_provider.py
@@ -332,19 +332,16 @@ class CloudflareProvider(Provider):
             return
         except PermissionDeniedError as error:
             error_str = str(error)
-            # Check for user-level authentication required (code 9109)
-            if "9109" in error_str:
-                logger.error(f"CloudflareUserTokenRequiredError: {error}")
-                raise CloudflareUserTokenRequiredError(
-                    file=os.path.basename(__file__),
-                )
             # Check for invalid API key or email (code 9103) - comes as 403
             if "9103" in error_str or "Unknown X-Auth-Key" in error_str:
                 logger.error(f"CloudflareInvalidAPIKeyError: {error}")
                 raise CloudflareInvalidAPIKeyError(
                     file=os.path.basename(__file__),
                 )
-            # For other permission errors, try accounts.list() as fallback
+            # For permission errors (including 9109 account-scoped tokens),
+            # try accounts.list() as fallback before failing.
+            # Error 9109 means the token is account-scoped, not user-level,
+            # which is valid for scanning — only fail if accounts.list() also fails.
             logger.warning(
                 f"Unable to retrieve Cloudflare user info: {error}. "
                 "Trying accounts.list() as fallback."

--- a/prowler/providers/cloudflare/cloudflare_provider.py
+++ b/prowler/providers/cloudflare/cloudflare_provider.py
@@ -338,7 +338,10 @@ class CloudflareProvider(Provider):
                 raise CloudflareInvalidAPIKeyError(
                     file=os.path.basename(__file__),
                 )
-            # For other permission errors (including 9109), try accounts.list() as fallback
+            # For permission errors (including 9109 account-scoped tokens),
+            # try accounts.list() as fallback before failing.
+            # Error 9109 means the token is account-scoped, not user-level,
+            # which is valid for scanning — only fail if accounts.list() also fails.
             logger.warning(
                 f"Unable to retrieve Cloudflare user info: {error}. "
                 "Trying accounts.list() as fallback."


### PR DESCRIPTION
### Context

Cloudflare account-scoped API tokens work correctly in the CLI but fail in the App with `CloudflareUserTokenRequiredError[9008]: User-level API token required` when adding a provider.

### Description

The `validate_credentials()` method was treating Cloudflare error code `9109` from `client.user.get()` as immediately fatal. However, `9109` simply means the token is account-scoped (not user-level), which is valid for scanning.

In the CLI, `setup_identity()` handles this gracefully by catching exceptions from `user.get()` and falling back to `client.accounts.list()`. The fix aligns `validate_credentials()` with the same behavior — let `9109` fall through to the `accounts.list()` fallback instead of raising immediately. If `accounts.list()` also fails with `9109`, the error is still raised.

### Steps to review

1. Review the change in `prowler/providers/cloudflare/cloudflare_provider.py`
2. Verify that the `9109` check is still present in the `accounts.list()` fallback block (line ~406)
3. Test with an account-scoped Cloudflare API token via the App provider connection flow

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.