### PR TITLE
fix(api): align latest_resources scan selection with completed_at

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [1.25.2] (Prowler v5.24.2)
+
+### 🐞 Fixed
+
+- `/finding-groups/latest/<check_id>/resources` now selects the latest completed scan per provider by `-completed_at` (then `-inserted_at`) instead of `-inserted_at`, matching the `/finding-groups/latest` summary path and the daily-summary upsert so overlapping scans no longer produce diverging `delta`/`new_count` between the two endpoints [(#10802)](https://github.com/prowler-cloud/prowler/pull/10802)
+
+---
+
 ## [1.25.1] (Prowler v5.24.1)
 
 ### 🔄 Changed

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -17271,3 +17271,111 @@ class TestFindingGroupViewSet:
             attrs = item["attributes"]
             assert "finding_id" in attrs
             assert attrs["finding_id"] in rds_finding_ids
+
+    def test_latest_resources_picks_scan_by_completed_at_when_overlap(
+        self,
+        authenticated_client,
+        tenants_fixture,
+        providers_fixture,
+        resources_fixture,
+    ):
+        """Overlapping scans on the same provider must resolve to the scan
+        with the latest completed_at, matching the /latest summary path and
+        the daily-summary upsert (keyed on midnight(completed_at)). Picking
+        by inserted_at here produced /resources and /latest reading from
+        different scans and reporting diverging delta/new counts.
+        """
+        tenant = tenants_fixture[0]
+        provider = providers_fixture[0]
+        resource = resources_fixture[0]
+        check_id = "overlap_regression_check"
+
+        t0 = datetime.now(timezone.utc) - timedelta(hours=5)
+        t1 = t0 + timedelta(hours=1)
+        t1_end = t1 + timedelta(minutes=30)
+        t2 = t0 + timedelta(hours=4)
+
+        scan_long = Scan.objects.create(
+            name="long overlap scan",
+            provider=provider,
+            trigger=Scan.TriggerChoices.MANUAL,
+            state=StateChoices.COMPLETED,
+            tenant_id=tenant.id,
+            started_at=t0,
+            completed_at=t2,
+        )
+        scan_short = Scan.objects.create(
+            name="short overlap scan",
+            provider=provider,
+            trigger=Scan.TriggerChoices.MANUAL,
+            state=StateChoices.COMPLETED,
+            tenant_id=tenant.id,
+            started_at=t1,
+            completed_at=t1_end,
+        )
+        # inserted_at is auto_now_add so override with .update() to recreate
+        # the overlap shape: short scan inserted later but completed earlier.
+        Scan.all_objects.filter(pk=scan_long.pk).update(inserted_at=t0)
+        Scan.all_objects.filter(pk=scan_short.pk).update(inserted_at=t1)
+        scan_long.refresh_from_db()
+        scan_short.refresh_from_db()
+
+        assert scan_short.inserted_at > scan_long.inserted_at
+        assert scan_long.completed_at > scan_short.completed_at
+
+        long_finding = Finding.objects.create(
+            tenant_id=tenant.id,
+            uid=f"{check_id}_long",
+            scan=scan_long,
+            delta=None,
+            status=Status.FAIL,
+            status_extended="long scan finding",
+            impact=Severity.high,
+            impact_extended="high",
+            severity=Severity.high,
+            raw_result={"status": Status.FAIL, "severity": Severity.high},
+            check_id=check_id,
+            check_metadata={
+                "CheckId": check_id,
+                "checktitle": "Overlap regression",
+                "Description": "Overlapping scan regression.",
+            },
+            first_seen_at=t0,
+            muted=False,
+        )
+        long_finding.add_resources([resource])
+
+        short_finding = Finding.objects.create(
+            tenant_id=tenant.id,
+            uid=f"{check_id}_short",
+            scan=scan_short,
+            delta="new",
+            status=Status.FAIL,
+            status_extended="short scan finding",
+            impact=Severity.high,
+            impact_extended="high",
+            severity=Severity.high,
+            raw_result={"status": Status.FAIL, "severity": Severity.high},
+            check_id=check_id,
+            check_metadata={
+                "CheckId": check_id,
+                "checktitle": "Overlap regression",
+                "Description": "Overlapping scan regression.",
+            },
+            first_seen_at=t1,
+            muted=False,
+        )
+        short_finding.add_resources([resource])
+
+        response = authenticated_client.get(
+            reverse(
+                "finding-group-latest_resources",
+                kwargs={"check_id": check_id},
+            ),
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert len(data) == 1
+        attrs = data[0]["attributes"]
+        assert attrs["finding_id"] == str(long_finding.id)
+        assert attrs["delta"] is None

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -8145,10 +8145,13 @@ class FindingGroupViewSet(BaseRLSViewSet):
         tenant_id = request.tenant_id
         queryset = self._get_finding_queryset()
 
-        # Get latest completed scan for each provider
+        # Order by -completed_at (matching the /latest summary path and the
+        # daily summary upsert keyed on midnight(completed_at)) so that
+        # overlapping scans do not make /resources and /latest read from
+        # different scans and report diverging counts.
         latest_scan_ids = (
             Scan.objects.filter(tenant_id=tenant_id, state=StateChoices.COMPLETED)
-            .order_by("provider_id", "-inserted_at")
+            .order_by("provider_id", "-completed_at", "-inserted_at")
             .distinct("provider_id")
             .values_list("id", flat=True)
         )


### PR DESCRIPTION
### Context

`/finding-groups/latest/<check_id>/resources` and `/finding-groups/latest` were disagreeing about which scan represents the "latest state" for a provider, which showed up as diverging `delta`/`new_count` values between the two endpoints on the same finding group.

Reproduced against a tenant with two overlapping completed scans for the same AWS provider:

| scan | inserted_at | completed_at |
|------|-------------|--------------|
| long | 2026-04-15 14:42 | 2026-04-16 06:15 |
| short | 2026-04-15 18:47 | 2026-04-15 19:26 |

- `/latest/<check_id>/resources` returned 4 resources with `delta=new` (findings from the short scan).
- `/latest` for the same `check_id` returned `new_count=1` / `new_fail_count=1` (summed from the long scan's daily summary).
- Re-running `reaggregate_finding_groups_for_provider` did not fix it, because that command also orders by `-completed_at` and therefore refreshes the long scan's summary every time.

Root cause: `latest_resources` picked the latest completed scan per provider by `-inserted_at`, while the `/latest` summary path reads the `FindingGroupDailySummary` row with the greatest `inserted_at` (which the upsert keys on `midnight(scan.completed_at)`), and the reaggregation management command orders by `-completed_at, -inserted_at`. Whenever two scans overlap, the two criteria resolve to different scans and the two endpoints report counts derived from different underlying data.

### Description

Change `FindingGroupViewSet.latest_resources` (`api/src/backend/api/v1/views.py`) to order candidate completed scans by `-completed_at, -inserted_at` before `distinct("provider_id")`, matching the criterion already used by the `/latest` summary path and by `reaggregate_finding_groups_for_provider`. After the fix all three paths always converge on the same scan for a given provider.

Added a regression test `TestFindingGroupViewSet::test_latest_resources_picks_scan_by_completed_at_when_overlap` that builds the overlapping-scan shape above in the fixture, creates one finding in each scan for the same `check_id`, and asserts the endpoint returns the finding from the scan with the greatest `completed_at` (not the greatest `inserted_at`).

No schema, serializer, or response-shape change. Other endpoints that also pick "latest scan per provider" by `-inserted_at` (e.g. resources listings at `views.py:2970`, `3107`, `3688`, `3716`, `5028`, `5085`, `5138`) are left untouched in this PR and can be aligned separately.

### Steps to review

1. Check out the branch and run the regression test:
   ```bash
   cd api
   poetry run pytest src/backend/api/tests/test_views.py::TestFindingGroupViewSet::test_latest_resources_picks_scan_by_completed_at_when_overlap -x --tb=short
   ```
2. To validate end-to-end against a tenant that has overlapping scans, run the reaggregation first and then hit both endpoints for the same `check_id`; `/latest` totals should match the sum of `delta=new` rows in `/latest/<check_id>/resources`:
   ```bash
   poetry run python src/backend/manage.py reaggregate_finding_groups_for_provider --tenant <TENANT_UUID>
   curl ".../api/v1/finding-groups/latest?filter[check_id]=<check_id>"
   curl ".../api/v1/finding-groups/latest/<check_id>/resources?filter[status]=FAIL"
   ```
3. Inspect the one-line change in `views.py` and confirm the ordering is now `("provider_id", "-completed_at", "-inserted_at")`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### API (if applicable)
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable) — see Context table
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — not applicable, ordering change on an already-indexed column
- [ ] Performance test results (if applicable) — not applicable
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated. — not needed, no schema change
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.