### PR TITLE
feat(azure): add MITRE D3FEND MVP compliance mapping

### DIFF
--- a/prowler/compliance/azure/mitre_d3fend_azure.json
+++ b/prowler/compliance/azure/mitre_d3fend_azure.json
@@ -1,0 +1,88 @@
+{
+  "Framework": "MITRE-D3FEND",
+  "Name": "MITRE D3FEND compliance framework",
+  "Version": "",
+  "Provider": "Azure",
+  "Description": "MITRE D3FEND is a knowledge graph of defensive countermeasures. This initial Azure mapping adds a small, review-friendly set of Prowler checks that align defensive techniques with concrete cloud hardening, monitoring, authentication, and recovery controls.",
+  "Requirements": [
+    {
+      "Id": "D3-ITF",
+      "Name": "Inbound Traffic Filtering",
+      "Description": "Restricting network traffic originating from untrusted networks destined towards a private host or enclave.",
+      "Attributes": [
+        {
+          "Section": "Harden",
+          "SubSection": "Network Exposure Reduction",
+          "SubGroup": "Inbound Traffic Filtering",
+          "Service": "Azure Network Security",
+          "Type": "Protect",
+          "Comment": "These checks reduce public reachability by disabling public endpoints or public blob access, which is a practical Azure-aligned application of D3-ITF."
+        }
+      ],
+      "Checks": [
+        "aks_clusters_public_access_disabled",
+        "containerregistry_not_publicly_accessible",
+        "keyvault_access_only_through_private_endpoints",
+        "storage_blob_public_access_level_is_disabled"
+      ]
+    },
+    {
+      "Id": "D3-MFA",
+      "Name": "Multi-factor Authentication",
+      "Description": "Requiring proof of two or more pieces of evidence in order to authenticate a user.",
+      "Attributes": [
+        {
+          "Section": "Harden",
+          "SubSection": "Identity Protection",
+          "SubGroup": "Multi-factor Authentication",
+          "Service": "Microsoft Entra ID",
+          "Type": "Protect",
+          "Comment": "These checks validate MFA enrollment for privileged and non-privileged users, directly supporting the D3-MFA defensive technique."
+        }
+      ],
+      "Checks": [
+        "entra_non_privileged_user_has_mfa",
+        "entra_privileged_user_has_mfa"
+      ]
+    },
+    {
+      "Id": "D3-PM",
+      "Name": "Platform Monitoring",
+      "Description": "Monitoring platform components such as operating systems software, hardware devices, or firmware.",
+      "Attributes": [
+        {
+          "Section": "Detect",
+          "SubSection": "Audit and Telemetry",
+          "SubGroup": "Platform Monitoring",
+          "Service": "Azure Monitor",
+          "Type": "Detect",
+          "Comment": "These checks ensure Azure control-plane or application telemetry exists, improving visibility that defenders rely on for D3FEND-style monitoring and analysis."
+        }
+      ],
+      "Checks": [
+        "app_http_logs_enabled",
+        "keyvault_logging_enabled",
+        "monitor_diagnostic_settings_exists"
+      ]
+    },
+    {
+      "Id": "D3-RO",
+      "Name": "Restore Object",
+      "Description": "Restoring an object for an entity to access. This is the broadest class for object restoral.",
+      "Attributes": [
+        {
+          "Section": "Restore",
+          "SubSection": "Backup and Recovery",
+          "SubGroup": "Restore Object",
+          "Service": "Azure Backup",
+          "Type": "Recover",
+          "Comment": "These checks verify backup coverage and retention, which are reasonable cloud control signals for object and workload restoration capabilities."
+        }
+      ],
+      "Checks": [
+        "vm_backup_enabled",
+        "vm_sufficient_daily_backup_retention_period"
+      ]
+    }
+  ]
+}

--- a/tests/lib/check/compliance_check_test.py
+++ b/tests/lib/check/compliance_check_test.py
@@ -7,6 +7,8 @@ from prowler.lib.check.compliance_models import (
     CIS_Requirement_Attribute_Profile,
     Compliance,
     Compliance_Requirement,
+    Generic_Compliance_Requirement_Attribute,
+    load_compliance_framework,
 )
 from prowler.lib.check.models import CheckMetadata
 
@@ -560,3 +562,29 @@ class TestCompliance:
         assert len(result) == 1
         assert "framework1_aws" in result.keys()
         mock_list_modules.assert_called_once()
