### PR TITLE
chore(devex): add worktrunk worktree bootstrap config

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,13 @@
+# Prowler worktree automation for worktrunk (wt CLI).
+# Runs automatically on `wt switch --create`.
+
+# Fast, blocking setup — AI skill symlinks + Python version must be ready
+# before dependency install.
+[[pre-start]]
+skills = "./skills/setup.sh --claude"
+python = "poetry env use python3.12"
+
+# Slow step runs in background so `wt switch` returns quickly.
+# Tail logs via `wt config state logs`.
+[post-start]
+deps = "poetry install --with dev"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -7,6 +7,12 @@
 skills = "./skills/setup.sh --claude"
 python = "poetry env use python3.12"
 
+# Reminder runs after earlier pre-start steps so it's the last visible
+# output before `wt switch` returns. Hooks can't mutate the parent shell,
+# so venv activation must be done manually.
+[[pre-start]]
+reminder = "echo '>> Reminder: activate the venv in this shell with: eval $(poetry env activate)'"
+
 # Slow step runs in background so `wt switch` returns quickly.
 # Tail logs via `wt config state logs`.
 [post-start]

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,23 +1,23 @@
 # Prowler worktree automation for worktrunk (wt CLI).
 # Runs automatically on `wt switch --create`.
 
-# Fast, blocking setup — AI skill symlinks + Python version must be ready
-# before dependency install.
+# Block 1: setup + copy env files from primary worktree (all concurrent).
 [[pre-start]]
 skills = "./skills/setup.sh --claude"
 python = "poetry env use python3.12"
-# Copies gitignored files listed in .worktreeinclude from the primary
-# worktree (.envrc, ui/.env.local).
-envs = "wt step copy-ignored"
+envrc = "cp {{ primary_worktree_path }}/.envrc ."
+env_local = "cp {{ primary_worktree_path }}/ui/.env.local ui/.env.local"
 
-# Reminder runs after earlier pre-start steps so it's the last visible
-# output before `wt switch` returns. Hooks can't mutate the parent shell,
-# so venv activation must be done manually.
+# Block 2: install Python deps (requires `poetry env use` from block 1).
+[[pre-start]]
+deps = "poetry install --with dev"
+
+# Block 3: reminder — last visible output before `wt switch` returns.
+# Hooks can't mutate the parent shell, so venv activation is manual.
 [[pre-start]]
 reminder = "echo '>> Reminder: activate the venv in this shell with: eval $(poetry env activate)'"
 
-# Slow steps run concurrently in background so `wt switch` returns quickly.
+# Background: pnpm install runs while you start working.
 # Tail logs via `wt config state logs`.
 [post-start]
-deps = "poetry install --with dev"
 ui = "cd ui && pnpm install"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -6,6 +6,9 @@
 [[pre-start]]
 skills = "./skills/setup.sh --claude"
 python = "poetry env use python3.12"
+# Copies gitignored files listed in .worktreeinclude from the primary
+# worktree (.envrc, ui/.env.local).
+envs = "wt step copy-ignored"
 
 # Reminder runs after earlier pre-start steps so it's the last visible
 # output before `wt switch` returns. Hooks can't mutate the parent shell,

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -13,7 +13,8 @@ python = "poetry env use python3.12"
 [[pre-start]]
 reminder = "echo '>> Reminder: activate the venv in this shell with: eval $(poetry env activate)'"
 
-# Slow step runs in background so `wt switch` returns quickly.
+# Slow steps run concurrently in background so `wt switch` returns quickly.
 # Tail logs via `wt config state logs`.
 [post-start]
 deps = "poetry install --with dev"
+ui = "cd ui && pnpm install"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,11 +2,21 @@
 # Runs automatically on `wt switch --create`.
 
 # Block 1: setup + copy env files from primary worktree (all concurrent).
