### PR TITLE
fix(ci): also gate cache-dependency-path on enable-cache in setup-python-poetry

### DIFF
--- a/.github/actions/setup-python-poetry/action.yml
+++ b/.github/actions/setup-python-poetry/action.yml
@@ -81,7 +81,7 @@ runs:
         # Disable cache when callers skip dependency install: Poetry 2.3.4 creates
         # the venv in a path setup-python can't hash, breaking the post-step save-cache.
         cache: ${{ inputs.enable-cache == 'true' && 'poetry' || '' }}
-        cache-dependency-path: ${{ inputs.working-directory }}/poetry.lock
+        cache-dependency-path: ${{ inputs.enable-cache == 'true' && format('{0}/poetry.lock', inputs.working-directory) || '' }}
 
     - name: Install Python dependencies
       if: inputs.install-dependencies == 'true'


### PR DESCRIPTION
### Context

Follow-up to #10881. The prior fix gated the `cache:` input on `enable-cache`, but `cache-dependency-path` remained unconditional (`${{ inputs.working-directory }}/poetry.lock`). When the file exists, `actions/setup-python@v6` still registers the post-cache-save step, so the `prepare-release` workflow kept crashing with `##[error]Index was out of range` on the 5.24.4 release run (head_sha `ca79300`, which already includes #10881).

Failing run: https://github.com/prowler-cloud/prowler/actions/runs/24883997850/job/72859324581

### Description

Wrap `cache-dependency-path` in the same `enable-cache == 'true'` ternary that already guards `cache:`. When `enable-cache: 'false'`, both inputs are empty strings and `actions/setup-python` does not register the post-cache-save step, which is what was crashing.

```yaml
cache-dependency-path: ${{ inputs.enable-cache == 'true' && format('{0}/poetry.lock', inputs.working-directory) || '' }}
```

One-line change, no caller updates required — callers that want caching off already pass `enable-cache: 'false'`.

### Steps to review

- Confirm the diff is limited to the single `cache-dependency-path` line in `.github/actions/setup-python-poetry/action.yml`.
- Confirm no caller of the composite needs to change: callers that disable caching already pass `enable-cache: 'false'`, and callers that enable it observe the same behavior as before (both `cache` and `cache-dependency-path` are set).
- After merge, re-run the failing prepare-release job and verify the post-step no longer executes.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.