### PR TITLE
fix(ci): poetry cache post-step failure on release workflows

### DIFF
--- a/.github/actions/setup-python-poetry/action.yml
+++ b/.github/actions/setup-python-poetry/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Run `poetry lock` during setup. Only enable when a prior step mutates pyproject.toml (e.g. API `@master` VCS rewrite). Default: false.'
     required: false
     default: 'false'
+  enable-cache:
+    description: 'Whether to enable Poetry dependency caching via actions/setup-python'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
@@ -74,7 +78,9 @@ runs:
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
         python-version: ${{ inputs.python-version }}
-        cache: 'poetry'
+        # Disable cache when callers skip dependency install: Poetry 2.3.4 creates
+        # the venv in a path setup-python can't hash, breaking the post-step save-cache.
+        cache: ${{ inputs.enable-cache == 'true' && 'poetry' || '' }}
         cache-dependency-path: ${{ inputs.working-directory }}/poetry.lock
 
     - name: Install Python dependencies

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -45,6 +45,7 @@ jobs:
       with:
         python-version: '3.12'
         install-dependencies: 'false'
+        enable-cache: 'false'
 
     - name: Configure Git
       run: |

--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           install-dependencies: 'false'
+          enable-cache: 'false'
 
       - name: Inject poetry-bumpversion plugin
         run: pipx inject poetry poetry-bumpversion

--- a/.github/workflows/sdk-pypi-release.yml
+++ b/.github/workflows/sdk-pypi-release.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           install-dependencies: 'false'
+          enable-cache: 'false'
 
       - name: Build Prowler package
         run: poetry build
@@ -116,6 +117,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           install-dependencies: 'false'
+          enable-cache: 'false'
 
       - name: Install toml package
         run: pip install toml


### PR DESCRIPTION
### Context

`prepare-release.yml` has been failing on every release since 5.24.2 (2026-04-14) with:

```
##[error]Index was out of range. Must be non-negative and less than the size of the collection.
```

in the post-step of `actions/setup-python@v6` (save-cache). The release draft is still created, but the job is marked red.

Root cause is the combination of:

- The recent Poetry bump from 2.1.1 to 2.3.4 (#10868), which changes the virtualenv path layout.
- Known upstream issue [actions/setup-python#984](https://github.com/actions/setup-python/issues/984): when `cache: 'poetry'` is set but the venv layout is not what setup-python expects, the post-step save-cache throws.

Evidence: failing run https://github.com/prowler-cloud/prowler/actions/runs/24782286133 (5.24.3 release).

### Description

The `setup-python-poetry` composite always set `cache: 'poetry'`. Three callers pass `install-dependencies: 'false'` — they only need Poetry itself available, so caching is pointless and is the exact path that triggers the broken post-step.

Changes:

- `setup-python-poetry/action.yml`: new input `enable-cache` (default `'true'`, no behavior change for existing callers). `cache:` is now conditional on this input.
- `prepare-release.yml`: set `enable-cache: 'false'` (actively failing).
- `sdk-container-build-push.yml`: set `enable-cache: 'false'` (preventive, same pattern).
- `sdk-pypi-release.yml`: set `enable-cache: 'false'` in both `publish-prowler` and `publish-prowler-cloud` jobs (preventive, same pattern).

All other callers (api-tests, sdk-tests, etc.) install dependencies and keep caching enabled — untouched.

### Steps to review

- Confirm the three non-install callers now pass `enable-cache: 'false'`.
- Confirm all other callers of `setup-python-poetry` are unchanged and still cache (default remains `'true'`).
- Confirm `cache-dependency-path` is still set — only the `cache` value is gated.

### Checklist

- [x] Review if the code is being covered by tests. (CI-only change; validated on the next release run.)
- [x] Review if backport is needed. (Yes — the failing release workflow lives on release branches too; backport to `v5.24` to stop bleeding.)
- [ ] Review if is needed to change the README.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable. (CI-only, no user-facing change.)

#### SDK/CLI
- Are there new checks included in this PR? No.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.