### PR TITLE
fix(ci): improve compliance check action

### DIFF
--- a/.github/workflows/pr-check-compliance-mapping.yml
+++ b/.github/workflows/pr-check-compliance-mapping.yml
@@ -20,7 +20,13 @@ permissions: {}
 
 jobs:
   check-compliance-mapping:
-    if: contains(github.event.pull_request.labels.*.name, 'no-compliance-check') == false
+    if: >-
+      github.event.pull_request.state == 'open' &&
+      contains(github.event.pull_request.labels.*.name, 'no-compliance-check') == false &&
+      (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled')
+        || github.event.label.name == 'no-compliance-check'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
### Description

- Scope the `pr-check-compliance-mapping` workflow to only run on PRs that are still `open`, so re-triggers on already-merged PRs (e.g. Dependabot PRs that receive `was-backported` after merge) don't spam false positives.
- Restrict `labeled`/`unlabeled` events to only fire the job when the label being added/removed is `no-compliance-check`. Other labels have no effect on the mapping and should not cause a recomputation.

## Context

On PR #10365 (a merged Dependabot `pyasn1` bump touching only `poetry.lock`), the action posted a comment listing 34 "new unmapped checks" that had nothing to do with the PR. Root cause:

1. The PR was labeled with `was-backported` after merge, triggering the `labeled` event.
2. `tj-actions/changed-files` could not locate the PR's original `base.sha` (`5a501b38…`) in the fetched history and logged `Unable to locate the commit sha`.
3. It fell back to diffing `origin/master` HEAD against the PR branch HEAD. Because the PR branch was behind master, every metadata/compliance file merged after #10365 appeared as "added", producing the bogus comment.

With this fix, the workflow won't re-run on merged PRs, and incidental label changes won't trigger recomputation.


### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
