### PR TITLE
[CHAIN] feat(ui): add custom alerts contracts and actions

### DIFF
--- a/ui/app/(prowler)/alerts/_actions/_request.ts
+++ b/ui/app/(prowler)/alerts/_actions/_request.ts
@@ -1,0 +1,167 @@
+"use server";
+
+import * as Sentry from "@sentry/nextjs";
+
+import { apiBaseUrl, getAuthHeaders } from "@/lib";
+
+import { buildAlertsDisabledResult, isAlertsEnabled } from "../_lib/env";
+import {
+  buildSuccessResult,
+  buildUnexpectedError,
+  mapJsonApiErrorToAction,
+} from "../_lib/error-mapping";
+import type { AlertsActionResult } from "../_types";
+
+export interface AlertsRequestOptions {
+  method?: "GET" | "POST" | "PATCH" | "DELETE" | "OPTIONS";
+  query?: URLSearchParams | Record<string, string | string[] | undefined>;
+  body?: unknown;
+  contentType?: boolean;
+  attachAuth?: boolean;
+  cache?: RequestCache;
+  signal?: AbortSignal;
+  /**
+   * Override the `Accept` / `Content-Type` headers. Useful for endpoints that
+   * use plain `JSONRenderer`/`JSONParser` instead of JSON:API renderers (e.g.
+   * the alerts dry-run endpoints `/preview` and `/{id}/test`).
+   */
+  acceptOverride?: string;
+  contentTypeOverride?: string;
+}
+
+const isPairArray = (
+  value: unknown,
+): value is ReadonlyArray<readonly [string, string]> =>
+  Array.isArray(value) &&
+  value.every(
+    (entry) =>
+      Array.isArray(entry) && entry.length >= 2 && typeof entry[0] === "string",
+  );
+
+const buildUrl = (
+  path: string,
+  query: AlertsRequestOptions["query"],
+): string => {
+  if (!apiBaseUrl) {
+    throw new Error("NEXT_PUBLIC_API_BASE_URL is not configured.");
+  }
+  const url = new URL(`${apiBaseUrl}${path}`);
+  if (!query) return url.toString();
+  // Real URLSearchParams (RSC → action call within the same process).
+  if (query instanceof URLSearchParams) {
+    query.forEach((value, key) => url.searchParams.append(key, value));
+    return url.toString();
+  }
+  // Serialized URLSearchParams shape (client → server action crosses the
+  // boundary; Next.js converts URLSearchParams to its [[k, v], ...] form).
+  if (isPairArray(query)) {
+    for (const [key, value] of query) {
+      url.searchParams.append(key, String(value ?? ""));
+    }
+    return url.toString();
+  }
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) url.searchParams.append(key, v);
+      continue;
+    }
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+};
+
+const safeJson = async (response: Response): Promise<unknown> => {
+  const text = await response.text().catch(() => "");
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+};
+
+export const alertsRequest = async <T>(
+  path: string,
+  options: AlertsRequestOptions = {},
+): Promise<AlertsActionResult<T>> => {
+  if (!isAlertsEnabled()) {
+    return buildAlertsDisabledResult<T>();
+  }
+
+  const {
+    method = "GET",
+    query,
+    body,
+    contentType = method !== "GET" && method !== "DELETE",
+    attachAuth = true,
+    cache,
+    signal,
+    acceptOverride,
+    contentTypeOverride,
+  } = options;
+  try {
+    const baseHeaders = attachAuth
+      ? await getAuthHeaders({ contentType })
+      : ({
+          Accept: "application/vnd.api+json",
+          ...(contentType
+            ? { "Content-Type": "application/vnd.api+json" }
+            : {}),
+        } as Record<string, string>);
+    const headers: Record<string, string> = { ...baseHeaders };
+    if (acceptOverride) headers.Accept = acceptOverride;
+    if (contentTypeOverride) headers["Content-Type"] = contentTypeOverride;
+
+    const url = buildUrl(path, query);
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+      cache: cache ?? "no-store",
+      signal,
+    });
+
+    if (!response.ok) {
+      const parsedBody = (await safeJson(response)) as Parameters<
+        typeof mapJsonApiErrorToAction
+      >[1];
+      const error = mapJsonApiErrorToAction(
+        response.status,
+        parsedBody,
+        response.headers.get("retry-after"),
+      );
+      Sentry.addBreadcrumb({
+        category: "alerts.request",
+        message: `${method} ${path} failed`,
+        level: "warning",
+        data: {
+          status: response.status,
+          code: error.code,
+          retry_after_seconds: error.retryAfterSeconds,
+        },
+      });
+      return { ok: false, error };
+    }
+
+    if (response.status === 204) {
+      return buildSuccessResult(undefined as T, null);
+    }
+
+    const parsed = (await safeJson(response)) as Parameters<
+      typeof mapJsonApiErrorToAction
+    >[1] & { data?: unknown };
+    return buildSuccessResult((parsed ?? null) as T, parsed);
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { error_source: "alerts.request", method },
+      level: "error",
+    });
+    return {
+      ok: false,
+      error: buildUnexpectedError(
+        error instanceof Error ? error.message : "Unexpected error.",
+      ),
+    };
+  }
+};

