### PR TITLE
[CHAIN] feat(ui): add custom alerts management UI

### DIFF
--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -1,0 +1,662 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ALERT_AGGREGATE_OPS,
+  ALERT_BOOLEAN_OPS,
+  ALERT_RECIPIENT_STATUS,
+  ALERT_TRIGGER_KINDS,
+  type AlertCondition,
+  type AlertRecipient,
+  type AlertRule,
+} from "@/app/(prowler)/alerts/_types";
+import type { ProviderProps } from "@/types/providers";
+
+import { AlertFormModal } from "../alert-form-modal";
+
+const recipientsActionMocks = vi.hoisted(() => ({
+  listAlertRecipients: vi.fn(),
+}));
+
+const alertsActionMocks = vi.hoisted(() => ({
+  previewAlertCondition: vi.fn(),
+}));
+
+vi.mock(
+  "@/app/(prowler)/alerts/_actions/recipients",
+  () => recipientsActionMocks,
+);
+
+vi.mock("@/app/(prowler)/alerts/_actions", () => alertsActionMocks);
+
+vi.mock(
+  "@/components/compliance/compliance-header/compliance-scan-info",
+  () => ({
+    ComplianceScanInfo: () => <span>Scan</span>,
+  }),
+);
+
+vi.mock("@/components/ui/entities/entity-info", () => ({
+  EntityInfo: ({
+    entityAlias,
+    entityId,
+  }: {
+    entityAlias?: string;
+    entityId?: string;
+  }) => <span>{entityAlias ?? entityId}</span>,
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: null, status: "unauthenticated" }),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/alerts",
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/shadcn/modal", () => ({
+  Modal: ({
+    open,
+    title,
+    description,
+    className,
+    onOpenAutoFocus,
+    children,
+  }: {
+    open: boolean;
+    title?: string;
+    description?: string;
+    className?: string;
+    onOpenAutoFocus?: (event: Event) => void;
+    children: ReactNode;
+  }) =>
+    open ? (
+      <div
+        role="dialog"
+        aria-label={title}
+        aria-description={description}
+        className={className}
+        data-allows-open-auto-focus={String(Boolean(onOpenAutoFocus))}
+      >
+        {children}
+      </div>
+    ) : null,
+}));
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+global.ResizeObserver = ResizeObserverMock;
+Element.prototype.scrollIntoView = vi.fn();
+
+const mockProviders: ProviderProps[] = [
+  {
+    id: "provider-aws-1",
+    type: "providers",
+    attributes: {
+      provider: "aws",
+      uid: "123456789012",
+      alias: "Production AWS",
+      status: "completed",
+      resources: 42,
+      connection: {
+        connected: true,
+        last_checked_at: "2026-04-30T00:00:00Z",
+      },
+      scanner_args: {
+        only_logs: false,
+        excluded_checks: [],
+        aws_retries_max_attempts: 3,
+      },
+      inserted_at: "2026-04-30T00:00:00Z",
+      updated_at: "2026-04-30T00:00:00Z",
+      created_by: { object: "users", id: "user-1" },
+    },
+    relationships: {
+      secret: { data: null },
+      provider_groups: { meta: { count: 0 }, data: [] },
+    },
+  },
+  {
+    id: "provider-gcp-1",
+    type: "providers",
+    attributes: {
+      provider: "gcp",
+      uid: "prowler-prod-project",
+      alias: "Production GCP",
+      status: "completed",
+      resources: 21,
+      connection: {
+        connected: true,
+        last_checked_at: "2026-04-30T00:00:00Z",
+      },
+      scanner_args: {
+        only_logs: false,
+        excluded_checks: [],
+        aws_retries_max_attempts: 3,
+      },
+      inserted_at: "2026-04-30T00:00:00Z",
+      updated_at: "2026-04-30T00:00:00Z",
+      created_by: { object: "users", id: "user-1" },
+    },
+    relationships: {
+      secret: { data: null },
+      provider_groups: { meta: { count: 0 }, data: [] },
+    },
+  },
+];
+
+const createRecipient = (
+  id: string,
+  email: string,
+  status: AlertRecipient["attributes"]["status"],
+): AlertRecipient => ({
+  id,
+  type: "alert-recipients",
+  attributes: {
+    email,
+    status,
+    inserted_at: "2026-04-30T00:00:00Z",
+    updated_at: "2026-04-30T00:00:00Z",
+  },
+  relationships: { rules: { data: [] } },
+});
+
+const confirmedRecipient = createRecipient(
+  "recipient-confirmed",
+  "security@example.com",
+  ALERT_RECIPIENT_STATUS.CONFIRMED,
+);
+
+const pendingRecipient = createRecipient(
+  "recipient-pending",
+  "pending@example.com",
+  ALERT_RECIPIENT_STATUS.PENDING,
+);
+
+const createEditingAlert = (
+  overrides: Partial<AlertRule["attributes"]> = {},
+): AlertRule => ({
+  id: "alert-1",
+  type: "alert-rules",
+  attributes: {
+    name: "Existing alert",
+    description: "Existing description",
+    enabled: true,
+    trigger: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+    condition: {
+      op: ALERT_AGGREGATE_OPS.COUNT_GTE,
+      filter: { severity: ["critical"] },
+      value: 1,
+    },
+    schema_version: 1,
+    recipient_emails: ["security@example.com"],
+    inserted_at: "2026-04-30T00:00:00Z",
+    updated_at: "2026-04-30T00:00:00Z",
+    ...overrides,
+  },
+});
+
+const mockRecipientsList = () => {
+  recipientsActionMocks.listAlertRecipients.mockResolvedValue({
+    ok: true,
+    data: {
+      data: [confirmedRecipient, pendingRecipient],
+      meta: { pagination: { page: 1, pages: 1, count: 2 } },
+    },
+  });
+};
+
+const renderCreateModal = (
+  props: Partial<React.ComponentProps<typeof AlertFormModal>> = {},
+) =>
+  render(
+    <AlertFormModal
+      open
+      defaultFrequency={ALERT_TRIGGER_KINDS.AFTER_SCAN}
+      onOpenChange={vi.fn()}
+      onSubmit={vi.fn()}
+      {...props}
+    />,
+  );
+
+const getVisibleFilterTrigger = (label: string): HTMLButtonElement => {
+  const trigger = screen
+    .getAllByRole("combobox")
+    .find(
+      (element) =>
+        element.textContent?.includes(label) &&
+        !element.closest('[aria-hidden="true"]'),
+    );
+
+  expect(trigger).toBeDefined();
+  return trigger as HTMLButtonElement;
+};
+
+describe("AlertFormModal", () => {
+  beforeEach(() => {
+    recipientsActionMocks.listAlertRecipients.mockReset();
+    recipientsActionMocks.listAlertRecipients.mockReturnValue(
+      new Promise(() => {}),
+    );
+    alertsActionMocks.previewAlertCondition.mockReset();
+  });
+
+  it("should render the simplified alert form without preview, delivery settings, or nested recipient management", () => {
+    // Given / When
+    renderCreateModal({
+      providers: mockProviders,
+      uniqueRegions: ["us-east-1", "europe-west1"],
+      uniqueServices: ["iam", "cloudsql"],
+      uniqueCategories: ["identity-security"],
+      uniqueGroups: ["prod"],
+    });
+
+    // Then
+    expect(screen.getByRole("dialog", { name: "Create Alert" })).toBeVisible();
+    expect(screen.getByLabelText(/^name$/i)).toBeVisible();
+    expect(screen.getByLabelText(/^description$/i)).toBeVisible();
+    expect(screen.getByLabelText(/^frequency$/i)).toBeVisible();
+    expect(screen.getByLabelText(/^recipients$/i)).toBeVisible();
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    expect(screen.queryByText("Alert criteria")).not.toBeInTheDocument();
+    expect(screen.queryByText(/delivery settings/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/notification method/i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/run preview/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /manage recipients/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Production AWS")).not.toBeInTheDocument();
+    expect(screen.queryByText(/resource type/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^date$/i)).not.toBeInTheDocument();
+  });
+
+  it("should provide accessible dialog description and allow initial focus when editing", () => {
+    // Given / When
+    renderCreateModal({
+      editingAlert: createEditingAlert(),
+    });
+
+    // Then
+    const dialog = screen.getByRole("dialog", { name: "Edit Alert" });
+    expect(dialog).toHaveAccessibleDescription(
+      "Update recipients, frequency, and finding filters for this alert.",
+    );
+    expect(dialog).toHaveAttribute("data-allows-open-auto-focus", "true");
+  });
+
+  it("should show selected Findings filters as chips while keeping criteria controls hidden", () => {
+    // Given / When
+    renderCreateModal({
+      initialFindingsFilters: {},
+      selectedFindingsFilterChips: [
+        { key: "filter[status__in]", label: "Status", value: "FAIL" },
+        { key: "filter[muted]", label: "Muted", value: "false" },
+      ],
+    });
+
+    // Then
+    expect(
+      screen.getByRole("region", { name: /active filters/i }),
+    ).toHaveTextContent("Status: FAIL");
+    expect(
+      screen.getByRole("region", { name: /active filters/i }),
+    ).toHaveTextContent("Muted: false");
+    expect(screen.queryByText("All Provider")).not.toBeInTheDocument();
+    expect(screen.queryByText(/run preview/i)).not.toBeInTheDocument();
+  });
+
+  it("should list tenant recipients with status and submit selected emails", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ ok: true, alertId: "alert-1" });
+    mockRecipientsList();
+    renderCreateModal({ onSubmit });
+
+    // When
+    await user.type(screen.getByLabelText(/^name$/i), "Critical alerts");
+    await user.click(getVisibleFilterTrigger("Select emails"));
+    expect((await screen.findAllByText("Confirmed")).at(-1)).toBeVisible();
+    expect(screen.getAllByText("Pending").at(-1)).toBeVisible();
+    const recipientOptions = await screen.findAllByText("pending@example.com");
+    const visibleRecipientOption = recipientOptions.at(-1);
+    expect(visibleRecipientOption).toBeDefined();
+    await user.click(visibleRecipientOption as HTMLElement);
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    // Then
+    expect(screen.getAllByText("pending@example.com").at(-1)).toBeVisible();
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          frequency: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+          recipientEmails: ["pending@example.com"],
+        }),
+        null,
+      ),
+    );
+    const recipientsParams = recipientsActionMocks.listAlertRecipients.mock
+      .calls[0][0] as URLSearchParams;
+    expect(recipientsParams.get("filter[status]")).toBeNull();
+    expect(recipientsParams.get("page[size]")).toBe("100");
+  });
+
+  it("should submit the configured alert frequency", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ ok: true, alertId: "alert-1" });
+    mockRecipientsList();
+    renderCreateModal({
+      defaultFrequency: ALERT_TRIGGER_KINDS.DAILY,
+      onSubmit,
+    });
+
+    // When
+    await user.type(screen.getByLabelText(/^name$/i), "Daily alerts");
+    expect(
+      screen.getByRole("combobox", { name: /frequency/i }),
+    ).toHaveTextContent("Daily digest");
+    await user.click(getVisibleFilterTrigger("Select emails"));
+    const recipientOptions = await screen.findAllByText("security@example.com");
+    const visibleRecipientOption = recipientOptions.at(-1);
+    expect(visibleRecipientOption).toBeDefined();
+    await user.click(visibleRecipientOption as HTMLElement);
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          frequency: ALERT_TRIGGER_KINDS.DAILY,
+        }),
+        null,
+      ),
+    );
+  });
+
+  it("should allow submitting without selected recipients", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ ok: true, alertId: "alert-1" });
+    mockRecipientsList();
+    renderCreateModal({ onSubmit });
+
+    // When
+    await user.type(screen.getByLabelText(/^name$/i), "Critical alerts");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientEmails: [],
+        }),
+        null,
+      ),
+    );
+    expect(
+      screen.queryByText(/select at least one recipient/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should reset form defaults when opening a different alert", () => {
+    // Given
+    const { rerender } = render(
+      <AlertFormModal
+        open
+        defaultFrequency={ALERT_TRIGGER_KINDS.AFTER_SCAN}
+        editingAlert={createEditingAlert({ name: "First alert" })}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    // When
+    rerender(
+      <AlertFormModal
+        open
+        defaultFrequency={ALERT_TRIGGER_KINDS.AFTER_SCAN}
+        editingAlert={createEditingAlert({
+          name: "Second alert",
+          updated_at: "2026-05-01T00:00:00Z",
+        })}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    // Then
+    expect(screen.getByLabelText(/^name$/i)).toHaveValue("Second alert");
+  });
+
+  it("should render the shared Findings batch filter controls for an existing alert", async () => {
+    // Given
+    const user = userEvent.setup();
+    mockRecipientsList();
+    renderCreateModal({
+      editingAlert: createEditingAlert({
+        condition: {
+          op: ALERT_BOOLEAN_OPS.AND,
+          children: [
+            {
+              op: ALERT_AGGREGATE_OPS.COUNT_GTE,
+              filter: { severity: ["critical"] },
+              value: 1,
+            },
+            {
+              op: ALERT_AGGREGATE_OPS.COUNT_GTE,
+              filter: { provider_type: ["aws"] },
+              value: 1,
+            },
+          ],
+        },
+      }),
+      providers: mockProviders,
+      uniqueRegions: ["us-east-1", "europe-west1"],
+      uniqueServices: ["iam", "cloudsql"],
+      uniqueResourceTypes: ["AWS::IAM::User"],
+      uniqueCategories: ["identity-security"],
+      uniqueGroups: ["prod"],
+    });
+
+    // When
+    await user.click(screen.getByRole("button", { name: /more filters/i }));
+
+    // Then
+    const recipientsTrigger = screen.getByLabelText(/^recipients$/i);
+    const filtersHeading = screen.getByRole("heading", { name: /^filters$/i });
+
+    expect(filtersHeading).toBeVisible();
+    expect(
+      recipientsTrigger.compareDocumentPosition(filtersHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(filtersHeading.closest('[data-slot="card"]')).toBeVisible();
+    expect(screen.getAllByText("Amazon Web Services")[0]).toBeVisible();
+    expect(screen.getByText("All accounts")).toBeVisible();
+    expect(screen.getByText("All Status")).toBeVisible();
+    expect(screen.getByText("All Delta")).toBeVisible();
+    expect(screen.getByText("All Resource Type")).toBeVisible();
+    expect(screen.queryByLabelText(/^severity$/i)).not.toBeInTheDocument();
+  });
+
+  it("should save edited filters as a normalized simple condition", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ ok: true, alertId: "alert-1" });
+    mockRecipientsList();
+    renderCreateModal({
+      editingAlert: createEditingAlert(),
+      providers: mockProviders,
+      onSubmit,
+    });
+
+    // When
+    await user.click(screen.getByRole("button", { name: /more filters/i }));
+    await user.click(screen.getByLabelText(/provider type/i));
+    const providerOptions = await screen.findAllByText("Google Cloud Platform");
+    const visibleProviderOption = providerOptions.at(-1);
+    expect(visibleProviderOption).toBeDefined();
+    await user.click(visibleProviderOption as HTMLElement);
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filterGroup: expect.objectContaining({
+            children: expect.arrayContaining([
+              { kind: "filter", field: "providers", values: ["gcp"] },
+            ]),
+          }),
+        }),
+        null,
+      ),
+    );
+  });
+
+  it("should preview the edited alert using current unsaved filters", async () => {
+    // Given
+    const user = userEvent.setup();
+    alertsActionMocks.previewAlertCondition.mockResolvedValue({
+      ok: true,
+      data: {
+        would_fire: true,
+        summary: {
+          finding_count_total: 7,
+          top_severity: "critical",
+        },
+        sample_finding_ids: [],
+        evaluation_failed: false,
+        duration_ms: 42,
+      },
+    });
+    mockRecipientsList();
+    renderCreateModal({
+      editingAlert: createEditingAlert(),
+      providers: mockProviders,
+    });
+
+    // When
+    await user.click(screen.getByRole("button", { name: /more filters/i }));
+    await user.click(screen.getByLabelText(/provider type/i));
+    const providerOptions = await screen.findAllByText("Google Cloud Platform");
+    const visibleProviderOption = providerOptions.at(-1);
+    expect(visibleProviderOption).toBeDefined();
+    await user.click(visibleProviderOption as HTMLElement);
+    await user.click(screen.getByRole("button", { name: /^test$/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(alertsActionMocks.previewAlertCondition).toHaveBeenCalledWith(
+        expect.objectContaining({
+          condition: expect.objectContaining({
+            op: ALERT_BOOLEAN_OPS.AND,
+            children: expect.arrayContaining([
+              expect.objectContaining({
+                filter: { provider_type: ["gcp"] },
+                value: 1,
+              }),
+            ]),
+          }),
+          trigger: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+        }),
+      ),
+    );
+    const previewStatus = await screen.findByText(/would fire/i);
+    expect(previewStatus).toBeVisible();
+    const previewCard = previewStatus.closest('[data-slot="card"]');
+    expect(previewCard).toBeInTheDocument();
+    const previewCardQueries = within(previewCard as HTMLElement);
+    expect(previewCardQueries.getByText(/^findings$/i)).toBeVisible();
+    expect(previewCardQueries.getByText("7")).toBeVisible();
+    expect(previewCardQueries.getByText(/^top severity$/i)).toBeVisible();
+    expect(previewCardQueries.getByText("Critical")).toBeVisible();
+    expect(previewCardQueries.getByText(/^duration$/i)).toBeVisible();
+    expect(previewCardQueries.getByText(/42 ms/i)).toBeVisible();
+  });
+
+  it("should render preview errors inline in edit mode", async () => {
+    // Given
+    const user = userEvent.setup();
+    alertsActionMocks.previewAlertCondition.mockResolvedValue({
+      ok: false,
+      error: { detail: "Invalid condition" },
+    });
+    mockRecipientsList();
+    renderCreateModal({ editingAlert: createEditingAlert() });
+
+    // When
+    await user.click(screen.getByRole("button", { name: /^test$/i }));
+
+    // Then
+    expect(await screen.findByText(/invalid condition/i)).toBeVisible();
+  });
+
+  it("should hydrate advanced edit mode filters and normalize them on save", async () => {
+    // Given
+    const user = userEvent.setup();
+    const advancedCondition: AlertCondition = {
+      op: ALERT_BOOLEAN_OPS.NOT,
+      child: {
+        op: ALERT_AGGREGATE_OPS.COUNT_GTE,
+        filter: { severity: ["critical"] },
+        value: 1,
+      },
+    };
+    const onSubmit = vi
+      .fn()
+      .mockResolvedValue({ ok: true, alertId: "alert-1" });
+    mockRecipientsList();
+    renderCreateModal({
+      editingAlert: createEditingAlert({
+        condition: advancedCondition,
+        recipient_emails: ["security@example.com"],
+      }),
+      onSubmit,
+    });
+
+    // When
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Existing alert",
+          recipientEmails: ["security@example.com"],
+          filterGroup: expect.objectContaining({
+            children: [
+              {
+                kind: "filter",
+                field: "checkSeverities",
+                values: ["critical"],
+              },
+            ],
+          }),
+        }),
+        null,
+      ),
+    );
+    expect(
+      screen.queryByText(/advanced condition preserved/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ALERT_AGGREGATE_OPS,
+  ALERT_TRIGGER_KINDS,
+  type AlertRule,
+} from "@/app/(prowler)/alerts/_types";
+
+import { AlertsManager } from "../alerts-manager";
+
+const actionMocks = vi.hoisted(() => ({
+  deleteAlert: vi.fn(),
+  disableAlert: vi.fn(),
+  enableAlert: vi.fn(),
+  updateAlert: vi.fn(),
+}));
+
+const routerMocks = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  replace: vi.fn(),
+  push: vi.fn(),
+}));
+
+const toastMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/app/(prowler)/alerts/_actions", () => actionMocks);
+
+vi.mock("@/lib", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/alerts",
+  useRouter: () => routerMocks,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/ui", () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/components/shadcn", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+    variant,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+    variant?: string;
+  }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      data-variant={variant}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("../alert-form-modal", () => ({
+  AlertFormModal: () => null,
+}));
+
+vi.mock("../alerts-empty-state", () => ({
+  AlertsEmptyState: () => <div>No alerts</div>,
+}));
+
+const makeAlert = (enabled: boolean): AlertRule => ({
+  id: enabled ? "enabled-alert" : "disabled-alert",
+  type: "alert-rules",
+  attributes: {
+    name: enabled ? "Enabled alert" : "Disabled alert",
+    description: "",
+    enabled,
+    trigger: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+    condition: {
+      op: ALERT_AGGREGATE_OPS.ANY,
+      filter: { severity: ["critical"] },
+    },
+    schema_version: 1,
+    recipient_emails: [],
+    inserted_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+});
+
+const renderManager = (alerts: AlertRule[]) =>
+  render(
+    <AlertsManager
+      alerts={alerts}
+      loadError={null}
+      providers={[]}
+      completedScanIds={[]}
+      scanDetails={[]}
+      uniqueRegions={[]}
+      uniqueServices={[]}
+      uniqueResourceTypes={[]}
+      uniqueCategories={[]}
+      uniqueGroups={[]}
+    />,
+  );
+
+describe("AlertsManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a success toast after disabling an alert", async () => {
+    // Given
+    const user = userEvent.setup();
+    const alert = makeAlert(true);
+    actionMocks.disableAlert.mockResolvedValue({
+      ok: true,
+      data: { data: alert },
+    });
+    renderManager([alert]);
+
+    // When
+    await user.click(
+      screen.getByRole("button", { name: /actions for enabled alert/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /disable/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Alert disabled",
+        description: "Enabled alert",
+      }),
+    );
+  });
+
+  it("shows a success toast after enabling an alert", async () => {
+    // Given
+    const user = userEvent.setup();
+    const alert = makeAlert(false);
+    actionMocks.enableAlert.mockResolvedValue({
+      ok: true,
+      data: { data: alert },
+    });
+    renderManager([alert]);
+
+    // When
+    await user.click(
+      screen.getByRole("button", { name: /actions for disabled alert/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /enable/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith({
+        title: "Alert enabled",
+        description: "Disabled alert",
+      }),
+    );
+  });
+});

--- a/ui/app/(prowler)/alerts/_components/__tests__/alerts-table.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alerts-table.test.tsx
@@ -1,0 +1,244 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ALERT_AGGREGATE_OPS,
+  ALERT_TRIGGER_KINDS,
+  type AlertRule,
+} from "@/app/(prowler)/alerts/_types";
+
+import { AlertsTable } from "../alerts-table";
+
+const navigationMocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  currentSearch: "",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/alerts",
+  useRouter: () => ({ push: navigationMocks.routerPush }),
+  useSearchParams: () => new URLSearchParams(navigationMocks.currentSearch),
+}));
+
+vi.mock("@/components/ui/table/data-table", () => ({
+  DataTable: ({
+    columns,
+    data,
+    metadata,
+  }: {
+    columns: {
+      id?: string;
+      size?: number;
+      minSize?: number;
+      cell?: (context: { row: { original: AlertRule } }) => ReactNode;
+    }[];
+    data: AlertRule[];
+    metadata?: { pagination?: { count?: number } };
+  }) => (
+    <div>
+      {metadata?.pagination?.count !== undefined && (
+        <span>{metadata.pagination.count} Total Entries</span>
+      )}
+      <table>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th
+                key={column.id}
+                data-testid={`column-${column.id}`}
+                data-size={column.size}
+                data-min-size={column.minSize}
+              >
+                <button
+                  type="button"
+                  onClick={() =>
+                    navigationMocks.routerPush(`/alerts?sort=${column.id}`, {
+                      scroll: false,
+                    })
+                  }
+                >
+                  {column.id === "enabled" ? "Status" : column.id}
+                </button>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((alert) => (
+            <tr key={alert.id}>
+              {columns.map((column) => (
+                <td key={`${alert.id}-${column.id}`}>
+                  {column.cell?.({ row: { original: alert } })}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/table/data-table-column-header", () => ({
+  DataTableColumnHeader: ({ title }: { title: string }) => <span>{title}</span>,
+}));
+
+interface AlertRuleOverrides extends Partial<Omit<AlertRule, "attributes">> {
+  attributes?: Partial<AlertRule["attributes"]>;
+}
+
+const makeRule = (overrides: AlertRuleOverrides = {}): AlertRule => ({
+  id: overrides.id ?? "alert-1",
+  type: "alert-rules",
+  attributes: {
+    name: "Critical findings",
+    description: "Notify security",
+    enabled: true,
+    trigger: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+    condition: {
+      op: ALERT_AGGREGATE_OPS.ANY,
+      filter: { severity: ["critical"] },
+    },
+    schema_version: 1,
+    recipient_emails: ["security@example.com"],
+    inserted_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides.attributes,
+  },
+});
+
+describe("AlertsTable", () => {
+  beforeEach(() => {
+    navigationMocks.currentSearch = "";
+    navigationMocks.routerPush.mockClear();
+  });
+
+  it("should render alert rows with dropdown actions and shared pagination", () => {
+    // Given / When
+    render(
+      <AlertsTable
+        alerts={[makeRule()]}
+        meta={{ pagination: { page: 1, pages: 2, count: 12 }, version: "1" }}
+        mutatingId={null}
+        onEdit={vi.fn()}
+        onToggleEnabled={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    // Then
+    expect(
+      screen.getByRole("cell", { name: /critical findings/i }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /actions for critical findings/i }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: /edit critical findings/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/12 total entries/i)).toBeVisible();
+    expect(screen.getByTestId("column-actions")).toHaveAttribute(
+      "data-size",
+      "72",
+    );
+    expect(screen.getByTestId("column-name")).toHaveAttribute(
+      "data-size",
+      "320",
+    );
+    expect(
+      screen.queryByRole("button", { name: /run preview|test/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /critical findings/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should sort alert columns through the shared DataTable column header pattern", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(
+      <AlertsTable
+        alerts={[
+          makeRule({ id: "alert-1", attributes: { name: "Beta alerts" } }),
+          makeRule({ id: "alert-2", attributes: { name: "Alpha alerts" } }),
+        ]}
+        mutatingId={null}
+        onEdit={vi.fn()}
+        onToggleEnabled={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button", { name: /^name$/i }));
+
+    // Then
+    expect(navigationMocks.routerPush).toHaveBeenCalledWith(
+      "/alerts?sort=name",
+      { scroll: false },
+    );
+  });
+
+  it("should truncate long descriptions in the name column", () => {
+    // Given
+    const description =
+      "This alert description is intentionally long enough to overflow the alerts table if it is not constrained by the cell renderer.";
+
+    // When
+    render(
+      <AlertsTable
+        alerts={[makeRule({ attributes: { description } })]}
+        mutatingId={null}
+        onEdit={vi.fn()}
+        onToggleEnabled={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    // Then
+    expect(screen.getByText(description)).toHaveClass("truncate");
+    expect(screen.getByText(description).parentElement).toHaveClass(
+      "max-w-[320px]",
+    );
+    expect(screen.getByText(description)).toHaveAttribute("title", description);
+  });
+
+  it("should call row action callbacks for edit, toggle, and delete", async () => {
+    // Given
+    const user = userEvent.setup();
+    const alert = makeRule({ id: "alert-enabled" });
+    const onEdit = vi.fn();
+    const onToggleEnabled = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <AlertsTable
+        alerts={[alert]}
+        mutatingId={null}
+        onEdit={onEdit}
+        onToggleEnabled={onToggleEnabled}
+        onDelete={onDelete}
+      />,
+    );
+
+    // When
+    await user.click(
+      screen.getByRole("button", { name: /actions for critical findings/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /edit/i }));
+    await user.click(
+      screen.getByRole("button", { name: /actions for critical findings/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /disable/i }));
+    await user.click(
+      screen.getByRole("button", { name: /actions for critical findings/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /delete/i }));
+
+    // Then
+    expect(onEdit).toHaveBeenCalledWith(alert);
+    expect(onToggleEnabled).toHaveBeenCalledWith(alert);
+    expect(onDelete).toHaveBeenCalledWith(alert);
+  });
+});

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -1,0 +1,710 @@
+"use client";
+
+import { useState } from "react";
+
+import { previewAlertCondition } from "@/app/(prowler)/alerts/_actions";
+import { listAlertRecipients } from "@/app/(prowler)/alerts/_actions/recipients";
+import {
+  ALERT_TRIGGER_KINDS,
+  type AlertCondition,
+  type AlertPreviewResponse,
+  type AlertRecipient,
+  type AlertRule,
+  type AlertTriggerKind,
+} from "@/app/(prowler)/alerts/_types";
+import type { FilterChip } from "@/components/filters/filter-summary-strip";
+import { FilterSummaryStrip } from "@/components/filters/filter-summary-strip";
+import { FindingsFilterBatchControls } from "@/components/findings/findings-filters";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  Skeleton,
+  Textarea,
+} from "@/components/shadcn";
+import { Modal } from "@/components/shadcn/modal";
+import {
+  MultiSelect,
+  MultiSelectContent,
+  MultiSelectItem,
+  MultiSelectSelectAll,
+  MultiSelectSeparator,
+  MultiSelectTrigger,
+  MultiSelectValue,
+} from "@/components/shadcn/select/multiselect";
+import { useMountEffect } from "@/hooks/use-mount-effect";
+import type { ScanEntity } from "@/types";
+import type { ProviderProps } from "@/types/providers";
+
+import {
+  buildAlertCondition,
+  getAlertFormDefaults,
+  getAlertFormDefaultsFromFindingsFilters,
+  getEmptyAlertFormDefaults,
+} from "../_lib/alert-adapter";
+import { alertFormSchema } from "../_lib/alert-form-schema";
+import type {
+  AlertFormFindingFilterBag,
+  AlertFormSubmitResult,
+  AlertFormValues,
+} from "../_types/alert-form";
+import { ALERT_NOTIFICATION_METHODS } from "../_types/alert-form";
+
+interface AlertFormModalProps {
+  open: boolean;
+  defaultFrequency: AlertTriggerKind;
+  providers?: ProviderProps[];
+  completedScanIds?: string[];
+  scanDetails?: { [key: string]: ScanEntity }[];
+  uniqueRegions?: string[];
+  uniqueServices?: string[];
+  uniqueResourceTypes?: string[];
+  uniqueCategories?: string[];
+  uniqueGroups?: string[];
+  editingAlert?: AlertRule | null;
+  initialFindingsFilters?: AlertFormFindingFilterBag | null;
+  selectedFindingsFilterChips?: FilterChip[];
+  defaultName?: string;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (
+    values: AlertFormValues,
+    advancedCondition: AlertCondition | null,
+  ) => Promise<AlertFormSubmitResult>;
+}
+
+interface FormErrors {
+  name?: string;
+  recipientEmails?: string;
+  root?: string;
+}
+
+const normalizeEmail = (email: string): string => email.trim().toLowerCase();
+
+const getRecipientEmails = (selectedEmails: Set<string>): string[] =>
+  Array.from(selectedEmails);
+
+const ALERT_FREQUENCY_OPTIONS = [
+  {
+    value: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+    label: "After each scan",
+  },
+  {
+    value: ALERT_TRIGGER_KINDS.DAILY,
+    label: "Daily digest",
+  },
+  {
+    value: ALERT_TRIGGER_KINDS.BOTH,
+    label: "After each scan and daily",
+  },
+] as const;
+
+const serializeFindingFilters = (
+  filters: AlertFormFindingFilterBag | null,
+): string => {
+  if (!filters) return "none";
+
+  return Object.entries(filters)
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([key, value]) => {
+      const serializedValue = Array.isArray(value) ? value.join(",") : value;
+      return `${key}:${serializedValue}`;
+    })
+    .join("|");
+};
+
+const getAlertFormModalResetKey = ({
+  open,
+  defaultFrequency,
+  editingAlert,
+  initialFindingsFilters,
+}: Pick<
+  AlertFormModalProps,
+  "open" | "defaultFrequency" | "editingAlert" | "initialFindingsFilters"
+>): string =>
+  [
+    open ? "open" : "closed",
+    editingAlert?.id ?? "create",
+    editingAlert?.attributes.updated_at ?? "",
+    defaultFrequency,
+    serializeFindingFilters(initialFindingsFilters ?? null),
+  ].join("|");
+
+const allowInitialDialogFocus = () => undefined;
+
+const uniqueValues = (values: string[]): string[] =>
+  Array.from(new Set(values));
+
+interface PreviewState {
+  status: "success" | "error";
+  data?: AlertPreviewResponse;
+  error?: string;
+}
+
+const formatPreviewNumber = (value: number): string =>
+  new Intl.NumberFormat("en-US").format(value);
+
+const getPreviewSeverityLabel = (severity: string): string =>
+  severity.charAt(0).toUpperCase() + severity.slice(1);
+
+const PreviewSummarySkeleton = () => (
+  <Card variant="inner" padding="sm">
+    <CardContent className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-5 w-20 rounded-full" />
+      </div>
+      <Separator />
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-5 w-12" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-5 w-16" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="h-5 w-10" />
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+);
+
+const PreviewSummary = ({ preview }: { preview: PreviewState }) => {
+  if (preview.status === "error") {
+    return (
+      <Card variant="danger" padding="sm">
+        <CardContent className="flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-text-neutral-primary text-sm font-medium">
+              Test result
+            </span>
+            <Badge variant="tag">Error</Badge>
+          </div>
+          <Separator />
+          <p className="text-destructive text-sm">{preview.error}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const data = preview.data;
+  if (!data) return null;
+
+  const totalFindings = data.summary.finding_count_total ?? 0;
+  const topSeverity = data.summary.top_severity ?? "none";
+  const duration = data.duration_ms === undefined ? null : data.duration_ms;
+  const statusLabel = data.would_fire ? "Would fire" : "Would not fire";
+
+  return (
+    <Card variant="inner" padding="sm">
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-text-neutral-primary text-sm font-medium">
+            Test result
+          </span>
+          <Badge variant="tag">{statusLabel}</Badge>
+        </div>
+        <Separator />
+        <div className="grid gap-3 text-sm sm:grid-cols-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-text-neutral-secondary text-xs">
+              Findings
+            </span>
+            <span className="text-text-neutral-primary font-medium">
+              {formatPreviewNumber(totalFindings)}
+            </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-text-neutral-secondary text-xs">
+              Top severity
+            </span>
+            <span className="text-text-neutral-primary font-medium">
+              {getPreviewSeverityLabel(topSeverity)}
+            </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-text-neutral-secondary text-xs">
+              Duration
+            </span>
+            <span className="text-text-neutral-primary font-medium">
+              {duration === null ? "-" : `${formatPreviewNumber(duration)} ms`}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const SIMPLE_FIELD_TO_FINDINGS_FILTER: Record<string, string> = {
+  provider_type: "filter[provider_type__in]",
+  provider_id: "filter[provider_id__in]",
+  severity: "filter[severity__in]",
+  delta: "filter[delta]",
+  resource_regions: "filter[region__in]",
+  resource_services: "filter[service__in]",
+  resource_types: "filter[resource_type__in]",
+  categories: "filter[category__in]",
+  resource_groups: "filter[resource_groups__in]",
+};
+
+const normalizeFindingsFilterKey = (filterKey: string): string =>
+  filterKey.startsWith("filter[") ? filterKey : `filter[${filterKey}]`;
+
+const conditionToPendingFindingsFilters = (
+  condition: AlertCondition,
+): Record<string, string[]> => {
+  if ("filter" in condition) {
+    return Object.entries(condition.filter).reduce<Record<string, string[]>>(
+      (filters, [field, value]) => {
+        const filterKey = SIMPLE_FIELD_TO_FINDINGS_FILTER[field];
+        if (!filterKey || !Array.isArray(value)) return filters;
+        filters[filterKey] = uniqueValues([
+          ...(filters[filterKey] ?? []),
+          ...value,
+        ]);
+        return filters;
+      },
+      {},
+    );
+  }
+
+  if ("child" in condition) {
+    return conditionToPendingFindingsFilters(condition.child);
+  }
+
+  return condition.children.reduce<Record<string, string[]>>(
+    (filters, child) => {
+      const childFilters = conditionToPendingFindingsFilters(child);
+      Object.entries(childFilters).forEach(([filterKey, values]) => {
+        filters[filterKey] = uniqueValues([
+          ...(filters[filterKey] ?? []),
+          ...values,
+        ]);
+      });
+      return filters;
+    },
+    {},
+  );
+};
+
+interface AlertRecipientsSelectProps {
+  selectedEmails: Set<string>;
+  onValuesChange: (emails: string[]) => void;
+}
+
+interface RecipientOption {
+  email: string;
+  status?: AlertRecipient["attributes"]["status"];
+}
+
+const getRecipientStatusLabel = (
+  status: AlertRecipient["attributes"]["status"],
+): string => status.charAt(0).toUpperCase() + status.slice(1);
+
+const getRecipientOptions = (
+  recipients: AlertRecipient[],
+  selectedEmails: string[],
+): RecipientOption[] => {
+  const options = new Map<string, RecipientOption>();
+
+  recipients.forEach((recipient) => {
+    const email = normalizeEmail(recipient.attributes.email);
+    if (!email) return;
+    options.set(email, { email, status: recipient.attributes.status });
+  });
+
+  selectedEmails.forEach((email) => {
+    const normalizedEmail = normalizeEmail(email);
+    if (!normalizedEmail || options.has(normalizedEmail)) return;
+    options.set(normalizedEmail, { email: normalizedEmail });
+  });
+
+  return Array.from(options.values()).sort((left, right) =>
+    left.email.localeCompare(right.email),
+  );
+};
+
+const AlertRecipientsSelect = ({
+  selectedEmails,
+  onValuesChange,
+}: AlertRecipientsSelectProps) => {
+  const [recipients, setRecipients] = useState<AlertRecipient[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useMountEffect(() => {
+    const params = new URLSearchParams();
+    params.set("page[size]", "100");
+    params.set("sort", "email");
+
+    listAlertRecipients(params).then((result) => {
+      setLoading(false);
+      if (result.ok) {
+        setRecipients(result.data.data);
+        setError(null);
+        return;
+      }
+      setRecipients([]);
+      setError(result.error.detail);
+    });
+  });
+
+  const selectedValues = Array.from(selectedEmails);
+  const options = getRecipientOptions(recipients, selectedValues);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <MultiSelect values={selectedValues} onValuesChange={onValuesChange}>
+        <MultiSelectTrigger
+          id="alert-recipients"
+          aria-label="Recipients"
+          size="default"
+        >
+          <MultiSelectValue
+            placeholder={loading ? "Loading recipients" : "Select emails"}
+          />
+        </MultiSelectTrigger>
+        <MultiSelectContent
+          search={{
+            placeholder: "Search recipients...",
+            emptyMessage: "No confirmed recipients found.",
+          }}
+          width="wide"
+        >
+          <MultiSelectSelectAll
+            mode="select"
+            values={options.map((option) => option.email)}
+          >
+            Select All
+          </MultiSelectSelectAll>
+          <MultiSelectSeparator />
+          {options.map((option) => (
+            <MultiSelectItem
+              key={option.email}
+              value={option.email}
+              badgeLabel={option.email}
+              keywords={[option.email, option.status ?? ""]}
+            >
+              <span className="truncate">{option.email}</span>
+              {option.status && (
+                <Badge variant="tag">
+                  {getRecipientStatusLabel(option.status)}
+                </Badge>
+              )}
+            </MultiSelectItem>
+          ))}
+        </MultiSelectContent>
+      </MultiSelect>
+      {error && <p className="text-destructive text-xs">{error}</p>}
+    </div>
+  );
+};
+
+export const AlertFormModal = (props: AlertFormModalProps) => {
+  const resetKey = getAlertFormModalResetKey(props);
+
+  return <AlertFormModalContent key={resetKey} {...props} />;
+};
+
+const AlertFormModalContent = ({
+  open,
+  defaultFrequency,
+  providers = [],
+  completedScanIds = [],
+  scanDetails = [],
+  uniqueRegions = [],
+  uniqueServices = [],
+  uniqueResourceTypes = [],
+  uniqueCategories = [],
+  uniqueGroups = [],
+  editingAlert = null,
+  initialFindingsFilters = null,
+  selectedFindingsFilterChips = [],
+  defaultName = "Findings filter alert",
+  onOpenChange,
+  onSubmit,
+}: AlertFormModalProps) => {
+  const defaults = editingAlert
+    ? getAlertFormDefaults(editingAlert)
+    : initialFindingsFilters
+      ? getAlertFormDefaultsFromFindingsFilters(
+          initialFindingsFilters,
+          defaultFrequency,
+        )
+      : getEmptyAlertFormDefaults(defaultFrequency);
+  const initialName = editingAlert
+    ? defaults.name
+    : defaults.name || defaultName;
+
+  // Local state needed: user edits are buffered until the modal form is submitted.
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(defaults.description);
+  const [frequency, setFrequency] = useState<AlertTriggerKind>(
+    defaults.frequency,
+  );
+  const [pendingFilters, setPendingFilters] = useState<
+    Record<string, string[]>
+  >(
+    editingAlert
+      ? conditionToPendingFindingsFilters(editingAlert.attributes.condition)
+      : {},
+  );
+  const [selectedRecipientEmails, setSelectedRecipientEmails] = useState(
+    () => new Set(defaults.recipientEmails.map(normalizeEmail)),
+  );
+  const [enabled] = useState(defaults.enabled);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [saving, setSaving] = useState(false);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [preview, setPreview] = useState<PreviewState | null>(null);
+
+  const submitLabel = editingAlert ? "Save" : "Create";
+
+  const setRecipientEmails = (emails: string[]) =>
+    setSelectedRecipientEmails(
+      new Set(emails.map(normalizeEmail).filter(Boolean)),
+    );
+
+  const setPendingFilter = (filterKey: string, values: string[]) => {
+    setPendingFilters((current) => ({
+      ...current,
+      [normalizeFindingsFilterKey(filterKey)]: uniqueValues(values),
+    }));
+    setPreview(null);
+  };
+
+  const getPendingFilterValue = (filterKey: string): string[] =>
+    pendingFilters[normalizeFindingsFilterKey(filterKey)] ?? [];
+
+  const buildCurrentValues = (): AlertFormValues => {
+    const filterDefaults = getAlertFormDefaultsFromFindingsFilters(
+      pendingFilters,
+      frequency,
+    );
+
+    return {
+      name,
+      description,
+      method: ALERT_NOTIFICATION_METHODS.EMAIL,
+      frequency,
+      filterGroup: filterDefaults.filterGroup,
+      severities: filterDefaults.severities,
+      deltas: filterDefaults.deltas,
+      providerTypes: filterDefaults.providerTypes,
+      providerIds: filterDefaults.providerIds,
+      checkIds: filterDefaults.checkIds,
+      categories: filterDefaults.categories,
+      regions: filterDefaults.regions,
+      services: filterDefaults.services,
+      resourceGroups: filterDefaults.resourceGroups,
+      resourceTypes: filterDefaults.resourceTypes,
+      recipientEmails: getRecipientEmails(selectedRecipientEmails),
+      enabled,
+    };
+  };
+
+  const handlePreview = async () => {
+    if (!editingAlert) return;
+
+    const values = buildCurrentValues();
+    const parsed = alertFormSchema.safeParse(values);
+    if (!parsed.success) {
+      setPreview({
+        status: "error",
+        error: "Fix alert fields before running test.",
+      });
+      return;
+    }
+
+    setPreviewLoading(true);
+    const result = await previewAlertCondition({
+      condition: buildAlertCondition(parsed.data.filterGroup),
+      trigger: frequency,
+    });
+    setPreviewLoading(false);
+
+    if (!result.ok) {
+      setPreview({ status: "error", error: result.error.detail });
+      return;
+    }
+
+    if (result.data.evaluation_failed) {
+      setPreview({
+        status: "error",
+        error: result.data.last_error ?? "Preview evaluation failed.",
+      });
+      return;
+    }
+
+    setPreview({ status: "success", data: result.data });
+  };
+
+  const handleSubmit = async () => {
+    const values = buildCurrentValues();
+    const parsed = alertFormSchema.safeParse(values);
+    if (!parsed.success) {
+      const fieldErrors = parsed.error.flatten().fieldErrors;
+      setErrors({
+        name: fieldErrors.name?.[0],
+        recipientEmails: fieldErrors.recipientEmails?.[0],
+      });
+      return;
+    }
+
+    setSaving(true);
+    const result = await onSubmit(parsed.data, null);
+    setSaving(false);
+    if (result.ok) {
+      setErrors({});
+      onOpenChange(false);
+      return;
+    }
+    setErrors({ root: result.error ?? "Could not save alert." });
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={editingAlert ? "Edit Alert" : "Create Alert"}
+      description={
+        editingAlert
+          ? "Update recipients, frequency, and finding filters for this alert."
+          : "Create an alert from the current Findings filters."
+      }
+      onOpenAutoFocus={allowInitialDialogFocus}
+      size={editingAlert ? "5xl" : "xl"}
+      className={
+        editingAlert
+          ? "minimal-scrollbar max-h-[calc(100vh-2rem)] overflow-y-auto"
+          : undefined
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <FilterSummaryStrip chips={selectedFindingsFilterChips} />
+        <Field>
+          <FieldLabel htmlFor="alert-name">Name</FieldLabel>
+          <Input
+            id="alert-name"
+            aria-label="Name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+          {errors.name && <FieldError>{errors.name}</FieldError>}
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="alert-description">Description</FieldLabel>
+          <Textarea
+            id="alert-description"
+            aria-label="Description"
+            textareaSize="lg"
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="alert-frequency">Frequency</FieldLabel>
+          <Select
+            value={frequency}
+            onValueChange={(value) => {
+              setFrequency(value as AlertTriggerKind);
+              setPreview(null);
+            }}
+          >
+            <SelectTrigger id="alert-frequency" aria-label="Frequency">
+              <SelectValue placeholder="Select frequency" />
+            </SelectTrigger>
+            <SelectContent width="wide" className="z-[60]">
+              {ALERT_FREQUENCY_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="alert-recipients">Recipients</FieldLabel>
+          <AlertRecipientsSelect
+            selectedEmails={selectedRecipientEmails}
+            onValuesChange={setRecipientEmails}
+          />
+          {errors.recipientEmails && (
+            <FieldError>{errors.recipientEmails}</FieldError>
+          )}
+        </Field>
+        {editingAlert && (
+          <div className="flex flex-col gap-3">
+            <Card variant="inner" padding="sm">
+              <CardContent className="flex flex-col gap-3">
+                <h3 className="text-text-neutral-primary text-sm font-medium">
+                  Filters
+                </h3>
+                <FindingsFilterBatchControls
+                  providers={providers}
+                  completedScanIds={completedScanIds}
+                  scanDetails={scanDetails}
+                  uniqueRegions={uniqueRegions}
+                  uniqueServices={uniqueServices}
+                  uniqueResourceTypes={uniqueResourceTypes}
+                  uniqueCategories={uniqueCategories}
+                  uniqueGroups={uniqueGroups}
+                  appliedFilters={{}}
+                  pendingFilters={pendingFilters}
+                  changedFilters={pendingFilters}
+                  setPending={setPendingFilter}
+                  getFilterValue={getPendingFilterValue}
+                  showSummaries={false}
+                />
+              </CardContent>
+            </Card>
+            {(previewLoading || preview) && (
+              <div className="pt-1">
+                {previewLoading ? (
+                  <PreviewSummarySkeleton />
+                ) : (
+                  preview && <PreviewSummary preview={preview} />
+                )}
+              </div>
+            )}
+          </div>
+        )}
+        {errors.root && (
+          <div className="text-destructive text-sm">{errors.root}</div>
+        )}
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          {editingAlert && (
+            <Button
+              variant="outline"
+              onClick={handlePreview}
+              disabled={previewLoading || saving}
+            >
+              {previewLoading ? "Running..." : "Test"}
+            </Button>
+          )}
+          <Button onClick={handleSubmit} disabled={saving}>
+            {submitLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/ui/app/(prowler)/alerts/_components/alerts-empty-state.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-empty-state.tsx
@@ -1,0 +1,29 @@
+import { BellRing, TagIcon } from "lucide-react";
+import Link from "next/link";
+
+import { Button, Card, CardContent } from "@/components/shadcn";
+
+export const AlertsEmptyState = () => (
+  <Card variant="base" padding="lg">
+    <CardContent className="flex flex-col items-center gap-4 text-center">
+      <div className="bg-button-primary/10 flex h-14 w-14 items-center justify-center rounded-full">
+        <BellRing className="text-button-primary h-7 w-7" aria-hidden="true" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <h3 className="text-text-neutral-primary text-lg font-semibold">
+          No alerts yet
+        </h3>
+        <p className="text-text-neutral-secondary max-w-md text-sm">
+          Create alerts from Findings page to notify selected recipients when
+          matching findings appear.
+        </p>
+      </div>
+      <Button asChild size="sm">
+        <Link href="/findings?filter[muted]=false&filter[status__in]=FAIL">
+          <TagIcon size={14} aria-hidden="true" />
+          Go to Findings
+        </Link>
+      </Button>
+    </CardContent>
+  </Card>
+);

--- a/ui/app/(prowler)/alerts/_components/alerts-manager.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-manager.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+
+import {
+  deleteAlert,
+  disableAlert,
+  enableAlert,
+  updateAlert,
+} from "@/app/(prowler)/alerts/_actions";
+import {
+  ALERT_TRIGGER_KINDS,
+  type AlertCondition,
+  type AlertRule,
+} from "@/app/(prowler)/alerts/_types";
+import { Button } from "@/components/shadcn";
+import { Modal } from "@/components/shadcn/modal";
+import { useToast } from "@/components/ui";
+import type { MetaDataProps } from "@/types";
+import type { ScanEntity } from "@/types";
+import type { ProviderProps } from "@/types/providers";
+
+import { toAlertPayload } from "../_lib/alert-adapter";
+import type {
+  AlertFormSubmitResult,
+  AlertFormValues,
+} from "../_types/alert-form";
+import { AlertFormModal } from "./alert-form-modal";
+import { AlertsEmptyState } from "./alerts-empty-state";
+import { AlertsTable } from "./alerts-table";
+
+interface AlertsManagerProps {
+  alerts: AlertRule[];
+  meta?: MetaDataProps;
+  loadError: string | null;
+  providers: ProviderProps[];
+  completedScanIds: string[];
+  scanDetails: { [key: string]: ScanEntity }[];
+  uniqueRegions: string[];
+  uniqueServices: string[];
+  uniqueResourceTypes: string[];
+  uniqueCategories: string[];
+  uniqueGroups: string[];
+  initialEditingAlert?: AlertRule | null;
+}
+
+export const AlertsManager = ({
+  alerts,
+  meta,
+  loadError,
+  providers,
+  completedScanIds,
+  scanDetails,
+  uniqueRegions,
+  uniqueServices,
+  uniqueResourceTypes,
+  uniqueCategories,
+  uniqueGroups,
+  initialEditingAlert = null,
+}: AlertsManagerProps) => {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [, startTransition] = useTransition();
+  const [modalOpen, setModalOpen] = useState(Boolean(initialEditingAlert));
+  const [editingAlert, setEditingRule] = useState<AlertRule | null>(
+    initialEditingAlert,
+  );
+  const [mutatingId, setMutatingId] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<AlertRule | null>(null);
+
+  const refresh = () => startTransition(() => router.refresh());
+
+  const closeModal = (open: boolean) => {
+    setModalOpen(open);
+    if (!open) {
+      setEditingRule(null);
+      router.replace("/alerts");
+    }
+  };
+
+  const submitAlert = async (
+    values: AlertFormValues,
+    advancedCondition: AlertCondition | null,
+  ): Promise<AlertFormSubmitResult> => {
+    if (!editingAlert) {
+      return { ok: false, error: "Create alerts from Findings." };
+    }
+    const payload = toAlertPayload(values, advancedCondition);
+    const result = await updateAlert(editingAlert.id, payload);
+    if (!result.ok) return { ok: false, error: result.error.detail };
+    toast({
+      title: "Alert updated",
+      description: result.data.data.attributes.name,
+    });
+    refresh();
+    return { ok: true, alertId: result.data.data.id };
+  };
+
+  const toggleAlert = async (alert: AlertRule) => {
+    setMutatingId(alert.id);
+    const result = alert.attributes.enabled
+      ? await disableAlert(alert.id)
+      : await enableAlert(alert.id);
+    setMutatingId(null);
+    if (!result.ok) {
+      toast({
+        variant: "destructive",
+        title: "Alert update failed",
+        description: result.error.detail,
+      });
+      return;
+    }
+    toast({
+      title: alert.attributes.enabled ? "Alert disabled" : "Alert enabled",
+      description: result.data.data.attributes.name,
+    });
+    refresh();
+  };
+
+  const confirmDelete = async () => {
+    if (!pendingDelete) return;
+    setMutatingId(pendingDelete.id);
+    const result = await deleteAlert(pendingDelete.id);
+    setMutatingId(null);
+    if (!result.ok) {
+      toast({
+        variant: "destructive",
+        title: "Alert delete failed",
+        description: result.error.detail,
+      });
+      return;
+    }
+    setPendingDelete(null);
+    refresh();
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex max-w-3xl flex-col gap-2">
+          <h1 className="text-text-neutral-primary text-2xl font-semibold">
+            Alerts
+          </h1>
+          <p className="text-text-neutral-secondary text-sm">
+            Manage alerts for finding conditions.
+          </p>
+        </div>
+      </div>
+
+      {loadError && (
+        <div className="border-destructive/40 bg-destructive/10 text-destructive rounded-md border p-4 text-sm">
+          Failed to load alerts: {loadError}
+        </div>
+      )}
+
+      {alerts.length === 0 && !loadError ? (
+        <AlertsEmptyState />
+      ) : (
+        <AlertsTable
+          alerts={alerts}
+          meta={meta}
+          mutatingId={mutatingId}
+          onEdit={(alert) => {
+            setEditingRule(alert);
+            setModalOpen(true);
+          }}
+          onToggleEnabled={toggleAlert}
+          onDelete={setPendingDelete}
+        />
+      )}
+
+      <AlertFormModal
+        key={editingAlert?.id ?? "edit"}
+        open={modalOpen}
+        defaultFrequency={ALERT_TRIGGER_KINDS.AFTER_SCAN}
+        providers={providers}
+        completedScanIds={completedScanIds}
+        scanDetails={scanDetails}
+        uniqueRegions={uniqueRegions}
+        uniqueServices={uniqueServices}
+        uniqueResourceTypes={uniqueResourceTypes}
+        uniqueCategories={uniqueCategories}
+        uniqueGroups={uniqueGroups}
+        editingAlert={editingAlert}
+        onOpenChange={closeModal}
+        onSubmit={submitAlert}
+      />
+
+      <Modal
+        open={Boolean(pendingDelete)}
+        onOpenChange={(open) => !open && setPendingDelete(null)}
+        title="Delete alert"
+        description={
+          pendingDelete
+            ? `Delete "${pendingDelete.attributes.name}"? This alert will stop evaluating.`
+            : ""
+        }
+        size="md"
+      >
+        <div className="flex justify-end gap-2 pt-4">
+          <Button variant="outline" onClick={() => setPendingDelete(null)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={mutatingId === pendingDelete?.id}
+            onClick={confirmDelete}
+          >
+            Delete alert
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+};

--- a/ui/app/(prowler)/alerts/_components/alerts-table.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-table.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { PencilIcon, PowerIcon, TrashIcon } from "lucide-react";
+
+import type { AlertRule } from "@/app/(prowler)/alerts/_types";
+import {
+  ActionDropdown,
+  ActionDropdownDangerZone,
+  ActionDropdownItem,
+} from "@/components/shadcn/dropdown";
+import { DataTable } from "@/components/ui/table/data-table";
+import { DataTableColumnHeader } from "@/components/ui/table/data-table-column-header";
+import type { MetaDataProps } from "@/types";
+
+interface AlertsTableProps {
+  alerts: AlertRule[];
+  meta?: MetaDataProps;
+  mutatingId: string | null;
+  onEdit: (alert: AlertRule) => void;
+  onToggleEnabled: (alert: AlertRule) => void;
+  onDelete: (alert: AlertRule) => void;
+}
+
+const TRIGGER_LABELS = {
+  after_scan: "After each scan",
+  daily: "Daily digest",
+  both: "After scan and daily",
+} as const satisfies Record<AlertRule["attributes"]["trigger"], string>;
+
+const formatRecipients = (alert: AlertRule): string => {
+  const recipients = alert.attributes.recipient_emails ?? [];
+  if (recipients.length === 0) return "No recipients";
+  if (recipients.length === 1) return recipients[0];
+  return `${recipients[0]} +${recipients.length - 1} more`;
+};
+
+interface GetAlertsTableColumnsOptions {
+  mutatingId: string | null;
+  onEdit: (alert: AlertRule) => void;
+  onToggleEnabled: (alert: AlertRule) => void;
+  onDelete: (alert: AlertRule) => void;
+}
+
+const getAlertsTableColumns = ({
+  mutatingId,
+  onEdit,
+  onToggleEnabled,
+  onDelete,
+}: GetAlertsTableColumnsOptions): ColumnDef<AlertRule>[] => [
+  {
+    id: "name",
+    size: 320,
+    minSize: 280,
+    accessorFn: (alert) => alert.attributes.name,
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Name" param="name" />
+    ),
+    cell: ({ row }) => {
+      const alert = row.original;
+      return (
+        <div className="flex w-[320px] max-w-[320px] min-w-0 flex-col gap-1">
+          <span className="truncate font-medium">{alert.attributes.name}</span>
+          {alert.attributes.description && (
+            <span
+              className="text-text-neutral-secondary block w-full truncate text-xs"
+              title={alert.attributes.description}
+            >
+              {alert.attributes.description}
+            </span>
+          )}
+        </div>
+      );
+    },
+  },
+  {
+    id: "enabled",
+    size: 140,
+    minSize: 120,
+    accessorFn: (alert) => (alert.attributes.enabled ? "Enabled" : "Disabled"),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Status" param="enabled" />
+    ),
+    cell: ({ row }) =>
+      row.original.attributes.enabled ? "Enabled" : "Disabled",
+  },
+  {
+    id: "trigger",
+    size: 190,
+    minSize: 170,
+    accessorFn: (alert) => TRIGGER_LABELS[alert.attributes.trigger],
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        column={column}
+        title="Frequency"
+        param="trigger"
+      />
+    ),
+    cell: ({ row }) => TRIGGER_LABELS[row.original.attributes.trigger],
+  },
+  {
+    id: "recipients",
+    size: 220,
+    minSize: 180,
+    accessorFn: (alert) => formatRecipients(alert),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Recipients" />
+    ),
+    cell: ({ row }) => formatRecipients(row.original),
+  },
+  {
+    id: "actions",
+    size: 72,
+    minSize: 64,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const alert = row.original;
+      const isMutating = mutatingId === alert.id;
+      const enabled = alert.attributes.enabled;
+      const toggleLabel = enabled ? "Disable" : "Enable";
+      return (
+        <div className="flex items-center justify-end">
+          <ActionDropdown ariaLabel={`Actions for ${alert.attributes.name}`}>
+            <ActionDropdownItem
+              icon={<PencilIcon />}
+              label="Edit"
+              onSelect={() => onEdit(alert)}
+            />
+            <ActionDropdownItem
+              icon={<PowerIcon />}
+              label={toggleLabel}
+              disabled={isMutating}
+              onSelect={() => onToggleEnabled(alert)}
+            />
+            <ActionDropdownDangerZone>
+              <ActionDropdownItem
+                icon={<TrashIcon />}
+                label="Delete"
+                destructive
+                disabled={isMutating}
+                onSelect={() => onDelete(alert)}
+              />
+            </ActionDropdownDangerZone>
+          </ActionDropdown>
+        </div>
+      );
+    },
+  },
+];
+
+export const AlertsTable = ({
+  alerts,
+  meta,
+  mutatingId,
+  onEdit,
+  onToggleEnabled,
+  onDelete,
+}: AlertsTableProps) => (
+  <DataTable
+    columns={getAlertsTableColumns({
+      mutatingId,
+      onEdit,
+      onToggleEnabled,
+      onDelete,
+    })}
+    data={alerts}
+    metadata={meta}
+    showSearch
+    searchPlaceholder="Search alerts"
+  />
+);

--- a/ui/app/(prowler)/alerts/page.tsx
+++ b/ui/app/(prowler)/alerts/page.tsx
@@ -1,0 +1,118 @@
+import { notFound } from "next/navigation";
+
+import { getLatestMetadataInfo } from "@/actions/findings";
+import { getProviders } from "@/actions/providers";
+import { getScans } from "@/actions/scans";
+import { getAlert, listAlerts } from "@/app/(prowler)/alerts/_actions";
+import { AlertsManager } from "@/app/(prowler)/alerts/_components/alerts-manager";
+import { isAlertsEnabled } from "@/app/(prowler)/alerts/_lib/env";
+import { ContentLayout } from "@/components/ui";
+import { createScanDetailsMapping } from "@/lib";
+import type { MetaDataProps, ScanEntity, ScanProps } from "@/types";
+
+interface AlertsPageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+const getParamValue = (
+  params: Awaited<AlertsPageProps["searchParams"]>,
+  key: string,
+): string | undefined => {
+  const value = params[key];
+  return Array.isArray(value) ? value[0] : value;
+};
+
+const toAlertsSearchParams = (
+  resolvedSearchParams: Awaited<AlertsPageProps["searchParams"]>,
+): URLSearchParams => {
+  const page = Number.parseInt(
+    getParamValue(resolvedSearchParams, "page") ?? "1",
+    10,
+  );
+  const pageSize = Number.parseInt(
+    getParamValue(resolvedSearchParams, "pageSize") ?? "20",
+    10,
+  );
+  const sort = getParamValue(resolvedSearchParams, "sort") ?? "-inserted_at";
+  const search = getParamValue(resolvedSearchParams, "filter[search]") ?? "";
+  const enabledFilter = getParamValue(resolvedSearchParams, "filter[enabled]");
+  const triggerFilter = getParamValue(resolvedSearchParams, "filter[trigger]");
+
+  const params = new URLSearchParams();
+  params.set("page[number]", String(page));
+  params.set("page[size]", String(pageSize));
+  params.set("sort", sort);
+  if (search) params.set("filter[search]", search);
+  if (enabledFilter) params.set("filter[enabled]", enabledFilter);
+  if (triggerFilter) params.set("filter[trigger]", triggerFilter);
+  return params;
+};
+
+export default async function AlertsPage({ searchParams }: AlertsPageProps) {
+  if (!isAlertsEnabled()) {
+    notFound();
+  }
+
+  const resolvedSearchParams = await searchParams;
+  const editAlertId = getParamValue(resolvedSearchParams, "edit");
+  const [result, providersData, scansData, metadataInfoData, editResult] =
+    await Promise.all([
+      listAlerts(toAlertsSearchParams(resolvedSearchParams)),
+      getProviders({ pageSize: 50 }),
+      getScans({ pageSize: 50 }),
+      getLatestMetadataInfo({}),
+      editAlertId ? getAlert(editAlertId) : Promise.resolve(null),
+    ]);
+  const alerts = result.ok ? result.data.data : [];
+  const apiMeta = result.ok ? result.data.meta : undefined;
+  const loadError = !result.ok ? result.error.detail : null;
+  const uniqueRegions = metadataInfoData?.data?.attributes?.regions || [];
+  const uniqueServices = metadataInfoData?.data?.attributes?.services || [];
+  const uniqueResourceTypes =
+    metadataInfoData?.data?.attributes?.resource_types || [];
+  const uniqueCategories = metadataInfoData?.data?.attributes?.categories || [];
+  const uniqueGroups = metadataInfoData?.data?.attributes?.groups || [];
+  const scans = scansData && "data" in scansData ? scansData.data : [];
+  const completedScans = scans?.filter(
+    (scan: ScanProps) =>
+      scan.attributes.state === "completed" &&
+      scan.attributes.unique_resource_count > 1,
+  );
+  const completedScanIds =
+    completedScans?.map((scan: ScanProps) => scan.id) || [];
+  const scanDetails = createScanDetailsMapping(
+    completedScans || [],
+    providersData,
+  ) as { [uid: string]: ScanEntity }[];
+  const editingAlert =
+    editResult && editResult.ok ? editResult.data.data : null;
+  const meta: MetaDataProps | undefined = apiMeta?.pagination
+    ? {
+        pagination: {
+          page: apiMeta.pagination.page,
+          pages: apiMeta.pagination.pages,
+          count: apiMeta.pagination.count,
+        },
+        version: "1",
+      }
+    : undefined;
+
+  return (
+    <ContentLayout title="Alerts" icon="lucide:bell-ring">
+      <AlertsManager
+        alerts={alerts}
+        meta={meta}
+        loadError={loadError}
+        providers={providersData?.data || []}
+        completedScanIds={completedScanIds}
+        scanDetails={scanDetails}
+        uniqueRegions={uniqueRegions}
+        uniqueServices={uniqueServices}
+        uniqueResourceTypes={uniqueResourceTypes}
+        uniqueCategories={uniqueCategories}
+        uniqueGroups={uniqueGroups}
+        initialEditingAlert={editingAlert}
+      />
+    </ContentLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds the cloud-gated custom alerts management page and components.
- Adds management UI tests for table, manager, and form modal behavior.
- Gates `/alerts` with `notFound()` before resolving search params or fetching alerts/provider/scan data.

## Chain
- Main PR: #11003
- Previous PR: #11005
- Next branch: `feat/PROWLER-1418-alerts-findings-seeding`

## Validation
- `cd ui && pnpm run healthcheck`
- Vitest suite for alerts management scope passed as part of the UI test run: 118 files / 659 tests passed.