### PR TITLE
fix(googleworkspace): treat secure Google defaults as PASS for Drive checks

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🐞 Fixed
 
 - Vercel firewall config handling for team-scoped projects and current API response shapes [(#10695)](https://github.com/prowler-cloud/prowler/pull/10695)
+- Google Workspace Drive checks false FAIL on unconfigured settings with secure Google defaults [(#10727)](https://github.com/prowler-cloud/prowler/pull/10727)
 
 ---
 

--- a/prowler/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users.py
@@ -33,21 +33,20 @@ class drive_external_sharing_warn_users(Check):
                     f"External sharing warnings for Drive and Docs are enabled "
                     f"in domain {drive_client.provider.identity.domain}."
                 )
+            elif warning_enabled is None:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"External sharing warnings for Drive and Docs use Google's "
+                    f"secure default configuration (enabled) "
+                    f"in domain {drive_client.provider.identity.domain}."
+                )
             else:
                 report.status = "FAIL"
-                if warning_enabled is None:
-                    report.status_extended = (
-                        f"External sharing warnings for Drive and Docs are not "
-                        f"explicitly configured in domain "
-                        f"{drive_client.provider.identity.domain}. "
-                        f"Users should be warned when sharing files outside the organization."
-                    )
-                else:
-                    report.status_extended = (
-                        f"External sharing warnings for Drive and Docs are disabled "
-                        f"in domain {drive_client.provider.identity.domain}. "
-                        f"Users should be warned when sharing files outside the organization."
-                    )
+                report.status_extended = (
+                    f"External sharing warnings for Drive and Docs are disabled "
+                    f"in domain {drive_client.provider.identity.domain}. "
+                    f"Users should be warned when sharing files outside the organization."
+                )
 
             findings.append(report)
 

--- a/prowler/providers/googleworkspace/services/drive/drive_shared_drive_creation_allowed/drive_shared_drive_creation_allowed.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_shared_drive_creation_allowed/drive_shared_drive_creation_allowed.py
@@ -35,22 +35,21 @@ class drive_shared_drive_creation_allowed(Check):
                     f"Users in domain {drive_client.provider.identity.domain} "
                     f"are allowed to create new shared drives."
                 )
+            elif allow_creation is None:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Shared drive creation uses Google's secure default "
+                    f"configuration (allowed) "
+                    f"in domain {drive_client.provider.identity.domain}."
+                )
             else:
                 report.status = "FAIL"
-                if allow_creation is None:
-                    report.status_extended = (
-                        f"Shared drive creation is not explicitly configured in "
-                        f"domain {drive_client.provider.identity.domain}. "
-                        f"Users should be allowed to create new shared drives to avoid "
-                        f"data loss when accounts are deleted."
-                    )
-                else:
-                    report.status_extended = (
-                        f"Users in domain {drive_client.provider.identity.domain} "
-                        f"are prevented from creating new shared drives. "
-                        f"Users should be allowed to create new shared drives to avoid "
-                        f"data loss when accounts are deleted."
-                    )
+                report.status_extended = (
+                    f"Users in domain {drive_client.provider.identity.domain} "
+                    f"are prevented from creating new shared drives. "
+                    f"Users should be allowed to create new shared drives to avoid "
+                    f"data loss when accounts are deleted."
+                )
 
             findings.append(report)
 

--- a/prowler/providers/googleworkspace/services/drive/drive_shared_drive_disable_download_print_copy/drive_shared_drive_disable_download_print_copy.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_shared_drive_disable_download_print_copy/drive_shared_drive_disable_download_print_copy.py
@@ -35,21 +35,21 @@ class drive_shared_drive_disable_download_print_copy(Check):
                     f"{drive_client.provider.identity.domain} is restricted to "
                     f"{allowed}."
                 )
+            elif allowed is None:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Download, print, and copy restrictions for shared drives use "
+                    f"Google's secure default configuration (disabled for viewers "
+                    f"and commenters) "
+                    f"in domain {drive_client.provider.identity.domain}."
+                )
             else:
                 report.status = "FAIL"
