### PR TITLE
chore(precommit): scope zizmor hook to workflows, actions and dependabot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,12 @@ repos:
     rev: v1.24.1
     hooks:
       - id: zizmor
-        files: ^\.github/
+        # Scope to the inputs zizmor actually audits: workflows, composite
+        # actions, and dependabot config. The previous `^\.github/` regex
+        # also matched issue templates / labeler / CODEOWNERS, which made
+        # zizmor exit 3 ("no audit was performed") on commits that touch
+        # those files.
+        files: ^\.github/(workflows|actions)/.+\.ya?ml$|^\.github/dependabot\.ya?ml$
         priority: 30
 
   ## BASH

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,11 +44,8 @@ repos:
     rev: v1.24.1
     hooks:
       - id: zizmor
-        # Scope to the inputs zizmor actually audits: workflows, composite
-        # actions, and dependabot config. The previous `^\.github/` regex
-        # also matched issue templates / labeler / CODEOWNERS, which made
-        # zizmor exit 3 ("no audit was performed") on commits that touch
-        # those files.
+        # zizmor only audits workflows, composite actions and dependabot
+        # config; broader paths trip exit 3 ("no audit was performed").
         files: ^\.github/(workflows|actions)/.+\.ya?ml$|^\.github/dependabot\.ya?ml$
         priority: 30
 


### PR DESCRIPTION
### Context

The `zizmor` pre-commit hook in `.pre-commit-config.yaml` was configured with `files: ^\.github/`, which matches **any** file under `.github/`. zizmor only audits GitHub Actions workflows, composite actions and Dependabot configs, so any commit touching a non-auditable `.github/` file (issue templates, `labeler.yml`, `CODEOWNERS`, the labeler-action config, `zizmor.yml` itself, …) failed the hook with `exit code 3`:

```
zizmor...................................................................Failed
- hook id: zizmor
- exit code: 3

  WARN collect_inputs: zizmor::registry::input: failed to validate input as workflow:
  input does not match expected validation schema
  fatal: no audit was performed
  error: no inputs collected
```

Reproducible on `master` today: the recent issue-template addition (`.github/ISSUE_TEMPLATE/new-check-request.yml`, #10976) is enough to break the hook for anyone whose chain runs zizmor on those paths.

### Description

Narrow the `files:` regex to the inputs zizmor actually audits:

```yaml
files: ^\.github/(workflows|actions)/.+\.ya?ml$|^\.github/dependabot\.ya?ml$
```

Coverage matrix (verified with `prek run zizmor --files <path>`):

| Path | Before | After | Audited by zizmor? |
|---|---|---|---|
| `.github/workflows/api-bump-version.yml` | run | run ✓ | yes (workflow) |
| `.github/actions/<x>/action.yml` | run | run ✓ | yes (composite action) |
| `.github/dependabot.yml` | run | run ✓ | yes |
| `.github/ISSUE_TEMPLATE/new-check-request.yml` | **fail (exit 3)** | skip ✓ | no |
| `.github/labeler.yml` / `CODEOWNERS` / `zizmor.yml` / `pull_request_template.md` | run-then-fail or skip | skip ✓ | no |
| `.pre-commit-config.yaml` (manifest) | n/a | skip ✓ | no |

An inline comment in the hook block records the why, so the next maintainer doesn't broaden the regex back.

### Steps to review

```bash
prek run zizmor --files .github/workflows/api-bump-version.yml         # passes
prek run zizmor --files .github/ISSUE_TEMPLATE/new-check-request.yml   # skipped, no error
prek run zizmor --files .github/labeler.yml                            # skipped, no error
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests. — N/A (pre-commit config only, no runtime code)
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings — inline comment added in the hook block
- [x] Review if backport is needed. — No, dev tooling only
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — No
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. — Not user-visible; `no-changelog` label applied

#### SDK/CLI
- Are there new checks included in this PR? **No**

#### UI
- [ ] All issue/task requirements work as expected on the UI — N/A
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) — N/A
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) — N/A
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) — N/A
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. — N/A

#### API
- [ ] All issue/task requirements work as expected on the API — N/A
- [ ] Endpoint response output (if applicable) — N/A
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — N/A
- [ ] Performance test results (if applicable) — N/A
- [ ] Any other relevant evidence of the implementation (if applicable) — N/A
- [ ] Verify if API specs need to be regenerated. — N/A
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.). — N/A
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. — N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.