### PR TITLE
docs(sdk): link route53 changelog entry to PR

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### 🔄 Changed
 
-- `route53_dangling_ip_subdomain_takeover` now also flags `CNAME` records pointing to S3 website endpoints whose buckets are missing from the account
+- `route53_dangling_ip_subdomain_takeover` now also flags `CNAME` records pointing to S3 website endpoints whose buckets are missing from the account [(#10920)](https://github.com/prowler-cloud/prowler/pull/10920)
 - Azure Network Watcher flow log checks now require workspace-backed Traffic Analytics for `network_flow_log_captured_sent` and align metadata with VNet-compatible flow log guidance [(#10645)](https://github.com/prowler-cloud/prowler/pull/10645)
 
 ---


### PR DESCRIPTION
### Context

The SDK changelog entry introduced by #10920 was missing its pull request link.

### Description

- Add the `[(#10920)](https://github.com/prowler-cloud/prowler/pull/10920)` link to the `route53_dangling_ip_subdomain_takeover` changelog entry

### Steps to review

- Confirm `prowler/CHANGELOG.md` links the #10920 entry in the unreleased SDK changelog section

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