-                if allowed is None:
-                    report.status_extended = (
-                        f"Download, print, and copy restrictions for shared drive "
-                        f"viewers and commenters are not explicitly configured in "
-                        f"domain {drive_client.provider.identity.domain}. "
-                        f"These actions should be restricted to editors or managers only."
-                    )
-                else:
-                    report.status_extended = (
-                        f"Download, print, and copy in shared drives in domain "
-                        f"{drive_client.provider.identity.domain} is set to {allowed}. "
-                        f"These actions should be restricted to editors or managers only."
-                    )
+                report.status_extended = (
+                    f"Download, print, and copy in shared drives in domain "
+                    f"{drive_client.provider.identity.domain} is set to {allowed}. "
+                    f"These actions should be restricted to editors or managers only."
+                )
 
             findings.append(report)
 

--- a/prowler/providers/googleworkspace/services/drive/drive_warn_sharing_with_allowlisted_domains/drive_warn_sharing_with_allowlisted_domains.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_warn_sharing_with_allowlisted_domains/drive_warn_sharing_with_allowlisted_domains.py
@@ -36,21 +36,20 @@ class drive_warn_sharing_with_allowlisted_domains(Check):
                     f"Users are warned when sharing files with allowlisted "
                     f"domains in domain {drive_client.provider.identity.domain}."
                 )
+            elif warn_enabled is None:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Warning when sharing with allowlisted domains uses Google's "
+                    f"secure default configuration (enabled) "
+                    f"in domain {drive_client.provider.identity.domain}."
+                )
             else:
                 report.status = "FAIL"
-                if warn_enabled is None:
-                    report.status_extended = (
-                        f"Warning when sharing with allowlisted domains is not "
-                        f"explicitly configured in domain "
-                        f"{drive_client.provider.identity.domain}. "
-                        f"Users should be warned when sharing files with users in allowlisted domains."
-                    )
-                else:
-                    report.status_extended = (
-                        f"Warning when sharing with allowlisted domains is disabled "
-                        f"in domain {drive_client.provider.identity.domain}. "
-                        f"Users should be warned when sharing files with users in allowlisted domains."
-                    )
+                report.status_extended = (
+                    f"Warning when sharing with allowlisted domains is disabled "
+                    f"in domain {drive_client.provider.identity.domain}. "
+                    f"Users should be warned when sharing files with users in allowlisted domains."
+                )
 
             findings.append(report)
 

--- a/tests/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users_test.py
+++ b/tests/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users_test.py
@@ -67,8 +67,8 @@ class TestDriveExternalSharingWarnUsers:
             assert findings[0].status == "FAIL"
             assert "disabled" in findings[0].status_extended
 