--- a/ui/app/(prowler)/alerts/_actions/alerts.test.ts
+++ b/ui/app/(prowler)/alerts/_actions/alerts.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib", () => ({
+  apiBaseUrl: "https://api.test/api/v1",
+  getAuthHeaders: vi.fn(async () => ({
+    Accept: "application/vnd.api+json",
+    Authorization: "Bearer test-token",
+    "Content-Type": "application/vnd.api+json",
+  })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+  unstable_cache: <T extends (...args: unknown[]) => unknown>(fn: T) => fn,
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+import {
+  ALERT_AGGREGATE_OPS,
+  ALERT_ERROR_CODES,
+  ALERT_TRIGGER_KINDS,
+} from "../_types";
+import {
+  createAlert,
+  deleteAlert,
+  disableAlert,
+  enableAlert,
+  listAlerts,
+  previewAlertCondition,
+  updateAlert,
+} from "./alerts";
+
+const mockFetchOnce = (
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+) => {
+  const response = new Response(body === null ? null : JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/vnd.api+json",
+      ...headers,
+    },
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => response),
+  );
+};
+
+const captureFetchArgs = (status: number, body: unknown) => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchMock = vi.fn(async (url: RequestInfo, init?: RequestInit) => {
+    calls.push({ url: url.toString(), init: init ?? {} });
+    return new Response(body === null ? null : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/vnd.api+json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return calls;
+};
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "true";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listAlerts", () => {
+  it("returns a controlled error without fetching when alerts are disabled", async () => {
+    process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "false";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await listAlerts();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ALERT_ERROR_CODES.FORBIDDEN);
+      expect(result.error.status).toBe(403);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the parsed list payload on success", async () => {
+    mockFetchOnce(200, { data: [], meta: { pagination: { count: 0 } } });
+    const result = await listAlerts(
+      new URLSearchParams("filter[enabled]=true"),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.data).toEqual([]);
+      expect(result.data.meta?.pagination?.count).toBe(0);
+    }
+  });
+
+  it("forwards searchParams as query string", async () => {
+    const calls = captureFetchArgs(200, { data: [] });
+    await listAlerts(new URLSearchParams("filter[trigger]=daily"));
+    expect(calls[0].url).toContain("filter%5Btrigger%5D=daily");
+  });
+});
+
+describe("createAlert", () => {
+  it("posts a JSON:API envelope and returns the new alert", async () => {
+    const calls = captureFetchArgs(201, {
+      data: {
+        id: "alert-1",
+        type: "alert-rules",
+        attributes: { name: "n", trigger: "after_scan" },
+      },
+    });
+    const result = await createAlert({
+      name: "Daily critical",
+      trigger: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+      condition: {
+        op: ALERT_AGGREGATE_OPS.ANY,
+        filter: { severity: ["critical"] },
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(calls[0].init.method).toBe("POST");
+    const body = JSON.parse((calls[0].init.body as string) ?? "{}");
+    expect(body.data.type).toBe("alert-rules");
+    expect(body.data.attributes.schema_version).toBe(1);
+  });
+
+  it("surfaces JSON:API validation errors with the API code", async () => {
+    mockFetchOnce(400, {
+      errors: [
+        {
+          code: "unknown_filter_field",
+          detail: "Unknown filter field 'foo'.",
+          source: { pointer: "/data/attributes/condition/filter/foo" },
+        },
+      ],
+    });
+    const result = await createAlert({
+      name: "x",
+      trigger: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+      condition: {
+        op: ALERT_AGGREGATE_OPS.ANY,
+        filter: { severity: ["high"] },
+      },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ALERT_ERROR_CODES.UNKNOWN_FILTER_FIELD);
+    }
+  });
+
+  it("sends an empty recipient list when provided", async () => {
+    const calls = captureFetchArgs(201, {
+      data: {
+        id: "alert-1",
+        type: "alert-rules",
+        attributes: { name: "n", trigger: "after_scan" },
+      },
+    });
+    await createAlert({
+      name: "No recipients yet",
+      trigger: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+      condition: {
+        op: ALERT_AGGREGATE_OPS.ANY,
+        filter: { severity: ["critical"] },
+      },
+      recipientEmails: [],
+    });
+
+    const body = JSON.parse((calls[0].init.body as string) ?? "{}");
+    expect(body.data.attributes.recipient_emails).toEqual([]);
+  });
+});
+
+describe("updateAlert", () => {
+  it("PATCHes the alert with the id in the URL", async () => {
+    const calls = captureFetchArgs(200, {
+      data: { id: "alert-1", type: "alert-rules", attributes: {} },
+    });
+    const result = await updateAlert("alert-1", {
+      name: "Updated",
+      trigger: ALERT_TRIGGER_KINDS.DAILY,
+      condition: {
+        op: ALERT_AGGREGATE_OPS.ANY,
+        filter: { severity: ["critical"] },
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(calls[0].url).toContain("/alerts/rules/alert-1");
+    expect(calls[0].init.method).toBe("PATCH");
+  });
+});
+
+describe("deleteAlert", () => {
+  it("returns ok on 204 without body", async () => {
+    const calls = captureFetchArgs(204, null);
+    const result = await deleteAlert("alert-1");
+    expect(result.ok).toBe(true);
+    expect(calls[0].init.method).toBe("DELETE");
+  });
+});
+
+describe("enable / disable", () => {
+  it("PATCHes enabled true to the alert rule endpoint", async () => {
+    const calls = captureFetchArgs(200, {
+      data: { id: "alert-1", type: "alert-rules", attributes: {} },
+    });
+    await enableAlert("alert-1");
+    expect(calls[0].url).toMatch(/\/alerts\/rules\/alert-1$/);
+    expect(calls[0].init.method).toBe("PATCH");
+    const body = JSON.parse((calls[0].init.body as string) ?? "{}");
+    expect(body).toEqual({
+      data: {
+        type: "alert-rules",
+        id: "alert-1",
+        attributes: { enabled: true },
+      },
+    });
+  });
+
+  it("PATCHes enabled false to the alert rule endpoint", async () => {
+    const calls = captureFetchArgs(200, {
+      data: { id: "alert-1", type: "alert-rules", attributes: {} },
+    });
+    await disableAlert("alert-1");
+    expect(calls[0].url).toMatch(/\/alerts\/rules\/alert-1$/);
+    expect(calls[0].init.method).toBe("PATCH");
+    const body = JSON.parse((calls[0].init.body as string) ?? "{}");
+    expect(body).toEqual({
+      data: {
+        type: "alert-rules",
+        id: "alert-1",
+        attributes: { enabled: false },
+      },
+    });
+  });
+});
+
+describe("previewAlertCondition", () => {
+  it("posts to /preview and forwards trigger", async () => {
+    const calls = captureFetchArgs(200, { data: { attributes: {} } });
+    await previewAlertCondition({
+      condition: {
+        op: ALERT_AGGREGATE_OPS.ANY,
+        filter: { severity: ["critical"] },
+      },
+      trigger: ALERT_TRIGGER_KINDS.DAILY,
+    });
+    expect(calls[0].url).toMatch(/\/alerts\/rules\/preview$/);
+    expect(calls[0].init.method).toBe("POST");
+    const body = JSON.parse((calls[0].init.body as string) ?? "{}");
+    expect(body.trigger).toBe("daily");
+  });
+
+  it("unwraps JSON:API preview attributes into the preview model", async () => {
+    mockFetchOnce(200, {
+      data: {
+        type: "alert-rule-previews",
+        id: "preview",
+        attributes: {
+          would_fire: true,
+          summary: {
+            finding_count_total: 7,
+            top_severity: "critical",
+          },
+          sample_finding_ids: [],
+          evaluation_failed: false,
+          duration_ms: 42,
+        },
+      },
+    });
+
+    const result = await previewAlertCondition({
+      condition: {
+        op: ALERT_AGGREGATE_OPS.ANY,
+        filter: { severity: ["critical"] },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.would_fire).toBe(true);
+      expect(result.data.summary.finding_count_total).toBe(7);
+      expect(result.data.duration_ms).toBe(42);
+    }
+  });
+});

--- a/ui/app/(prowler)/alerts/_actions/alerts.ts
+++ b/ui/app/(prowler)/alerts/_actions/alerts.ts
@@ -1,0 +1,257 @@
+"use server";
+
+import * as Sentry from "@sentry/nextjs";
+import { revalidatePath } from "next/cache";
+
+import {
+  ALERT_SCHEMA_VERSION,
+  type AlertCondition,
+  type AlertPreviewResponse,
+  type AlertRule,
+  type AlertsActionResult,
+  type AlertTriggerKind,
+} from "../_types";
+import { alertsRequest } from "./_request";
+
+const ALERT_RULES_API_PATH = "/alerts/rules";
+const ALERTS_BASE_PATH = "/alerts";
+
+const revalidateAlertsBase = () => {
+  revalidatePath(ALERTS_BASE_PATH);
+};
+
+const revalidateAlert = (alertId: string) => {
+  revalidatePath(`${ALERTS_BASE_PATH}/${alertId}`);
+};
+
+const breadcrumb = (
+  category: string,
+  message: string,
+  data?: Record<string, unknown>,
+) => {
+  Sentry.addBreadcrumb({ category, message, level: "info", data });
+};
+
+export interface AlertsListResponse {
+  data: AlertRule[];
+  meta?: {
+    pagination?: { count: number; pages: number; page: number };
+  };
+}
+
+export const listAlerts = async (
+  searchParams?: URLSearchParams,
+): Promise<AlertsActionResult<AlertsListResponse>> =>
+  alertsRequest<AlertsListResponse>(ALERT_RULES_API_PATH, {
+    method: "GET",
+    query: searchParams,
+  });
+
+export const getAlert = async (
+  alertId: string,
+): Promise<AlertsActionResult<{ data: AlertRule }>> =>
+  alertsRequest<{ data: AlertRule }>(`${ALERT_RULES_API_PATH}/${alertId}`, {
+    method: "GET",
+  });
+
+export interface AlertPayload {
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  trigger: AlertTriggerKind;
+  condition: AlertCondition;
+  /**
+   * List of recipient email addresses. The API resolves them to existing
+   * `AlertRecipient` rows or creates new pending ones with confirmation
+   * emails. Recipient IDs are NOT used by the rule write path.
+   */
+  recipientEmails?: string[];
+}
+
+const buildRuleEnvelope = (payload: AlertPayload, alertId?: string) => ({
+  data: {
+    type: "alert-rules",
+    ...(alertId ? { id: alertId } : {}),
+    attributes: {
+      name: payload.name,
+      description: payload.description ?? "",
+      enabled: payload.enabled ?? true,
+      trigger: payload.trigger,
+      condition: payload.condition,
+      schema_version: ALERT_SCHEMA_VERSION,
+      ...(payload.recipientEmails !== undefined
+        ? { recipient_emails: payload.recipientEmails }
+        : {}),
+    },
+  },
+});
+
+const buildEnabledEnvelope = (alertId: string, enabled: boolean) => ({
+  data: {
+    type: "alert-rules",
+    id: alertId,
+    attributes: { enabled },
+  },
+});
+
+export const createAlert = async (
+  payload: AlertPayload,
+): Promise<AlertsActionResult<{ data: AlertRule }>> => {
+  const result = await alertsRequest<{ data: AlertRule }>(
+    ALERT_RULES_API_PATH,
+    {
+      method: "POST",
+      body: buildRuleEnvelope(payload),
+    },
+  );
+  if (result.ok) {
+    breadcrumb("alerts.create", "Created alert", {
+      alertId: result.data?.data?.id,
+    });
+    revalidateAlertsBase();
+  }
+  return result;
+};
+
+export const updateAlert = async (
+  alertId: string,
+  payload: AlertPayload,
+): Promise<AlertsActionResult<{ data: AlertRule }>> => {
+  const result = await alertsRequest<{ data: AlertRule }>(
+    `${ALERT_RULES_API_PATH}/${alertId}`,
+    {
+      method: "PATCH",
+      body: buildRuleEnvelope(payload, alertId),
+    },
+  );
+  if (result.ok) {
+    breadcrumb("alerts.update", "Updated alert", { alertId });
+    revalidateAlertsBase();
+    revalidateAlert(alertId);
+  }
+  return result;
+};
+
+export const deleteAlert = async (
+  alertId: string,
+): Promise<AlertsActionResult<undefined>> => {
+  const result = await alertsRequest<undefined>(
+    `${ALERT_RULES_API_PATH}/${alertId}`,
+    {
+      method: "DELETE",
+    },
+  );
+  if (result.ok) {
+    breadcrumb("alerts.delete", "Deleted alert", { alertId });
+    revalidateAlertsBase();
+  }
+  return result;
+};
+
+export const enableAlert = async (
+  alertId: string,
+): Promise<AlertsActionResult<{ data: AlertRule }>> => {
+  const result = await alertsRequest<{ data: AlertRule }>(
+    `${ALERT_RULES_API_PATH}/${alertId}`,
+    {
+      method: "PATCH",
+      body: buildEnabledEnvelope(alertId, true),
+    },
+  );
+  if (result.ok) {
+    breadcrumb("alerts.enable", "Enabled alert", { alertId });
+    revalidateAlertsBase();
+    revalidateAlert(alertId);
+  }
+  return result;
+};
+
+export const disableAlert = async (
+  alertId: string,
+): Promise<AlertsActionResult<{ data: AlertRule }>> => {
+  const result = await alertsRequest<{ data: AlertRule }>(
+    `${ALERT_RULES_API_PATH}/${alertId}`,
+    {
+      method: "PATCH",
+      body: buildEnabledEnvelope(alertId, false),
+    },
+  );
+  if (result.ok) {
+    breadcrumb("alerts.disable", "Disabled alert", { alertId });
+    revalidateAlertsBase();
+    revalidateAlert(alertId);
+  }
+  return result;
+};
+
+interface AlertPreviewEnvelope {
+  data?: {
+    type?: "alert-rule-previews";
+    id?: string;
+    attributes?: Partial<AlertPreviewResponse>;
+  };
+  meta?: Record<string, unknown>;
+}
+
+const isAlertPreviewEnvelope = (
+  value: AlertPreviewResponse | AlertPreviewEnvelope,
+): value is AlertPreviewEnvelope =>
+  "data" in value &&
+  typeof value.data === "object" &&
+  value.data !== null &&
+  "attributes" in value.data;
+
+const normalizePreviewResponse = (
+  value: AlertPreviewResponse | AlertPreviewEnvelope,
+): AlertPreviewResponse => {
+  const attributes = isAlertPreviewEnvelope(value)
+    ? value.data?.attributes
+    : value;
+
+  if (!attributes) {
+    return {
+      would_fire: false,
+      summary: { finding_count_total: 0 },
+      sample_finding_ids: [],
+      evaluation_failed: true,
+      last_error: "Preview response is missing attributes.",
+    };
+  }
+
+  const summary = attributes.summary ?? { finding_count_total: 0 };
+
+  return {
+    would_fire: attributes.would_fire ?? false,
+    summary,
+    sample_finding_ids:
+      attributes.sample_finding_ids ?? summary.top_findings ?? [],
+    evaluation_failed: attributes.evaluation_failed ?? false,
+    last_error: attributes.last_error,
+    summary_fallback: attributes.summary_fallback,
+    duration_ms: attributes.duration_ms,
+  };
+};
+
+export const previewAlertCondition = async (payload: {
+  condition: AlertCondition;
+  trigger?: AlertTriggerKind;
+}): Promise<AlertsActionResult<AlertPreviewResponse>> => {
+  const result = await alertsRequest<
+    AlertPreviewResponse | AlertPreviewEnvelope
+  >(`${ALERT_RULES_API_PATH}/preview`, {
+    method: "POST",
+    body: {
+      condition: payload.condition,
+      trigger: payload.trigger,
+    },
+    acceptOverride: "application/vnd.api+json, application/json",
+    contentTypeOverride: "application/json",
+  });
+  breadcrumb(
+    result.ok ? "alerts.preview" : "alerts.preview.failed",
+    "Previewed alert condition",
+    { ok: result.ok },
+  );
+  if (!result.ok) return result;
+  return { ...result, data: normalizePreviewResponse(result.data) };
+};

--- a/ui/app/(prowler)/alerts/_actions/index.ts
+++ b/ui/app/(prowler)/alerts/_actions/index.ts
@@ -1,0 +1,3 @@
+export * from "./alerts";
+export * from "./public";
+export * from "./recipients";

--- a/ui/app/(prowler)/alerts/_actions/public.test.ts
+++ b/ui/app/(prowler)/alerts/_actions/public.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib", () => ({
+  apiBaseUrl: "https://api.test/api/v1",
+  getAuthHeaders: vi.fn(async () => ({
+    Accept: "application/vnd.api+json",
+    Authorization: "Bearer test-token",
+  })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+import { confirmRecipient, unsubscribeRecipient } from "./public";
+
+const captureFetchArgs = (status: number, body: unknown) => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchMock = vi.fn(async (url: RequestInfo, init?: RequestInit) => {
+    calls.push({ url: url.toString(), init: init ?? {} });
+    return new Response(body === null ? null : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return calls;
+};
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "true";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("confirmRecipient", () => {
+  it("returns a controlled response without fetching when alerts are disabled", async () => {
+    process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "false";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await confirmRecipient("token-123");
+
+    expect(result.state).toBe("network_error");
+    expect(result.message).toMatch(/Prowler Cloud/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT attach Authorization header (public endpoint)", async () => {
+    const calls = captureFetchArgs(200, {
+      state: "confirmed",
+      message: "Recipient confirmed.",
+    });
+    await confirmRecipient("token-123");
+    const headers = (calls[0].init.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    expect(calls[0].url).toContain("/alerts/recipients/confirm");
+    expect(calls[0].url).toContain("token=token-123");
+  });
+
+  it("returns the API state on a 200 response", async () => {
+    captureFetchArgs(200, {
+      state: "already_confirmed",
+      message: "Already confirmed.",
+    });
+    const result = await confirmRecipient("token-123");
+    expect(result.state).toBe("already_confirmed");
+    expect(result.message).toBe("Already confirmed.");
+  });
+
+  it("surfaces invalid_token state from a 400 response", async () => {
+    captureFetchArgs(400, {
+      state: "invalid_token",
+      message: "Token is malformed.",
+    });
+    const result = await confirmRecipient("bad-token");
+    expect(result.state).toBe("invalid_token");
+  });
+
+  it("folds malformed bodies into network_error", async () => {
+    captureFetchArgs(500, "not-json");
+    const result = await confirmRecipient("token-123");
+    expect(result.state).toBe("network_error");
+  });
+});
+
+describe("unsubscribeRecipient", () => {
+  it("hits /unsubscribe with the token and returns the API state", async () => {
+    const calls = captureFetchArgs(200, {
+      state: "unsubscribed",
+      message: "Unsubscribed.",
+    });
+    const result = await unsubscribeRecipient("token-xyz");
+    expect(result.state).toBe("unsubscribed");
+    expect(calls[0].url).toContain("/alerts/recipients/unsubscribe");
+  });
+});

--- a/ui/app/(prowler)/alerts/_actions/public.ts
+++ b/ui/app/(prowler)/alerts/_actions/public.ts
@@ -1,0 +1,65 @@
+"use server";
+
+import { apiBaseUrl } from "@/lib";
+
+import {
+  buildAlertsDisabledPublicResponse,
+  isAlertsEnabled,
+} from "../_lib/env";
+import type { AlertPublicResponse } from "../_types";
+
+// NOT FOR THE MVP: public confirm/unsubscribe endpoints are only needed for
+// recipient consent links. MVP tenant recipients are already confirmed.
+const PUBLIC_PATH = "/alerts/recipients";
+
+const _call = async (
+  endpoint: "confirm" | "unsubscribe",
+  token: string,
+): Promise<AlertPublicResponse> => {
+  if (!isAlertsEnabled()) {
+    return buildAlertsDisabledPublicResponse();
+  }
+
+  if (!apiBaseUrl) {
+    return {
+      state: "network_error",
+      message: "API base URL is not configured.",
+    };
+  }
+  try {
+    const url = `${apiBaseUrl}${PUBLIC_PATH}/${endpoint}?token=${encodeURIComponent(token)}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    const body = (await response
+      .json()
+      .catch(() => null)) as AlertPublicResponse | null;
+    if (body && typeof body === "object" && "state" in body) {
+      return body;
+    }
+    return {
+      state: "network_error",
+      message: `Unexpected response from server (HTTP ${response.status}).`,
+    };
+  } catch (err) {
+    return {
+      state: "network_error",
+      message:
+        err instanceof Error ? err.message : "Could not reach the server.",
+    };
+  }
+};
+
+export async function confirmRecipient(
+  token: string,
+): Promise<AlertPublicResponse> {
+  return _call("confirm", token);
+}
+
+export async function unsubscribeRecipient(
+  token: string,
+): Promise<AlertPublicResponse> {
+  return _call("unsubscribe", token);
+}

--- a/ui/app/(prowler)/alerts/_actions/recipients.test.ts
+++ b/ui/app/(prowler)/alerts/_actions/recipients.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib", () => ({
+  apiBaseUrl: "https://api.test/api/v1",
+  getAuthHeaders: vi.fn(async () => ({
+    Accept: "application/vnd.api+json",
+    Authorization: "Bearer test-token",
+    "Content-Type": "application/vnd.api+json",
+  })),
+}));
+
+import { listAlertRecipients } from "./recipients";
+
+const captureFetchArgs = (status: number, body: unknown) => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchMock = vi.fn(async (url: RequestInfo, init?: RequestInit) => {
+    calls.push({ url: url.toString(), init: init ?? {} });
+    return new Response(body === null ? null : JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/vnd.api+json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return calls;
+};
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "true";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("listAlertRecipients", () => {
+  it("returns a controlled error without fetching when alerts are disabled", async () => {
+    process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "false";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await listAlertRecipients();
+
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the parsed list payload", async () => {
+    const calls = captureFetchArgs(200, {
+      data: [
+        {
+          id: "1",
+          type: "alert-recipients",
+          attributes: { email: "a@b.test", status: "pending" },
+        },
+      ],
+      meta: { pagination: { count: 1, page: 1, pages: 1 } },
+    });
+    const result = await listAlertRecipients(
+      new URLSearchParams("filter[status]=pending"),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.data).toHaveLength(1);
+      expect(result.data.data[0].attributes.email).toBe("a@b.test");
+    }
+    expect(calls[0].url).toContain("filter%5Bstatus%5D=pending");
+  });
+});

--- a/ui/app/(prowler)/alerts/_actions/recipients.ts
+++ b/ui/app/(prowler)/alerts/_actions/recipients.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import type { AlertRecipient, AlertsActionResult } from "../_types";
+import { alertsRequest } from "./_request";
+
+const RECIPIENTS_PATH = "/alerts/recipients";
+
+export interface AlertRecipientsListResponse {
+  data: AlertRecipient[];
+  meta?: {
+    pagination?: { count: number; pages: number; page: number };
+  };
+}
+
+export const listAlertRecipients = async (
+  searchParams?: URLSearchParams,
+): Promise<AlertsActionResult<AlertRecipientsListResponse>> =>
+  alertsRequest<AlertRecipientsListResponse>(RECIPIENTS_PATH, {
+    method: "GET",
+    query: searchParams,
+  });

--- a/ui/app/(prowler)/alerts/_lib/__tests__/alert-adapter.test.ts
+++ b/ui/app/(prowler)/alerts/_lib/__tests__/alert-adapter.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ALERT_AGGREGATE_OPS,
+  ALERT_BOOLEAN_OPS,
+  ALERT_TRIGGER_KINDS,
+  type AlertCondition,
+  type AlertLeafFilter,
+  type AlertRule,
+} from "@/app/(prowler)/alerts/_types";
+
+import type { AlertFormValues } from "../../_types/alert-form";
+import {
+  buildAlertCondition,
+  getAlertFormDefaults,
+  getAlertFormDefaultsFromFindingsFilters,
+  toAlertPayload,
+} from "../alert-adapter";
+
+const baseValues = {
+  name: "  Critical findings  ",
+  description: "  Notify security  ",
+  method: "email",
+  frequency: ALERT_TRIGGER_KINDS.DAILY,
+  filterGroup: {
+    operator: "all",
+    children: [
+      {
+        kind: "filter",
+        field: "checkSeverities",
+        values: ["critical", "high"],
+      },
+      { kind: "filter", field: "type", values: ["new"] },
+      { kind: "filter", field: "providers", values: ["aws"] },
+      { kind: "filter", field: "accounts", values: ["provider-1"] },
+      { kind: "filter", field: "checks", values: ["iam_user_no_mfa"] },
+      { kind: "filter", field: "regions", values: ["us-east-1"] },
+      { kind: "filter", field: "services", values: ["iam"] },
+      { kind: "filter", field: "categories", values: ["identity-security"] },
+      { kind: "filter", field: "resourceGroups", values: ["prod"] },
+      { kind: "filter", field: "resourceTypes", values: ["AWS::IAM::User"] },
+      {
+        kind: "filter",
+        field: "resources",
+        values: ["arn:aws:iam::123:user/alice"],
+      },
+      { kind: "filter", field: "checkStatuses", values: ["FAIL"] },
+    ],
+  },
+  severities: ["critical", "high"],
+  deltas: ["new"],
+  providerTypes: ["aws"],
+  providerIds: ["provider-1"],
+  checkIds: ["iam_user_no_mfa"],
+  categories: ["identity-security"],
+  regions: ["us-east-1"],
+  services: ["iam"],
+  resourceGroups: ["prod"],
+  resourceTypes: ["AWS::IAM::User"],
+  recipientEmails: [" Security@Example.COM ", "ops@example.com"],
+  enabled: true,
+} satisfies AlertFormValues;
+
+const advancedCondition: AlertCondition = {
+  op: "not",
+  child: { op: ALERT_AGGREGATE_OPS.ANY, filter: { severity: ["critical"] } },
+};
+
+const countFilter = (filter: AlertLeafFilter) => ({
+  op: ALERT_AGGREGATE_OPS.COUNT_GTE,
+  filter,
+  value: 1,
+});
+
+const existingRule = {
+  id: "alert-1",
+  type: "alert-rules",
+  attributes: {
+    name: "Existing alert",
+    description: "Existing description",
+    enabled: false,
+    trigger: ALERT_TRIGGER_KINDS.BOTH,
+    condition: {
+      op: ALERT_AGGREGATE_OPS.ANY,
+      filter: { severity: ["medium", "low"] },
+    },
+    schema_version: 1,
+    recipient_emails: ["alerts@example.com"],
+    inserted_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+} satisfies AlertRule;
+
+describe("simple alert adapter", () => {
+  describe("payload mapping", () => {
+    it("should map simple form values to the existing create payload contract", () => {
+      // Given / When
+      const payload = toAlertPayload(baseValues);
+
+      // Then
+      expect(payload).toEqual({
+        name: "Critical findings",
+        description: "Notify security",
+        enabled: true,
+        trigger: ALERT_TRIGGER_KINDS.DAILY,
+        condition: {
+          op: ALERT_BOOLEAN_OPS.AND,
+          children: [
+            countFilter({ severity: ["critical", "high"] }),
+            countFilter({ delta: ["new"] }),
+            countFilter({ provider_type: ["aws"] }),
+            countFilter({ provider_id: ["provider-1"] }),
+            countFilter({ check_id: ["iam_user_no_mfa"] }),
+            countFilter({ resource_regions: ["us-east-1"] }),
+            countFilter({ resource_services: ["iam"] }),
+            countFilter({ categories: ["identity-security"] }),
+            countFilter({ resource_groups: ["prod"] }),
+            countFilter({ resource_types: ["AWS::IAM::User"] }),
+            countFilter({ resource_uid: ["arn:aws:iam::123:user/alice"] }),
+          ],
+        },
+        recipientEmails: ["security@example.com", "ops@example.com"],
+      });
+      expect(payload).not.toHaveProperty("method");
+    });
+
+    it("should normalize an edited alert to a simple condition instead of preserving an advanced condition", () => {
+      // Given / When
+      const payload = toAlertPayload(baseValues, advancedCondition);
+
+      // Then
+      expect(payload.condition).not.toBe(advancedCondition);
+      expect(payload.condition).toEqual(
+        expect.objectContaining({
+          op: ALERT_BOOLEAN_OPS.AND,
+        }),
+      );
+      expect(payload.trigger).toBe(ALERT_TRIGGER_KINDS.DAILY);
+    });
+
+    it("should build supported Findings-equivalent filters without Date or Status", () => {
+      // Given / When
+      const condition = buildAlertCondition({
+        operator: "all",
+        children: [
+          { kind: "filter", field: "providers", values: ["gcp"] },
+          { kind: "filter", field: "accounts", values: ["provider-2"] },
+          { kind: "filter", field: "checkStatuses", values: ["FAIL"] },
+          { kind: "filter", field: "checkSeverities", values: ["medium"] },
+          { kind: "filter", field: "resources", values: ["resource-1"] },
+          { kind: "filter", field: "regions", values: ["global"] },
+          { kind: "filter", field: "services", values: ["compute"] },
+          { kind: "filter", field: "categories", values: ["forensics"] },
+          { kind: "filter", field: "resourceGroups", values: ["prod"] },
+          { kind: "filter", field: "type", values: ["new"] },
+          {
+            kind: "group",
+            operator: "any",
+            children: [
+              { kind: "filter", field: "checks", values: ["gcp_check"] },
+              { kind: "filter", field: "regions", values: ["europe-west1"] },
+            ],
+          },
+        ],
+      });
+
+      // Then
+      expect(condition).toEqual({
+        op: ALERT_BOOLEAN_OPS.AND,
+        children: [
+          countFilter({ provider_type: ["gcp"] }),
+          countFilter({ provider_id: ["provider-2"] }),
+          countFilter({ severity: ["medium"] }),
+          countFilter({ resource_uid: ["resource-1"] }),
+          countFilter({ resource_regions: ["global"] }),
+          countFilter({ resource_services: ["compute"] }),
+          countFilter({ categories: ["forensics"] }),
+          countFilter({ resource_groups: ["prod"] }),
+          countFilter({ delta: ["new"] }),
+          {
+            op: ALERT_BOOLEAN_OPS.OR,
+            children: [
+              countFilter({ check_id: ["gcp_check"] }),
+              countFilter({ resource_regions: ["europe-west1"] }),
+            ],
+          },
+        ],
+      });
+      expect(JSON.stringify(condition)).not.toContain("status");
+      expect(JSON.stringify(condition)).not.toContain("muted");
+      expect(JSON.stringify(condition)).not.toContain("inserted_at");
+    });
+
+    it("should prefill modal defaults from active Findings filters and drop unsupported fields", () => {
+      // Given / When
+      const defaults = getAlertFormDefaultsFromFindingsFilters({
+        "filter[provider_type__in]": "aws,gcp",
+        "filter[provider_id__in]": "provider-1",
+        "filter[severity__in]": "critical,high",
+        "filter[delta__in]": "new",
+        "filter[region__in]": "us-east-1",
+        "filter[service__in]": "iam",
+        "filter[category__in]": "identity-security",
+        "filter[resource_groups__in]": "prod",
+        "filter[check_id__in]": "iam_user_no_mfa",
+        "filter[resource_uid__in]": "arn:aws:iam::123:user/alice",
+        "filter[status__in]": "FAIL",
+        "filter[resource_type__in]": "AWS::IAM::User",
+        "filter[inserted_at]": "2026-01-01",
+        "filter[muted]": "false",
+      });
+
+      // Then
+      expect(defaults.filterGroup.children).toEqual([
+        { kind: "filter", field: "providers", values: ["aws", "gcp"] },
+        { kind: "filter", field: "accounts", values: ["provider-1"] },
+        {
+          kind: "filter",
+          field: "checkSeverities",
+          values: ["critical", "high"],
+        },
+        { kind: "filter", field: "type", values: ["new"] },
+        { kind: "filter", field: "regions", values: ["us-east-1"] },
+        { kind: "filter", field: "services", values: ["iam"] },
+        {
+          kind: "filter",
+          field: "categories",
+          values: ["identity-security"],
+        },
+        { kind: "filter", field: "resourceGroups", values: ["prod"] },
+        { kind: "filter", field: "checks", values: ["iam_user_no_mfa"] },
+        {
+          kind: "filter",
+          field: "resourceTypes",
+          values: ["AWS::IAM::User"],
+        },
+        {
+          kind: "filter",
+          field: "resources",
+          values: ["arn:aws:iam::123:user/alice"],
+        },
+      ]);
+      expect(JSON.stringify(defaults.filterGroup)).not.toContain("inserted_at");
+      expect(JSON.stringify(defaults.filterGroup)).not.toContain("status");
+      expect(JSON.stringify(defaults.filterGroup)).not.toContain("muted");
+    });
+
+    it("should keep ALL type as an unbounded delta while NEW maps to delta=new", () => {
+      // Given / When
+      const condition = buildAlertCondition({
+        operator: "any",
+        children: [
+          { kind: "filter", field: "type", values: ["all"] },
+          { kind: "filter", field: "type", values: ["new"] },
+        ],
+      });
+
+      // Then
+      expect(condition).toEqual({
+        ...countFilter({ delta: ["new"] }),
+      });
+    });
+
+    it("should build a broad threshold-one condition when no portable filter remains", () => {
+      // Given / When
+      const condition = buildAlertCondition({
+        operator: "all",
+        children: [],
+      });
+
+      // Then
+      expect(condition).toEqual(
+        countFilter({
+          severity: ["critical", "high", "medium", "low", "informational"],
+        }),
+      );
+    });
+  });
+
+  describe("edit defaults", () => {
+    it("should hydrate simple defaults from an existing severity-only alert", () => {
+      // Given / When
+      const defaults = getAlertFormDefaults(existingRule);
+
+      // Then
+      expect(defaults).toEqual({
+        name: "Existing alert",
+        description: "Existing description",
+        method: "email",
+        frequency: ALERT_TRIGGER_KINDS.BOTH,
+        filterGroup: {
+          operator: "all",
+          children: [
+            {
+              kind: "filter",
+              field: "checkSeverities",
+              values: ["medium", "low"],
+            },
+          ],
+        },
+        severities: ["medium", "low"],
+        deltas: [],
+        providerTypes: [],
+        providerIds: [],
+        checkIds: [],
+        categories: [],
+        regions: [],
+        services: [],
+        resourceGroups: [],
+        resourceTypes: [],
+        recipientEmails: ["alerts@example.com"],
+        enabled: false,
+        advancedCondition: null,
+      });
+    });
+
+    it("should extract supported filters from advanced conditions and allow simple edits", () => {
+      // Given
+      const alert = {
+        ...existingRule,
+        attributes: {
+          ...existingRule.attributes,
+          condition: {
+            op: ALERT_BOOLEAN_OPS.NOT,
+            child: {
+              op: ALERT_BOOLEAN_OPS.AND,
+              children: [
+                countFilter({ severity: ["critical"] }),
+                countFilter({ provider_type: ["aws"] }),
+                countFilter({ status: ["FAIL"] } as AlertLeafFilter),
+              ],
+            },
+          },
+        },
+      } satisfies AlertRule;
+
+      // When
+      const defaults = getAlertFormDefaults(alert);
+
+      // Then
+      expect(defaults.filterGroup.children).toEqual([
+        {
+          kind: "filter",
+          field: "checkSeverities",
+          values: ["critical"],
+        },
+        { kind: "filter", field: "providers", values: ["aws"] },
+      ]);
+      expect(defaults.advancedCondition).toBeNull();
+    });
+  });
+});

--- a/ui/app/(prowler)/alerts/_lib/__tests__/error-mapping.test.ts
+++ b/ui/app/(prowler)/alerts/_lib/__tests__/error-mapping.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { ALERT_ERROR_CODES } from "../../_types";
+import {
+  buildSuccessResult,
+  buildUnexpectedError,
+  isThrottled,
+  mapJsonApiErrorToAction,
+} from "../error-mapping";
+
+describe("mapJsonApiErrorToAction", () => {
+  it("maps a JSON:API validation error with a known code", () => {
+    const error = mapJsonApiErrorToAction(
+      400,
+      {
+        errors: [
+          {
+            code: "unknown_filter_field",
+            detail: "Unknown filter field 'foo'.",
+            source: { pointer: "/data/attributes/condition/filter/foo" },
+          },
+        ],
+      },
+      null,
+    );
+
+    expect(error.code).toBe(ALERT_ERROR_CODES.UNKNOWN_FILTER_FIELD);
+    expect(error.detail).toBe("Unknown filter field 'foo'.");
+    expect(error.source?.pointer).toContain("foo");
+    expect(error.status).toBe(400);
+  });
+
+  it("falls back to status-based code when API code is unknown", () => {
+    const error = mapJsonApiErrorToAction(
+      404,
+      { errors: [{ detail: "Not found." }] },
+      null,
+    );
+    expect(error.code).toBe(ALERT_ERROR_CODES.NOT_FOUND);
+  });
+
+  it("parses Retry-After in seconds for throttled responses", () => {
+    const error = mapJsonApiErrorToAction(429, null, "42");
+    expect(error.code).toBe(ALERT_ERROR_CODES.THROTTLED);
+    expect(error.retryAfterSeconds).toBe(42);
+  });
+
+  it("collects seeding warnings from meta", () => {
+    const error = mapJsonApiErrorToAction(
+      400,
+      {
+        errors: [{ code: "unknown_operator", detail: "bad op" }],
+        meta: { warnings: ["non_portable_date_filter", "garbage_warning"] },
+      },
+      null,
+    );
+    expect(error.warnings).toEqual(["non_portable_date_filter"]);
+  });
+
+  it("returns UNKNOWN with status fallback for unrecognised 5xx", () => {
+    const error = mapJsonApiErrorToAction(500, null, null);
+    expect(error.code).toBe(ALERT_ERROR_CODES.UNKNOWN);
+    expect(error.status).toBe(500);
+  });
+});
+
+describe("buildSuccessResult", () => {
+  it("returns ok=true with no warnings when meta has none", () => {
+    const result = buildSuccessResult({ id: "1" }, null);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ id: "1" });
+      expect(result.warnings).toBeUndefined();
+    }
+  });
+
+  it("filters meta.warnings to known seeding warnings", () => {
+    const result = buildSuccessResult(
+      { id: "1" },
+      { meta: { warnings: ["pagination_not_supported", "totally_made_up"] } },
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.warnings).toEqual(["pagination_not_supported"]);
+    }
+  });
+});
+
+describe("isThrottled", () => {
+  it("identifies a throttled action result", () => {
+    const result = {
+      ok: false as const,
+      error: buildUnexpectedError(),
+    };
+    expect(isThrottled(result)).toBe(false);
+
+    const throttled = {
+      ok: false as const,
+      error: { code: ALERT_ERROR_CODES.THROTTLED, detail: "x" },
+    };
+    expect(isThrottled(throttled)).toBe(true);
+  });
+});

--- a/ui/app/(prowler)/alerts/_lib/__tests__/seeding.test.ts
+++ b/ui/app/(prowler)/alerts/_lib/__tests__/seeding.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canSeedAlertFromFindingsFilters,
+  toPortableAlertFilterBag,
+} from "../seeding";
+
+describe("canSeedAlertFromFindingsFilters", () => {
+  it("should accept status, muted, and scan filters as real Findings filters", () => {
+    // Given
+    const filterBag = {
+      "filter[status__in]": "FAIL",
+      "filter[muted]": "false",
+      "filter[scan__in]": "scan-1",
+    };
+
+    // When
+    const result = canSeedAlertFromFindingsFilters(filterBag);
+
+    // Then
+    expect(result).toBe(true);
+  });
+
+  it("should reject sort and pagination without a real filter", () => {
+    // Given
+    const filterBag = {
+      sort: "-inserted_at",
+      page: "2",
+      pageSize: "50",
+    };
+
+    // When
+    const result = canSeedAlertFromFindingsFilters(filterBag);
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("should accept finding group id filters because the backend treats them as portable", () => {
+    // Given
+    const filterBag = {
+      "filter[finding_group_id]": "group-1",
+    };
+
+    // When
+    const result = canSeedAlertFromFindingsFilters(filterBag);
+
+    // Then
+    expect(result).toBe(true);
+  });
+
+  it("should accept at least one supported portable finding filter", () => {
+    // Given
+    const filterBag = {
+      "filter[status__in]": "FAIL",
+      "filter[severity__in]": "critical,high",
+    };
+
+    // When
+    const result = canSeedAlertFromFindingsFilters(filterBag);
+
+    // Then
+    expect(result).toBe(true);
+  });
+});
+
+describe("toPortableAlertFilterBag", () => {
+  it("should keep backend-compatible filters and drop UI-only filters", () => {
+    // Given
+    const filterBag = {
+      "filter[status__in]": "FAIL",
+      "filter[muted]": "false",
+      "filter[scan__in]": "scan-1",
+      "filter[severity__in]": "critical,high",
+      "filter[region__in]": "us-east-1",
+      sort: "-inserted_at",
+      page: "2",
+    };
+
+    // When
+    const result = toPortableAlertFilterBag(filterBag);
+
+    // Then
+    expect(result).toEqual({
+      "filter[severity__in]": "critical,high",
+      "filter[region__in]": "us-east-1",
+    });
+  });
+
+  it("should return an empty bag when only unsupported filters are selected", () => {
+    // Given
+    const filterBag = {
+      "filter[status__in]": "FAIL",
+      "filter[muted]": "false",
+      "filter[scan__in]": "scan-1",
+    };
+
+    // When
+    const result = toPortableAlertFilterBag(filterBag);
+
+    // Then
+    expect(result).toEqual({});
+  });
+});

--- a/ui/app/(prowler)/alerts/_lib/alert-adapter.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-adapter.ts
@@ -1,0 +1,553 @@
+import type { AlertPayload } from "@/app/(prowler)/alerts/_actions/alerts";
+import {
+  ALERT_AGGREGATE_OPS,
+  ALERT_BOOLEAN_OPS,
+  ALERT_DELTA_VALUES,
+  ALERT_SEVERITY_VALUES,
+  ALERT_TRIGGER_KINDS,
+  type AlertCondition,
+  type AlertDelta,
+  type AlertLeafFilter,
+  type AlertProviderType,
+  type AlertRule,
+  type AlertSeverity,
+} from "@/app/(prowler)/alerts/_types";
+
+import {
+  ALERT_FILTER_FIELDS,
+  ALERT_FILTER_OPERATORS,
+  ALERT_NOTIFICATION_METHODS,
+  type AlertFormDefaults,
+  type AlertFormFilterGroup,
+  type AlertFormFilterItem,
+  type AlertFormFilterNode,
+  type AlertFormFindingFilterBag,
+  type AlertFormValues,
+} from "../_types/alert-form";
+
+const DEFAULT_SEVERITIES: AlertSeverity[] = [...ALERT_SEVERITY_VALUES];
+
+const normalizeStringValues = (values: string[]): string[] =>
+  values.map((value) => value.trim()).filter(Boolean);
+
+const createFilterNode = (
+  field: AlertFormFilterItem["field"],
+  values: string[],
+): AlertFormFilterItem => ({ kind: "filter", field, values });
+
+const getStringArrayFilterValue = (
+  filter: AlertLeafFilter,
+  field: keyof AlertLeafFilter,
+): string[] => {
+  const value = filter[field];
+  return Array.isArray(value) ? value : [];
+};
+
+const normalizeRecipientEmails = (emails: string[]): string[] =>
+  emails
+    .map((email) => email.trim().toLowerCase())
+    .filter((email) => email.length > 0);
+
+const filterItemToLeafFilter = (
+  item: AlertFormFilterItem,
+): AlertLeafFilter | null => {
+  const normalized = normalizeStringValues(item.values);
+  if (normalized.length === 0) return null;
+
+  switch (item.field) {
+    case ALERT_FILTER_FIELDS.PROVIDERS:
+      return { provider_type: normalized as AlertProviderType[] };
+    case ALERT_FILTER_FIELDS.ACCOUNTS:
+      return { provider_id: normalized };
+    case ALERT_FILTER_FIELDS.CHECK_SEVERITIES:
+      return { severity: normalized as AlertSeverity[] };
+    case ALERT_FILTER_FIELDS.RESOURCES:
+      return { resource_uid: normalized };
+    case ALERT_FILTER_FIELDS.RESOURCE_TYPES:
+      return { resource_types: normalized };
+    case ALERT_FILTER_FIELDS.REGIONS:
+      return { resource_regions: normalized };
+    case ALERT_FILTER_FIELDS.SERVICES:
+      return { resource_services: normalized };
+    case ALERT_FILTER_FIELDS.CATEGORIES:
+      return { categories: normalized };
+    case ALERT_FILTER_FIELDS.RESOURCE_GROUPS:
+      return { resource_groups: normalized };
+    case ALERT_FILTER_FIELDS.TYPE: {
+      const deltas = normalized.filter((value) =>
+        ALERT_DELTA_VALUES.includes(value as AlertDelta),
+      ) as AlertDelta[];
+      return deltas.length > 0 ? { delta: deltas } : null;
+    }
+    case ALERT_FILTER_FIELDS.CHECKS:
+      return { check_id: normalized };
+    case ALERT_FILTER_FIELDS.CHECK_STATUSES:
+    case ALERT_FILTER_FIELDS.ACCOUNT_TAGS:
+    case ALERT_FILTER_FIELDS.DATA_DATE_WINDOW:
+    case ALERT_FILTER_FIELDS.INCLUDE_MUTED_FINDINGS:
+      return null;
+  }
+};
+
+const buildConditionFromNode = (
+  node: AlertFormFilterNode,
+): AlertCondition | null => {
+  if (node.kind === "filter") {
+    const filter = filterItemToLeafFilter(node);
+    return filter
+      ? { op: ALERT_AGGREGATE_OPS.COUNT_GTE, filter, value: 1 }
+      : null;
+  }
+
+  return buildConditionFromGroup(node);
+};
+
+const buildConditionFromGroup = (
+  group: AlertFormFilterGroup,
+): AlertCondition => {
+  const children = group.children
+    .map(buildConditionFromNode)
+    .filter((condition): condition is AlertCondition => condition !== null);
+
+  if (children.length === 0) {
+    return {
+      op: ALERT_AGGREGATE_OPS.COUNT_GTE,
+      filter: { severity: DEFAULT_SEVERITIES },
+      value: 1,
+    };
+  }
+
+  if (children.length === 1) return children[0];
+
+  return group.operator === ALERT_FILTER_OPERATORS.ANY
+    ? { op: ALERT_BOOLEAN_OPS.OR, children }
+    : { op: ALERT_BOOLEAN_OPS.AND, children };
+};
+
+const legacyValuesToFilterGroup = (
+  values: Partial<AlertFormValues>,
+): AlertFormFilterGroup => ({
+  operator: ALERT_FILTER_OPERATORS.ALL,
+  children: [
+    createFilterNode(
+      ALERT_FILTER_FIELDS.CHECK_SEVERITIES,
+      values.severities ?? DEFAULT_SEVERITIES,
+    ),
+    createFilterNode(ALERT_FILTER_FIELDS.TYPE, values.deltas ?? []),
+    createFilterNode(ALERT_FILTER_FIELDS.PROVIDERS, values.providerTypes ?? []),
+    createFilterNode(ALERT_FILTER_FIELDS.ACCOUNTS, values.providerIds ?? []),
+    createFilterNode(ALERT_FILTER_FIELDS.CHECKS, values.checkIds ?? []),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+      values.resourceTypes ?? [],
+    ),
+    createFilterNode(ALERT_FILTER_FIELDS.REGIONS, values.regions ?? []),
+    createFilterNode(ALERT_FILTER_FIELDS.SERVICES, values.services ?? []),
+    createFilterNode(ALERT_FILTER_FIELDS.CATEGORIES, values.categories ?? []),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.RESOURCE_GROUPS,
+      values.resourceGroups ?? [],
+    ),
+    createFilterNode(ALERT_FILTER_FIELDS.RESOURCES, []),
+  ],
+});
+
+const isAlertFormFilterGroup = (
+  values: AlertFormFilterGroup | Partial<AlertFormValues>,
+): values is AlertFormFilterGroup =>
+  "children" in values && "operator" in values;
+
+export const buildAlertCondition = (
+  values: AlertFormFilterGroup | Partial<AlertFormValues>,
+): AlertCondition => {
+  const group = isAlertFormFilterGroup(values)
+    ? values
+    : (values.filterGroup ?? legacyValuesToFilterGroup(values));
+  return buildConditionFromGroup(group);
+};
+
+const ALERT_FILTER_FIELDS_ALLOWED = new Set<keyof AlertLeafFilter>([
+  "severity",
+  "delta",
+  "provider_type",
+  "provider_id",
+  "check_id",
+  "resource_regions",
+  "resource_services",
+  "resource_types",
+  "categories",
+  "resource_groups",
+  "resource_uid",
+]);
+
+const isAlertFormFilter = (condition: AlertCondition): boolean => {
+  if (
+    condition.op !== ALERT_AGGREGATE_OPS.ANY &&
+    condition.op !== ALERT_AGGREGATE_OPS.COUNT_GTE
+  ) {
+    return false;
+  }
+  if (condition.op === ALERT_AGGREGATE_OPS.COUNT_GTE && condition.value !== 1) {
+    return false;
+  }
+  return Object.keys(condition.filter).every((field) =>
+    ALERT_FILTER_FIELDS_ALLOWED.has(field as keyof AlertLeafFilter),
+  );
+};
+
+const mergeLeafFilters = (filters: AlertLeafFilter[]): AlertLeafFilter => {
+  const merged: AlertLeafFilter = {};
+
+  filters.forEach((filter) => {
+    Object.entries(filter).forEach(([field, value]) => {
+      if (!Array.isArray(value)) return;
+      const key = field as keyof AlertLeafFilter;
+      const current = Array.isArray(merged[key]) ? merged[key] : [];
+      merged[key] = Array.from(new Set([...current, ...value]));
+    });
+  });
+
+  return merged;
+};
+
+const getSimpleFilterFromCondition = (
+  condition: AlertCondition,
+): AlertLeafFilter | null => {
+  if (
+    isAlertFormFilter(condition) &&
+    (condition.op === ALERT_AGGREGATE_OPS.ANY ||
+      condition.op === ALERT_AGGREGATE_OPS.COUNT_GTE)
+  ) {
+    return condition.filter;
+  }
+
+  if (condition.op !== ALERT_BOOLEAN_OPS.AND) return null;
+
+  const childFilters = condition.children.map((child) =>
+    isAlertFormFilter(child) &&
+    (child.op === ALERT_AGGREGATE_OPS.ANY ||
+      child.op === ALERT_AGGREGATE_OPS.COUNT_GTE)
+      ? child.filter
+      : null,
+  );
+
+  if (childFilters.some((filter) => filter === null)) return null;
+
+  return mergeLeafFilters(childFilters as AlertLeafFilter[]);
+};
+
+const pickAlertFormFilterFields = (
+  filter: AlertLeafFilter,
+): AlertLeafFilter | null => {
+  const simpleFilter: AlertLeafFilter = {};
+
+  Object.entries(filter).forEach(([field, value]) => {
+    if (
+      !ALERT_FILTER_FIELDS_ALLOWED.has(field as keyof AlertLeafFilter) ||
+      !Array.isArray(value) ||
+      value.length === 0
+    ) {
+      return;
+    }
+
+    simpleFilter[field as keyof AlertLeafFilter] = value;
+  });
+
+  return Object.keys(simpleFilter).length > 0 ? simpleFilter : null;
+};
+
+const getPortableFiltersFromCondition = (
+  condition: AlertCondition,
+): AlertLeafFilter[] => {
+  if ("filter" in condition) {
+    const simpleFilter = pickAlertFormFilterFields(condition.filter);
+    return simpleFilter ? [simpleFilter] : [];
+  }
+
+  if ("child" in condition) {
+    return getPortableFiltersFromCondition(condition.child);
+  }
+
+  return condition.children.flatMap(getPortableFiltersFromCondition);
+};
+
+const getEditableFilterFromCondition = (
+  condition: AlertCondition,
+): AlertLeafFilter | null =>
+  getSimpleFilterFromCondition(condition) ??
+  (() => {
+    const portableFilters = getPortableFiltersFromCondition(condition);
+    return portableFilters.length > 0
+      ? mergeLeafFilters(portableFilters)
+      : null;
+  })();
+
+const filterToSimpleGroup = (
+  filter: AlertLeafFilter,
+): AlertFormFilterGroup => ({
+  operator: ALERT_FILTER_OPERATORS.ALL,
+  children: [
+    createFilterNode(
+      ALERT_FILTER_FIELDS.CHECK_SEVERITIES,
+      getStringArrayFilterValue(filter, "severity"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.TYPE,
+      getStringArrayFilterValue(filter, "delta"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.PROVIDERS,
+      getStringArrayFilterValue(filter, "provider_type"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.ACCOUNTS,
+      getStringArrayFilterValue(filter, "provider_id"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.CHECKS,
+      getStringArrayFilterValue(filter, "check_id"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.REGIONS,
+      getStringArrayFilterValue(filter, "resource_regions"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.SERVICES,
+      getStringArrayFilterValue(filter, "resource_services"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.CATEGORIES,
+      getStringArrayFilterValue(filter, "categories"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.RESOURCE_GROUPS,
+      getStringArrayFilterValue(filter, "resource_groups"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.RESOURCES,
+      getStringArrayFilterValue(filter, "resource_uid"),
+    ),
+    createFilterNode(
+      ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+      getStringArrayFilterValue(filter, "resource_types"),
+    ),
+  ].filter((node) => node.values.length > 0),
+});
+
+export const toAlertPayload = (
+  values: AlertFormValues,
+  _existingCondition?: AlertCondition | null,
+): AlertPayload => ({
+  name: values.name.trim(),
+  description: values.description.trim(),
+  enabled: values.enabled,
+  trigger: values.frequency,
+  condition: buildAlertCondition(values.filterGroup),
+  recipientEmails: normalizeRecipientEmails(values.recipientEmails),
+});
+
+export const getEmptyAlertFormDefaults = (
+  frequency: AlertFormValues["frequency"] = ALERT_TRIGGER_KINDS.AFTER_SCAN,
+): AlertFormDefaults => ({
+  name: "",
+  description: "",
+  method: ALERT_NOTIFICATION_METHODS.EMAIL,
+  frequency,
+  filterGroup: {
+    operator: ALERT_FILTER_OPERATORS.ALL,
+    children: [
+      createFilterNode(
+        ALERT_FILTER_FIELDS.CHECK_SEVERITIES,
+        DEFAULT_SEVERITIES,
+      ),
+    ],
+  },
+  severities: DEFAULT_SEVERITIES,
+  deltas: [],
+  providerTypes: [],
+  providerIds: [],
+  checkIds: [],
+  categories: [],
+  regions: [],
+  services: [],
+  resourceGroups: [],
+  resourceTypes: [],
+  recipientEmails: [],
+  enabled: true,
+  advancedCondition: null,
+});
+
+export const getAlertFormDefaults = (alert: AlertRule): AlertFormDefaults => {
+  const simpleFilter = getEditableFilterFromCondition(
+    alert.attributes.condition,
+  );
+  const simpleSeverities = Array.isArray(simpleFilter?.severity)
+    ? (simpleFilter.severity as AlertSeverity[])
+    : null;
+
+  return {
+    name: alert.attributes.name,
+    description: alert.attributes.description,
+    method: ALERT_NOTIFICATION_METHODS.EMAIL,
+    frequency: alert.attributes.trigger,
+    filterGroup: simpleFilter
+      ? filterToSimpleGroup(simpleFilter)
+      : getEmptyAlertFormDefaults(alert.attributes.trigger).filterGroup,
+    severities: simpleSeverities ?? DEFAULT_SEVERITIES,
+    deltas: (simpleFilter?.delta ?? []) as AlertDelta[],
+    providerTypes: (simpleFilter?.provider_type ?? []) as AlertProviderType[],
+    providerIds: getStringArrayFilterValue(simpleFilter ?? {}, "provider_id"),
+    checkIds: getStringArrayFilterValue(simpleFilter ?? {}, "check_id"),
+    categories: getStringArrayFilterValue(simpleFilter ?? {}, "categories"),
+    regions: getStringArrayFilterValue(simpleFilter ?? {}, "resource_regions"),
+    services: getStringArrayFilterValue(
+      simpleFilter ?? {},
+      "resource_services",
+    ),
+    resourceGroups: getStringArrayFilterValue(
+      simpleFilter ?? {},
+      "resource_groups",
+    ),
+    resourceTypes: getStringArrayFilterValue(
+      simpleFilter ?? {},
+      "resource_types",
+    ),
+    recipientEmails: alert.attributes.recipient_emails ?? [],
+    enabled: alert.attributes.enabled,
+    advancedCondition: null,
+  };
+};
+
+const FINDINGS_FILTER_KEY_TO_SIMPLE_FIELD: Record<
+  string,
+  AlertFormFilterItem["field"]
+> = {
+  provider_type: ALERT_FILTER_FIELDS.PROVIDERS,
+  provider_type__in: ALERT_FILTER_FIELDS.PROVIDERS,
+  "provider_type.in": ALERT_FILTER_FIELDS.PROVIDERS,
+  provider_id: ALERT_FILTER_FIELDS.ACCOUNTS,
+  provider_id__in: ALERT_FILTER_FIELDS.ACCOUNTS,
+  "provider_id.in": ALERT_FILTER_FIELDS.ACCOUNTS,
+  severity: ALERT_FILTER_FIELDS.CHECK_SEVERITIES,
+  severity__in: ALERT_FILTER_FIELDS.CHECK_SEVERITIES,
+  "severity.in": ALERT_FILTER_FIELDS.CHECK_SEVERITIES,
+  delta: ALERT_FILTER_FIELDS.TYPE,
+  delta__in: ALERT_FILTER_FIELDS.TYPE,
+  "delta.in": ALERT_FILTER_FIELDS.TYPE,
+  region: ALERT_FILTER_FIELDS.REGIONS,
+  region__in: ALERT_FILTER_FIELDS.REGIONS,
+  resource_regions: ALERT_FILTER_FIELDS.REGIONS,
+  resource_regions__in: ALERT_FILTER_FIELDS.REGIONS,
+  "resource_regions.in": ALERT_FILTER_FIELDS.REGIONS,
+  service: ALERT_FILTER_FIELDS.SERVICES,
+  service__in: ALERT_FILTER_FIELDS.SERVICES,
+  resource_services: ALERT_FILTER_FIELDS.SERVICES,
+  resource_services__in: ALERT_FILTER_FIELDS.SERVICES,
+  "resource_services.in": ALERT_FILTER_FIELDS.SERVICES,
+  category: ALERT_FILTER_FIELDS.CATEGORIES,
+  category__in: ALERT_FILTER_FIELDS.CATEGORIES,
+  categories: ALERT_FILTER_FIELDS.CATEGORIES,
+  categories__in: ALERT_FILTER_FIELDS.CATEGORIES,
+  "categories.in": ALERT_FILTER_FIELDS.CATEGORIES,
+  resource_groups: ALERT_FILTER_FIELDS.RESOURCE_GROUPS,
+  resource_groups__in: ALERT_FILTER_FIELDS.RESOURCE_GROUPS,
+  "resource_groups.in": ALERT_FILTER_FIELDS.RESOURCE_GROUPS,
+  check_id: ALERT_FILTER_FIELDS.CHECKS,
+  check_id__in: ALERT_FILTER_FIELDS.CHECKS,
+  "check_id.in": ALERT_FILTER_FIELDS.CHECKS,
+  resource_uid: ALERT_FILTER_FIELDS.RESOURCES,
+  resource_uid__in: ALERT_FILTER_FIELDS.RESOURCES,
+  "resource_uid.in": ALERT_FILTER_FIELDS.RESOURCES,
+  resource_type: ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+  resource_type__in: ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+  resource_types: ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+  resource_types__in: ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+  "resource_types.in": ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+};
+
+const unwrapFindingsFilterKey = (rawKey: string): string => {
+  if (rawKey.startsWith("filter[") && rawKey.endsWith("]")) {
+    return rawKey.slice("filter[".length, -1);
+  }
+
+  return rawKey;
+};
+
+const splitFindingsFilterValues = (
+  value: AlertFormFindingFilterBag[string],
+): string[] => {
+  const values = Array.isArray(value) ? value : [value];
+  return normalizeStringValues(
+    values.flatMap((entry) => String(entry).split(",")),
+  );
+};
+
+const getFieldValuesFromFindingsFilters = (
+  filterBag: AlertFormFindingFilterBag,
+): Partial<Record<AlertFormFilterItem["field"], string[]>> => {
+  const fieldValues: Partial<Record<AlertFormFilterItem["field"], string[]>> =
+    {};
+
+  Object.entries(filterBag).forEach(([rawKey, rawValue]) => {
+    const field =
+      FINDINGS_FILTER_KEY_TO_SIMPLE_FIELD[unwrapFindingsFilterKey(rawKey)];
+    if (!field) return;
+    const values = splitFindingsFilterValues(rawValue);
+    if (values.length === 0) return;
+    fieldValues[field] = [...(fieldValues[field] ?? []), ...values];
+  });
+
+  return fieldValues;
+};
+
+const FINDINGS_FILTER_FIELD_ORDER = [
+  ALERT_FILTER_FIELDS.PROVIDERS,
+  ALERT_FILTER_FIELDS.ACCOUNTS,
+  ALERT_FILTER_FIELDS.CHECK_SEVERITIES,
+  ALERT_FILTER_FIELDS.TYPE,
+  ALERT_FILTER_FIELDS.REGIONS,
+  ALERT_FILTER_FIELDS.SERVICES,
+  ALERT_FILTER_FIELDS.CATEGORIES,
+  ALERT_FILTER_FIELDS.RESOURCE_GROUPS,
+  ALERT_FILTER_FIELDS.CHECKS,
+  ALERT_FILTER_FIELDS.RESOURCE_TYPES,
+  ALERT_FILTER_FIELDS.RESOURCES,
+] as const;
+
+export const getAlertFormDefaultsFromFindingsFilters = (
+  filterBag: AlertFormFindingFilterBag,
+  frequency: AlertFormValues["frequency"] = ALERT_TRIGGER_KINDS.AFTER_SCAN,
+): AlertFormDefaults => {
+  const fieldValues = getFieldValuesFromFindingsFilters(filterBag);
+  const children = FINDINGS_FILTER_FIELD_ORDER.flatMap((field) => {
+    const values = fieldValues[field] ?? [];
+    return values.length > 0 ? [createFilterNode(field, values)] : [];
+  });
+  const defaults = getEmptyAlertFormDefaults(frequency);
+
+  return {
+    ...defaults,
+    filterGroup: {
+      operator: ALERT_FILTER_OPERATORS.ALL,
+      children: children.length > 0 ? children : defaults.filterGroup.children,
+    },
+    severities: (fieldValues[ALERT_FILTER_FIELDS.CHECK_SEVERITIES] ??
+      defaults.severities) as AlertFormValues["severities"],
+    deltas: (fieldValues[ALERT_FILTER_FIELDS.TYPE] ??
+      defaults.deltas) as AlertFormValues["deltas"],
+    providerTypes: (fieldValues[ALERT_FILTER_FIELDS.PROVIDERS] ??
+      defaults.providerTypes) as AlertFormValues["providerTypes"],
+    providerIds:
+      fieldValues[ALERT_FILTER_FIELDS.ACCOUNTS] ?? defaults.providerIds,
+    checkIds: fieldValues[ALERT_FILTER_FIELDS.CHECKS] ?? defaults.checkIds,
+    regions: fieldValues[ALERT_FILTER_FIELDS.REGIONS] ?? defaults.regions,
+    categories:
+      fieldValues[ALERT_FILTER_FIELDS.CATEGORIES] ?? defaults.categories,
+    services: fieldValues[ALERT_FILTER_FIELDS.SERVICES] ?? defaults.services,
+    resourceGroups:
+      fieldValues[ALERT_FILTER_FIELDS.RESOURCE_GROUPS] ??
+      defaults.resourceGroups,
+    resourceTypes:
+      fieldValues[ALERT_FILTER_FIELDS.RESOURCE_TYPES] ?? defaults.resourceTypes,
+  };
+};

--- a/ui/app/(prowler)/alerts/_lib/alert-form-schema.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-form-schema.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+import {
+  ALERT_DELTA_VALUES,
+  ALERT_PROVIDER_TYPE_VALUES,
+  ALERT_SEVERITY_VALUES,
+  ALERT_TRIGGER_KIND_VALUES,
+} from "@/app/(prowler)/alerts/_types";
+
+import {
+  ALERT_FILTER_FIELDS,
+  ALERT_FILTER_OPERATORS,
+  ALERT_NOTIFICATION_METHODS,
+} from "../_types/alert-form";
+
+const alertFilterItemSchema = z.object({
+  kind: z.literal("filter"),
+  field: z.enum(Object.values(ALERT_FILTER_FIELDS)),
+  values: z.array(z.string().trim()).default([]),
+});
+
+type AlertFormFilterNodeSchema =
+  | z.infer<typeof alertFilterItemSchema>
+  | {
+      kind: "group";
+      operator: (typeof ALERT_FILTER_OPERATORS)[keyof typeof ALERT_FILTER_OPERATORS];
+      children: AlertFormFilterNodeSchema[];
+    };
+
+const alertFilterNodeSchema: z.ZodType<AlertFormFilterNodeSchema> = z.lazy(() =>
+  z.union([
+    alertFilterItemSchema,
+    z.object({
+      kind: z.literal("group"),
+      operator: z.enum(Object.values(ALERT_FILTER_OPERATORS)),
+      children: z.array(alertFilterNodeSchema),
+    }),
+  ]),
+);
+
+export const alertFormSchema = z.object({
+  name: z.string().trim().min(1, { error: "Name is required." }).max(120),
+  description: z.string().trim().max(2000).default(""),
+  method: z.literal(ALERT_NOTIFICATION_METHODS.EMAIL),
+  frequency: z.enum(ALERT_TRIGGER_KIND_VALUES),
+  filterGroup: z.object({
+    operator: z.enum(Object.values(ALERT_FILTER_OPERATORS)),
+    children: z.array(alertFilterNodeSchema).min(1),
+  }),
+  severities: z.array(z.enum(ALERT_SEVERITY_VALUES)).default([]),
+  deltas: z.array(z.enum(ALERT_DELTA_VALUES)).default([]),
+  providerTypes: z.array(z.enum(ALERT_PROVIDER_TYPE_VALUES)).default([]),
+  providerIds: z.array(z.string().trim().min(1)).default([]),
+  checkIds: z.array(z.string().trim().min(1)).default([]),
+  categories: z.array(z.string().trim().min(1)).default([]),
+  regions: z.array(z.string().trim().min(1)).default([]),
+  services: z.array(z.string().trim().min(1)).default([]),
+  resourceGroups: z.array(z.string().trim().min(1)).default([]),
+  resourceTypes: z.array(z.string().trim().min(1)).default([]),
+  recipientEmails: z
+    .array(z.email({ error: "Enter a valid email address." }))
+    .default([]),
+  enabled: z.boolean(),
+});
+
+export type AlertFormSchemaValues = z.infer<typeof alertFormSchema>;

--- a/ui/app/(prowler)/alerts/_lib/env.ts
+++ b/ui/app/(prowler)/alerts/_lib/env.ts
@@ -1,0 +1,25 @@
+import {
+  ALERT_ERROR_CODES,
+  type AlertPublicResponse,
+  type AlertsActionResult,
+} from "../_types";
+
+const ALERTS_DISABLED_MESSAGE =
+  "Custom alerts are only available in Prowler Cloud.";
+
+export const isAlertsEnabled = () =>
+  process.env.NEXT_PUBLIC_IS_CLOUD_ENV === "true";
+
+export const buildAlertsDisabledResult = <T>(): AlertsActionResult<T> => ({
+  ok: false,
+  error: {
+    code: ALERT_ERROR_CODES.FORBIDDEN,
+    detail: ALERTS_DISABLED_MESSAGE,
+    status: 403,
+  },
+});
+
+export const buildAlertsDisabledPublicResponse = (): AlertPublicResponse => ({
+  state: "network_error",
+  message: ALERTS_DISABLED_MESSAGE,
+});

--- a/ui/app/(prowler)/alerts/_lib/error-mapping.ts
+++ b/ui/app/(prowler)/alerts/_lib/error-mapping.ts
@@ -1,0 +1,112 @@
+import {
+  ALERT_ERROR_CODES,
+  ALERT_SEEDING_WARNINGS,
+  type AlertsActionError,
+  type AlertsActionErrorSource,
+  type AlertsActionResult,
+  type AlertSeedingWarning,
+  type AlertsErrorCode,
+} from "../_types";
+
+interface JsonApiErrorObject {
+  status?: string | number;
+  code?: string;
+  detail?: string;
+  source?: AlertsActionErrorSource;
+  meta?: { code?: string; warnings?: string[] };
+}
+
+interface JsonApiErrorBody {
+  errors?: JsonApiErrorObject[];
+  detail?: string;
+  message?: string;
+  meta?: { warnings?: string[] };
+}
+
+const KNOWN_ERROR_CODES = new Set<string>(Object.values(ALERT_ERROR_CODES));
+const KNOWN_WARNINGS = new Set<string>(Object.values(ALERT_SEEDING_WARNINGS));
+
+const STATUS_FALLBACK_CODES: Record<number, AlertsErrorCode> = {
+  401: ALERT_ERROR_CODES.FORBIDDEN,
+  403: ALERT_ERROR_CODES.FORBIDDEN,
+  404: ALERT_ERROR_CODES.NOT_FOUND,
+  409: ALERT_ERROR_CODES.CONFLICT,
+  429: ALERT_ERROR_CODES.THROTTLED,
+};
+
+const pickCode = (raw: string | undefined): AlertsErrorCode | undefined => {
+  if (!raw) return undefined;
+  return KNOWN_ERROR_CODES.has(raw) ? (raw as AlertsErrorCode) : undefined;
+};
+
+const pickWarning = (raw: string): AlertSeedingWarning | undefined =>
+  KNOWN_WARNINGS.has(raw) ? (raw as AlertSeedingWarning) : undefined;
+
+const collectWarnings = (
+  body: JsonApiErrorBody | null,
+): AlertSeedingWarning[] =>
+  (body?.meta?.warnings ?? [])
+    .map((w) => pickWarning(w))
+    .filter((w): w is AlertSeedingWarning => w !== undefined);
+
+const parseRetryAfter = (header: string | null): number | undefined => {
+  if (!header) return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds;
+  const date = Date.parse(header);
+  if (Number.isNaN(date)) return undefined;
+  return Math.max(0, Math.round((date - Date.now()) / 1000));
+};
+
+export const mapJsonApiErrorToAction = (
+  status: number,
+  body: JsonApiErrorBody | null,
+  retryAfterHeader: string | null,
+): AlertsActionError => {
+  const firstError = body?.errors?.[0];
+  const detail =
+    firstError?.detail ||
+    body?.detail ||
+    body?.message ||
+    "Custom alerts request failed.";
+  const apiCode =
+    pickCode(firstError?.code) ||
+    pickCode(firstError?.meta?.code) ||
+    pickCode((body as { code?: string } | null)?.code);
+  const fallback = STATUS_FALLBACK_CODES[status] ?? ALERT_ERROR_CODES.UNKNOWN;
+  const code: AlertsErrorCode = apiCode ?? fallback;
+  const warnings = collectWarnings(body);
+  return {
+    code,
+    detail,
+    source: firstError?.source,
+    status,
+    retryAfterSeconds:
+      code === ALERT_ERROR_CODES.THROTTLED
+        ? parseRetryAfter(retryAfterHeader)
+        : undefined,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
+};
+
+export const buildSuccessResult = <T>(
+  data: T,
+  body: JsonApiErrorBody | null,
+): AlertsActionResult<T> => {
+  const warnings = collectWarnings(body);
+  return warnings.length > 0
+    ? { ok: true, data, warnings }
+    : { ok: true, data };
+};
+
+export const isThrottled = (
+  result: AlertsActionResult<unknown>,
+): result is { ok: false; error: AlertsActionError } =>
+  !result.ok && result.error.code === ALERT_ERROR_CODES.THROTTLED;
+
+export const buildUnexpectedError = (
+  detail = "Unexpected error.",
+): AlertsActionError => ({
+  code: ALERT_ERROR_CODES.UNKNOWN,
+  detail,
+});

--- a/ui/app/(prowler)/alerts/_lib/seeding.ts
+++ b/ui/app/(prowler)/alerts/_lib/seeding.ts
@@ -1,0 +1,102 @@
+import type { AlertsFilterBag } from "../_types";
+
+const PORTABLE_FINDINGS_FILTER_KEYS = [
+  "severity",
+  "severity.in",
+  "severity__in",
+  "delta",
+  "delta.in",
+  "delta__in",
+  "check_id",
+  "check_id.in",
+  "check_id__in",
+  "finding_group_id",
+  "finding_group_id.in",
+  "finding_group_id__in",
+  "categories",
+  "categories.in",
+  "categories__in",
+  "category",
+  "category__in",
+  "resource_regions",
+  "resource_regions.in",
+  "resource_regions__in",
+  "region",
+  "region__in",
+  "resource_services",
+  "resource_services.in",
+  "resource_services__in",
+  "service",
+  "service__in",
+  "resource_types",
+  "resource_types.in",
+  "resource_types__in",
+  "resource_type",
+  "resource_type__in",
+  "resource_groups",
+  "resource_groups.in",
+  "resource_groups__in",
+  "resource_uid",
+  "resource_uid.in",
+  "resource_uid__in",
+  "provider_id",
+  "provider_id.in",
+  "provider_id__in",
+  "provider_type",
+  "provider_type.in",
+  "provider_type__in",
+] as const;
+
+const PORTABLE_FINDINGS_FILTER_KEY_SET = new Set<string>(
+  PORTABLE_FINDINGS_FILTER_KEYS,
+);
+
+const NON_FILTER_QUERY_KEYS = new Set(["sort", "page", "pageSize"]);
+
+const unwrapFilterKey = (rawKey: string): string => {
+  if (rawKey.startsWith("filter[") && rawKey.endsWith("]")) {
+    return rawKey.slice("filter[".length, -1);
+  }
+
+  return rawKey;
+};
+
+const isFilterKey = (rawKey: string): boolean =>
+  rawKey.startsWith("filter[") && rawKey.endsWith("]");
+
+const hasSeedableFilterValue = (value: AlertsFilterBag[string]): boolean => {
+  const values = Array.isArray(value) ? value : [value];
+
+  return values.some((entry) =>
+    entry
+      .split(",")
+      .map((part) => part.trim())
+      .some(Boolean),
+  );
+};
+
+/**
+ * Product invariant for the Findings entry point: any visible filter can open
+ * the alert modal, but only backend-portable filters are sent as rule criteria.
+ */
+export const canSeedAlertFromFindingsFilters = (
+  filterBag: AlertsFilterBag,
+): boolean =>
+  Object.entries(filterBag).some(([rawKey, value]) => {
+    if (!isFilterKey(rawKey) || NON_FILTER_QUERY_KEYS.has(rawKey)) return false;
+
+    return hasSeedableFilterValue(value);
+  });
+
+export const toPortableAlertFilterBag = (
+  filterBag: AlertsFilterBag,
+): AlertsFilterBag =>
+  Object.fromEntries(
+    Object.entries(filterBag).filter(([rawKey, value]) => {
+      const key = unwrapFilterKey(rawKey);
+      return (
+        PORTABLE_FINDINGS_FILTER_KEY_SET.has(key) &&
+        hasSeedableFilterValue(value)
+      );
+    }),
+  );

--- a/ui/app/(prowler)/alerts/_types/alert-form.ts
+++ b/ui/app/(prowler)/alerts/_types/alert-form.ts
@@ -1,0 +1,106 @@
+import type {
+  AlertCondition,
+  AlertDelta,
+  AlertProviderType,
+  AlertSeverity,
+  AlertTriggerKind,
+} from "@/app/(prowler)/alerts/_types";
+
+export const ALERT_FILTER_OPERATORS = {
+  ALL: "all",
+  ANY: "any",
+} as const;
+
+export type AlertFormFilterOperator =
+  (typeof ALERT_FILTER_OPERATORS)[keyof typeof ALERT_FILTER_OPERATORS];
+
+export const ALERT_FILTER_FIELDS = {
+  PROVIDERS: "providers",
+  ACCOUNTS: "accounts",
+  CHECK_STATUSES: "checkStatuses",
+  CHECK_SEVERITIES: "checkSeverities",
+  RESOURCES: "resources",
+  RESOURCE_TYPES: "resourceTypes",
+  REGIONS: "regions",
+  SERVICES: "services",
+  CATEGORIES: "categories",
+  RESOURCE_GROUPS: "resourceGroups",
+  ACCOUNT_TAGS: "accountTags",
+  TYPE: "type",
+  DATA_DATE_WINDOW: "dataDateWindow",
+  INCLUDE_MUTED_FINDINGS: "includeMutedFindings",
+  CHECKS: "checks",
+} as const;
+
+export type AlertFormFilterField =
+  (typeof ALERT_FILTER_FIELDS)[keyof typeof ALERT_FILTER_FIELDS];
+
+export const ALERT_FINDING_TYPES = {
+  NEW: "new",
+  ALL: "all",
+} as const;
+
+export type AlertFormFindingType =
+  (typeof ALERT_FINDING_TYPES)[keyof typeof ALERT_FINDING_TYPES];
+
+export interface AlertFormFilterItem {
+  kind: "filter";
+  field: AlertFormFilterField;
+  values: string[];
+}
+
+export interface AlertFormFilterGroup {
+  kind?: "group";
+  operator: AlertFormFilterOperator;
+  children: AlertFormFilterNode[];
+}
+
+export type AlertFormFilterNode =
+  | AlertFormFilterItem
+  | (AlertFormFilterGroup & { kind: "group" });
+
+export const ALERT_NOTIFICATION_METHODS = {
+  EMAIL: "email",
+} as const;
+
+export type AlertNotificationMethod =
+  (typeof ALERT_NOTIFICATION_METHODS)[keyof typeof ALERT_NOTIFICATION_METHODS];
+
+export const ALERT_NOTIFICATION_METHOD_OPTIONS = [
+  {
+    value: ALERT_NOTIFICATION_METHODS.EMAIL,
+    label: "Email",
+  },
+] as const;
+
+export interface AlertFormValues {
+  name: string;
+  description: string;
+  method: AlertNotificationMethod;
+  frequency: AlertTriggerKind;
+  filterGroup: AlertFormFilterGroup;
+  severities: AlertSeverity[];
+  deltas: AlertDelta[];
+  providerTypes: AlertProviderType[];
+  providerIds: string[];
+  checkIds: string[];
+  categories: string[];
+  regions: string[];
+  services: string[];
+  resourceGroups: string[];
+  resourceTypes: string[];
+  recipientEmails: string[];
+  enabled: boolean;
+}
+
+export interface AlertFormDefaults extends AlertFormValues {
+  advancedCondition: AlertCondition | null;
+}
+
+export interface AlertFormSubmitResult {
+  ok: boolean;
+  alertId?: string;
+  error?: string;
+}
+
+export type AlertFormFindingFilterBag = Record<string, string | string[]>;

--- a/ui/app/(prowler)/alerts/_types/index.ts
+++ b/ui/app/(prowler)/alerts/_types/index.ts
@@ -1,0 +1,384 @@
+// Canonical DSL vocabulary and resource types for the Alerts UI.
+// Mirrors api/src/backend/alerts/dsl.py — every constant declared here MUST
+// match the API. Drift is a bug; reviewers compare the two files when either
+// changes.
+
+// ---- operator vocabulary -------------------------------------------------
+
+export const ALERT_BOOLEAN_OPS = {
+  AND: "and",
+  OR: "or",
+  NOT: "not",
+} as const;
+export type AlertBooleanOp =
+  (typeof ALERT_BOOLEAN_OPS)[keyof typeof ALERT_BOOLEAN_OPS];
+
+export const ALERT_AGGREGATE_OPS = {
+  COUNT_GTE: "count_gte",
+  COUNT_LTE: "count_lte",
+  ANY: "any",
+  NONE: "none",
+} as const;
+export type AlertAggregateOp =
+  (typeof ALERT_AGGREGATE_OPS)[keyof typeof ALERT_AGGREGATE_OPS];
+
+export const ALERT_BOOLEAN_OP_VALUES = Object.values(
+  ALERT_BOOLEAN_OPS,
+) as readonly AlertBooleanOp[];
+export const ALERT_AGGREGATE_OP_VALUES = Object.values(
+  ALERT_AGGREGATE_OPS,
+) as readonly AlertAggregateOp[];
+
+// ---- filter field vocabulary --------------------------------------------
+
+export const ALERT_FILTER_FIELDS = {
+  SEVERITY: "severity",
+  DELTA: "delta",
+  CHECK_ID: "check_id",
+  FINDING_GROUP_ID: "finding_group_id",
+  CATEGORIES: "categories",
+  RESOURCE_REGIONS: "resource_regions",
+  RESOURCE_SERVICES: "resource_services",
+  RESOURCE_TYPES: "resource_types",
+  RESOURCE_UID: "resource_uid",
+  RESOURCE_GROUPS: "resource_groups",
+  PROVIDER_ID: "provider_id",
+  PROVIDER_TYPE: "provider_type",
+} as const;
+export type AlertFilterField =
+  (typeof ALERT_FILTER_FIELDS)[keyof typeof ALERT_FILTER_FIELDS];
+
+export const ALERT_FILTER_FIELD_VALUES = Object.values(
+  ALERT_FILTER_FIELDS,
+) as readonly AlertFilterField[];
+
+// Field-kind classification — drives the value editor rendered by the
+// condition builder and the runtime type checks in the validator.
+export const ALERT_FILTER_FIELD_KIND = {
+  ENUM_LIST: "enum_list",
+  BOOLEAN: "boolean",
+  UUID_LIST: "uuid_list",
+  STRING_LIST: "string_list",
+} as const;
+export type AlertFilterFieldKind =
+  (typeof ALERT_FILTER_FIELD_KIND)[keyof typeof ALERT_FILTER_FIELD_KIND];
+
+export const ALERT_FILTER_FIELD_KIND_BY_FIELD: Readonly<
+  Record<AlertFilterField, AlertFilterFieldKind>
+> = {
+  severity: ALERT_FILTER_FIELD_KIND.ENUM_LIST,
+  delta: ALERT_FILTER_FIELD_KIND.ENUM_LIST,
+  provider_type: ALERT_FILTER_FIELD_KIND.ENUM_LIST,
+  provider_id: ALERT_FILTER_FIELD_KIND.UUID_LIST,
+  check_id: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+  finding_group_id: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+  categories: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+  resource_regions: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+  resource_services: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+  resource_types: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+  resource_uid: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+  resource_groups: ALERT_FILTER_FIELD_KIND.STRING_LIST,
+};
+
+// Closed enums for fields whose values are bounded. Builder uses them to
+// render multi-selects; validator uses them to reject out-of-range inputs.
+export const ALERT_SEVERITY_VALUES = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "informational",
+] as const;
+export type AlertSeverity = (typeof ALERT_SEVERITY_VALUES)[number];
+
+export const ALERT_DELTA_VALUES = ["new", "changed"] as const;
+export type AlertDelta = (typeof ALERT_DELTA_VALUES)[number];
+
+// Mirrors api.models.Provider.ProviderChoices. Keep in sync if a new
+// platform is registered there; the API rejects values outside this set.
+export const ALERT_PROVIDER_TYPE_VALUES = [
+  "aws",
+  "azure",
+  "gcp",
+  "kubernetes",
+  "m365",
+  "github",
+  "mongodbatlas",
+  "iac",
+  "oraclecloud",
+  "alibabacloud",
+  "cloudflare",
+  "openstack",
+  "image",
+  "googleworkspace",
+  "vercel",
+] as const;
+export type AlertProviderType = (typeof ALERT_PROVIDER_TYPE_VALUES)[number];
+
+export const ALERT_ENUM_VALUES_BY_FIELD = {
+  severity: ALERT_SEVERITY_VALUES,
+  delta: ALERT_DELTA_VALUES,
+  provider_type: ALERT_PROVIDER_TYPE_VALUES,
+} as const;
+
+// Forbidden filter fields — the validator rejects these with a clear error
+// instead of "unknown field". Mirrors `dsl.py::FORBIDDEN_FILTER_FIELDS`.
+export const ALERT_FORBIDDEN_FILTER_FIELDS = [
+  "inserted_at",
+  "inserted_at__gte",
+  "inserted_at__lte",
+  "inserted_at__date",
+  "updated_at",
+  "updated_at__gte",
+  "updated_at__lte",
+  "first_seen_at",
+  "first_seen_at__gte",
+  "first_seen_at__lte",
+  "search",
+  "sort",
+  "page",
+  "page[number]",
+  "page[size]",
+  "include",
+] as const;
+export type AlertForbiddenFilterField =
+  (typeof ALERT_FORBIDDEN_FILTER_FIELDS)[number];
+
+// ---- limits --------------------------------------------------------------
+
+export const ALERT_SCHEMA_VERSION = 1 as const;
+export const ALERT_MAX_DEPTH = 5 as const;
+export const ALERT_MAX_NODES = 100 as const;
+export const ALERT_AGGREGATE_VALUE_MIN = 1 as const;
+export const ALERT_AGGREGATE_VALUE_MAX = 1_000_000 as const;
+
+// ---- triggers ------------------------------------------------------------
+
+export const ALERT_TRIGGER_KINDS = {
+  AFTER_SCAN: "after_scan",
+  DAILY: "daily",
+  BOTH: "both",
+} as const;
+export type AlertTriggerKind =
+  (typeof ALERT_TRIGGER_KINDS)[keyof typeof ALERT_TRIGGER_KINDS];
+
+export const ALERT_TRIGGER_KIND_VALUES = Object.values(
+  ALERT_TRIGGER_KINDS,
+) as readonly AlertTriggerKind[];
+
+// ---- recipient lifecycle -------------------------------------------------
+
+export const ALERT_RECIPIENT_STATUS = {
+  PENDING: "pending",
+  CONFIRMED: "confirmed",
+  UNSUBSCRIBED: "unsubscribed",
+  BOUNCED: "bounced",
+} as const;
+export type AlertRecipientStatus =
+  (typeof ALERT_RECIPIENT_STATUS)[keyof typeof ALERT_RECIPIENT_STATUS];
+
+export const ALERT_RECIPIENT_STATUS_VALUES = Object.values(
+  ALERT_RECIPIENT_STATUS,
+) as readonly AlertRecipientStatus[];
+
+// ---- error codes ---------------------------------------------------------
+
+export const ALERT_ERROR_CODES = {
+  UNKNOWN_OPERATOR: "unknown_operator",
+  UNKNOWN_FILTER_FIELD: "unknown_filter_field",
+  FORBIDDEN_FILTER_FIELD: "forbidden_filter_field",
+  INVALID_VALUE: "invalid_value",
+  INVALID_SHAPE: "invalid_shape",
+  CROSS_TENANT_REFERENCE: "cross_tenant_reference",
+  CONDITION_TOO_COMPLEX: "condition_too_complex",
+  UNKNOWN_SCHEMA_VERSION: "unknown_schema_version",
+  THROTTLED: "throttled",
+  NOT_FOUND: "not_found",
+  FORBIDDEN: "forbidden",
+  CONFLICT: "conflict",
+  INVALID_TOKEN: "invalid_token",
+  EXPIRED_TOKEN: "expired_token",
+  UNKNOWN: "unknown",
+} as const;
+export type AlertsErrorCode =
+  (typeof ALERT_ERROR_CODES)[keyof typeof ALERT_ERROR_CODES];
+
+// ---- seeding warnings ----------------------------------------------------
+
+export const ALERT_SEEDING_WARNINGS = {
+  NON_PORTABLE_DATE_FILTER: "non_portable_date_filter",
+  TEXT_SEARCH_NOT_PORTABLE: "text_search_not_portable",
+  ORDERING_NOT_SUPPORTED: "ordering_not_supported",
+  PAGINATION_NOT_SUPPORTED: "pagination_not_supported",
+  SIDELOADING_NOT_SUPPORTED: "sideloading_not_supported",
+  UNKNOWN_OR_NON_PORTABLE_FIELD: "unknown_or_non_portable_field",
+  INVALID_VALUE_DROPPED: "invalid_value_dropped",
+} as const;
+export type AlertSeedingWarning =
+  (typeof ALERT_SEEDING_WARNINGS)[keyof typeof ALERT_SEEDING_WARNINGS];
+
+// ---- discriminated condition union --------------------------------------
+
+// Leaf filter is a partial mapping from a whitelisted field name to its
+// validated value. Kept loose at the type level (the Zod schema in
+// ./lib/schemas.ts does the strict per-kind validation).
+export type AlertLeafFilterValue = string[] | boolean;
+export type AlertLeafFilter = Partial<
+  Record<AlertFilterField, AlertLeafFilterValue>
+>;
+
+export interface AlertConditionAnd {
+  op: typeof ALERT_BOOLEAN_OPS.AND;
+  children: AlertCondition[];
+}
+
+export interface AlertConditionOr {
+  op: typeof ALERT_BOOLEAN_OPS.OR;
+  children: AlertCondition[];
+}
+
+export interface AlertConditionNot {
+  op: typeof ALERT_BOOLEAN_OPS.NOT;
+  child: AlertCondition;
+}
+
+export interface AlertConditionCountGte {
+  op: typeof ALERT_AGGREGATE_OPS.COUNT_GTE;
+  filter: AlertLeafFilter;
+  value: number;
+}
+
+export interface AlertConditionCountLte {
+  op: typeof ALERT_AGGREGATE_OPS.COUNT_LTE;
+  filter: AlertLeafFilter;
+  value: number;
+}
+
+export interface AlertConditionAny {
+  op: typeof ALERT_AGGREGATE_OPS.ANY;
+  filter: AlertLeafFilter;
+}
+
+export interface AlertConditionNone {
+  op: typeof ALERT_AGGREGATE_OPS.NONE;
+  filter: AlertLeafFilter;
+}
+
+export type AlertConditionGroup =
+  | AlertConditionAnd
+  | AlertConditionOr
+  | AlertConditionNot;
+
+export type AlertConditionLeaf =
+  | AlertConditionCountGte
+  | AlertConditionCountLte
+  | AlertConditionAny
+  | AlertConditionNone;
+
+export type AlertCondition = AlertConditionGroup | AlertConditionLeaf;
+
+// ---- resource attribute shapes ------------------------------------------
+
+export interface AlertRuleAttributes {
+  name: string;
+  description: string;
+  enabled: boolean;
+  trigger: AlertTriggerKind;
+  condition: AlertCondition;
+  schema_version: number;
+  /**
+   * Emails of the recipients attached to the rule. The API exposes the
+   * relationship as a list of email strings (write- and read-side via the
+   * `recipient_emails` attribute), not as a JSON:API relationships block.
+   */
+  recipient_emails?: string[];
+  created_by?: string | null;
+  inserted_at: string;
+  updated_at: string;
+}
+
+export interface AlertRecipientAttributes {
+  email: string;
+  status: AlertRecipientStatus;
+  confirmation_sent_at?: string | null;
+  confirmation_expires_at?: string | null;
+  confirmed_at?: string | null;
+  unsubscribed_at?: string | null;
+  last_bounce_at?: string | null;
+  inserted_at: string;
+  updated_at: string;
+}
+
+export interface AlertPreviewSummary {
+  finding_count_total?: number;
+  counts_by_severity?: Record<string, number>;
+  top_severity?: string;
+  top_findings?: string[];
+  deep_link_filter_hint?: Record<string, unknown>;
+}
+
+export interface AlertPreviewResponse {
+  would_fire: boolean;
+  summary: AlertPreviewSummary;
+  sample_finding_ids?: string[];
+  evaluation_failed: boolean;
+  last_error?: string | null;
+  summary_fallback?: boolean;
+  duration_ms?: number;
+}
+
+// ---- JSON:API envelopes --------------------------------------------------
+
+export interface JsonApiRelationshipRef {
+  id: string;
+  type: string;
+}
+
+export interface JsonApiRelationship {
+  data: JsonApiRelationshipRef | JsonApiRelationshipRef[] | null;
+}
+
+export interface AlertRule {
+  id: string;
+  type: "alert-rules";
+  attributes: AlertRuleAttributes;
+  relationships?: {
+    recipients?: JsonApiRelationship;
+    last_event?: JsonApiRelationship;
+  };
+}
+
+export interface AlertRecipient {
+  id: string;
+  type: "alert-recipients";
+  attributes: AlertRecipientAttributes;
+  relationships?: {
+    rules?: JsonApiRelationship;
+  };
+}
+
+// ---- typed action result -------------------------------------------------
+
+export interface AlertsActionErrorSource {
+  pointer?: string;
+  parameter?: string;
+}
+
+export interface AlertsActionError {
+  code: AlertsErrorCode;
+  detail: string;
+  source?: AlertsActionErrorSource;
+  status?: number;
+  retryAfterSeconds?: number;
+  warnings?: AlertSeedingWarning[];
+}
+
+export type AlertsActionResult<T> =
+  | { ok: true; data: T; warnings?: AlertSeedingWarning[] }
+  | { ok: false; error: AlertsActionError };
+
+// ---- seeding payloads ----------------------------------------------------
+
+export type AlertsFilterBag = Record<string, string | string[]>;
+
+export type { AlertPublicResponse } from "./public";

--- a/ui/app/(prowler)/alerts/_types/public.ts
+++ b/ui/app/(prowler)/alerts/_types/public.ts
@@ -1,0 +1,25 @@
+// Public confirm / unsubscribe contract for Alerts public pages.
+// NOT FOR THE MVP: keep only if public recipient consent links are required.
+// Mirrors the API's ``{state, message}`` JSON contract from the public
+// alert recipient endpoints. ``network_error`` is UI-side only: the
+// fetch wrapper folds connection failures into the same shape so the
+// caller has a single switch to render.
+export const ALERT_PUBLIC_STATES = {
+  CONFIRMED: "confirmed",
+  ALREADY_CONFIRMED: "already_confirmed",
+  CANNOT_CONFIRM: "cannot_confirm",
+  UNSUBSCRIBED: "unsubscribed",
+  ALREADY_UNSUBSCRIBED: "already_unsubscribed",
+  MISSING_TOKEN: "missing_token",
+  INVALID_TOKEN: "invalid_token",
+  SUPERSEDED: "superseded",
+  NOT_FOUND: "not_found",
+  NETWORK_ERROR: "network_error",
+} as const;
+export type AlertPublicState =
+  (typeof ALERT_PUBLIC_STATES)[keyof typeof ALERT_PUBLIC_STATES];
+
+export interface AlertPublicResponse {
+  state: AlertPublicState;
+  message: string;
+}


### PR DESCRIPTION
## Description

Adds custom alerts UI contracts, server actions, adapters, validation schema, and action-layer tests. The action layer is Cloud-gated so OSS non-Cloud builds do not call Cloud-only alerts endpoints accidentally.

## Part of Chained PRs

| Field | Value |
| --- | --- |
| Main PR | #11003 |
| Base branch | `feat/PROWLER-1418-custom-alerts-oss` |
| This PR | 2 / 5 |
| Previous PR | #11004 |
| Next PR | `feat/PROWLER-1418-alerts-management-ui` |

## Chain Overview

```text
#11003 feat/PROWLER-1418-custom-alerts-oss
├── [1/5] #11004 shared UI foundation
└── [2/5] feat/PROWLER-1418-alerts-contracts-actions  <- this PR
    └── [3/5] feat/PROWLER-1418-alerts-management-ui
        └── [4/5] feat/PROWLER-1418-alerts-findings-seeding
            └── [5/5] feat/PROWLER-1418-alerts-navigation-tests
```

## Changes

- Adds alerts DSL/types, form types, and public recipient response types.
- Adds alert adapter, schema, seeding, and error-mapping helpers.
- Adds server actions for alert rules, previews, recipients, and public confirm/unsubscribe flows.
- Adds `isAlertsEnabled` Cloud guard and controlled disabled responses when `NEXT_PUBLIC_IS_CLOUD_ENV !== "true"`.
- Adds tests for actions, adapters, error mapping, and seeding.

## Steps to Review

1. Review type/DSL constants for API contract compatibility.
2. Review `alertsRequest` and public action guard behavior.
3. Review adapter/schema behavior and unit tests.
4. Confirm this PR does not add visible UI routes or navigation yet.

## Validation

- [x] `cd ui && pnpm run healthcheck`
- [x] `cd ui && pnpm test -- --run ...` (Vitest ran 115 files / 641 tests)

## Checklist

- [x] No private links or references
- [x] No visible alerts route or navigation
- [x] Cloud-only backend calls are guarded
- [x] Chained PR targeting feature branch, not `master`
