### PR TITLE
fix(sdk): align googleworkspace finding resources

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - Alibaba Cloud CS service SDK compatibility, harden other services and improve documentation [(#10871)](https://github.com/prowler-cloud/prowler/pull/10871)
 - `admincenter_groups_not_public_visibility` check for M365 provider evaluating Security and Distribution groups, now restricted to Microsoft 365 (Unified) groups per CIS M365 Foundations 1.2.1 [(#10899)](https://github.com/prowler-cloud/prowler/pull/10899)
+- Google Workspace check reports now store the actual domain or account resource subject instead of `provider.identity` [(#10901)](https://github.com/prowler-cloud/prowler/pull/10901)
 
 ---
 

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -945,7 +945,7 @@ class CheckReportGoogleWorkspace(Check_Report):
         resource_name: str = None,
         resource_id: str = None,
         customer_id: str = None,
-        location: str = None,
+        location: str = "global",
     ) -> None:
         """Initialize the Google Workspace Check's finding information.
 
@@ -960,17 +960,12 @@ class CheckReportGoogleWorkspace(Check_Report):
         super().__init__(metadata, resource)
         self.resource_name = (
             resource_name
-            or getattr(resource, "name", "")
             or getattr(resource, "email", "")
-            or getattr(resource, "resource_name", "")
+            or getattr(resource, "name", "")
         )
-        self.resource_id = (
-            resource_id
-            or getattr(resource, "id", "")
-            or getattr(resource, "resource_id", "")
-        )
+        self.resource_id = resource_id or getattr(resource, "id", "")
         self.customer_id = customer_id or getattr(resource, "customer_id", "")
-        self.location = location or getattr(resource, "location", "global")
+        self.location = location
 
 
 @dataclass

--- a/prowler/lib/check/models.py
+++ b/prowler/lib/check/models.py
@@ -945,7 +945,7 @@ class CheckReportGoogleWorkspace(Check_Report):
         resource_name: str = None,
         resource_id: str = None,
         customer_id: str = None,
-        location: str = "global",
+        location: str = None,
     ) -> None:
         """Initialize the Google Workspace Check's finding information.
 
@@ -960,12 +960,17 @@ class CheckReportGoogleWorkspace(Check_Report):
         super().__init__(metadata, resource)
         self.resource_name = (
             resource_name
-            or getattr(resource, "email", "")
             or getattr(resource, "name", "")
+            or getattr(resource, "email", "")
+            or getattr(resource, "resource_name", "")
         )
-        self.resource_id = resource_id or getattr(resource, "id", "")
+        self.resource_id = (
+            resource_id
+            or getattr(resource, "id", "")
+            or getattr(resource, "resource_id", "")
+        )
         self.customer_id = customer_id or getattr(resource, "customer_id", "")
-        self.location = location
+        self.location = location or getattr(resource, "location", "global")
 
 
 @dataclass

--- a/prowler/providers/googleworkspace/googleworkspace_provider.py
+++ b/prowler/providers/googleworkspace/googleworkspace_provider.py
@@ -31,6 +31,7 @@ from prowler.providers.googleworkspace.lib.mutelist.mutelist import (
 )
 from prowler.providers.googleworkspace.models import (
     GoogleWorkspaceIdentityInfo,
+    GoogleWorkspaceResource,
     GoogleWorkspaceSession,
 )
 
@@ -55,6 +56,7 @@ class GoogleworkspaceProvider(Provider):
     _type: str = "googleworkspace"
     _session: GoogleWorkspaceSession
     _identity: GoogleWorkspaceIdentityInfo
+    _domain_resource: GoogleWorkspaceResource
     _audit_config: dict
     _mutelist: GoogleWorkspaceMutelist
     audit_metadata: Audit_Metadata
@@ -112,6 +114,7 @@ class GoogleworkspaceProvider(Provider):
             self._session,
             resolved_delegated_user,
         )
+        self._domain_resource = GoogleWorkspaceResource.from_identity(self._identity)
 
         # Audit Config
         if config_content:
@@ -152,6 +155,12 @@ class GoogleworkspaceProvider(Provider):
     def type(self):
         """Returns the type of the Google Workspace provider."""
         return self._type
+
+    @property
+    def domain_resource(self) -> GoogleWorkspaceResource:
+        """Returns the domain-level resource for account-wide checks."""
+
+        return self._domain_resource
 
     @property
     def audit_config(self):

--- a/prowler/providers/googleworkspace/lib/service/service.py
+++ b/prowler/providers/googleworkspace/lib/service/service.py
@@ -13,6 +13,7 @@ class GoogleWorkspaceService:
         provider: GoogleworkspaceProvider,
     ):
         self.provider = provider
+        self.domain_resource = provider.domain_resource
         self.audit_config = provider.audit_config
         self.fixer_config = provider.fixer_config
         self.credentials = provider.session.credentials

--- a/prowler/providers/googleworkspace/models.py
+++ b/prowler/providers/googleworkspace/models.py
@@ -26,6 +26,40 @@ class GoogleWorkspaceIdentityInfo(BaseModel):
     profile: Optional[str] = "default"
 
 
+class GoogleWorkspaceResource(BaseModel):
+    """Generic Google Workspace resource used by findings."""
+
+    id: str
+    customer_id: str
+    location: str = "global"
+    name: Optional[str] = None
+    email: Optional[str] = None
+
+    @classmethod
+    def from_identity(
+        cls, identity: "GoogleWorkspaceIdentityInfo"
+    ) -> "GoogleWorkspaceResource":
+        """Build the domain-level resource from provider identity."""
+
+        return cls(
+            id=identity.customer_id,
+            name=identity.domain,
+            customer_id=identity.customer_id,
+        )
+
+    @classmethod
+    def from_user(
+        cls, user: BaseModel | object, customer_id: str
+    ) -> "GoogleWorkspaceResource":
+        """Build a user-level resource from a Google Workspace user object."""
+
+        return cls(
+            id=getattr(user, "id", ""),
+            email=getattr(user, "email", ""),
+            customer_id=customer_id,
+        )
+
+
 class GoogleWorkspaceOutputOptions(ProviderOutputOptions):
     """Google Workspace specific output options"""
 

--- a/prowler/providers/googleworkspace/services/calendar/calendar_external_invitations_warning/calendar_external_invitations_warning.py
+++ b/prowler/providers/googleworkspace/services/calendar/calendar_external_invitations_warning/calendar_external_invitations_warning.py
@@ -20,11 +20,7 @@ class calendar_external_invitations_warning(Check):
         if calendar_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=calendar_client.provider.identity,
-                resource_name=calendar_client.provider.identity.domain,
-                resource_id=calendar_client.provider.identity.customer_id,
-                customer_id=calendar_client.provider.identity.customer_id,
-                location="global",
+                resource=calendar_client.provider.domain_resource,
             )
 
             warning_enabled = calendar_client.policies.external_invitations_warning

--- a/prowler/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar.py
+++ b/prowler/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar.py
@@ -20,11 +20,7 @@ class calendar_external_sharing_primary_calendar(Check):
         if calendar_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=calendar_client.provider.identity,
-                resource_name=calendar_client.provider.identity.domain,
-                resource_id=calendar_client.provider.identity.customer_id,
-                customer_id=calendar_client.provider.identity.customer_id,
-                location="global",
+                resource=calendar_client.provider.domain_resource,
             )
 
             sharing = calendar_client.policies.primary_calendar_external_sharing

--- a/prowler/providers/googleworkspace/services/calendar/calendar_external_sharing_secondary_calendar/calendar_external_sharing_secondary_calendar.py
+++ b/prowler/providers/googleworkspace/services/calendar/calendar_external_sharing_secondary_calendar/calendar_external_sharing_secondary_calendar.py
@@ -20,11 +20,7 @@ class calendar_external_sharing_secondary_calendar(Check):
         if calendar_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=calendar_client.provider.identity,
-                resource_name=calendar_client.provider.identity.domain,
-                resource_id=calendar_client.provider.identity.customer_id,
-                customer_id=calendar_client.provider.identity.customer_id,
-                location="global",
+                resource=calendar_client.provider.domain_resource,
             )
 
             sharing = calendar_client.policies.secondary_calendar_external_sharing