+
+    def test_load_mitre_d3fend_azure_framework(self):
+        compliance = load_compliance_framework(
+            "prowler/compliance/azure/mitre_d3fend_azure.json"
+        )
+
+        assert compliance.Framework == "MITRE-D3FEND"
+        assert compliance.Provider == "Azure"
+        assert compliance.Name == "MITRE D3FEND compliance framework"
+        assert len(compliance.Requirements) == 4
+
+        inbound_filtering = compliance.Requirements[0]
+        assert inbound_filtering.Id == "D3-ITF"
+        assert inbound_filtering.Name == "Inbound Traffic Filtering"
+        assert (
+            "aks_clusters_public_access_disabled" in inbound_filtering.Checks
+        )
+        assert (
+            "storage_blob_public_access_level_is_disabled"
+            in inbound_filtering.Checks
+        )
+        assert isinstance(
+            inbound_filtering.Attributes[0],
+            Generic_Compliance_Requirement_Attribute,
+        )
+        assert inbound_filtering.Attributes[0].Type == "Protect"

--- a/tests/lib/outputs/compliance/compliance_test.py
+++ b/tests/lib/outputs/compliance/compliance_test.py
@@ -5,6 +5,7 @@ from prowler.lib.check.compliance_models import (
     CIS_Requirement_Attribute,
     Compliance,
     Compliance_Requirement,
+    Generic_Compliance_Requirement_Attribute,
 )
 from prowler.lib.check.models import Check_Report, load_check_metadata
 from prowler.lib.outputs.compliance.compliance import get_check_compliance
@@ -255,6 +256,55 @@ class TestCompliance:
         assert get_check_compliance(finding, "azure", bulk_checks_metadata) == {
             "CIS-2.0": ["2.1.3"],
             "CIS-2.1": ["2.1.3"],
+        }
+
+    def test_get_check_compliance_azure_mitre_d3fend(self):
+        check_compliance = [
+            Compliance(
+                Framework="MITRE-D3FEND",
+                Name="MITRE D3FEND compliance framework",
+                Provider="Azure",
+                Version="",
+                Description="MITRE D3FEND Azure MVP mappings",
+                Requirements=[
+                    Compliance_Requirement(
+                        Checks=[],
+                        Id="D3-MFA",
+                        Description="Requiring proof of two or more pieces of evidence in order to authenticate a user.",
+                        Attributes=[
+                            Generic_Compliance_Requirement_Attribute(
+                                Section="Harden",
+                                SubSection="Identity Protection",
+                                SubGroup="Multi-factor Authentication",
+                                Service="Microsoft Entra ID",
+                                Type="Protect",
+                                Comment="MFA requirement for Entra identities.",
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+
+        finding = Check_Report(
+            metadata=load_check_metadata(
+                f"{path.dirname(path.realpath(__file__))}/../fixtures/metadata.json"
+            ).json(),
+            resource={},
+        )
+        finding.resource_details = "Test resource details"
+        finding.resource_id = "test-resource"
+        finding.resource_arn = "test-arn"
+        finding.region = "eu-west-1"
+        finding.status = "PASS"
+        finding.status_extended = "This is a test"
+
+        bulk_checks_metadata = {}
+        bulk_checks_metadata["iam_user_accesskey_unused"] = mock.MagicMock()
+        bulk_checks_metadata["iam_user_accesskey_unused"].Compliance = check_compliance
+
+        assert get_check_compliance(finding, "azure", bulk_checks_metadata) == {
+            "MITRE-D3FEND": ["D3-MFA"],
         }
 
     def test_get_check_compliance_kubernetes(self):


### PR DESCRIPTION
## Summary

This PR adds an initial MITRE D3FEND MVP mapping for Azure compliance in Prowler.

It introduces a new Azure compliance framework file for `MITRE-D3FEND` and keeps the scope intentionally small and review-friendly:
- adds a new compliance framework definition at `prowler/compliance/azure/mitre_d3fend_azure.json`
- maps a limited set of Azure checks to a small set of D3FEND techniques
- adds tests to validate framework loading and `get_check_compliance()` behavior

## Included D3FEND Techniques

This MVP includes the following Azure mappings:
- `D3-ITF` Inbound Traffic Filtering
- `D3-MFA` Multi-factor Authentication
- `D3-PM` Platform Monitoring
- `D3-RO` Restore Object

## Notes

This change is intended as a small defensive-enrichment MVP, not as a full canonical ATT&CK-to-D3FEND crosswalk.

The goal is to extend Prowler's existing MITRE-related compliance model with an initial D3FEND layer that can be reviewed incrementally and expanded in follow-up work.

## Testing

Validated with:
- `tests/lib/check/compliance_check_test.py`
- `tests/lib/outputs/compliance/compliance_test.py`

Result:
- `23 passed`
