### PR TITLE
fix(api): skip null service/region in scan summary aggregation

### DIFF
--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -1197,6 +1197,8 @@ def aggregate_findings(tenant_id: str, scan_id: str):
                 muted_changed=agg["muted_changed"],
             )
             for agg in aggregation
+            if agg["resources__service"] is not None
+            and agg["resources__region"] is not None
         }
         # Upsert so re-runs (post-mute reaggregation) don't trip
         # `unique_scan_summary`; race-safe under concurrent writers.

--- a/api/src/backend/tasks/tests/test_scan.py
+++ b/api/src/backend/tasks/tests/test_scan.py
@@ -3359,6 +3359,85 @@ class TestAggregateFindings:
         regions = {s.region for s in summaries}
         assert regions == {"us-east-1", "us-west-2"}
 
+    @patch("tasks.jobs.scan.Finding.objects.filter")
+    @patch("tasks.jobs.scan.ScanSummary.objects.bulk_create")
+    @patch("tasks.jobs.scan.rls_transaction")
+    def test_aggregate_findings_skips_rows_with_null_service_or_region(
+        self, mock_rls_transaction, mock_bulk_create, mock_findings_filter
+    ):
+        """Aggregation rows with NULL service or region (orphan Findings whose
+        ResourceFindingMapping is missing) must be dropped before
+        ``bulk_create`` so the NOT NULL constraints on ``scan_summaries`` are
+        not violated. Valid rows in the same batch must still be persisted."""
+        tenant_id = str(uuid.uuid4())
+        scan_id = str(uuid.uuid4())
+
+        base_counts = {
+            "fail": 1,
+            "_pass": 0,
+            "muted_count": 0,
+            "total": 1,
+            "new": 0,
+            "changed": 0,
+            "unchanged": 1,
+            "fail_new": 0,
+            "fail_changed": 0,
+            "pass_new": 0,
+            "pass_changed": 0,
+            "muted_new": 0,
+            "muted_changed": 0,
+        }
+
+        mock_queryset = MagicMock()
+        mock_queryset.values.return_value = mock_queryset
+        mock_queryset.annotate.return_value = [
+            {
+                "check_id": "check_valid",
+                "resources__service": "s3",
+                "severity": "high",
+                "resources__region": "us-east-1",
+                **base_counts,
+            },
+            {
+                "check_id": "check_null_service",
+                "resources__service": None,
+                "severity": "high",
+                "resources__region": "us-east-1",
+                **base_counts,
+            },
+            {
+                "check_id": "check_null_region",
+                "resources__service": "ec2",
+                "severity": "low",
+                "resources__region": None,
+                **base_counts,
+            },
+            {
+                "check_id": "check_null_both",
+                "resources__service": None,
+                "severity": "medium",
+                "resources__region": None,
+                **base_counts,
+            },
+        ]
+
+        ctx = MagicMock()
+        ctx.__enter__.return_value = None
+        ctx.__exit__.return_value = False
+        mock_rls_transaction.return_value = ctx
+        mock_findings_filter.return_value = mock_queryset
+
+        aggregate_findings(tenant_id, scan_id)
+
+        mock_bulk_create.assert_called_once()
+        args, _ = mock_bulk_create.call_args
+        summaries = list(args[0])
+
+        assert len(summaries) == 1
+        assert summaries[0].check_id == "check_valid"
+        assert summaries[0].service == "s3"
+        assert summaries[0].region == "us-east-1"
+
     def test_aggregate_findings_is_idempotent_on_rerun(
         self,
         tenants_fixture,


### PR DESCRIPTION
### Context

`aggregate_findings` was failing with `null value in column "service" of relation "scan_summaries" violates not-null constraint` on Azure scans (and any scan where a `Finding` ends up without a `ResourceFindingMapping`).

The aggregation traverses the `Finding.resources` M2M (`findings.values("resources__service", "resources__region", ...)`). When the underlying join produces a row with no matching resource, both `resources__service` and `resources__region` come back as `NULL`, get fed into `ScanSummary(...)`, and the subsequent `bulk_create` fails because both columns are `NOT NULL`.

### Description

Defensive filter in the aggregation dict comprehension: skip rows where `resources__service` or `resources__region` is `NULL` before building the `ScanSummary` instances. Two-line change in `aggregate_findings`.

This is a mitigation, not a root-cause fix: the upstream bug is that `_process_finding_micro_batch` can leave a `Finding` without its `ResourceFindingMapping` (the `bulk_create(..., ignore_conflicts=True)` mismatch is currently logged but does not raise / rollback). That should be tackled separately.

### Steps to review

1. Read the diff in `api/src/backend/tasks/jobs/scan.py` (`aggregate_findings`).
2. Re-run a scan whose previous run hit the NOT NULL violation; the aggregation completes and no `scan_summaries` row is written for the orphan group.
3. Confirm existing aggregations still get upserted (no regression on the `unique_scan_summary` upsert path).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [x] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.