### PR TITLE
fix(googleworkspace): treat secure Google defaults as PASS for Calendar checks

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🐞 Fixed
 
 - Vercel firewall config handling for team-scoped projects and current API response shapes [(#10695)](https://github.com/prowler-cloud/prowler/pull/10695)
+- Google Workspace Calendar checks false FAIL on unconfigured settings with secure Google defaults [(#10726)](https://github.com/prowler-cloud/prowler/pull/10726)
 
 ---
 

--- a/prowler/providers/googleworkspace/services/calendar/calendar_external_invitations_warning/calendar_external_invitations_warning.py
+++ b/prowler/providers/googleworkspace/services/calendar/calendar_external_invitations_warning/calendar_external_invitations_warning.py
@@ -35,21 +35,20 @@ class calendar_external_invitations_warning(Check):
                     f"External invitation warnings for Google Calendar are enabled "
                     f"in domain {calendar_client.provider.identity.domain}."
                 )
+            elif warning_enabled is None:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"External invitation warnings for Google Calendar use Google's "
+                    f"secure default configuration (enabled) "
+                    f"in domain {calendar_client.provider.identity.domain}."
+                )
             else:
                 report.status = "FAIL"
-                if warning_enabled is None:
-                    report.status_extended = (
-                        f"External invitation warnings for Google Calendar are not "
-                        f"explicitly configured in domain "
-                        f"{calendar_client.provider.identity.domain}. "
-                        f"Users should be warned when inviting guests outside the organization."
-                    )
-                else:
-                    report.status_extended = (
-                        f"External invitation warnings for Google Calendar are disabled "
-                        f"in domain {calendar_client.provider.identity.domain}. "
-                        f"Users should be warned when inviting guests outside the organization."
-                    )
+                report.status_extended = (
+                    f"External invitation warnings for Google Calendar are disabled "
+                    f"in domain {calendar_client.provider.identity.domain}. "
+                    f"Users should be warned when inviting guests outside the organization."
+                )
 
             findings.append(report)
 

--- a/prowler/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar.py
+++ b/prowler/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar.py
@@ -36,20 +36,20 @@ class calendar_external_sharing_primary_calendar(Check):
                     f"{calendar_client.provider.identity.domain} is restricted to "
                     f"free/busy information only."
                 )
+            elif sharing is None:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Primary calendar external sharing uses Google's secure default "
+                    f"configuration (free/busy only) "
+                    f"in domain {calendar_client.provider.identity.domain}."
+                )
             else:
                 report.status = "FAIL"
-                if sharing is None:
-                    report.status_extended = (
-                        f"Primary calendar external sharing is not explicitly configured "
-                        f"in domain {calendar_client.provider.identity.domain}. "
-                        f"External sharing should be restricted to free/busy information only."
-                    )
-                else:
-                    report.status_extended = (
-                        f"Primary calendar external sharing in domain "
-                        f"{calendar_client.provider.identity.domain} is set to {sharing}. "
-                        f"External sharing should be restricted to free/busy information only."
-                    )
+                report.status_extended = (
+                    f"Primary calendar external sharing in domain "
+                    f"{calendar_client.provider.identity.domain} is set to {sharing}. "
+                    f"External sharing should be restricted to free/busy information only."
+                )
 
             findings.append(report)
 

--- a/tests/providers/googleworkspace/services/calendar/calendar_external_invitations_warning/calendar_external_invitations_warning_test.py
+++ b/tests/providers/googleworkspace/services/calendar/calendar_external_invitations_warning/calendar_external_invitations_warning_test.py
@@ -73,8 +73,8 @@ class TestCalendarExternalInvitationsWarning:
             assert findings[0].status == "FAIL"
             assert "disabled" in findings[0].status_extended
 
-    def test_fail_no_policy_set(self):
-        """Test FAIL when no explicit policy is set (None) but fetch succeeded"""
+    def test_pass_using_default(self):
+        """Test PASS when no explicit policy is set (None) — Google default is secure (enabled)"""
         mock_provider = set_mocked_googleworkspace_provider()
 
         with (
@@ -100,8 +100,8 @@ class TestCalendarExternalInvitationsWarning:
             findings = check.execute()
 
             assert len(findings) == 1
-            assert findings[0].status == "FAIL"
-            assert "not explicitly configured" in findings[0].status_extended
+            assert findings[0].status == "PASS"
+            assert "secure default" in findings[0].status_extended
 
     def test_no_findings_when_fetch_failed(self):
         """Test no findings returned when the API fetch failed"""

--- a/tests/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar_test.py
+++ b/tests/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar_test.py
@@ -104,8 +104,8 @@ class TestCalendarExternalSharingPrimaryCalendar:
             assert findings[0].status == "FAIL"
             assert "EXTERNAL_ALL_INFO_READ_WRITE" in findings[0].status_extended
 
-    def test_fail_no_policy_set(self):
-        """Test FAIL when no explicit policy is set (None) but fetch succeeded"""
+    def test_pass_using_default(self):
+        """Test PASS when no explicit policy is set (None) — Google default is secure (free/busy only)"""
         mock_provider = set_mocked_googleworkspace_provider()
 
         with (
@@ -131,8 +131,8 @@ class TestCalendarExternalSharingPrimaryCalendar:
             findings = check.execute()
 
             assert len(findings) == 1
-            assert findings[0].status == "FAIL"
-            assert "not explicitly configured" in findings[0].status_extended
+            assert findings[0].status == "PASS"
+            assert "secure default" in findings[0].status_extended
 
     def test_no_findings_when_fetch_failed(self):
         """Test no findings returned when the API fetch failed"""


### PR DESCRIPTION
### Context

Fix for Calendar service. Follow-up to the customer-level policy filter fix. The Policy API only returns settings that have been explicitly configured by an admin — settings left at their default don't appear in the API response. Previously, all our checks treated this `None` response as FAIL, generating false positives for customers who never modified secure defaults.

### Description

Updates the Calendar checks to distinguish between "explicitly set to insecure value" and "not configured (secure default applies)". 
 
**Updated to PASS on None (secure defaults):**
- `calendar_external_sharing_primary_calendar` — default: "Only free/busy information" (secure)
- `calendar_external_invitations_warning` — default: "Warn users when inviting guests" enabled (secure)
 
**Unchanged, still FAIL on None (insecure default):**
- `calendar_external_sharing_secondary_calendar` — default: "Share all information, but outsiders cannot change" — shares event details externally
 
Default values are documented in the CIS Google Workspace Foundations Benchmark v1.3.0 "Default Value" sections.
 
Messages for PASS on None now indicate that Google's secure default applies, distinguishing them from cases where the admin explicitly configured the setting.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
