### PR TITLE
fix(ui): centralize default muted findings filter on finding groups

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,11 +11,11 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ---
 
-## [1.24.2] (Prowler UNRELEASED)
+## [1.24.2] (Prowler v5.24.2)
 
 ### 🐞 Fixed
 
-- Default muted filter now applied consistently on the findings SSR page and the finding-group resource drill-down, keeping muted findings hidden unless the "include muted findings" checkbox is opted in [(#10818)](https://github.com/prowler-cloud/prowler/pull/10818)
+- Default muted filter now applied consistently on the findings page and the finding-group resource drill-down, keeping muted findings hidden unless the "include muted findings" checkbox is opted in [(#10818)](https://github.com/prowler-cloud/prowler/pull/10818)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Redesign compliance page with a horizontal ThreatScore card (always-visible pillar breakdown + ActionDropdown), client-side search for compliance frameworks, compact scan selector trigger, responsive mobile filters, download-started toasts for CSV/PDF exports, enhanced compliance cards with truncated titles, and Alert-based empty/error states; migrate Progress component from HeroUI to shadcn [(#10767)](https://github.com/prowler-cloud/prowler/pull/10767)
 - Backward-compatibility middleware redirect from `/sign-up?invitation_token=…` to `/invitation/accept?invitation_token=…`; new invitation emails use `/invitation/accept` directly [(#10797)](https://github.com/prowler-cloud/prowler/pull/10797)
 
+### 🐞 Fixed
+
+- Default muted filter now applied consistently on the findings SSR page and the finding-group resource drill-down, keeping muted findings hidden unless the "include muted findings" checkbox is opted in
+
 ---
 
 ## [1.24.1] (Prowler v5.24.1)

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -9,9 +9,13 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Redesign compliance page with a horizontal ThreatScore card (always-visible pillar breakdown + ActionDropdown), client-side search for compliance frameworks, compact scan selector trigger, responsive mobile filters, download-started toasts for CSV/PDF exports, enhanced compliance cards with truncated titles, and Alert-based empty/error states; migrate Progress component from HeroUI to shadcn [(#10767)](https://github.com/prowler-cloud/prowler/pull/10767)
 - Backward-compatibility middleware redirect from `/sign-up?invitation_token=…` to `/invitation/accept?invitation_token=…`; new invitation emails use `/invitation/accept` directly [(#10797)](https://github.com/prowler-cloud/prowler/pull/10797)
 
+---
+
+## [1.24.2] (Prowler UNRELEASED)
+
 ### 🐞 Fixed
 
-- Default muted filter now applied consistently on the findings SSR page and the finding-group resource drill-down, keeping muted findings hidden unless the "include muted findings" checkbox is opted in
+- Default muted filter now applied consistently on the findings SSR page and the finding-group resource drill-down, keeping muted findings hidden unless the "include muted findings" checkbox is opted in [(#10818)](https://github.com/prowler-cloud/prowler/pull/10818)
 
 ---
 

--- a/ui/app/(prowler)/findings/page.test.ts
+++ b/ui/app/(prowler)/findings/page.test.ts
@@ -36,4 +36,8 @@ describe("findings page", () => {
   it("guards errors array access with a length check", () => {
     expect(source).toContain("errors?.length > 0");
   });
+
+  it("applies the shared default muted filter so muted findings are hidden unless the caller opts in", () => {
+    expect(source).toContain("applyDefaultMutedFilter");
+  });
 });

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -16,6 +16,7 @@ import {
 import { ContentLayout } from "@/components/ui";
 import { FilterTransitionWrapper } from "@/contexts";
 import {
+  applyDefaultMutedFilter,
   createScanDetailsMapping,
   extractFiltersAndQuery,
   extractSortAndKey,
@@ -39,14 +40,16 @@ export default async function Findings({
     getScans({ pageSize: 50 }),
   ]);
 
-  const filtersWithScanDates = await resolveFindingScanDateFilters({
-    filters,
-    scans: scansData?.data || [],
-    loadScan: async (scanId: string) => {
-      const response = await getScan(scanId);
-      return response?.data;
-    },
-  });
+  const filtersWithScanDates = applyDefaultMutedFilter(
+    await resolveFindingScanDateFilters({
+      filters,
+      scans: scansData?.data || [],
+      loadScan: async (scanId: string) => {
+        const response = await getScan(scanId);
+        return response?.data;
+      },
+    }),
+  );
 
   const hasHistoricalData = hasDateOrScanFilter(filtersWithScanDates);
 

--- a/ui/hooks/use-finding-group-resource-state.test.ts
+++ b/ui/hooks/use-finding-group-resource-state.test.ts
@@ -12,4 +12,9 @@ describe("useFindingGroupResourceState", () => {
   it("enables muted findings only for the finding-group resource drawer", () => {
     expect(source).toContain("includeMutedInOtherFindings: true");
   });
+
+  it("applies the shared default muted filter before fetching group resources", () => {
+    expect(source).toContain("applyDefaultMutedFilter(filters)");
+    expect(source).toContain("filters: effectiveFilters");
+  });
 });

--- a/ui/hooks/use-finding-group-resource-state.ts
+++ b/ui/hooks/use-finding-group-resource-state.ts
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { canMuteFindingResource } from "@/components/findings/table/finding-resource-selection";
 import { useResourceDetailDrawer } from "@/components/findings/table/resource-detail-drawer";
 import { useFindingGroupResources } from "@/hooks/use-finding-group-resources";
+import { applyDefaultMutedFilter } from "@/lib";
 import { FindingGroupRow, FindingResourceRow } from "@/types";
 
 interface UseFindingGroupResourceStateOptions {
@@ -67,11 +68,13 @@ export function useFindingGroupResourceState({
     setIsLoading(loading);
   };
 
+  const effectiveFilters = applyDefaultMutedFilter(filters);
+
   const { sentinelRef, refresh, loadMore, totalCount } =
     useFindingGroupResources({
       checkId: group.checkId,
       hasDateOrScanFilter: hasHistoricalData,
-      filters,
+      filters: effectiveFilters,
       onSetResources: handleSetResources,
       onAppendResources: handleAppendResources,
       onSetLoading: handleSetLoading,

--- a/ui/lib/findings-filters.test.ts
+++ b/ui/lib/findings-filters.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { applyDefaultMutedFilter, MUTED_FILTER } from "./findings-filters";
+
+describe("applyDefaultMutedFilter", () => {
+  it("injects filter[muted]=false when the caller has not set it", () => {
+    const input: Record<string, string> = { "filter[status__in]": "FAIL" };
+    const result = applyDefaultMutedFilter(input);
+
+    expect(result["filter[muted]"]).toBe(MUTED_FILTER.EXCLUDE);
+    expect(result["filter[status__in]"]).toBe("FAIL");
+  });
+
+  it("preserves an explicit filter[muted]=include opt-in from the checkbox", () => {
+    const result = applyDefaultMutedFilter({
+      "filter[muted]": MUTED_FILTER.INCLUDE,
+    });
+
+    expect(result["filter[muted]"]).toBe(MUTED_FILTER.INCLUDE);
+  });
+
+  it("preserves an explicit filter[muted]=false (no silent overwrite)", () => {
+    const result = applyDefaultMutedFilter({
+      "filter[muted]": MUTED_FILTER.EXCLUDE,
+    });
+
+    expect(result["filter[muted]"]).toBe(MUTED_FILTER.EXCLUDE);
+  });
+
+  it("does not mutate the input object", () => {
+    const input = { "filter[status__in]": "FAIL" };
+    applyDefaultMutedFilter(input);
+
+    expect(input).not.toHaveProperty("filter[muted]");
+  });
+
+  it("returns a default-filled object when called with no caller filters", () => {
+    const result = applyDefaultMutedFilter({} as Record<string, string>);
+
+    expect(result["filter[muted]"]).toBe(MUTED_FILTER.EXCLUDE);
+  });
+});

--- a/ui/lib/findings-filters.ts
+++ b/ui/lib/findings-filters.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helpers for findings filter handling.
+ *
+ * The `/findings` SSR page and the finding-group resource drill-down both
+ * need to hide muted findings by default — unless the user has opted in via
+ * the "include muted findings" checkbox. Keeping that default in one place
+ * prevents surfaces from drifting.
+ */
+
+export const MUTED_FILTER = {
+  /** Wire value sent to the API to exclude muted findings. */
+  EXCLUDE: "false",
+  /**
+   * Sentinel value that tells the API to return both muted and non-muted
+   * findings. The checkbox writes this to the URL when the user opts in.
+   */
+  INCLUDE: "include",
+} as const;
+
+export type MutedFilterValue = (typeof MUTED_FILTER)[keyof typeof MUTED_FILTER];
+
+/**
+ * Returns a new filter object with the default muted behaviour applied:
+ * hide muted findings unless the caller already set `filter[muted]`.
+ *
+ * The default is spread BEFORE the caller filters so any explicit value
+ * (including `"false"` or the `"include"` opt-in) wins.
+ */
+export function applyDefaultMutedFilter<
+  T extends Record<string, string | string[] | undefined>,
+>(filters: T): T {
+  return {
+    "filter[muted]": MUTED_FILTER.EXCLUDE,
+    ...filters,
+  };
+}

--- a/ui/lib/index.ts
+++ b/ui/lib/index.ts
@@ -1,5 +1,6 @@
 export * from "./error-mappings";
 export * from "./external-urls";
+export * from "./findings-filters";
 export * from "./helper";
 export * from "./helper-filters";
 export * from "./menu-list";


### PR DESCRIPTION
### Context

The \"include muted findings\" checkbox default was enforced inline on the findings SSR page but not on the finding-group resource drill-down, so a user without the toggle could still see muted findings when expanding a group. This PR centralizes the default behind a shared helper and wires both surfaces through it.

This is the minimal standalone fix for the muted-filter regression. The broader filter/sort refactor (shared `composeSort`, `splitCsvFilterValues`, overview widgets migration, etc.) remains in #10803.

### Description

- Add `ui/lib/findings-filters.ts` with `MUTED_FILTER` (const object) and `applyDefaultMutedFilter<T>(filters: T): T`. The helper spreads `filter[muted]=false` BEFORE the caller filters so any explicit value (`"false"` or the `\"include\"` opt-in from the checkbox) wins and never gets silently overwritten.
- Export the helper from `ui/lib/index.ts`.
- Wire `applyDefaultMutedFilter` into `ui/app/(prowler)/findings/page.tsx` by wrapping the result of `resolveFindingScanDateFilters` so metadata, fetch, and table all receive the same defaulted filters.
- Wire `applyDefaultMutedFilter` into `ui/hooks/use-finding-group-resource-state.ts` via a derived `effectiveFilters` const passed to `useFindingGroupResources`, so the drill-down honors the same default as the top-level page.
- Add unit tests for the helper (default injection, opt-in preserved, explicit `\"false\"` preserved, no input mutation, empty input).
- Extend source-level assertions in `page.test.ts` and `use-finding-group-resource-state.test.ts` to lock in the wiring.
- Add a changelog entry under `[1.25.0]` → `🐞 Fixed` in `ui/CHANGELOG.md`.

### Steps to review

1. Read `ui/lib/findings-filters.ts` and `ui/lib/findings-filters.test.ts` to confirm the spread order (default first, caller last) guarantees opt-in wins.
2. In `ui/app/(prowler)/findings/page.tsx`, verify that `filtersWithScanDates` is now the result of `applyDefaultMutedFilter(await resolveFindingScanDateFilters(...))` so every downstream consumer (metadata info, fetch finding groups, client table) receives the defaulted value.
3. In `ui/hooks/use-finding-group-resource-state.ts`, verify that `effectiveFilters = applyDefaultMutedFilter(filters)` is derived once and passed to `useFindingGroupResources`. The hardcoded `includeMutedInOtherFindings: true` for the drawer is intentionally unchanged (pre-existing behavior for the \"Other Findings for this resource\" tab).
4. Load `/findings` locally without the muted checkbox toggled: confirm no muted rows appear in either the top-level list or inside any expanded group.
5. Toggle the \"include muted findings\" checkbox and confirm muted rows appear in both surfaces.
6. Run \`pnpm --filter ui exec vitest run lib/findings-filters.test.ts hooks/use-finding-group-resource-state.test.ts 'app/(prowler)/findings/page.test.ts'\` — 12 tests across 3 files should pass.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.