--- a/prowler/providers/googleworkspace/services/directory/directory_super_admin_count/directory_super_admin_count.py
+++ b/prowler/providers/googleworkspace/services/directory/directory_super_admin_count/directory_super_admin_count.py
@@ -23,11 +23,7 @@ class directory_super_admin_count(Check):
 
         report = CheckReportGoogleWorkspace(
             metadata=self.metadata(),
-            resource=directory_client.provider.identity,
-            resource_name=directory_client.provider.identity.domain,
-            resource_id=directory_client.provider.identity.customer_id,
-            customer_id=directory_client.provider.identity.customer_id,
-            location="global",
+            resource=directory_client.provider.domain_resource,
         )
 
         if 2 <= admin_count <= 4:

--- a/prowler/providers/googleworkspace/services/directory/directory_super_admin_only_admin_roles/directory_super_admin_only_admin_roles.py
+++ b/prowler/providers/googleworkspace/services/directory/directory_super_admin_only_admin_roles/directory_super_admin_only_admin_roles.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from prowler.lib.check.models import Check, CheckReportGoogleWorkspace
+from prowler.providers.googleworkspace.models import GoogleWorkspaceResource
 from prowler.providers.googleworkspace.services.directory.directory_client import (
     directory_client,
 )
@@ -18,7 +19,6 @@ class directory_super_admin_only_admin_roles(Check):
         findings = []
 
         if directory_client.users:
