### PR TITLE
chore(ui): reorganize changelog and open 1.24.4 section

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -6,16 +6,17 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🔄 Changed
 
+- Redesign compliance page, client-side search for compliance frameworks, compact scan selector trigger, enhanced compliance cards [(#10767)](https://github.com/prowler-cloud/prowler/pull/10767)
 - Allows tenant owners to expel users from their organizations  [(#10787)](https://github.com/prowler-cloud/prowler/pull/10787)
+- Backward-compatibility middleware redirect from `/sign-up?invitation_token=…` to `/invitation/accept?invitation_token=…`; new invitation emails use `/invitation/accept` directly [(#10797)](https://github.com/prowler-cloud/prowler/pull/10797)
+
+---
+
+## [1.24.4] (Prowler UNRELEASED)
 
 ### 🐞 Fixed
 
-- Provider wizard no longer advances to the Launch Scan step when rotating credentials: the modal closes after a successful connection test, preventing inadvertent scan rescheduling during credential updates [(#10851)](https://github.com/prowler-cloud/prowler/pull/10851)
-
-### ❌ Removed
-
-- Redesign compliance page with a horizontal ThreatScore card (always-visible pillar breakdown + ActionDropdown), client-side search for compliance frameworks, compact scan selector trigger, responsive mobile filters, download-started toasts for CSV/PDF exports, enhanced compliance cards with truncated titles, and Alert-based empty/error states; migrate Progress component from HeroUI to shadcn [(#10767)](https://github.com/prowler-cloud/prowler/pull/10767)
-- Backward-compatibility middleware redirect from `/sign-up?invitation_token=…` to `/invitation/accept?invitation_token=…`; new invitation emails use `/invitation/accept` directly [(#10797)](https://github.com/prowler-cloud/prowler/pull/10797)
+- Provider wizard no longer advances to the Launch Scan step when rotating credentials [(#10851)](https://github.com/prowler-cloud/prowler/pull/10851)
 
 ---
 


### PR DESCRIPTION
### Context

Tidy up the `ui/CHANGELOG.md` UNRELEASED sections:

- Two entries under `1.25.0` → `❌ Removed` (the compliance page redesign #10767 and the invitation-link middleware redirect #10797) were misclassified — both are changes/refactors, not removals. They belong under `🔄 Changed`.
- The credential-rotation wizard fix (#10851) deserves its own patch release line, so it is split out into a new `1.24.4 (Prowler UNRELEASED)` section.

No Jira issue — purely a changelog housekeeping change.

### Description

- Move #10767 and #10797 back under `🔄 Changed` in `[1.25.0] (Prowler UNRELEASED)`, with shorter, cleaner descriptions.
- Delete the now-empty `❌ Removed` block from `1.25.0`.
- Open a new `## [1.24.4] (Prowler UNRELEASED)` with `🐞 Fixed` containing the trimmed #10851 description.
- No code changes; the only file touched is `ui/CHANGELOG.md`.

### Steps to review

1. `git diff master...HEAD -- ui/CHANGELOG.md` — confirm only the UNRELEASED area is touched.
2. Open `ui/CHANGELOG.md` and verify the version order top-to-bottom stays descending: `1.25.0` → `1.24.4` → `1.24.2` → `1.24.1` → `1.24.0`.
3. Confirm each of #10767, #10787, #10797, #10851 appears exactly once and under the correct keepachangelog bucket.
4. This PR is itself a changelog change, so the `no-changelog` label is needed for the `pr-check-changelog` gate to pass.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI _(N/A — docs-only change)_
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.