### PR TITLE
fix(sdk): move #10726 changelog entry to unreleased version

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - Cloudflare account-scoped API tokens failing connection test in the App with `CloudflareUserTokenRequiredError` [(#10723)](https://github.com/prowler-cloud/prowler/pull/10723)
 - `prowler image --registry` failing with `ImageNoImagesProvidedError` due to registry arguments not being forwarded to `ImageProvider` in `init_global_provider` [(#10470)](https://github.com/prowler-cloud/prowler/pull/10470)
+- Google Workspace Calendar checks false FAIL on unconfigured settings with secure Google defaults [(#10726)](https://github.com/prowler-cloud/prowler/pull/10726)
 
 ---
 
@@ -38,7 +39,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `prowler image --registry-list` crashes with `AttributeError` because `ImageProvider.__init__` returns early before registering the global provider [(#10691)](https://github.com/prowler-cloud/prowler/pull/10691)
 - Vercel firewall config handling for team-scoped projects and current API response shapes [(#10695)](https://github.com/prowler-cloud/prowler/pull/10695)
 - Google Workspace Drive checks false FAIL on unconfigured settings with secure Google defaults [(#10727)](https://github.com/prowler-cloud/prowler/pull/10727)
-- Google Workspace Calendar checks false FAIL on unconfigured settings with secure Google defaults [(#10726)](https://github.com/prowler-cloud/prowler/pull/10726)
 
 ---
 


### PR DESCRIPTION
### Context

PR #10726 added its changelog entry under `[5.24.0]` (already released) instead of `[5.24.1]` (UNRELEASED).

### Description

Move the #10726 changelog entry ("Google Workspace Calendar checks false FAIL on unconfigured settings with secure Google defaults") from the `[5.24.0]` section to the `[5.24.1] (Prowler UNRELEASED)` section in `prowler/CHANGELOG.md`.

### Steps to review

1. Open `prowler/CHANGELOG.md`
2. Verify the #10726 entry is under `[5.24.1] (Prowler UNRELEASED)`
3. Verify it is no longer under `[5.24.0] (Prowler v5.24.0)`

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.