-    def test_fail_no_policy_set(self):
-        """Test FAIL when no explicit policy is set (None) but fetch succeeded"""
+    def test_pass_using_default(self):
+        """Test PASS when no explicit policy is set (None) — Google default is secure"""
         mock_provider = set_mocked_googleworkspace_provider()
 
         with (
@@ -92,8 +92,8 @@ class TestDriveExternalSharingWarnUsers:
             findings = check.execute()
 
             assert len(findings) == 1
-            assert findings[0].status == "FAIL"
-            assert "not explicitly configured" in findings[0].status_extended
+            assert findings[0].status == "PASS"
+            assert "secure default" in findings[0].status_extended
 
     def test_no_findings_when_fetch_failed(self):
         """Test no findings returned when the API fetch failed"""

--- a/tests/providers/googleworkspace/services/drive/drive_shared_drive_creation_allowed/drive_shared_drive_creation_allowed_test.py
+++ b/tests/providers/googleworkspace/services/drive/drive_shared_drive_creation_allowed/drive_shared_drive_creation_allowed_test.py
@@ -69,8 +69,8 @@ class TestDriveSharedDriveCreationAllowed:
             assert findings[0].status == "FAIL"
             assert "prevented" in findings[0].status_extended
 
-    def test_fail_no_policy_set(self):
-        """Test FAIL when no explicit policy is set (None) but fetch succeeded"""
+    def test_pass_using_default(self):
+        """Test PASS when no explicit policy is set (None) — Google default is secure"""
         mock_provider = set_mocked_googleworkspace_provider()
 
         with (
@@ -94,8 +94,8 @@ class TestDriveSharedDriveCreationAllowed:
             findings = check.execute()
 
             assert len(findings) == 1
-            assert findings[0].status == "FAIL"
-            assert "not explicitly configured" in findings[0].status_extended
+            assert findings[0].status == "PASS"
+            assert "secure default" in findings[0].status_extended
 
     def test_no_findings_when_fetch_failed(self):
         """Test no findings returned when the API fetch failed"""

--- a/tests/providers/googleworkspace/services/drive/drive_shared_drive_disable_download_print_copy/drive_shared_drive_disable_download_print_copy_test.py
+++ b/tests/providers/googleworkspace/services/drive/drive_shared_drive_disable_download_print_copy/drive_shared_drive_disable_download_print_copy_test.py
@@ -101,8 +101,8 @@ class TestDriveSharedDriveDisableDownloadPrintCopy:
             assert findings[0].status == "FAIL"
             assert "ALL" in findings[0].status_extended
 
-    def test_fail_no_policy_set(self):
-        """Test FAIL when no explicit policy is set (None) but fetch succeeded"""
+    def test_pass_using_default(self):
+        """Test PASS when no explicit policy is set (None) — Google default is secure"""
         mock_provider = set_mocked_googleworkspace_provider()
 
         with (
@@ -128,8 +128,8 @@ class TestDriveSharedDriveDisableDownloadPrintCopy:
             findings = check.execute()
 
             assert len(findings) == 1
-            assert findings[0].status == "FAIL"
-            assert "not explicitly configured" in findings[0].status_extended
+            assert findings[0].status == "PASS"
+            assert "secure default" in findings[0].status_extended
 
     def test_no_findings_when_fetch_failed(self):
         """Test no findings returned when the API fetch failed"""

--- a/tests/providers/googleworkspace/services/drive/drive_warn_sharing_with_allowlisted_domains/drive_warn_sharing_with_allowlisted_domains_test.py
+++ b/tests/providers/googleworkspace/services/drive/drive_warn_sharing_with_allowlisted_domains/drive_warn_sharing_with_allowlisted_domains_test.py
@@ -71,8 +71,8 @@ class TestDriveWarnSharingWithAllowlistedDomains:
             assert findings[0].status == "FAIL"
             assert "disabled" in findings[0].status_extended
 
-    def test_fail_no_policy_set(self):
-        """Test FAIL when no explicit policy is set (None) but fetch succeeded"""
+    def test_pass_using_default(self):
+        """Test PASS when no explicit policy is set (None) — Google default is secure"""
         mock_provider = set_mocked_googleworkspace_provider()
 
         with (
@@ -98,8 +98,8 @@ class TestDriveWarnSharingWithAllowlistedDomains:
             findings = check.execute()
 
             assert len(findings) == 1
-            assert findings[0].status == "FAIL"
-            assert "not explicitly configured" in findings[0].status_extended
+            assert findings[0].status == "PASS"
+            assert "secure default" in findings[0].status_extended
 
     def test_no_findings_when_fetch_failed(self):
         """Test no findings returned when the API fetch failed"""


### PR DESCRIPTION
### Context

Fix for Drive and Docs service. Follow-up to the customer-level policy filter fix. The Policy API only returns settings that have been explicitly configured by an admin — settings left at their default don't appear in the API response. Previously, all our checks treated this `None` response as FAIL, generating false positives for customers who never modified secure defaults.

### Description

Updates the Drive and Docs checks to distinguish between "explicitly set to insecure value" and "not configured (secure default applies)".
 
**Updated to PASS on None (secure defaults):**
 
- `drive_external_sharing_warn_users` — default: warn enabled (secure)
- `drive_warn_sharing_with_allowlisted_domains` — default: warn enabled (secure)
- `drive_shared_drive_creation_allowed` — default: users can create shared drives (secure)
- `drive_shared_drive_disable_download_print_copy` — default: download/print/copy disabled for viewers and commenters (secure)
 
**Unchanged, still FAIL on None (insecure defaults):**
 
- `drive_publishing_files_disabled` — default: publishing to web enabled
- `drive_sharing_allowlisted_domains` — default: sharing open to all external accounts
- `drive_access_checker_recipients_only` — default: recipients + audience + public
- `drive_internal_users_distribute_content` — default: anyone can distribute externally
- `drive_shared_drive_managers_cannot_override` — default: managers can override settings
- `drive_shared_drive_members_only_access` — default: non-members can be added to files
- `drive_desktop_access_disabled` — default: Drive for desktop enabled
 
Default values are documented in the CIS Google Workspace Foundations Benchmark v1.3.0 "Default Value" sections.
 
Messages for PASS on None now indicate that Google's secure default applies, distinguishing them from cases where the admin explicitly configured the setting.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
