### PR TITLE
chore(ci): align sdk-bump-version PR titles with other bump workflows

### DIFF
--- a/.github/workflows/sdk-bump-version.yml
+++ b/.github/workflows/sdk-bump-version.yml
@@ -113,9 +113,9 @@ jobs:
           author: prowler-bot <179230569+prowler-bot@users.noreply.github.com>
           token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
           base: master
-          commit-message: 'chore(release): Bump version to v${{ env.NEXT_MINOR_VERSION }}'
-          branch: version-bump-to-v${{ env.NEXT_MINOR_VERSION }}
-          title: 'chore(release): Bump version to v${{ env.NEXT_MINOR_VERSION }}'
+          commit-message: 'chore(sdk): Bump version to v${{ env.NEXT_MINOR_VERSION }}'
+          branch: sdk-version-bump-to-v${{ env.NEXT_MINOR_VERSION }}
+          title: 'chore(sdk): Bump version to v${{ env.NEXT_MINOR_VERSION }}'
           labels: no-changelog,skip-sync
           body: |
             ### Description
@@ -165,9 +165,9 @@ jobs:
           author: prowler-bot <179230569+prowler-bot@users.noreply.github.com>
           token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
           base: ${{ env.VERSION_BRANCH }}
-          commit-message: 'chore(release): Bump version to v${{ env.FIRST_PATCH_VERSION }}'
-          branch: version-bump-to-v${{ env.FIRST_PATCH_VERSION }}
-          title: 'chore(release): Bump version to v${{ env.FIRST_PATCH_VERSION }}'
+          commit-message: 'chore(sdk): Bump version to v${{ env.FIRST_PATCH_VERSION }}'
+          branch: sdk-version-bump-to-v${{ env.FIRST_PATCH_VERSION }}
+          title: 'chore(sdk): Bump version to v${{ env.FIRST_PATCH_VERSION }}'
           labels: no-changelog,skip-sync
           body: |
             ### Description
@@ -233,9 +233,9 @@ jobs:
           author: prowler-bot <179230569+prowler-bot@users.noreply.github.com>
           token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
           base: ${{ env.VERSION_BRANCH }}
-          commit-message: 'chore(release): Bump version to v${{ env.NEXT_PATCH_VERSION }}'
-          branch: version-bump-to-v${{ env.NEXT_PATCH_VERSION }}
-          title: 'chore(release): Bump version to v${{ env.NEXT_PATCH_VERSION }}'
+          commit-message: 'chore(sdk): Bump version to v${{ env.NEXT_PATCH_VERSION }}'
+          branch: sdk-version-bump-to-v${{ env.NEXT_PATCH_VERSION }}
+          title: 'chore(sdk): Bump version to v${{ env.NEXT_PATCH_VERSION }}'
           labels: no-changelog,skip-sync
           body: |
             ### Description


### PR DESCRIPTION
### Context

The four bump workflows (`api`, `docs`, `sdk`, `ui`) all fire on `release: published` and open a PR with the version bump. Their PR titles and branch names had diverged over time:

| Workflow | Title (before) |
|---|---|
| api  | `chore(api): Bump version to v<X>` |
| docs | `docs: Update version to v<X>` |
| sdk  | `chore(release): Bump version to v<X>` |
| ui   | `chore(ui): Bump version to v<X>` |

`api` and `ui` were already aligned. `docs` is being aligned in #10896. This PR aligns `sdk`.

### Description

Three `peter-evans/create-pull-request` steps in `sdk-bump-version.yml` (one per release shape: minor, first patch, next patch) updated to:

- Title / commit message: `chore(release): …` → `chore(sdk): …`
- Branch name: `version-bump-to-v<X>` → `sdk-version-bump-to-v<X>`

No behavioral change — same trigger, same files modified, same review flow. Only label/branch/title metadata.

### Steps to review

- Confirm the three steps in `sdk-bump-version.yml` consistently use `chore(sdk): Bump version to v<X>` and `sdk-version-bump-to-v<X>` for the branch.
- No other workflows reference the old `chore(release):` title or the unprefixed `version-bump-to-v<X>` branch name (verified — search returns zero hits in `.github/`).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
