### PR TITLE
feat: add SAML_ACS_BASE_URL for reverse proxy deployments

### DIFF
--- a/.env
+++ b/.env
@@ -173,3 +173,9 @@ LANGCHAIN_PROJECT=""
 RSS_FEED_SOURCES='[{"id":"prowler-releases","name":"Prowler Releases","type":"github_releases","url":"https://github.com/prowler-cloud/prowler/releases.atom","enabled":true}]'
 # Example with multiple sources (no trailing comma after last item):
 # RSS_FEED_SOURCES='[{"id":"prowler-releases","name":"Prowler Releases","type":"github_releases","url":"https://github.com/prowler-cloud/prowler/releases.atom","enabled":true},{"id":"prowler-blog","name":"Prowler Blog","type":"blog","url":"https://prowler.com/blog/rss","enabled":false}]'
+
+# SAML ACS URL Override
+# Set this to your external Prowler URL when running behind a reverse proxy.
+# This ensures SAML ACS URLs use your public domain instead of the internal container hostname.
+# Example: https://prowler.example.com
+# SAML_ACS_BASE_URL=

--- a/api/src/backend/api/middleware.py
+++ b/api/src/backend/api/middleware.py
@@ -53,3 +53,62 @@ class APILoggingMiddleware:
         )
 
         return response
+
+
+class SAMLACSURLMiddleware:
+    """
+    Middleware to override the host used for SAML ACS URL generation.
+
+    When Prowler runs behind a reverse proxy or load balancer, Django's
+    request.build_absolute_uri() uses the internal container hostname
+    (e.g., prowler-api:8080) instead of the external domain. This causes
+    SAML ACS URLs to be incorrect, breaking SSO authentication.
+
+    Set SAML_ACS_BASE_URL in your environment (e.g., https://prowler.example.com)
+    to override the host for SAML-related endpoints.
+
+    Fixes: https://github.com/prowler-cloud/prowler/issues/10533
+    """
+
+    SAML_PATH_PREFIX = "/accounts/saml/"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.saml_acs_base_url = None
+
+        from config.env import env
+
+        url = env("SAML_ACS_BASE_URL", default="")
+        if url:
+            # Parse the URL to extract scheme, host, and port
+            from urllib.parse import urlparse
+
+            parsed = urlparse(url.rstrip("/"))
+            if parsed.scheme and parsed.hostname:
+                self.saml_acs_base_url = parsed
+                logging.getLogger("prowler").info(
+                    f"SAML ACS URL override active: {url}"
+                )
+
+    def __call__(self, request):
+        if (
+            self.saml_acs_base_url
+            and self.SAML_PATH_PREFIX in request.path
+        ):
+            parsed = self.saml_acs_base_url
+
+            # Override the host so build_absolute_uri() uses the external URL
+            host = parsed.hostname
+            if parsed.port and parsed.port not in (80, 443):
+                host = f"{host}:{parsed.port}"
+
+            request.META["HTTP_HOST"] = host
+            request.META["SERVER_NAME"] = parsed.hostname
+            request.META["SERVER_PORT"] = str(parsed.port or (443 if parsed.scheme == "https" else 80))
+
+            # Ensure the scheme is correct
+            if parsed.scheme == "https":
+                request.META["HTTP_X_FORWARDED_PROTO"] = "https"
+                request.META["wsgi.url_scheme"] = "https"
+
+        return self.get_response(request)

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -57,6 +57,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "api.middleware.APILoggingMiddleware",
+    "api.middleware.SAMLACSURLMiddleware",
     "allauth.account.middleware.AccountMiddleware",
 ]
 


### PR DESCRIPTION
Fixes #10533
Related: #9724, #10498

## Problem
When Prowler runs behind a reverse proxy (nginx, Traefik, etc.), SAML ACS URLs are generated using the internal container hostname (`http://prowler-api:8080/...`) instead of the external domain. This breaks SSO authentication because the IdP's reply URL doesn't match.

The current workaround requires rebuilding the UI container with custom `NEXT_PUBLIC_API_BASE_URL` — impractical for most deployments.

## Solution
Added a `SAML_ACS_BASE_URL` environment variable and a lightweight middleware (`SAMLACSURLMiddleware`) that overrides request metadata for `/accounts/saml/*` paths so `request.build_absolute_uri()` produces the correct external URL.

### Usage
```env
SAML_ACS_BASE_URL=https://prowler.example.com
```

### How it works
- Middleware parses the env var at startup (zero overhead when not set)
- For SAML endpoints only, it overwrites `HTTP_HOST`, `SERVER_NAME`, `SERVER_PORT`, and `X-Forwarded-Proto`
- Django's `build_absolute_uri()` then generates correct external ACS URLs
- No-op when env var is empty — zero impact on existing deployments

### Files changed
- `api/src/backend/api/middleware.py` — added `SAMLACSURLMiddleware`
- `api/src/backend/config/django/base.py` — registered middleware
- `.env` — added `SAML_ACS_BASE_URL` with documentation