### PR TITLE
chore(deps): enable Dependabot pre-commit ecosystem and bump hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,18 @@ updates:
     cooldown:
       default-days: 7
 
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 25
+    target-branch: master
+    labels:
+      - "dependencies"
+      - "pre-commit"
+    cooldown:
+      default-days: 7
+
   # Dependabot Updates are temporary disabled - 2025/04/15
   # v4.6
   # - package-ecosystem: "pip"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   ## GENERAL
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -16,7 +16,7 @@ repos:
 
   ## TOML
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.13.0
+    rev: v2.16.0
     hooks:
       - id: pretty-format-toml
         args: [--autofix]
@@ -24,21 +24,21 @@ repos:
 
   ## GITHUB ACTIONS
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.6.0
+    rev: v1.24.1
     hooks:
       - id: zizmor
         files: ^\.github/
 
   ## BASH
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
         exclude: contrib
 
   ## PYTHON
   - repo: https://github.com/myint/autoflake
-    rev: v2.3.1
+    rev: v2.3.3
     hooks:
       - id: autoflake
         exclude: ^skills/
@@ -50,20 +50,20 @@ repos:
           ]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 8.0.1
     hooks:
       - id: isort
         exclude: ^skills/
         args: ["--profile", "black"]
 
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 26.3.1
     hooks:
       - id: black
         exclude: ^skills/
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.3.0
     hooks:
       - id: flake8
         exclude: (contrib|^skills/)
@@ -93,7 +93,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.0-beta
+    rev: v2.14.0
     hooks:
       - id: hadolint
         args: ["--ignore=DL3013"]


### PR DESCRIPTION
### Context

GitHub announced on 2026-03-10 that Dependabot now supports `pre-commit` as a `package-ecosystem`:
https://github.blog/changelog/2026-03-10-dependabot-now-supports-pre-commit-hooks/

This PR wires up that capability for Prowler so hook revisions declared in `.pre-commit-config.yaml` are kept up to date on the same cadence as our Python, GitHub Actions, and Docker dependencies, instead of drifting until someone bumps them by hand.

### Description

- Add a `pre-commit` ecosystem entry to `.github/dependabot.yml`, mirroring the conventions already used by the other ecosystems: monthly schedule, 25 open-PR limit, `master` target, 7-day cooldown, and `dependencies` + `pre-commit` labels.
- One-time baseline bump of every hook in `.pre-commit-config.yaml` to its latest released revision so Dependabot starts from a clean state:
  - `pre-commit/pre-commit-hooks` v4.6.0 -> v6.0.0
  - `macisamuele/language-formatters-pre-commit-hooks` v2.13.0 -> v2.16.0
  - `zizmorcore/zizmor-pre-commit` v1.6.0 -> v1.24.1
  - `koalaman/shellcheck-precommit` v0.10.0 -> v0.11.0
  - `myint/autoflake` v2.3.1 -> v2.3.3
  - `pycqa/isort` 5.13.2 -> 8.0.1
  - `psf/black` 24.4.2 -> 26.3.1
  - `pycqa/flake8` 7.0.0 -> 7.3.0
  - `hadolint/hadolint` v2.13.0-beta -> v2.14.0

### Steps to review

1. Confirm the new `pre-commit` block in `.github/dependabot.yml` matches the style of the existing `pip` / `github-actions` / `docker` blocks.
2. Confirm each hook revision in `.pre-commit-config.yaml` maps to a current release tag on its upstream repo.
3. Optional: create the `pre-commit` repo label (the other ecosystems already have dedicated labels — `pip`, `github_actions`, `docker`). Dependabot will auto-create it on the first PR if missing, but pre-creating it keeps colors/description consistent with the existing ones.

### Checklist

- [x] No runtime code changes (config-only PR, no `api/`, `ui/`, `prowler/`, or `mcp_server/` changes, so no `CHANGELOG.md` entry required).
- [x] Conventional-commit PR title (`chore(deps): ...`).
- [x] No backport needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.