### PR TITLE
chore(ui): decrement changelog entry version to 1.25.2

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.26.0] (Prowler UNRELEASED)
+## [1.25.2] (Prowler UNRELEASED)
 
 ### 🔄 Changed
 


### PR DESCRIPTION
### Context

The previous changelog entry for #10949 was added under `[1.26.0] (Prowler UNRELEASED)`. This release is a patch (`1.25.2`), not a minor bump, so the version label needs to be corrected.

### Description

In `ui/CHANGELOG.md`:

- Rename the unreleased section header from `[1.26.0] (Prowler UNRELEASED)` to `[1.25.2] (Prowler UNRELEASED)`.

No content changes — only the version label.

### Steps to review

1. Open `ui/CHANGELOG.md`.
2. Confirm the top section reads `## [1.25.2] (Prowler UNRELEASED)` and the entry for [(#10949)](https://github.com/prowler-cloud/prowler/pull/10949) sits under it.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.