### PR TITLE
fix(permissions): add missing sesv2 permissions for SES checks

### DIFF
--- a/permissions/prowler-additions-policy.json
+++ b/permissions/prowler-additions-policy.json
@@ -37,6 +37,8 @@
         "macie2:GetMacieSession",
         "macie2:GetAutomatedDiscoveryConfiguration",
         "s3:GetAccountPublicAccessBlock",
+        "sesv2:GetEmailIdentity",
+        "sesv2:ListEmailIdentities",
         "shield:DescribeProtection",
         "shield:GetSubscriptionState",
         "securityhub:BatchImportFindings",

--- a/permissions/templates/cloudformation/prowler-scan-role.yml
+++ b/permissions/templates/cloudformation/prowler-scan-role.yml
@@ -130,6 +130,8 @@ Resources:
                   - "macie2:GetMacieSession"
                   - "macie2:GetAutomatedDiscoveryConfiguration"
                   - "s3:GetAccountPublicAccessBlock"
+                  - "sesv2:GetEmailIdentity"
+                  - "sesv2:ListEmailIdentities"
                   - "shield:DescribeProtection"
                   - "shield:GetSubscriptionState"
                   - "securityhub:BatchImportFindings"


### PR DESCRIPTION
## Summary

This PR adds missing `sesv2` permissions to the Prowler additions policy and CloudFormation scan role template.

## Problem

The SES service in Prowler uses the **SESv2 API** (not the v1 SES API) to list and retrieve email identity details. The AWS managed `SecurityAudit` policy only includes `ses:Get*` and `ses:List*` permissions for the v1 API, but does **not** cover `sesv2` API calls.

Without these permissions, the SES checks fail with `AccessDenied` errors when using the Prowler scan role:
- `ses_identity_not_publicly_accessible` - checks SES identity resource policies
- `ses_identity_dkim_enabled` (new) - checks DKIM signing status

## Changes

Added to both `permissions/prowler-additions-policy.json` and `permissions/templates/cloudformation/prowler-scan-role.yml`:
- `sesv2:GetEmailIdentity` - required to retrieve email identity details including DKIM status and policies
- `sesv2:ListEmailIdentities` - required to list all email identities in the account

## Testing

These permissions are the minimum required for the existing SES service code which calls:
- `regional_client.list_email_identities()` → requires `sesv2:ListEmailIdentities`
- `regional_client.get_email_identity()` → requires `sesv2:GetEmailIdentity`