+#
+# We use explicit `cp` instead of `wt step copy-ignored` because the latter
+# reads `.worktreeinclude` from the SOURCE worktree (the primary, usually on
+# master), so the filter is ignored until `.worktreeinclude` lands on master
+# — without filtering it copies every gitignored file (.venv/, node_modules/,
+# caches, etc.), which is not what we want.
+#
+# Once `.worktreeinclude` is merged to master, drop the `cp` lines and
+# uncomment the copy-ignored hook below.
 [[pre-start]]
 skills = "./skills/setup.sh --claude"
 python = "poetry env use python3.12"
 envrc = "cp {{ primary_worktree_path }}/.envrc ."
 env_local = "cp {{ primary_worktree_path }}/ui/.env.local ui/.env.local"
+# envs = "wt step copy-ignored"
 
 # Block 2: install Python deps (requires `poetry env use` from block 1).
 [[pre-start]]

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,22 +1,12 @@
 # Prowler worktree automation for worktrunk (wt CLI).
 # Runs automatically on `wt switch --create`.
 
-# Block 1: setup + copy env files from primary worktree (all concurrent).
-#
-# We use explicit `cp` instead of `wt step copy-ignored` because the latter
-# reads `.worktreeinclude` from the SOURCE worktree (the primary, usually on
-# master), so the filter is ignored until `.worktreeinclude` lands on master
-# — without filtering it copies every gitignored file (.venv/, node_modules/,
-# caches, etc.), which is not what we want.
-#
-# Once `.worktreeinclude` is merged to master, drop the `cp` lines and
-# uncomment the copy-ignored hook below.
+# Block 1: setup + copy gitignored env files (.envrc, ui/.env.local)
+# from the primary worktree — patterns selected via .worktreeinclude.
 [[pre-start]]
 skills = "./skills/setup.sh --claude"
 python = "poetry env use python3.12"
-envrc = "cp {{ primary_worktree_path }}/.envrc ."
-env_local = "cp {{ primary_worktree_path }}/ui/.env.local ui/.env.local"
-# envs = "wt step copy-ignored"
+envs = "wt step copy-ignored"
 
 # Block 2: install Python deps (requires `poetry env use` from block 1).
 [[pre-start]]

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,0 @@
-.envrc
-ui/.env.local

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.envrc
+ui/.env.local


### PR DESCRIPTION
### Context

Every new Prowler worktree needs the same manual setup: running `./skills/setup.sh --claude`, pinning Poetry to Python 3.12, `poetry install --with dev`, `pnpm install` in `ui/`, and copying `.envrc` + `ui/.env.local` from the primary worktree. This automates the sequence via [worktrunk](https://worktrunk.dev)'s project config so `wt switch --create <branch>` handles everything.

### Description

Adds `.config/wt.toml` and `.worktreeinclude` consumed by the `wt` CLI. On `wt switch --create`:

**Blocking (`pre-start`):**
- `./skills/setup.sh --claude` — AI assistant skill symlinks
- `poetry env use python3.12` — pin Python interpreter
- `wt step copy-ignored` — copies `.envrc` and `ui/.env.local` from the primary worktree (filter via `.worktreeinclude`)
- `poetry install --with dev`
- Prints a reminder to run `eval $(poetry env activate)` in the new shell (hooks can't mutate the parent shell)

**Background (`post-start`):**
- `cd ui && pnpm install`

No effect on contributors who don't use `wt` — the files are only read by worktrunk. Internal dev tooling only, so no CHANGELOG entry needed.

### Steps to review

1. Inspect `.config/wt.toml` and `.worktreeinclude` for intent.
2. After this PR merges to master (so `.worktreeinclude` is present on the source worktree — `wt step copy-ignored` reads its filter from the source), from a worktree on master:
   ```bash
   wt switch -c wadus
   ```
   Approve the hook commands on first run (or pre-approve with `wt hook approvals add`). Expect: `.envrc` + `ui/.env.local` copied, skill symlinks in place, `poetry install` completed, `pnpm install` running in background (logs via `wt config state logs`), activation reminder shown.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? **No**
- [x] Review if the code is being covered by tests. — N/A (config files)
- [x] Review if code is being documented — inline comments in `.config/wt.toml`
- [x] Review if backport is needed. — No
- [x] Review if is needed to change the Readme.md — No
- [x] Ensure new entries are added to CHANGELOG.md, if applicable. — Not applicable (internal tooling)

#### SDK/CLI
- Are there new checks included in this PR? **No**

#### UI (if applicable)
N/A

#### API (if applicable)
N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.