-            dual_role_admins = {}
             for user in directory_client.users.values():
                 if user.is_admin:
                     extra_roles = [
@@ -27,34 +27,32 @@ class directory_super_admin_only_admin_roles(Check):
                         if not r.is_super_admin_role
                     ]
                     if extra_roles:
-                        dual_role_admins[user.email] = extra_roles
+                        report = CheckReportGoogleWorkspace(
+                            metadata=self.metadata(),
+                            resource=GoogleWorkspaceResource.from_user(
+                                user,
+                                directory_client.provider.identity.customer_id,
+                            ),
+                        )
+                        details = ", ".join(extra_roles)
+                        report.status = "FAIL"
+                        report.status_extended = (
+                            f"Super admin account {user.email} also holds additional admin roles: "
+                            f"{details}. Super admin accounts should be used only for "
+                            f"super admin activities."
+                        )
+                        findings.append(report)
 
-            report = CheckReportGoogleWorkspace(
-                metadata=self.metadata(),
-                resource=directory_client.provider.identity,
-                resource_name=directory_client.provider.identity.domain,
-                resource_id=directory_client.provider.identity.customer_id,
-                customer_id=directory_client.provider.identity.customer_id,
-                location="global",
-            )
-
-            if dual_role_admins:
-                details = ", ".join(
-                    f"{email} ({', '.join(roles)})"
-                    for email, roles in dual_role_admins.items()
+            if not findings:
+                report = CheckReportGoogleWorkspace(
+                    metadata=self.metadata(),
+                    resource=directory_client.provider.domain_resource,
                 )
-                report.status = "FAIL"
-                report.status_extended = (
-                    f"Super admin accounts also holding additional admin roles: {details}. "
-                    f"Super admin accounts should be used only for super admin activities."
-                )
-            else:
                 report.status = "PASS"
                 report.status_extended = (
                     f"All super admin accounts in domain {directory_client.provider.identity.domain} "
                     f"are used only for super admin activities."
                 )
-
-            findings.append(report)
+                findings.append(report)
 
         return findings

--- a/prowler/providers/googleworkspace/services/drive/drive_access_checker_recipients_only/drive_access_checker_recipients_only.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_access_checker_recipients_only/drive_access_checker_recipients_only.py
@@ -19,11 +19,7 @@ class drive_access_checker_recipients_only(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             access_checker = drive_client.policies.access_checker_suggestions

--- a/prowler/providers/googleworkspace/services/drive/drive_desktop_access_disabled/drive_desktop_access_disabled.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_desktop_access_disabled/drive_desktop_access_disabled.py
@@ -20,11 +20,7 @@ class drive_desktop_access_disabled(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             allow_desktop = drive_client.policies.allow_drive_for_desktop

--- a/prowler/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users.py
@@ -18,11 +18,7 @@ class drive_external_sharing_warn_users(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             warning_enabled = drive_client.policies.warn_for_external_sharing

--- a/prowler/providers/googleworkspace/services/drive/drive_internal_users_distribute_content/drive_internal_users_distribute_content.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_internal_users_distribute_content/drive_internal_users_distribute_content.py
@@ -19,11 +19,7 @@ class drive_internal_users_distribute_content(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             allowed = drive_client.policies.allowed_parties_for_distributing_content

--- a/prowler/providers/googleworkspace/services/drive/drive_publishing_files_disabled/drive_publishing_files_disabled.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_publishing_files_disabled/drive_publishing_files_disabled.py
@@ -19,11 +19,7 @@ class drive_publishing_files_disabled(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             allow_publishing = drive_client.policies.allow_publishing_files

--- a/prowler/providers/googleworkspace/services/drive/drive_shared_drive_creation_allowed/drive_shared_drive_creation_allowed.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_shared_drive_creation_allowed/drive_shared_drive_creation_allowed.py
@@ -20,11 +20,7 @@ class drive_shared_drive_creation_allowed(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             allow_creation = drive_client.policies.allow_shared_drive_creation

--- a/prowler/providers/googleworkspace/services/drive/drive_shared_drive_disable_download_print_copy/drive_shared_drive_disable_download_print_copy.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_shared_drive_disable_download_print_copy/drive_shared_drive_disable_download_print_copy.py
@@ -19,11 +19,7 @@ class drive_shared_drive_disable_download_print_copy(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             allowed = drive_client.policies.allowed_parties_for_download_print_copy

--- a/prowler/providers/googleworkspace/services/drive/drive_shared_drive_managers_cannot_override/drive_shared_drive_managers_cannot_override.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_shared_drive_managers_cannot_override/drive_shared_drive_managers_cannot_override.py
@@ -19,11 +19,7 @@ class drive_shared_drive_managers_cannot_override(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             allow_override = drive_client.policies.allow_managers_to_override_settings

--- a/prowler/providers/googleworkspace/services/drive/drive_shared_drive_members_only_access/drive_shared_drive_members_only_access.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_shared_drive_members_only_access/drive_shared_drive_members_only_access.py
@@ -19,11 +19,7 @@ class drive_shared_drive_members_only_access(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             allow_non_member = drive_client.policies.allow_non_member_access

--- a/prowler/providers/googleworkspace/services/drive/drive_sharing_allowlisted_domains/drive_sharing_allowlisted_domains.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_sharing_allowlisted_domains/drive_sharing_allowlisted_domains.py
@@ -18,11 +18,7 @@ class drive_sharing_allowlisted_domains(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             mode = drive_client.policies.external_sharing_mode

--- a/prowler/providers/googleworkspace/services/drive/drive_warn_sharing_with_allowlisted_domains/drive_warn_sharing_with_allowlisted_domains.py
+++ b/prowler/providers/googleworkspace/services/drive/drive_warn_sharing_with_allowlisted_domains/drive_warn_sharing_with_allowlisted_domains.py
@@ -19,11 +19,7 @@ class drive_warn_sharing_with_allowlisted_domains(Check):
         if drive_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=drive_client.provider.identity,
-                resource_name=drive_client.provider.identity.domain,
-                resource_id=drive_client.provider.identity.customer_id,
-                customer_id=drive_client.provider.identity.customer_id,
-                location="global",
+                resource=drive_client.provider.domain_resource,
             )
 
             warn_enabled = (

--- a/prowler/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled.py
@@ -18,11 +18,7 @@ class gmail_auto_forwarding_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             forwarding_enabled = gmail_client.policies.enable_auto_forwarding

--- a/prowler/providers/googleworkspace/services/gmail/gmail_comprehensive_mail_storage_enabled/gmail_comprehensive_mail_storage_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_comprehensive_mail_storage_enabled/gmail_comprehensive_mail_storage_enabled.py
@@ -18,11 +18,7 @@ class gmail_comprehensive_mail_storage_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             storage_enabled = gmail_client.policies.comprehensive_mail_storage_enabled

--- a/prowler/providers/googleworkspace/services/gmail/gmail_enhanced_pre_delivery_scanning_enabled/gmail_enhanced_pre_delivery_scanning_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_enhanced_pre_delivery_scanning_enabled/gmail_enhanced_pre_delivery_scanning_enabled.py
@@ -18,11 +18,7 @@ class gmail_enhanced_pre_delivery_scanning_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             scanning_enabled = (

--- a/prowler/providers/googleworkspace/services/gmail/gmail_external_image_scanning_enabled/gmail_external_image_scanning_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_external_image_scanning_enabled/gmail_external_image_scanning_enabled.py
@@ -18,11 +18,7 @@ class gmail_external_image_scanning_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             scanning_enabled = gmail_client.policies.enable_external_image_scanning

--- a/prowler/providers/googleworkspace/services/gmail/gmail_mail_delegation_disabled/gmail_mail_delegation_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_mail_delegation_disabled/gmail_mail_delegation_disabled.py
@@ -18,11 +18,7 @@ class gmail_mail_delegation_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             delegation_enabled = gmail_client.policies.enable_mail_delegation

--- a/prowler/providers/googleworkspace/services/gmail/gmail_per_user_outbound_gateway_disabled/gmail_per_user_outbound_gateway_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_per_user_outbound_gateway_disabled/gmail_per_user_outbound_gateway_disabled.py
@@ -18,11 +18,7 @@ class gmail_per_user_outbound_gateway_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             gateway_allowed = gmail_client.policies.allow_per_user_outbound_gateway

--- a/prowler/providers/googleworkspace/services/gmail/gmail_pop_imap_access_disabled/gmail_pop_imap_access_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_pop_imap_access_disabled/gmail_pop_imap_access_disabled.py
@@ -18,11 +18,7 @@ class gmail_pop_imap_access_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             pop_enabled = gmail_client.policies.enable_pop_access

--- a/prowler/providers/googleworkspace/services/gmail/gmail_shortener_scanning_enabled/gmail_shortener_scanning_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_shortener_scanning_enabled/gmail_shortener_scanning_enabled.py
@@ -18,11 +18,7 @@ class gmail_shortener_scanning_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             scanning_enabled = gmail_client.policies.enable_shortener_scanning

--- a/prowler/providers/googleworkspace/services/gmail/gmail_untrusted_link_warnings_enabled/gmail_untrusted_link_warnings_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_untrusted_link_warnings_enabled/gmail_untrusted_link_warnings_enabled.py
@@ -18,11 +18,7 @@ class gmail_untrusted_link_warnings_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.identity,
-                resource_name=gmail_client.provider.identity.domain,
-                resource_id=gmail_client.provider.identity.customer_id,
-                customer_id=gmail_client.provider.identity.customer_id,
-                location="global",
+                resource=gmail_client.provider.domain_resource,
             )
 
             warnings_enabled = (

--- a/tests/providers/googleworkspace/googleworkspace_fixtures.py
+++ b/tests/providers/googleworkspace/googleworkspace_fixtures.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import MagicMock
 
-from prowler.providers.googleworkspace.models import GoogleWorkspaceIdentityInfo
+from prowler.providers.googleworkspace.models import (
+    GoogleWorkspaceIdentityInfo,
+    GoogleWorkspaceResource,
+)
 
 # Google Workspace test constants
 DOMAIN = "test-company.com"
@@ -89,4 +92,15 @@ def set_mocked_googleworkspace_provider(
     provider = MagicMock()
     provider.type = "googleworkspace"
     provider.identity = identity
+    provider.domain_resource = build_googleworkspace_domain_resource()
     return provider
+
+
+def build_googleworkspace_domain_resource() -> GoogleWorkspaceResource:
+    """Build the domain-level Google Workspace resource for tests."""
+
+    return GoogleWorkspaceResource(
+        id=CUSTOMER_ID,
+        name=DOMAIN,
+        customer_id=CUSTOMER_ID,
+    )

--- a/tests/providers/googleworkspace/googleworkspace_provider_test.py
+++ b/tests/providers/googleworkspace/googleworkspace_provider_test.py
@@ -69,6 +69,8 @@ class TestGoogleWorkspaceProvider:
                 delegated_user=DELEGATED_USER,
                 profile="default",
             )
+            assert provider.domain_resource.id == CUSTOMER_ID
+            assert provider.domain_resource.name == DOMAIN
             assert provider._audit_config == {}
 
     def test_googleworkspace_provider_with_credentials_content(self):
@@ -108,6 +110,7 @@ class TestGoogleWorkspaceProvider:
             assert provider.identity.domain == DOMAIN
             assert provider.identity.customer_id == CUSTOMER_ID
             assert provider.identity.delegated_user == DELEGATED_USER
+            assert provider.domain_resource.customer_id == CUSTOMER_ID
 
     def test_googleworkspace_provider_missing_delegated_user(self):
         """Test that missing delegated_user raises exception"""

--- a/tests/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar_test.py
+++ b/tests/providers/googleworkspace/services/calendar/calendar_external_sharing_primary_calendar/calendar_external_sharing_primary_calendar_test.py
@@ -41,7 +41,9 @@ class TestCalendarExternalSharingPrimaryCalendar:
             assert findings[0].status == "PASS"
             assert "free/busy information only" in findings[0].status_extended
             assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_id == CUSTOMER_ID
             assert findings[0].customer_id == CUSTOMER_ID
+            assert findings[0].resource == mock_provider.domain_resource.dict()
 
     def test_fail_read_only(self):
         """Test FAIL when external sharing allows read-only access"""

--- a/tests/providers/googleworkspace/services/directory/directory_service_test.py
+++ b/tests/providers/googleworkspace/services/directory/directory_service_test.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
+    CUSTOMER_ID,
+    DOMAIN,
     GROUPS_ADMIN_ROLE_ID,
     ROLE_GROUPS_ADMIN,
     ROLE_SEED_ADMIN,
@@ -66,6 +68,7 @@ class TestDirectoryService:
             directory = Directory(mock_provider)
 
             assert len(directory.users) == 3
+            assert directory.domain_resource == mock_provider.domain_resource
             assert "user1-id" in directory.users
             assert "user2-id" in directory.users
             assert "user3-id" in directory.users
@@ -119,6 +122,8 @@ class TestDirectoryService:
             directory = Directory(mock_provider)
 
             assert len(directory.users) == 0
+            assert directory.domain_resource.id == CUSTOMER_ID
+            assert directory.domain_resource.name == DOMAIN
 
     def test_directory_api_error_handling(self):
         """Test handling of API errors"""

--- a/tests/providers/googleworkspace/services/directory/directory_super_admin_count/directory_super_admin_count_test.py
+++ b/tests/providers/googleworkspace/services/directory/directory_super_admin_count/directory_super_admin_count_test.py
@@ -55,7 +55,9 @@ class TestDirectorySuperAdminCount:
             assert "2 super administrator(s)" in findings[0].status_extended
             assert "within the recommended range" in findings[0].status_extended
             assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_id == CUSTOMER_ID
             assert findings[0].customer_id == CUSTOMER_ID
+            assert findings[0].resource == mock_provider.domain_resource.dict()
 
     def test_directory_super_admin_count_pass_4_admins(self):
         """Test PASS when there are 4 super admins (within range)"""

--- a/tests/providers/googleworkspace/services/directory/directory_super_admin_only_admin_roles/directory_super_admin_only_admin_roles_test.py
+++ b/tests/providers/googleworkspace/services/directory/directory_super_admin_only_admin_roles/directory_super_admin_only_admin_roles_test.py
@@ -91,7 +91,9 @@ class TestDirectorySuperAdminOnlyAdminRoles:
             assert findings[0].status == "PASS"
             assert "used only for super admin activities" in findings[0].status_extended
             assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_id == CUSTOMER_ID
             assert findings[0].customer_id == CUSTOMER_ID
+            assert findings[0].resource == mock_provider.domain_resource.dict()
 
     def test_pass_super_admin_with_seed_admin_role(self):
         """Test PASS when a super admin only holds _SEED_ADMIN_ROLE.
@@ -213,7 +215,8 @@ class TestDirectorySuperAdminOnlyAdminRoles:
             assert "Groups Administrator" in findings[0].status_extended
             assert "_GROUPS_ADMIN_ROLE" not in findings[0].status_extended
             assert "used only for super admin activities" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "admin1@test-company.com"
+            assert findings[0].resource_id == "admin1-id"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_seed_admin_with_additional_roles(self):
@@ -254,6 +257,8 @@ class TestDirectorySuperAdminOnlyAdminRoles:
             assert "Groups Administrator" in findings[0].status_extended
             assert "_GROUPS_ADMIN_ROLE" not in findings[0].status_extended
             assert "_SEED_ADMIN_ROLE" not in findings[0].status_extended
+            assert findings[0].resource_name == "playground@prowler.cloud"
+            assert findings[0].resource_id == "admin1-id"
 
     def test_fail_multiple_super_admins_with_extra_roles(self):
         """Test FAIL lists all super admins that have additional roles"""
@@ -299,11 +304,12 @@ class TestDirectorySuperAdminOnlyAdminRoles:
             check = directory_super_admin_only_admin_roles()
             findings = check.execute()
 
-            assert len(findings) == 1
-            assert findings[0].status == "FAIL"
-            assert "admin1@test-company.com" in findings[0].status_extended
-            assert "admin2@test-company.com" in findings[0].status_extended
+            assert len(findings) == 2
+            assert all(finding.status == "FAIL" for finding in findings)
+            assert findings[0].resource_name == "admin1@test-company.com"
+            assert findings[1].resource_name == "admin2@test-company.com"
             assert "admin3@test-company.com" not in findings[0].status_extended
+            assert "admin3@test-company.com" not in findings[1].status_extended
 
     def test_no_findings_when_no_users(self):
         """Test no findings when there are no users"""
@@ -444,3 +450,4 @@ class TestDirectorySuperAdminOnlyAdminRoles:
             assert len(findings) == 1
             assert findings[0].status == "FAIL"
             assert "custom-helpdesk-role" in findings[0].status_extended
+            assert findings[0].resource_name == "admin1@test-company.com"

--- a/tests/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users_test.py
+++ b/tests/providers/googleworkspace/services/drive/drive_external_sharing_warn_users/drive_external_sharing_warn_users_test.py
@@ -37,7 +37,9 @@ class TestDriveExternalSharingWarnUsers:
             assert findings[0].status == "PASS"
             assert "enabled" in findings[0].status_extended
             assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_id == CUSTOMER_ID
             assert findings[0].customer_id == CUSTOMER_ID
+            assert findings[0].resource == mock_provider.domain_resource.dict()
 
     def test_fail_warning_disabled(self):
         """Test FAIL when external sharing warning is explicitly disabled"""

--- a/tests/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled_test.py
@@ -36,7 +36,9 @@ class TestGmailAutoForwardingDisabled:
             assert findings[0].status == "PASS"
             assert "disabled" in findings[0].status_extended
             assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_id == CUSTOMER_ID
             assert findings[0].customer_id == CUSTOMER_ID
+            assert findings[0].resource == mock_provider.domain_resource.dict()
 
     def test_fail_disabled(self):
         mock_provider = set_mocked_googleworkspace_provider()


### PR DESCRIPTION
### Context

Google Workspace was building many findings with `provider.identity` plus manual `resource_name` and `resource_id` overrides instead of using the actual finding resource object. That does not scale as the provider adds heterogeneous resources, and it diverges from the resource-driven check/report pattern used across the SDK.

### Description

- add a reusable Google Workspace resource model and expose the domain-scoped resource from the provider
- make `CheckReportGoogleWorkspace` derive report fields from the resource object instead of relying on manual overrides
- migrate all domain-scoped Google Workspace checks to use the provider domain resource
- update `directory_super_admin_only_admin_roles` to emit FAIL findings per affected admin account so the resource matches the subject of the finding
- expand provider, service and check tests around the new resource contract

### Steps to review

- run `poetry run pytest tests/providers/googleworkspace tests/lib/outputs/finding_test.py tests/lib/outputs/outputs_test.py -k 'googleworkspace' -q`
- verify domain-scoped checks now pass `provider.domain_resource` into `CheckReportGoogleWorkspace`
- verify `directory_super_admin_only_admin_roles` emits one FAIL per offending admin account and keeps the PASS case domain-scoped

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
