### PR TITLE
fix(api): reaggregate overview summaries after muting findings

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🐞 Fixed
 
 - Finding groups aggregated `status` now treats muted findings as resolved: a group is `FAIL` only while at least one non-muted FAIL remains, otherwise it is `PASS` (including fully-muted groups). The `filter[status]` filter and the `sort=status` ordering share the same semantics, keeping `status` consistent with `fail_count` and the orthogonal `muted` flag [(#10825)](https://github.com/prowler-cloud/prowler/pull/10825)
+- `/overviews/findings`, `/overviews/findings-severity` and `/overviews/services` now reflect newly-muted findings without waiting for the next scan. The post-mute `reaggregate-all-finding-group-summaries` task was extended to re-run the same per-scan pipeline that scan completion runs (`ScanSummary`, `DailySeveritySummary`, `FindingGroupDailySummary`) on the latest scan of every `(provider, day)` pair, keeping the pre-aggregated tables in sync with `Finding.muted` updates [(#10827)](https://github.com/prowler-cloud/prowler/pull/10827)
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ## [1.25.3] (Prowler v5.24.3)
 
+### 🚀 Added
+
+- `/overviews/findings`, `/overviews/findings-severity` and `/overviews/services` now reflect newly-muted findings without waiting for the next scan. The post-mute `reaggregate-all-finding-group-summaries` task was extended to re-run the same per-scan pipeline that scan completion runs (`ScanSummary`, `DailySeveritySummary`, `FindingGroupDailySummary`) on the latest scan of every `(provider, day)` pair, keeping the pre-aggregated tables in sync with `Finding.muted` updates [(#10827)](https://github.com/prowler-cloud/prowler/pull/10827)
+
 ### 🐞 Fixed
 
 - Finding groups aggregated `status` now treats muted findings as resolved: a group is `FAIL` only while at least one non-muted FAIL remains, otherwise it is `PASS` (including fully-muted groups). The `filter[status]` filter and the `sort=status` ordering share the same semantics, keeping `status` consistent with `fail_count` and the orthogonal `muted` flag [(#10825)](https://github.com/prowler-cloud/prowler/pull/10825)
-- `/overviews/findings`, `/overviews/findings-severity` and `/overviews/services` now reflect newly-muted findings without waiting for the next scan. The post-mute `reaggregate-all-finding-group-summaries` task was extended to re-run the same per-scan pipeline that scan completion runs (`ScanSummary`, `DailySeveritySummary`, `FindingGroupDailySummary`) on the latest scan of every `(provider, day)` pair, keeping the pre-aggregated tables in sync with `Finding.muted` updates [(#10827)](https://github.com/prowler-cloud/prowler/pull/10827)
+- `aggregate_findings` is now idempotent: it deletes the scan's existing `ScanSummary` rows before `bulk_create`, so re-runs (such as the post-mute reaggregation pipeline) no longer violate the `unique_scan_summary` constraint and no longer abort the downstream `DailySeveritySummary` / `FindingGroupDailySummary` recomputation for the affected scan [(#10827)](https://github.com/prowler-cloud/prowler/pull/10827)
 
 ---
 

--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -1198,6 +1198,9 @@ def aggregate_findings(tenant_id: str, scan_id: str):
             )
             for agg in aggregation
         }
+        # Delete first so re-runs (e.g. post-mute reaggregation) don't hit
+        # the `unique_scan_summary` constraint.
+        ScanSummary.objects.filter(tenant_id=tenant_id, scan_id=scan_id).delete()
         ScanSummary.objects.bulk_create(scan_aggregations, batch_size=3000)
 
 

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -771,15 +771,22 @@ def aggregate_finding_group_summaries_task(tenant_id: str, scan_id: str):
 )
 @set_tenant(keep_tenant=True)
 def reaggregate_all_finding_group_summaries_task(tenant_id: str):
-    """Reaggregate finding group summaries for every (provider, day) combination.
+    """Reaggregate every pre-aggregated summary table for this tenant.
 
     Mirrors the unbounded scope of `mute_historical_findings_task`: that task
     rewrites every Finding row whose UID matches a mute rule, with no time
-    limit. To keep the daily summaries consistent with that update, this task
-    re-runs the aggregator on the latest completed scan of every (provider,
-    day) pair that exists in the database. Tasks are dispatched in parallel
-    via a Celery group so the wallclock scales with the worker pool, not with
-    the number of pairs.
+    limit. To keep the pre-aggregated tables consistent with that update,
+    this task re-runs the same per-scan aggregation pipeline that scan
+    completion runs on the latest completed scan of every (provider, day)
+    pair, rebuilding the three tables that power the read endpoints:
+
+      - `ScanSummary` and `DailySeveritySummary` -> `/overviews/findings`,
+        `/overviews/findings-severity`, `/overviews/services`.
+      - `FindingGroupDailySummary` -> `/finding-groups` and
+        `/finding-groups/latest`.
+
+    Per-scan pipelines are dispatched in parallel via a Celery group so
+    wallclock scales with the worker pool.
     """
     completed_scans = list(
         Scan.objects.filter(
@@ -804,12 +811,23 @@ def reaggregate_all_finding_group_summaries_task(tenant_id: str):
     scan_ids = list(latest_scans.values())
     if scan_ids:
         logger.info(
-            "Reaggregating finding group summaries for %d scans (provider x day)",
+            "Reaggregating overview summaries for %d scans (provider x day)",
             len(scan_ids),
         )
+        # DailySeveritySummary reads from ScanSummary, so ScanSummary must be
+        # recomputed first; FindingGroupDailySummary reads from Finding
+        # directly and can run in parallel with the severity step.
         group(
-            aggregate_finding_group_summaries_task.si(
-                tenant_id=tenant_id, scan_id=scan_id
+            chain(
+                perform_scan_summary_task.si(tenant_id=tenant_id, scan_id=scan_id),
+                group(
+                    aggregate_daily_severity_task.si(
+                        tenant_id=tenant_id, scan_id=scan_id
+                    ),
+                    aggregate_finding_group_summaries_task.si(
+                        tenant_id=tenant_id, scan_id=scan_id
+                    ),
+                ),
             )
             for scan_id in scan_ids
         ).apply_async()

--- a/api/src/backend/tasks/tasks.py
+++ b/api/src/backend/tasks/tasks.py
@@ -811,7 +811,7 @@ def reaggregate_all_finding_group_summaries_task(tenant_id: str):
     scan_ids = list(latest_scans.values())
     if scan_ids:
         logger.info(
-            "Reaggregating overview summaries for %d scans (provider x day)",
+            "Reaggregating overview/finding summaries for %d scans (provider x day)",
             len(scan_ids),
         )
         # DailySeveritySummary reads from ScanSummary, so ScanSummary must be

--- a/api/src/backend/tasks/tests/test_scan.py
+++ b/api/src/backend/tasks/tests/test_scan.py
@@ -36,6 +36,7 @@ from api.models import (
     Provider,
     Resource,
     Scan,
+    ScanSummary,
     StateChoices,
     StatusChoices,
 )
@@ -3357,6 +3358,64 @@ class TestAggregateFindings:
 
         regions = {s.region for s in summaries}
         assert regions == {"us-east-1", "us-west-2"}
+
+    def test_aggregate_findings_is_idempotent_on_rerun(
+        self,
+        tenants_fixture,
+        scans_fixture,
+        findings_fixture,
+    ):
+        """Re-running `aggregate_findings` for the same scan must not violate
+        the `unique_scan_summary` constraint, and the resulting row set for
+        the scan must match the single-run output. This is exercised by the
+        post-mute reaggregation pipeline, which re-dispatches
+        `perform_scan_summary_task` against scans whose summaries already
+        exist."""
+        tenant = tenants_fixture[0]
+        scan = scans_fixture[0]
+
+        aggregate_findings(str(tenant.id), str(scan.id))
+        first_run_ids = set(
+            ScanSummary.all_objects.filter(
+                tenant_id=tenant.id, scan_id=scan.id
+            ).values_list("id", flat=True)
+        )
+        first_run_rows = list(
+            ScanSummary.all_objects.filter(tenant_id=tenant.id, scan_id=scan.id).values(
+                "check_id",
+                "service",
+                "severity",
+                "region",
+                "fail",
+                "_pass",
+                "muted",
+                "total",
+            )
+        )
+
+        # Second invocation must not raise and must replace the rows without
+        # leaving duplicates behind.
+        aggregate_findings(str(tenant.id), str(scan.id))
+        second_run_ids = set(
+            ScanSummary.all_objects.filter(
+                tenant_id=tenant.id, scan_id=scan.id
+            ).values_list("id", flat=True)
+        )
+        second_run_rows = list(
+            ScanSummary.all_objects.filter(tenant_id=tenant.id, scan_id=scan.id).values(
+                "check_id",
+                "service",
+                "severity",
+                "region",
+                "fail",
+                "_pass",
+                "muted",
+                "total",
+            )
+        )
+
+        assert second_run_rows == first_run_rows
+        assert first_run_ids.isdisjoint(second_run_ids)
 
 
 @pytest.mark.django_db

--- a/api/src/backend/tasks/tests/test_tasks.py
+++ b/api/src/backend/tasks/tests/test_tasks.py
@@ -2359,11 +2359,20 @@ class TestReaggregateAllFindingGroupSummaries:
     def setup_method(self):
         self.tenant_id = str(uuid.uuid4())
 
+    @patch("tasks.tasks.chain")
     @patch("tasks.tasks.group")
     @patch("tasks.tasks.aggregate_finding_group_summaries_task")
+    @patch("tasks.tasks.aggregate_daily_severity_task")
+    @patch("tasks.tasks.perform_scan_summary_task")
     @patch("tasks.tasks.Scan.objects.filter")
     def test_dispatches_subtasks_for_each_provider_per_day(
-        self, mock_scan_filter, mock_agg_task, mock_group
+        self,
+        mock_scan_filter,
+        mock_scan_summary_task,
+        mock_daily_severity_task,
+        mock_finding_group_task,
+        mock_group,
+        mock_chain,
     ):
         provider_id_1 = uuid.uuid4()
         provider_id_2 = uuid.uuid4()
@@ -2373,8 +2382,13 @@ class TestReaggregateAllFindingGroupSummaries:
         today = datetime.now(tz=timezone.utc)
         yesterday = today - timedelta(days=1)
 
-        mock_group_result = MagicMock()
-        mock_group.side_effect = lambda gen: (list(gen), mock_group_result)[1]
+        mock_outer_group_result = MagicMock()
+        # The first `group()` call wraps the inner (severity, finding-group)
+        # parallel step; subsequent calls wrap the outer per-scan generator.
+        mock_group.side_effect = lambda *args, **kwargs: (
+            list(args[0]) if args and hasattr(args[0], "__iter__") else None,
+            mock_outer_group_result,
+        )[1]
 
         mock_scan_filter.return_value.order_by.return_value.values.return_value = [
             {
@@ -2397,23 +2411,40 @@ class TestReaggregateAllFindingGroupSummaries:
         result = reaggregate_all_finding_group_summaries_task(tenant_id=self.tenant_id)
 
         assert result == {"scans_reaggregated": 3}
-        assert mock_agg_task.si.call_count == 3
-        mock_agg_task.si.assert_any_call(
-            tenant_id=self.tenant_id, scan_id=str(scan_id_today_p1)
-        )
-        mock_agg_task.si.assert_any_call(
-            tenant_id=self.tenant_id, scan_id=str(scan_id_today_p2)
-        )
-        mock_agg_task.si.assert_any_call(
-            tenant_id=self.tenant_id, scan_id=str(scan_id_yesterday_p1)
-        )
-        mock_group_result.apply_async.assert_called_once()
+        expected_scan_ids = {
+            str(scan_id_today_p1),
+            str(scan_id_today_p2),
+            str(scan_id_yesterday_p1),
+        }
+        for task_mock in (
+            mock_scan_summary_task,
+            mock_daily_severity_task,
+            mock_finding_group_task,
+        ):
+            assert task_mock.si.call_count == 3
+            dispatched = {
+                call.kwargs["scan_id"] for call in task_mock.si.call_args_list
+            }
+            assert dispatched == expected_scan_ids
+            for call in task_mock.si.call_args_list:
+                assert call.kwargs["tenant_id"] == self.tenant_id
+        assert mock_chain.call_count == 3
+        mock_outer_group_result.apply_async.assert_called_once()
 
+    @patch("tasks.tasks.chain")
     @patch("tasks.tasks.group")
     @patch("tasks.tasks.aggregate_finding_group_summaries_task")
+    @patch("tasks.tasks.aggregate_daily_severity_task")
+    @patch("tasks.tasks.perform_scan_summary_task")
     @patch("tasks.tasks.Scan.objects.filter")
     def test_dedupes_scans_to_latest_per_provider_per_day(
-        self, mock_scan_filter, mock_agg_task, mock_group
+        self,
+        mock_scan_filter,
+        mock_scan_summary_task,
+        mock_daily_severity_task,
+        mock_finding_group_task,
+        mock_group,
+        mock_chain,
     ):
         """When several scans run on the same day for the same provider, only
         the latest one is dispatched (matching the daily summary unique key)."""
@@ -2423,8 +2454,11 @@ class TestReaggregateAllFindingGroupSummaries:
         today_late = datetime.now(tz=timezone.utc)
         today_early = today_late - timedelta(hours=4)
 
-        mock_group_result = MagicMock()
-        mock_group.side_effect = lambda gen: (list(gen), mock_group_result)[1]
+        mock_outer_group_result = MagicMock()
+        mock_group.side_effect = lambda *args, **kwargs: (
+            list(args[0]) if args and hasattr(args[0], "__iter__") else None,
+            mock_outer_group_result,
+        )[1]
 
         # Returned ordered by `-completed_at`, so the most recent comes first.
         mock_scan_filter.return_value.order_by.return_value.values.return_value = [
@@ -2443,17 +2477,27 @@ class TestReaggregateAllFindingGroupSummaries:
         result = reaggregate_all_finding_group_summaries_task(tenant_id=self.tenant_id)
 
         assert result == {"scans_reaggregated": 1}
-        mock_agg_task.si.assert_called_once_with(
-            tenant_id=self.tenant_id, scan_id=str(latest_scan_today)
-        )
-        mock_group_result.apply_async.assert_called_once()
+        for task_mock in (
+            mock_scan_summary_task,
+            mock_daily_severity_task,
+            mock_finding_group_task,
+        ):
+            task_mock.si.assert_called_once_with(
+                tenant_id=self.tenant_id, scan_id=str(latest_scan_today)
+            )
+        mock_chain.assert_called_once()
+        mock_outer_group_result.apply_async.assert_called_once()
 
+    @patch("tasks.tasks.chain")
     @patch("tasks.tasks.group")
     @patch("tasks.tasks.Scan.objects.filter")
-    def test_no_completed_scans_skips_dispatch(self, mock_scan_filter, mock_group):
+    def test_no_completed_scans_skips_dispatch(
+        self, mock_scan_filter, mock_group, mock_chain
+    ):
         mock_scan_filter.return_value.order_by.return_value.values.return_value = []
 
         result = reaggregate_all_finding_group_summaries_task(tenant_id=self.tenant_id)
 
         assert result == {"scans_reaggregated": 0}
         mock_group.assert_not_called()
+        mock_chain.assert_not_called()


### PR DESCRIPTION
### Context

After creating a mute rule, `/finding-groups` already reflected the newly-muted findings, but the Overview endpoints (`/overviews/findings`, `/overviews/findings-severity`, `/overviews/services`) kept showing the pre-mute totals. Those endpoints read from the pre-aggregated `ScanSummary` / `DailySeveritySummary` tables, which were not being recomputed after `mute_historical_findings_task` updated `Finding.muted`. `reaggregate_all_finding_group_summaries_task` only re-ran the finding-group aggregator, leaving the rest of the summaries stale until the next scan completed.

### Description

Extend `reaggregate_all_finding_group_summaries_task` (already chained after `mute_historical_findings_task` in `MuteRuleViewSet.create`) to re-run the same per-scan pipeline that the scan-completion flow executes, on the latest completed scan per `(provider, day)` pair:

```python
chain(
    perform_scan_summary_task.si(...),        # rebuilds ScanSummary
    group(
        aggregate_daily_severity_task.si(...),            # rebuilds DailySeveritySummary
        aggregate_finding_group_summaries_task.si(...),   # rebuilds FindingGroupDailySummary
    ),
)
```

- `DailySeveritySummary` depends on `ScanSummary`, so the inner pipeline is a chain with a parallel fan-out for the two leaf aggregators.
- Per-scan pipelines are still dispatched through an outer Celery `group` so wall-clock scales with the worker pool.
- Celery task name is intentionally preserved (`reaggregate-all-finding-group-summaries`) so tasks already enqueued during a deploy keep resolving. Docstring and log message updated to describe the broader scope.

Unit tests for the task were updated to assert that all three sub-tasks (`perform_scan_summary_task`, `aggregate_daily_severity_task`, `aggregate_finding_group_summaries_task`) are dispatched for each de-duplicated `(provider, day)` scan.

### Steps to review

1. Run a scan that produces several FAIL findings for a provider.
2. `GET /api/v1/overviews/findings` and note `fail` / `muted` totals.
3. `POST /api/v1/mute-rules` selecting some of those finding IDs.
4. Wait for the Celery `overview` queue to drain (or `docker compose logs worker | grep reaggregate`).
5. `GET /api/v1/overviews/findings` again → `muted` should increase and `fail` decrease by the same amount.
6. `GET /api/v1/overviews/findings-severity` and `/api/v1/overviews/services` → severity / service buckets should reflect the mute.
7. `GET /api/v1/finding-groups` → `fail_count` / `muted_count` for affected groups should continue to reflect the mute (unchanged behavior).

Automated:

```bash
cd api && poetry run pytest src/backend/tasks/tests/test_tasks.py::TestReaggregateAllFindingGroupSummaries -x
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.