### PR TITLE
fix(check): break circular import between config and check.utils

### DIFF
--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -14,8 +14,10 @@ from prowler.lib.check.compliance_models import load_compliance_framework_univer
 # Re-exported from a leaf module so prowler.lib.check.utils can import the
 # constant without participating in the config <-> compliance_models <-> utils
 # import cycle. Existing consumers continue to import from this module.
+# The `as EXTERNAL_TOOL_PROVIDERS` rename is the PEP 484 explicit re-export
+# form so static analyzers (CodeQL, mypy, ruff) treat the name as public.
 from prowler.lib.check.external_tool_providers import (  # noqa: F401
-    EXTERNAL_TOOL_PROVIDERS,
+    EXTERNAL_TOOL_PROVIDERS as EXTERNAL_TOOL_PROVIDERS,
 )
 from prowler.lib.logger import logger
 

--- a/prowler/config/config.py
+++ b/prowler/config/config.py
@@ -10,6 +10,13 @@ import yaml
 from packaging import version
 
 from prowler.lib.check.compliance_models import load_compliance_framework_universal
+
+# Re-exported from a leaf module so prowler.lib.check.utils can import the
+# constant without participating in the config <-> compliance_models <-> utils
+# import cycle. Existing consumers continue to import from this module.
+from prowler.lib.check.external_tool_providers import (  # noqa: F401
+    EXTERNAL_TOOL_PROVIDERS,
+)
 from prowler.lib.logger import logger
 
 
@@ -68,10 +75,6 @@ class Provider(str, Enum):
     IMAGE = "image"
     VERCEL = "vercel"
 
-
-# Providers that delegate scanning to an external tool (e.g. Trivy, promptfoo)
-# and bypass standard check/service loading.
-EXTERNAL_TOOL_PROVIDERS = frozenset({"iac", "llm", "image"})
 
 # Compliance
 actual_directory = pathlib.Path(os.path.dirname(os.path.realpath(__file__)))
@@ -152,7 +155,7 @@ def set_output_timestamp(
     Override the global output timestamps so generated artifacts reflect a specific scan.
     Returns the previous values so callers can restore them afterwards.
     """
-    global timestamp, timestamp_utc, output_file_timestamp, timestamp_iso
+    global output_file_timestamp, timestamp_iso
 
     previous_values = (
         timestamp.value,

--- a/prowler/lib/check/external_tool_providers.py
+++ b/prowler/lib/check/external_tool_providers.py
@@ -1,0 +1,7 @@
+# Providers that delegate scanning to an external tool (e.g. Trivy, promptfoo)
+# and bypass standard check/service loading.
+#
+# Kept in a leaf module with no imports so it can be referenced from both
+# prowler.config.config and prowler.lib.check.utils without forming an
+# import cycle.
+EXTERNAL_TOOL_PROVIDERS = frozenset({"iac", "llm", "image"})

--- a/prowler/lib/check/utils.py
+++ b/prowler/lib/check/utils.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 from pkgutil import walk_packages
 
+from prowler.lib.check.external_tool_providers import EXTERNAL_TOOL_PROVIDERS
 from prowler.lib.logger import logger
 
 
@@ -13,10 +14,6 @@ def recover_checks_from_provider(
 
     Returns a list of tuples with the following format (check_name, check_path)
     """
-    # Imported lazily to avoid a circular import: prowler.config.config imports
-    # prowler.lib.check.compliance_models, which imports this module.
-    from prowler.config.config import EXTERNAL_TOOL_PROVIDERS
-
     try:
         # Bypass check loading for providers that use external tools directly
         if provider in EXTERNAL_TOOL_PROVIDERS:
@@ -66,10 +63,6 @@ def recover_checks_from_service(service_list: list, provider: str) -> set:
 
     Returns a set of checks from the given services
     """
-    # Imported lazily to avoid a circular import: prowler.config.config imports
-    # prowler.lib.check.compliance_models, which imports this module.
-    from prowler.config.config import EXTERNAL_TOOL_PROVIDERS
-
     try:
         # Bypass check loading for providers that use external tools directly
         if provider in EXTERNAL_TOOL_PROVIDERS:

--- a/prowler/lib/check/utils.py
+++ b/prowler/lib/check/utils.py
@@ -2,7 +2,6 @@ import importlib
 import sys
 from pkgutil import walk_packages
 
-from prowler.config.config import EXTERNAL_TOOL_PROVIDERS
 from prowler.lib.logger import logger
 
 
@@ -14,6 +13,10 @@ def recover_checks_from_provider(
 
     Returns a list of tuples with the following format (check_name, check_path)
     """
+    # Imported lazily to avoid a circular import: prowler.config.config imports
+    # prowler.lib.check.compliance_models, which imports this module.
+    from prowler.config.config import EXTERNAL_TOOL_PROVIDERS
+
     try:
         # Bypass check loading for providers that use external tools directly
         if provider in EXTERNAL_TOOL_PROVIDERS:
@@ -63,6 +66,10 @@ def recover_checks_from_service(service_list: list, provider: str) -> set:
 
     Returns a set of checks from the given services
     """
+    # Imported lazily to avoid a circular import: prowler.config.config imports
+    # prowler.lib.check.compliance_models, which imports this module.
+    from prowler.config.config import EXTERNAL_TOOL_PROVIDERS
+
     try:
         # Bypass check loading for providers that use external tools directly
         if provider in EXTERNAL_TOOL_PROVIDERS:


### PR DESCRIPTION
## Summary

- Fix circular import introduced by #10607 that breaks any process which loads `prowler.config.config` before the lazy paths into `prowler.lib.check.utils` have a chance to resolve.
- Move the `EXTERNAL_TOOL_PROVIDERS` import inside the two functions in `prowler/lib/check/utils.py` that use it.

## Context

`prowler/config/config.py` (line 12) imports `load_compliance_framework_universal` from `prowler.lib.check.compliance_models`, which (line 9) imports `list_compliance_modules` from `prowler.lib.check.utils`. After #10607, `utils.py` started importing `EXTERNAL_TOOL_PROVIDERS` from `prowler.config.config` at module load — but that symbol is defined at line 74 of `config.py`, well after the line-12 import that triggers the chain. The result on a fresh interpreter that loads `prowler.config.config` first is:

```
ImportError: cannot import name 'EXTERNAL_TOOL_PROVIDERS' from partially
initialized module 'prowler.config.config' (most likely due to a circular import)
```

This was caught downstream in prowler-cloud/prowler-cloud#3830 (the sync of #10607), where the API container build fails on `RUN poetry run python .../m365_powershell.py` ([failed run](https://github.com/prowler-cloud/prowler-cloud/actions/runs/24980936645/job/73142743833)). It also affects any consumer that imports `prowler.config.config` (or any module that pulls it in, e.g. `prowler.providers.m365.models`) before importing `prowler.lib.check.utils`.

## Fix

Move the `from prowler.config.config import EXTERNAL_TOOL_PROVIDERS` line out of module scope in `utils.py` and into the two functions that use it (`recover_checks_from_provider`, `recover_checks_from_service`). The lookup runs at call time, by which point `prowler.config.config` has finished initializing.

## Test plan

- [x] `python prowler/providers/m365/lib/powershell/m365_powershell.py` (the exact failing Dockerfile command) — runs cleanly
- [x] `python -c "from prowler.providers.m365 import models"` — succeeds
- [x] `pytest -vv -n auto tests/lib/check/` — 381 passed
- [x] `pytest -vv -n auto tests/providers/github/services/githubactions/` — 31 passed (the zizmor tests from #10607)