### PR TITLE
fix(ci): allow github.com egress in backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -35,6 +35,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            github.com:443
 
       - name: Check labels
         id: label_check


### PR DESCRIPTION
### Context

The `backport.yml` workflow hardens its runner egress with `step-security/harden-runner` in `egress-policy: block` mode and an explicit allowlist. Until now that list only contained `api.github.com:443`.

`sorenlouv/backport-github-action`, which the workflow invokes, performs a plain `git clone https://github.com/<owner>/<repo>.git` under the hood — i.e. it talks to `github.com:443`, not `api.github.com:443`. For a long time StepSecurity's agent was lenient enough to let that through, so the gap went unnoticed.

On 2026-04-24 StepSecurity tightened the agent's enforcement. The clone now gets blocked by the egress firewall and the action exits with `128`, so every backport job fails. This is currently blocking automatic backports to release branches (e.g. PR #10864 labelled `backport-to-v5.24`).

- Failing run: https://github.com/prowler-cloud/prowler/actions/runs/24878218778/job/72840269134
- Blocked backport PR: https://github.com/prowler-cloud/prowler/pull/10864

### Description

Add `github.com:443` to the Harden Runner `allowed-endpoints` list in `.github/workflows/backport.yml` so it matches what `sorenlouv/backport-github-action` actually does (API calls to `api.github.com` + `git clone` against `github.com`).

One-line diff, no other workflow or action changes.

### Steps to review

1. Open `.github/workflows/backport.yml` and confirm the `Harden Runner` step's `allowed-endpoints` now contains both `api.github.com:443` and `github.com:443`.
2. Cross-check against the failing run linked above: the action's error is `fatal: unable to access 'https://github.com/prowler-cloud/prowler.git/'` from inside the backport step, consistent with `github.com:443` being blocked.
3. After merge, re-run the backport on PR #10864 (or push the `backport-to-v5.24` label again) and confirm the job succeeds end-to-end.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests. _N/A — CI workflow config._
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings _N/A — workflow YAML._
- [ ] Review if backport is needed. _N/A — this IS the backport workflow fix; it lives on `master` and governs future backports._
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) _N/A._
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. _N/A — CI-only change._

#### SDK/CLI
- Are there new checks included in this PR? **No** — CI-only change, no SDK/CLI impact.

#### UI
- [ ] All issue/task requirements work as expected on the UI _N/A._
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) _N/A._
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) _N/A._
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) _N/A._
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. _N/A._

#### API
- [ ] All issue/task requirements work as expected on the API _N/A._
- [ ] Endpoint response output (if applicable) _N/A._
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) _N/A._
- [ ] Performance test results (if applicable) _N/A._
- [ ] Any other relevant evidence of the implementation (if applicable) _N/A._
- [ ] Verify if API specs need to be regenerated. _N/A._
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.). _N/A._
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. _N/A._

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.