### PR TITLE
fix(api): exclude muted findings from pass_count, fail_count and manual_count

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🐞 Fixed
 
 - Attack Paths: Missing `tenant_id` filter while getting related findings after scan completes [(#10722)](https://github.com/prowler-cloud/prowler/pull/10722)
+- Finding group counters `pass_count`, `fail_count` and `manual_count` now exclude muted findings [(#10753)](https://github.com/prowler-cloud/prowler/pull/10753)
 
 ---
 

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -11802,7 +11802,8 @@ class TestSAMLConfigurationViewSet:
             "data": {
                 "type": "saml-configurations",
                 "id": str(config.id),
-                "attributes": {"metadata_xml": """<?xml version='1.0' encoding='UTF-8'?>
+                "attributes": {
+                    "metadata_xml": """<?xml version='1.0' encoding='UTF-8'?>
         <md:EntityDescriptor entityID='TEST' xmlns:md='urn:oasis:names:tc:SAML:2.0:metadata'>
         <md:IDPSSODescriptor WantAuthnRequestsSigned='false' protocolSupportEnumeration='urn:oasis:names:tc:SAML:2.0:protocol'>
             <md:KeyDescriptor use='signing'>
@@ -11817,7 +11818,8 @@ class TestSAMLConfigurationViewSet:
             <md:SingleSignOnService Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect' Location='https://TEST/sso/saml'/>
         </md:IDPSSODescriptor>
         </md:EntityDescriptor>
-        """},
+        """
+                },
             }
         }
         response = authenticated_client.patch(

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -11802,8 +11802,7 @@ class TestSAMLConfigurationViewSet:
             "data": {
                 "type": "saml-configurations",
                 "id": str(config.id),
-                "attributes": {
-                    "metadata_xml": """<?xml version='1.0' encoding='UTF-8'?>
+                "attributes": {"metadata_xml": """<?xml version='1.0' encoding='UTF-8'?>
         <md:EntityDescriptor entityID='TEST' xmlns:md='urn:oasis:names:tc:SAML:2.0:metadata'>
         <md:IDPSSODescriptor WantAuthnRequestsSigned='false' protocolSupportEnumeration='urn:oasis:names:tc:SAML:2.0:protocol'>
             <md:KeyDescriptor use='signing'>
@@ -11818,8 +11817,7 @@ class TestSAMLConfigurationViewSet:
             <md:SingleSignOnService Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect' Location='https://TEST/sso/saml'/>
         </md:IDPSSODescriptor>
         </md:EntityDescriptor>
-        """
-                },
+        """},
             }
         }
         response = authenticated_client.patch(
@@ -15466,7 +15464,7 @@ class TestFindingGroupViewSet:
         attrs = data[0]["attributes"]
         assert attrs["status"] == "FAIL"
         assert attrs["muted"] is True
-        assert attrs["fail_count"] == 2
+        assert attrs["fail_count"] == 0
         assert attrs["fail_muted_count"] == 2
         assert attrs["pass_muted_count"] == 0
         assert attrs["manual_muted_count"] == 0

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -7127,17 +7127,16 @@ class FindingGroupViewSet(BaseRLSViewSet):
             output_field=IntegerField(),
         )
 
-        # `pass_count`, `fail_count` and `manual_count` count *every* finding
-        # for the check (muted or not) so the aggregated `status` reflects the
-        # underlying check outcome regardless of mute state. Whether the group
-        # is actionable is signalled by the orthogonal `muted` flag below.
+        # `pass_count`, `fail_count` and `manual_count` only count non-muted
+        # findings. Muted findings are tracked separately via the
+        # `*_muted_count` fields.
         return (
             queryset.values("check_id")
             .annotate(
                 severity_order=Max(severity_case),
-                pass_count=Count("id", filter=Q(status="PASS")),
-                fail_count=Count("id", filter=Q(status="FAIL")),
-                manual_count=Count("id", filter=Q(status="MANUAL")),
+                pass_count=Count("id", filter=Q(status="PASS", muted=False)),
+                fail_count=Count("id", filter=Q(status="FAIL", muted=False)),
+                manual_count=Count("id", filter=Q(status="MANUAL", muted=False)),
                 pass_muted_count=Count("id", filter=Q(status="PASS", muted=True)),
                 fail_muted_count=Count("id", filter=Q(status="FAIL", muted=True)),
                 manual_muted_count=Count("id", filter=Q(status="MANUAL", muted=True)),

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -7281,12 +7281,14 @@ class FindingGroupViewSet(BaseRLSViewSet):
             # finding-level aggregation path.
             row.pop("nonmuted_count", None)
 
-            # Compute aggregated status. Counts are inclusive of muted findings,
-            # so the underlying check outcome surfaces even when the group is
-            # fully muted.
-            if row.get("fail_count", 0) > 0:
+            # Compute aggregated status from non-muted counts first, then
+            # fall back to muted counts so fully-muted groups still reflect
+            # the underlying check outcome.
+            total_fail = row.get("fail_count", 0) + row.get("fail_muted_count", 0)
+            total_pass = row.get("pass_count", 0) + row.get("pass_muted_count", 0)
+            if total_fail > 0:
                 row["status"] = "FAIL"
-            elif row.get("pass_count", 0) > 0:
+            elif total_pass > 0:
                 row["status"] = "PASS"
             else:
                 row["status"] = "MANUAL"
@@ -7386,9 +7388,12 @@ class FindingGroupViewSet(BaseRLSViewSet):
 
         if computed_params.get("status") or computed_params.getlist("status__in"):
             queryset = queryset.annotate(
+                total_fail=F("fail_count") + F("fail_muted_count"),
+                total_pass=F("pass_count") + F("pass_muted_count"),
+            ).annotate(
                 aggregated_status=Case(
-                    When(fail_count__gt=0, then=Value("FAIL")),
-                    When(pass_count__gt=0, then=Value("PASS")),
+                    When(total_fail__gt=0, then=Value("FAIL")),
+                    When(total_pass__gt=0, then=Value("PASS")),
                     default=Value("MANUAL"),
                     output_field=CharField(),
                 )
@@ -7772,16 +7777,14 @@ class FindingGroupViewSet(BaseRLSViewSet):
                 sort_param, self._FINDING_GROUP_SORT_MAP
             )
             if ordering:
-                # status_order is annotated on demand so groups can be sorted by
-                # their aggregated status (FAIL > PASS > MANUAL), mirroring the
-                # priority used in _post_process_aggregation. Counts are
-                # inclusive of muted findings, so the underlying check outcome
-                # surfaces even for fully muted groups.
                 if any(field.lstrip("-") == "status_order" for field in ordering):
                     aggregated_queryset = aggregated_queryset.annotate(
+                        total_fail_for_sort=F("fail_count") + F("fail_muted_count"),
+                        total_pass_for_sort=F("pass_count") + F("pass_muted_count"),
+                    ).annotate(
                         status_order=Case(
-                            When(fail_count__gt=0, then=Value(3)),
-                            When(pass_count__gt=0, then=Value(2)),
+                            When(total_fail_for_sort__gt=0, then=Value(3)),
+                            When(total_pass_for_sort__gt=0, then=Value(2)),
                             default=Value(1),
                             output_field=IntegerField(),
                         )

--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -1804,11 +1804,9 @@ def aggregate_finding_group_summaries(tenant_id: str, scan_id: str):
         )
 
         # Aggregate findings by check_id for this scan.
-        # `pass_count`, `fail_count` and `manual_count` count *every* finding
-        # in this group, regardless of mute state, so the aggregated `status`
-        # always reflects the underlying check outcome (FAIL > PASS > MANUAL)
-        # even when the group is fully muted. The orthogonal `muted` flag is
-        # what tells whether the group has any actionable (non-muted) findings.
+        # `pass_count`, `fail_count` and `manual_count` only count non-muted
+        # findings. Muted findings are tracked separately via the
+        # `*_muted_count` fields.
         aggregated = (
             Finding.objects.filter(
                 tenant_id=tenant_id,
@@ -1817,9 +1815,9 @@ def aggregate_finding_group_summaries(tenant_id: str, scan_id: str):
             .values("check_id")
             .annotate(
                 severity_order=Max(severity_case),
-                pass_count=Count("id", filter=Q(status="PASS")),
-                fail_count=Count("id", filter=Q(status="FAIL")),
-                manual_count=Count("id", filter=Q(status="MANUAL")),
+                pass_count=Count("id", filter=Q(status="PASS", muted=False)),
+                fail_count=Count("id", filter=Q(status="FAIL", muted=False)),
+                manual_count=Count("id", filter=Q(status="MANUAL", muted=False)),
                 pass_muted_count=Count("id", filter=Q(status="PASS", muted=True)),
                 fail_muted_count=Count("id", filter=Q(status="FAIL", muted=True)),
                 manual_muted_count=Count("id", filter=Q(status="MANUAL", muted=True)),


### PR DESCRIPTION
### Context

`pass_count`, `fail_count` and `manual_count` in finding-group responses were including muted findings. This made the counters inconsistent - a group could report `fail_count: 1` while `fail_muted_count: 1`, implying there was an actionable failure when in reality the only failing finding was muted.

Backport of #10708.

### Description

Added `muted=False` filter to the `pass_count`, `fail_count` and `manual_count` annotations in both aggregation paths:

- **`scan.py`** (`aggregate_finding_group_summaries`): the primary path that stores counters in `FindingGroupDailySummary` during scan processing.
- **`views.py`** (`_aggregate_findings`): the runtime fallback path used when finding-level filters are applied.

The `*_muted_count` fields (`pass_muted_count`, `fail_muted_count`, `manual_muted_count`) continue to track muted findings separately, so no information is lost.

Updated the existing test `test_finding_groups_fully_muted_group_reflects_underlying_status` to expect `fail_count == 0` for a fully-muted group.

### Steps to review

1. Check the annotation changes in `scan.py` and `views.py` - both now use `muted=False` for the base counters.
2. Verify the test update reflects the new expected behavior.
3. Confirm that `*_muted_count` fields are unaffected.

### Checklist

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed.

#### API
- [x] All issue/task requirements work as expected on the API

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.