### PR TITLE
fix(ui): disable Next.js 16 Server Function arg logging

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔒 Security
 
 - Upgrade React to 19.2.5 and Next.js to 16.2.3 to mitigate CVE-2026-23869 (React2DoS), a high-severity unauthenticated remote DoS vulnerability in the React Flight Protocol's Server Function deserialization [(#10754)](https://github.com/prowler-cloud/prowler/pull/10754)
-- Disable Next.js 16 Server Function argument logging to prevent sign-in credentials (email/password) from being printed to the terminal during development
+- Disable Next.js 16 Server Function argument logging to prevent sign-in credentials (email/password) from being printed to the terminal during development[(#10760)](https://github.com/prowler-cloud/prowler/pull/10760)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔒 Security
 
 - Upgrade React to 19.2.5 and Next.js to 16.2.3 to mitigate CVE-2026-23869 (React2DoS), a high-severity unauthenticated remote DoS vulnerability in the React Flight Protocol's Server Function deserialization [(#10754)](https://github.com/prowler-cloud/prowler/pull/10754)
+- Disable Next.js 16 Server Function argument logging to prevent sign-in credentials (email/password) from being printed to the terminal during development
 
 ---
 

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -46,6 +46,12 @@ const nextConfig = {
   turbopack: {
     root: __dirname,
   },
+  logging: {
+    // Next.js 16 prints every Server Function call with its arguments
+    // (e.g. `authenticate(null, {email, password}) ...`), which leaks
+    // credentials and other sensitive payloads to the terminal.
+    serverFunctions: false,
+  },
   async headers() {
     const sentryEndpoint = getSentryReportEndpoint();
     const headers = [


### PR DESCRIPTION
### Description

Next.js 16.2 enables Server Function logging by default, which prints the function name, arguments and duration of every invocation to the terminal. Since the `authenticate` Server Action receives `{ email, password }` as its second argument, every `POST /sign-in` was dumping something like this to stdout:

```
POST /sign-in?callbackUrl=%2F 200 in 41ms
  └─ ƒ authenticate(null, {"email":"email@email.com","password":"passwordmail"}) in 19ms actions/auth/auth.ts
```

This leaks plaintext credentials to any development terminal, container, or log aggregator that captures stdout. The regression was introduced implicitly when we bumped to Next.js 16.2.3 (PR #10752) — the upgrade didn't touch the auth action, it only changed the framework's default logging behavior.

Fix: add `logging.serverFunctions: false` in `ui/next.config.js`, which is the official Next.js 16 knob to disable this log (https://nextjs.org/docs/app/api-reference/config/next-config-js/logging).

## Changes

- `ui/next.config.js`: added `logging: { serverFunctions: false }` with an inline comment explaining why.
- `ui/CHANGELOG.md`: security note under `1.24.1`.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
