### PR TITLE
fix(cloudflare): guard validate_credentials against paginator infinite loops

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Cloudflare account-scoped API tokens failing connection test in the App with `CloudflareUserTokenRequiredError` [(#10723)](https://github.com/prowler-cloud/prowler/pull/10723)
 - `prowler image --registry` failing with `ImageNoImagesProvidedError` due to registry arguments not being forwarded to `ImageProvider` in `init_global_provider` [(#10470)](https://github.com/prowler-cloud/prowler/pull/10470)
 - Google Workspace Calendar checks false FAIL on unconfigured settings with secure Google defaults [(#10726)](https://github.com/prowler-cloud/prowler/pull/10726)
-- Cloudflare `validate_credentials` can hang in an infinite pagination loop when the SDK repeats accounts, blocking connection tests [(#NEW)](https://github.com/prowler-cloud/prowler/pull/NEW)
+- Cloudflare `validate_credentials` can hang in an infinite pagination loop when the SDK repeats accounts, blocking connection tests [(#10771)](https://github.com/prowler-cloud/prowler/pull/10771)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Cloudflare account-scoped API tokens failing connection test in the App with `CloudflareUserTokenRequiredError` [(#10723)](https://github.com/prowler-cloud/prowler/pull/10723)
 - `prowler image --registry` failing with `ImageNoImagesProvidedError` due to registry arguments not being forwarded to `ImageProvider` in `init_global_provider` [(#10470)](https://github.com/prowler-cloud/prowler/pull/10470)
 - Google Workspace Calendar checks false FAIL on unconfigured settings with secure Google defaults [(#10726)](https://github.com/prowler-cloud/prowler/pull/10726)
+- Cloudflare `validate_credentials` can hang in an infinite pagination loop when the SDK repeats accounts, blocking connection tests [(#NEW)](https://github.com/prowler-cloud/prowler/pull/NEW)
 
 ---
 

--- a/prowler/providers/cloudflare/cloudflare_provider.py
+++ b/prowler/providers/cloudflare/cloudflare_provider.py
@@ -274,8 +274,12 @@ class CloudflareProvider(Provider):
 
             for account in client.accounts.list():
                 account_id = getattr(account, "id", None)
-                # Prevent infinite loop - skip if we've seen this account
+                # Prevent infinite loop on repeated pages from the SDK paginator
                 if account_id in seen_account_ids:
+                    logger.warning(
+                        "Detected repeated Cloudflare account ID while listing accounts. "
+                        "Stopping pagination to avoid an infinite loop."
+                    )
                     break
                 seen_account_ids.add(account_id)
 
@@ -395,7 +399,20 @@ class CloudflareProvider(Provider):
 
         # Fallback: try accounts.list()
         try:
-            accounts = list(client.accounts.list())
+            accounts: list = []
+            seen_account_ids: set = set()
+            for account in client.accounts.list():
+                account_id = getattr(account, "id", None)
+                # Prevent infinite loop on repeated pages from the SDK paginator
+                if account_id in seen_account_ids:
+                    logger.warning(
+                        "Detected repeated Cloudflare account ID while validating credentials. "
+                        "Stopping pagination to avoid an infinite loop."
+                    )
+                    break
+                seen_account_ids.add(account_id)
+                accounts.append(account)
+
             if not accounts:
                 logger.error("CloudflareNoAccountsError: No accounts found")
                 raise CloudflareNoAccountsError(

--- a/tests/providers/cloudflare/cloudflare_provider_test.py
+++ b/tests/providers/cloudflare/cloudflare_provider_test.py
@@ -433,6 +433,29 @@ class TestCloudflareValidateCredentials:
         with pytest.raises(CloudflareNoAccountsError):
             CloudflareProvider.validate_credentials(session)
 
+    def test_validate_credentials_breaks_on_repeated_account_ids(self):
+        """Pagination must stop when the SDK repeats account IDs to avoid infinite loops."""
+
+        def repeating_accounts():
+            account = MagicMock()
+            account.id = ACCOUNT_ID
+            while True:
+                yield account
+
+        mock_client = MagicMock()
+        mock_client.user.get.side_effect = Exception("Some other error")
+        mock_client.accounts.list.return_value = repeating_accounts()
+
+        session = CloudflareSession(
+            client=mock_client,
+            api_token=API_TOKEN,
+            api_key=None,
+            api_email=None,
+        )
+
+        # Must return without hanging; repeated IDs break the loop.
+        CloudflareProvider.validate_credentials(session)
+
 
 class TestCloudflareTestConnection:
     """Tests for test_connection method."""


### PR DESCRIPTION
## Context

While reviewing `prowler/providers/cloudflare/cloudflare_provider.py`, Codex flagged an inconsistency: `setup_identity` is already protected against an infinite loop when iterating `client.accounts.list()` (lines 275–280 guard against repeated account IDs), but `validate_credentials` calls `list(client.accounts.list())` in its fallback path without any guard. If the Cloudflare SDK paginator repeats accounts, that `list()` can hang and block a worker slot (this fallback is hit via `test_connection`).

## Description

- Add the same `seen_account_ids` guard in `validate_credentials`' `accounts.list()` fallback so it cannot loop forever on repeated pages.
- Align `setup_identity` to log a `logger.warning` when the guard triggers (previously silent) for consistency and observability.
- Add a regression test (`test_validate_credentials_breaks_on_repeated_account_ids`) that feeds an infinite generator of the same account ID and verifies `validate_credentials` returns without hanging.
- Add an entry under `5.24.1` in `prowler/CHANGELOG.md`.

## Steps to review

- Check the diff in `prowler/providers/cloudflare/cloudflare_provider.py` — the new fallback mirrors the existing guard in `setup_identity`.
- Run `pytest -vv tests/providers/cloudflare/cloudflare_provider_test.py::TestCloudflareValidateCredentials::test_validate_credentials_breaks_on_repeated_account_ids` — must pass (test hangs without the guard).
- Confirm the `CHANGELOG.md` entry under `[5.24.1]` → `Fixed`.

## Checklist

- [x] Tests added
- [x] CHANGELOG updated
- [x] No new comments on clear code
