### PR TITLE
fix(ui): prevent rescheduling scans during credential update

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Allows tenant owners to expel users from their organizations  [(#10787)](https://github.com/prowler-cloud/prowler/pull/10787)
 
+### 🐞 Fixed
+
+- Provider wizard no longer advances to the Launch Scan step when rotating credentials: the modal closes after a successful connection test, preventing inadvertent scan rescheduling during credential updates [(#10851)](https://github.com/prowler-cloud/prowler/pull/10851)
+
 ### ❌ Removed
 
 - Redesign compliance page with a horizontal ThreatScore card (always-visible pillar breakdown + ActionDropdown), client-side search for compliance frameworks, compact scan selector trigger, responsive mobile filters, download-started toasts for CSV/PDF exports, enhanced compliance cards with truncated titles, and Alert-based empty/error states; migrate Progress component from HeroUI to shadcn [(#10767)](https://github.com/prowler-cloud/prowler/pull/10767)

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx
@@ -153,7 +153,7 @@ describe("useProviderWizardController", () => {
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it("moves to launch step after a successful connection test in update mode", async () => {
+  it("closes the wizard after a successful connection test in update mode", async () => {
     // Given
     const onOpenChange = vi.fn();
     const { result } = renderHook(() =>
@@ -181,9 +181,10 @@ describe("useProviderWizardController", () => {
       result.current.handleTestSuccess();
     });
 
-    // Then
-    expect(result.current.currentStep).toBe(PROVIDER_WIZARD_STEP.LAUNCH);
-    expect(onOpenChange).not.toHaveBeenCalled();
+    // Then: credential rotation never surfaces the launch/schedule step
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(result.current.currentStep).not.toBe(PROVIDER_WIZARD_STEP.LAUNCH);
   });
 
   it("does not override launch footer config in the controller", () => {

--- a/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
+++ b/ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts
@@ -197,6 +197,12 @@ export function useProviderWizardController({
   };
 
   const handleTestSuccess = () => {
+    if (
+      useProviderWizardStore.getState().mode === PROVIDER_WIZARD_MODE.UPDATE
+    ) {
+      handleClose();
+      return;
+    }
     setCurrentStep(PROVIDER_WIZARD_STEP.LAUNCH);
   };
 
@@ -234,6 +240,7 @@ export function useProviderWizardController({
     handleTestSuccess,
     isOrgDirectEntry,
     isProviderFlow,
+    mode,
     modalTitle,
     openOrganizationsFlow,
     orgCurrentStep,

--- a/ui/components/providers/wizard/provider-wizard-modal.tsx
+++ b/ui/components/providers/wizard/provider-wizard-modal.tsx
@@ -28,7 +28,10 @@ import { TestConnectionStep } from "./steps/test-connection-step";
 import type { OrgWizardInitialData, ProviderWizardInitialData } from "./types";
 import { PROVIDER_WIZARD_STEPS, WizardStepper } from "./wizard-stepper";
 
-const UPDATE_MODE_WIZARD_STEPS = PROVIDER_WIZARD_STEPS.slice(0, 3);
+const UPDATE_MODE_WIZARD_STEPS = PROVIDER_WIZARD_STEPS.slice(
+  0,
+  PROVIDER_WIZARD_STEP.LAUNCH,
+);
 
 interface ProviderWizardModalProps {
   open: boolean;

--- a/ui/components/providers/wizard/provider-wizard-modal.tsx
+++ b/ui/components/providers/wizard/provider-wizard-modal.tsx
@@ -10,7 +10,10 @@ import { DialogHeader, DialogTitle } from "@/components/shadcn/dialog";
 import { Modal } from "@/components/shadcn/modal";
 import { useScrollHint } from "@/hooks/use-scroll-hint";
 import { ORG_SETUP_PHASE, ORG_WIZARD_STEP } from "@/types/organizations";
-import { PROVIDER_WIZARD_STEP } from "@/types/provider-wizard";
+import {
+  PROVIDER_WIZARD_MODE,
+  PROVIDER_WIZARD_STEP,
+} from "@/types/provider-wizard";
 
 import { useProviderWizardController } from "./hooks/use-provider-wizard-controller";
 import {
@@ -23,7 +26,9 @@ import { WIZARD_FOOTER_ACTION_TYPE } from "./steps/footer-controls";
 import { LaunchStep } from "./steps/launch-step";
 import { TestConnectionStep } from "./steps/test-connection-step";
 import type { OrgWizardInitialData, ProviderWizardInitialData } from "./types";
-import { WizardStepper } from "./wizard-stepper";
+import { PROVIDER_WIZARD_STEPS, WizardStepper } from "./wizard-stepper";
+
+const UPDATE_MODE_WIZARD_STEPS = PROVIDER_WIZARD_STEPS.slice(0, 3);
 
 interface ProviderWizardModalProps {
   open: boolean;
@@ -47,6 +52,7 @@ export function ProviderWizardModal({
     handleTestSuccess,
     isOrgDirectEntry,
     isProviderFlow,
+    mode,
     modalTitle,
     openOrganizationsFlow,
     orgCurrentStep,
@@ -97,7 +103,14 @@ export function ProviderWizardModal({
       <div className="mt-6 flex min-h-0 flex-1 flex-col overflow-hidden lg:mt-8 lg:flex-row">
         <div className="mb-4 box-border w-full shrink-0 lg:mb-0 lg:w-[328px]">
           {isProviderFlow ? (
-            <WizardStepper currentStep={currentStep} />
+            <WizardStepper
+              currentStep={currentStep}
+              steps={
+                mode === PROVIDER_WIZARD_MODE.UPDATE
+                  ? UPDATE_MODE_WIZARD_STEPS
+                  : undefined
+              }
+            />
           ) : (
             <WizardStepper
               currentStep={orgCurrentStep}

--- a/ui/components/providers/wizard/wizard-stepper.tsx
+++ b/ui/components/providers/wizard/wizard-stepper.tsx
@@ -7,15 +7,16 @@ import { ProwlerShort } from "@/components/icons/prowler/ProwlerIcons";
 import { cn } from "@/lib/utils";
 import { IconComponent, IconSvgProps } from "@/types/components";
 
-interface WizardStepperProps {
-  currentStep: number;
-  stepOffset?: number;
-}
-
 interface StepConfig {
   label: string;
   description: string;
   icon: IconComponent;
+}
+
+interface WizardStepperProps {
+  currentStep: number;
+  stepOffset?: number;
+  steps?: StepConfig[];
 }
 
 const STEPS: StepConfig[] = [
@@ -43,18 +44,21 @@ const STEPS: StepConfig[] = [
   },
 ];
 
+export const PROVIDER_WIZARD_STEPS = STEPS;
+
 export function WizardStepper({
   currentStep,
   stepOffset = 0,
+  steps = STEPS,
 }: WizardStepperProps) {
   const activeVisualStep = Math.max(
     0,
-    Math.min(currentStep + stepOffset, STEPS.length - 1),
+    Math.min(currentStep + stepOffset, steps.length - 1),
   );
 
   return (
     <nav aria-label="Wizard progress" className="flex flex-col gap-0">
-      {STEPS.map((step, index) => {
+      {steps.map((step, index) => {
         const isComplete = index < activeVisualStep;
         const isActive = index === activeVisualStep;
         const isInactive = index > activeVisualStep;
@@ -67,7 +71,7 @@ export function WizardStepper({
                 isActive={isActive}
                 icon={step.icon}
               />
-              {index < STEPS.length - 1 && (
+              {index < steps.length - 1 && (
                 <StepConnector isComplete={isComplete} />
               )}
             </div>


### PR DESCRIPTION
### Context

Fix PROWLER-1426.

When updating provider credentials through the Provider Wizard, the UI was incorrectly advancing to the **Launch Scan** step after a successful connection test. This allowed users with no existing schedule to silently create one during a credential rotation, and users with an existing schedule hit a confusing `409 Conflict` from the backend. Scheduling must remain a deliberate, separate action — never a side effect of rotating credentials.

### Description

- `handleTestSuccess` in `use-provider-wizard-controller.ts` now short-circuits in UPDATE mode by calling `handleClose()` (which closes the modal and refreshes the providers list), instead of advancing to the Launch step.
- `WizardStepper` now accepts an optional `steps` prop so UPDATE mode renders only the first 3 steps (hides the misleading "Launch Scan" entry). The existing `STEPS` array remains the single source of truth and is re-exported as `PROVIDER_WIZARD_STEPS`.
- `ProviderWizardModal` reads `mode` from the controller and passes the filtered 3-step list to `WizardStepper` in UPDATE mode.
- The controller unit test that previously codified the buggy behavior (`moves to launch step after a successful connection test in update mode`) is rewritten as `closes the wizard after a successful connection test in update mode` and asserts the correct UX (`onOpenChange(false)` + `router.refresh()` called; current step is not `LAUNCH`).
- **No backend changes.** `api/src/backend/tasks/beat.py` already guards against duplicate schedules with `ConflictException`; that stays as defense in depth.

### Steps to review

1. **Controller change** — `ui/components/providers/wizard/hooks/use-provider-wizard-controller.ts`
   - Confirm `handleTestSuccess` branches on `useProviderWizardStore.getState().mode`. `getState()` is used (instead of the subscribed `mode` closure) so the handler always reads the latest store value at click time.
   - Confirm `mode` is exposed in the controller's return object for the modal to consume.
2. **Stepper change** — `ui/components/providers/wizard/wizard-stepper.tsx`
   - Confirm the new optional `steps` prop defaults to the full `STEPS` array.
   - Confirm the connector-rendering check uses `steps.length - 1` (not the hardcoded `STEPS.length - 1`), so subsets don't grow a trailing connector.
3. **Modal change** — `ui/components/providers/wizard/provider-wizard-modal.tsx`
   - Confirm `UPDATE_MODE_WIZARD_STEPS = PROVIDER_WIZARD_STEPS.slice(0, 3)` is passed only when `mode === PROVIDER_WIZARD_MODE.UPDATE`; otherwise `undefined` lets the stepper fall back to its default (all 4 steps).
4. **Test change** — `ui/components/providers/wizard/hooks/use-provider-wizard-controller.test.tsx`
   - Confirm the renamed test asserts `onOpenChange(false)`, `refreshMock` called once, and `currentStep !== LAUNCH`.
5. **Manual UI QA**
   - **UPDATE on provider without schedule:** open row actions → Update Credentials → Credentials → Test → expect modal to close and providers table to refresh.
   - **UPDATE on provider with existing schedule:** same as above; no 409 reachable from this path.
   - **ADD (regression):** new provider end-to-end still reaches the Launch Scan step and can schedule.
   - **Stepper:** UPDATE shows 3 steps (no "Launch Scan"); ADD shows 4 steps.
6. **Automated checks** (run from `ui/`):
   - `pnpm run healthcheck` — typecheck + lint clean.
   - `pnpm exec vitest run` — 535/535 tests passing, including the rewritten wizard test.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No**

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.