### PR TITLE
fix(ui): reposition compliance card export menu

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.26.0] (Prowler UNRELEASED)
+## [1.25.1] (Prowler UNRELEASED)
 
 ### 🐞 Fixed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -6,8 +6,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🐞 Fixed
 
-- Compliance card export menu repositioned to the card's top-right corner with a lighter, `rounded-md` ghost trigger so it scales naturally on small screens [(#10918)](https://github.com/prowler-cloud/prowler/pull/10918)
-- Compliance page now renders frameworks for the auto-selected scan on first load instead of showing "no compliance data available" until the user re-selects the same scan
+- Compliance page export menu now scales on small screens, and frameworks load on first render without requiring a manual scan re-selection [(#10918)](https://github.com/prowler-cloud/prowler/pull/10918)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - Compliance card export menu repositioned to the card's top-right corner with a lighter, `rounded-md` ghost trigger so it scales naturally on small screens [(#10918)](https://github.com/prowler-cloud/prowler/pull/10918)
+- Compliance page now renders frameworks for the auto-selected scan on first load instead of showing "no compliance data available" until the user re-selects the same scan
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.25.1] (Prowler UNRELEASED)
+## [1.25.1] (Prowler v5.25.1)
 
 ### 🐞 Fixed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.26.0] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Compliance card export menu repositioned to the card's top-right corner with a lighter, `rounded-md` ghost trigger so it scales naturally on small screens [(#10918)](https://github.com/prowler-cloud/prowler/pull/10918)
+
+---
+
 ## [1.25.0] (Prowler v5.25.0)
 
 ### 🚀 Added

--- a/ui/app/(prowler)/compliance/page.tsx
+++ b/ui/app/(prowler)/compliance/page.tsx
@@ -166,6 +166,7 @@ export default async function Compliance({
           >
             <SSRComplianceGrid
               searchParams={resolvedSearchParams}
+              scanId={selectedScanId}
               selectedScan={selectedScanData}
             />
           </Suspense>
@@ -179,12 +180,13 @@ export default async function Compliance({
 
 const SSRComplianceGrid = async ({
   searchParams,
+  scanId,
   selectedScan,
 }: {
   searchParams: SearchParamsProps;
+  scanId: string | null;
   selectedScan?: ScanEntity;
 }) => {
-  const scanId = searchParams.scanId?.toString() || "";
   const regionFilter = searchParams["filter[region__in]"]?.toString() || "";
 
   // Only fetch compliance data if we have a valid scanId
@@ -247,7 +249,7 @@ const SSRComplianceGrid = async ({
     <ComplianceOverviewPanel>
       <ComplianceOverviewGrid
         frameworks={frameworks}
-        scanId={scanId}
+        scanId={scanId ?? ""}
         selectedScan={selectedScan}
         latestCisIds={latestCisIds}
       />

--- a/ui/components/compliance/compliance-card.tsx
+++ b/ui/components/compliance/compliance-card.tsx
@@ -89,12 +89,38 @@ export const ComplianceCard: React.FC<ComplianceCardProps> = ({
     <Card
       variant="base"
       padding="md"
-      className="cursor-pointer transition-shadow hover:shadow-md"
+      className="relative cursor-pointer transition-shadow hover:shadow-md"
       onClick={navigateToDetail}
     >
+      <div
+        className="absolute top-2 right-2 z-10"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.stopPropagation();
+          }
+        }}
+        role="group"
+        tabIndex={0}
+      >
+        <ComplianceDownloadContainer
+          compact
+          orientation="column"
+          buttonWidth="icon"
+          presentation="dropdown"
+          scanId={scanId}
+          complianceId={complianceId}
+          reportType={getReportTypeForCompliance(
+            title,
+            complianceId,
+            isLatestCisForProvider,
+          )}
+          disabled={hasRegionFilter}
+        />
+      </div>
       <CardContent className="p-0">
         <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-start">
-          <div className="flex shrink-0 items-center justify-between sm:flex-col sm:items-start sm:gap-2">
+          <div className="flex shrink-0 items-center sm:flex-col sm:items-start sm:gap-2">
             {getComplianceIcon(title) && (
               <Image
                 src={getComplianceIcon(title)}
@@ -102,37 +128,11 @@ export const ComplianceCard: React.FC<ComplianceCardProps> = ({
                 className="h-10 w-10 min-w-10 self-start rounded-md border border-gray-300 bg-white object-contain p-1"
               />
             )}
-            <div
-              className="shrink-0"
-              onClick={(e) => e.stopPropagation()}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.stopPropagation();
-                }
-              }}
-              role="group"
-              tabIndex={0}
-            >
-              <ComplianceDownloadContainer
-                compact
-                orientation="column"
-                buttonWidth="icon"
-                presentation="dropdown"
-                scanId={scanId}
-                complianceId={complianceId}
-                reportType={getReportTypeForCompliance(
-                  title,
-                  complianceId,
-                  isLatestCisForProvider,
-                )}
-                disabled={hasRegionFilter}
-              />
-            </div>
           </div>
           <div className="flex w-full min-w-0 flex-col gap-3">
             <Tooltip>
               <TooltipTrigger asChild>
-                <h4 className="text-small truncate leading-5 font-bold">
+                <h4 className="text-small truncate pr-9 leading-5 font-bold">
                   {formatTitle(title)}
                   {version ? ` - ${version}` : ""}
                 </h4>

--- a/ui/components/compliance/compliance-download-container.test.tsx
+++ b/ui/components/compliance/compliance-download-container.test.tsx
@@ -70,7 +70,7 @@ describe("ComplianceDownloadContainer", () => {
     const trigger = screen.getByRole("button", {
       name: "Open compliance export actions",
     });
-    expect(trigger.className).toContain("border-text-neutral-secondary");
+    expect(trigger.className).toContain("rounded-md");
   });
 
   it("should open export actions from the compact trigger", async () => {

--- a/ui/components/shadcn/dropdown/action-dropdown.tsx
+++ b/ui/components/shadcn/dropdown/action-dropdown.tsx
@@ -15,8 +15,7 @@ import {
 
 const ACTION_TRIGGER_STYLES = {
   table: "hover:bg-bg-neutral-tertiary rounded-full p-1 transition-colors",
-  bordered:
-    "hover:bg-bg-neutral-tertiary rounded-full border border-text-neutral-secondary p-2 transition-colors",
+  bordered: "hover:bg-bg-neutral-tertiary rounded-md p-1.5 transition-colors",
 } as const;
 
 type ActionDropdownVariant = keyof typeof ACTION_TRIGGER_STYLES;
@@ -24,7 +23,7 @@ type ActionDropdownVariant = keyof typeof ACTION_TRIGGER_STYLES;
 interface ActionDropdownProps {
   /** The dropdown trigger element. Defaults to a vertical dots icon button */
   trigger?: ReactNode;
-  /** Trigger style variant. "table" = no border, "bordered" = circular border */
+  /** Trigger style variant. "table" = compact pill, "bordered" = card action */
   variant?: ActionDropdownVariant;
   /** Alignment of the dropdown content */
   align?: "start" | "center" | "end";
@@ -62,7 +61,12 @@ export function ActionDropdown({
             aria-label={ariaLabel}
             className={ACTION_TRIGGER_STYLES[variant]}
           >
-            <EllipsisVertical className="text-text-neutral-secondary size-6" />
+            <EllipsisVertical
+              className={cn(
+                "text-text-neutral-secondary",
+                variant === "bordered" ? "size-5" : "size-6",
+              )}
+            />
           </button>
         )}
       </DropdownMenuTrigger>


### PR DESCRIPTION
### Context

The export action `⋮` button on each compliance framework card sat under the provider logo in the left column, with a circular bordered design (~42 px, `rounded-full`, visible border). It competed visually with the logo, did not match the card's `rounded-md` aesthetic, and felt disproportionate on small screens because its size was fixed.

Before
<img width="1598" height="368" alt="image" src="https://github.com/user-attachments/assets/d2061267-9f91-4a78-8c69-71f5e714774c" />

After
<img width="1589" height="374" alt="image" src="https://github.com/user-attachments/assets/28ebeccc-1db7-448e-965e-dcb53ef62f05" />


### Description

Restyles and repositions the export dropdown trigger inside `ComplianceCard`:

- Moved the trigger out of the left icon column and floated it absolute in the card's top-right corner (`absolute top-2 right-2 z-10`).
- The left column now contains only the provider logo, freeing vertical space and removing the visual competition between logo and button.
- The `bordered` variant of `ActionDropdown` is now ghost-style: `rounded-md`, `p-1.5`, no border, with a slightly smaller icon (`size-5` instead of `size-6`). Total trigger size drops from ~42 px to ~32 px and now mirrors the card's corner radius.
- Updated the existing `ComplianceDownloadContainer` test that asserted on the old border class.

No behavior change: the dropdown still opens the same CSV/PDF download options, click propagation to the card is still stopped, and the PDF item is still gated by `reportType` / `isLatestCisForProvider`.

### Steps to review

1. Open `/compliance` on a scan with frameworks and inspect any framework card.
2. The `⋮` icon should appear in the **top-right corner** of the card (no longer under the logo).
3. The button should be a small `rounded-md` square (no circular border, no `rounded-full`).
4. Hover the trigger — only a subtle background should appear; no border line.
5. Open the dropdown — both items (CSV and, when applicable, PDF) should still trigger the existing download flows.
6. Resize from mobile (~370 px) to desktop:
   - On mobile, the title row reserves `pr-9` so the title doesn't overlap the floating trigger.
   - On desktop, the layout still reads logo → title → score, with the trigger floating top-right.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [x] Screenshots/Video - Desktop (X > 1024px)
- [ ] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.