### PR TITLE
chore: remove legacy ui-checks hook from root pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,12 +138,3 @@ repos:
         entry: bash -c 'vulture --exclude "contrib,.venv,api/src/backend/api/tests/,api/src/backend/conftest.py,api/src/backend/tasks/tests/,skills/" --min-confidence 100 .'
         language: system
         files: '.*\.py'
-
-      - id: ui-checks
-        name: UI - Husky Pre-commit
-        description: "Run UI pre-commit checks (Claude Code validation + healthcheck)"
-        entry: bash -c 'cd ui && .husky/pre-commit'
-        language: system
-        files: '^ui/.*\.(ts|tsx|js|jsx|json|css)$'
-        pass_filenames: false
-        verbose: true


### PR DESCRIPTION
## Context

The root `.pre-commit-config.yaml` contained a `ui-checks` hook that shelled into `ui/.husky/pre-commit` to run UI validation. This was a transitional shim from the Husky-based setup.

## Description

Remove the legacy `ui-checks` block from `.pre-commit-config.yaml`.

UI checks have since been migrated to prek and are declared natively in `ui/.pre-commit-config.yaml` (typecheck, lint, tests, build). Keeping the root shim would:

- Duplicate execution of UI checks.
- Re-enter the now-unused Husky hook path.
- Couple the root pre-commit run to `ui/.husky/pre-commit`, which is no longer the source of truth.

Removing the block leaves prek as the single entry point for UI pre-commit checks.

## Steps to review

- Confirm `ui/.pre-commit-config.yaml` already covers typecheck, lint, tests and build.
- Verify the removed hook is not referenced elsewhere in the repo.

## Checklist

- [x] No functional code changes
- [x] UI checks still run via `ui/.pre-commit-config.yaml`