### PR TITLE
docs: add troubleshooting guide for stuck scans after worker crash

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -159,6 +159,40 @@ When these environment variables are set, the API will use them directly instead
 A fix addressing this permission issue is being evaluated in [PR #9953](https://github.com/prowler-cloud/prowler/pull/9953).
 </Note>
 
+### Scan Stuck in Executing State After Worker Crash
+
+When running Prowler App via Docker Compose, a scan may remain indefinitely in the `executing` state if the worker process crashes (for example, due to an Out of Memory condition) before it can update the scan status. Since it is not currently possible to cancel a scan in `executing` state through the UI, the workaround is to manually update the scan record in the database.
+
+**Root Cause:**
+
+The Celery worker process terminates unexpectedly (OOM, node failure, etc.) before transitioning the scan state to `completed` or `failed`. The scan record remains in `executing` with no active process to advance it.
+
+**Solution:**
+
+Connect to the database using the `prowler_admin` user. Due to Row-Level Security (RLS), the default database user cannot see scan records — you must use `prowler_admin`:
+
+```bash
+psql -U prowler_admin -d prowler_db
+```
+
+Identify the stuck scan by filtering for scans in `executing` state:
+
+```sql
+SELECT id, name, state, started_at FROM scans WHERE state = 'executing';
+```
+
+Update the scan state to `failed` using the scan ID:
+
+```sql
+UPDATE scans SET state = 'failed' WHERE id = '<scan-id>';
+```
+
+After this change, the scan will appear as failed in the UI and you can launch a new scan.
+
+<Note>
+A feature to cancel executing scans directly from the UI is being tracked in [GitHub Issue #6893](https://github.com/prowler-cloud/prowler/issues/6893).
+</Note>
+
 ### SAML/OAuth ACS URL Incorrect When Running Behind a Proxy or Load Balancer
 
 See [GitHub Issue #9724](https://github.com/prowler-cloud/prowler/issues/9724) for more details.


### PR DESCRIPTION
## Context

When a Celery worker crashes (e.g., due to OOM), scans can get stuck in `executing` state indefinitely. There is currently no way to cancel an executing scan from the UI (tracked in #6893). Users have reported this issue and needed guidance on the database workaround.

## Description

Adds a new troubleshooting section documenting how to resolve scans stuck in `executing` state:

- Explains the root cause (worker crash before state transition)
- Documents the RLS requirement (`prowler_admin` user)
- Provides step-by-step SQL commands to identify and fix stuck scans
- References #6893 for the planned UI cancellation feature

## Checklist

- [x] Documentation follows Prowler style guide
- [x] No code changes involved
- [x] Section placed logically within existing Docker Compose troubleshooting