### PR TITLE
[CHAIN] feat(ui): seed custom alerts from findings filters

### DIFF
--- a/ui/app/(prowler)/alerts/_components/__tests__/seed-from-findings-button.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/seed-from-findings-button.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AlertCondition } from "@/app/(prowler)/alerts/_types";
+import type {
+  AlertFormSubmitResult,
+  AlertFormValues,
+} from "@/app/(prowler)/alerts/_types/alert-form";
+
+const routerMocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+const actionMocks = vi.hoisted(() => ({
+  createAlert: vi.fn(),
+}));
+
+const toastMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMocks,
+}));
+
+vi.mock("@/components/ui", () => ({
+  ToastAction: ({
+    asChild,
+    children,
+    ...props
+  }: ComponentProps<"button"> & {
+    asChild?: boolean;
+    children?: ReactNode;
+  }) => (asChild ? children : <button {...props}>{children}</button>),
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/app/(prowler)/alerts/_actions", () => ({
+  createAlert: actionMocks.createAlert,
+}));
+
+vi.mock("@/app/(prowler)/alerts/_components/alert-form-modal", () => ({
+  AlertFormModal: ({
+    open,
+    initialFindingsFilters,
+    selectedFindingsFilterChips,
+    defaultName,
+    onSubmit,
+  }: {
+    open: boolean;
+    initialFindingsFilters?: Record<string, string | string[]>;
+    selectedFindingsFilterChips?: Array<{
+      label: string;
+      displayValue?: string;
+      value: string;
+    }>;
+    defaultName?: string;
+    onSubmit: (
+      values: AlertFormValues,
+      advancedCondition: AlertCondition | null,
+    ) => Promise<AlertFormSubmitResult>;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="Create alert">
+        <output data-testid="initial-filters">
+          {JSON.stringify(initialFindingsFilters)}
+        </output>
+        <output data-testid="selected-filter-chips">
+          {(selectedFindingsFilterChips ?? [])
+            .map((chip) => `${chip.label}:${chip.displayValue ?? chip.value}`)
+            .join("|")}
+        </output>
+        <button
+          type="button"
+          onClick={() =>
+            onSubmit(
+              {
+                name: defaultName ?? "Findings filter alert",
+                description: "",
+                method: "email",
+                frequency: "after_scan",
+                filterGroup: { operator: "all", children: [] },
+                severities: [],
+                deltas: [],
+                providerTypes: [],
+                providerIds: [],
+                checkIds: [],
+                categories: [],
+                regions: [],
+                services: [],
+                resourceGroups: [],
+                resourceTypes: [],
+                recipientEmails: ["security@example.com"],
+                enabled: true,
+              },
+              null,
+            )
+          }
+        >
+          Submit mock alert
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { SeedFromFindingsButton } from "../seed-from-findings-button";
+
+describe("SeedFromFindingsButton", () => {
+  it("should explain why creating an alert is disabled when no real filters are applied", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<SeedFromFindingsButton filterBag={{ sort: "-inserted_at" }} />);
+
+    // When
+    const button = screen.getByRole("button", {
+      name: /Create Alert/i,
+    });
+    const tooltipTrigger = button.parentElement;
+    expect(tooltipTrigger).not.toBeNull();
+    await user.hover(tooltipTrigger as HTMLElement);
+
+    // Then
+    expect(button).toBeDisabled();
+    expect(
+      await screen.findAllByText(/at least one findings filter/i),
+    ).not.toHaveLength(0);
+  });
+
+  it("should enable creation from the first real filter, including unsupported backend filters", () => {
+    // Given / When
+    render(
+      <SeedFromFindingsButton
+        filterBag={{
+          "filter[status__in]": "FAIL",
+          "filter[muted]": "false",
+          "filter[scan__in]": "11111111-1111-1111-1111-111111111111",
+        }}
+      />,
+    );
+
+    // Then
+    expect(
+      screen.getByRole("button", { name: /Create Alert/i }),
+    ).not.toBeDisabled();
+  });
+
+  it("should open the modal in Findings and keep unsupported filters out of the payload seed", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(
+      <SeedFromFindingsButton
+        filterBag={{
+          "filter[status__in]": "FAIL",
+          "filter[muted]": "false",
+          "filter[scan__in]": "11111111-1111-1111-1111-111111111111",
+          "filter[severity__in]": "critical,high",
+        }}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button", { name: /Create Alert/i }));
+
+    // Then
+    expect(screen.getByRole("dialog", { name: /create alert/i })).toBeVisible();
+    expect(routerMocks.push).not.toHaveBeenCalled();
+    expect(screen.getByTestId("selected-filter-chips")).toHaveTextContent(
+      /status:fail/i,
+    );
+    expect(screen.getByTestId("selected-filter-chips")).toHaveTextContent(
+      /muted:false/i,
+    );
+    expect(screen.getByTestId("initial-filters")).toHaveTextContent(
+      "filter[severity__in]",
+    );
+    expect(screen.getByTestId("initial-filters")).not.toHaveTextContent(
+      "filter[status__in]",
+    );
+    expect(screen.getByTestId("initial-filters")).not.toHaveTextContent(
+      "filter[muted]",
+    );
+    expect(screen.getByTestId("initial-filters")).not.toHaveTextContent(
+      "filter[scan__in]",
+    );
+  });
+
+  it("should create the alert through the existing alert action from the modal", async () => {
+    // Given
+    const user = userEvent.setup();
+    actionMocks.createAlert.mockResolvedValue({
+      ok: true,
+      data: {
+        data: {
+          id: "alert-1",
+          attributes: { name: "Findings filter alert" },
+        },
+      },
+    });
+    render(
+      <SeedFromFindingsButton
+        filterBag={{ "filter[severity__in]": "critical" }}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button", { name: /Create Alert/i }));
+    await user.click(
+      screen.getByRole("button", { name: /submit mock alert/i }),
+    );
+
+    // Then
+    await waitFor(() =>
+      expect(actionMocks.createAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Findings filter alert",
+          trigger: "after_scan",
+          recipientEmails: ["security@example.com"],
+        }),
+      ),
+    );
+    expect(routerMocks.refresh).toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Alert created",
+        action: expect.anything(),
+      }),
+    );
+  });
+
+  it("should add a toast action to navigate to alerts after creating an alert", async () => {
+    // Given
+    const user = userEvent.setup();
+    actionMocks.createAlert.mockResolvedValue({
+      ok: true,
+      data: {
+        data: {
+          id: "alert-1",
+          attributes: { name: "Findings filter alert" },
+        },
+      },
+    });
+    render(
+      <SeedFromFindingsButton
+        filterBag={{ "filter[severity__in]": "critical" }}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button", { name: /Create Alert/i }));
+    await user.click(
+      screen.getByRole("button", { name: /submit mock alert/i }),
+    );
+
+    // Then
+    await waitFor(() => expect(toastMock).toHaveBeenCalled());
+    const toastAction = toastMock.mock.calls[0][0].action;
+    render(toastAction);
+    expect(screen.getByRole("link", { name: /view alerts/i })).toHaveAttribute(
+      "href",
+      "/alerts",
+    );
+  });
+});

--- a/ui/app/(prowler)/alerts/_components/index.ts
+++ b/ui/app/(prowler)/alerts/_components/index.ts
@@ -1,0 +1,1 @@
+export * from "./seed-from-findings-button";

--- a/ui/app/(prowler)/alerts/_components/seed-from-findings-button.tsx
+++ b/ui/app/(prowler)/alerts/_components/seed-from-findings-button.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { BellPlusIcon } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { createAlert } from "@/app/(prowler)/alerts/_actions";
+import { AlertFormModal } from "@/app/(prowler)/alerts/_components/alert-form-modal";
+import { toAlertPayload } from "@/app/(prowler)/alerts/_lib/alert-adapter";
+import {
+  canSeedAlertFromFindingsFilters,
+  toPortableAlertFilterBag,
+} from "@/app/(prowler)/alerts/_lib/seeding";
+import {
+  ALERT_TRIGGER_KINDS,
+  type AlertCondition,
+  type AlertsFilterBag,
+} from "@/app/(prowler)/alerts/_types";
+import type {
+  AlertFormSubmitResult,
+  AlertFormValues,
+} from "@/app/(prowler)/alerts/_types/alert-form";
+import { buildFindingsFilterChips } from "@/components/findings/findings-filters.utils";
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn";
+import { ToastAction, useToast } from "@/components/ui";
+import type { ScanEntity } from "@/types";
+import type { ProviderProps } from "@/types/providers";
+
+const DISABLED_FILTER_TOOLTIP =
+  "Apply at least one Findings filter to create an alert from filters.";
+
+interface SeedFromFindingsButtonProps {
+  filterBag: AlertsFilterBag;
+  providers?: ProviderProps[];
+  scans?: Array<{ [scanId: string]: ScanEntity }>;
+  uniqueRegions?: string[];
+  uniqueServices?: string[];
+  uniqueResourceTypes?: string[];
+  uniqueCategories?: string[];
+  uniqueGroups?: string[];
+  className?: string;
+  size?: "sm" | "default";
+  defaultName?: string;
+}
+
+const toChipFilterMap = (
+  filterBag: AlertsFilterBag,
+): Record<string, string[]> =>
+  Object.fromEntries(
+    Object.entries(filterBag)
+      .filter(([key]) => key.startsWith("filter["))
+      .map(([key, value]) => [
+        key,
+        (Array.isArray(value) ? value : value.split(","))
+          .map((entry) => entry.trim())
+          .filter(Boolean),
+      ])
+      .filter(([, values]) => values.length > 0),
+  );
+
+export const SeedFromFindingsButton = ({
+  filterBag,
+  providers = [],
+  scans = [],
+  uniqueRegions = [],
+  uniqueServices = [],
+  uniqueResourceTypes = [],
+  uniqueCategories = [],
+  uniqueGroups = [],
+  className,
+  size = "sm",
+  defaultName = "Findings filter alert",
+}: SeedFromFindingsButtonProps) => {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const canSeedFromFilters = canSeedAlertFromFindingsFilters(filterBag);
+  const portableFilterBag = toPortableAlertFilterBag(filterBag);
+  const selectedFindingsFilterChips = buildFindingsFilterChips(
+    toChipFilterMap(filterBag),
+    { providers, scans, includeMuted: true },
+  );
+
+  const handleClick = () => {
+    if (!canSeedFromFilters) return;
+    setModalOpen(true);
+  };
+
+  const submitAlert = async (
+    values: AlertFormValues,
+    advancedCondition: AlertCondition | null,
+  ): Promise<AlertFormSubmitResult> => {
+    const result = await createAlert(toAlertPayload(values, advancedCondition));
+    if (!result.ok) return { ok: false, error: result.error.detail };
+    toast({
+      title: "Alert created",
+      description: result.data.data.attributes.name,
+      action: (
+        <ToastAction altText="View alerts" asChild>
+          <Link href="/alerts">View Alerts</Link>
+        </ToastAction>
+      ),
+    });
+    router.refresh();
+    return { ok: true, alertId: result.data.data.id };
+  };
+
+  const button = (
+    <Button
+      size={size}
+      variant="default"
+      onClick={handleClick}
+      disabled={!canSeedFromFilters}
+      className={className}
+    >
+      <BellPlusIcon size={14} />
+      Create Alert
+    </Button>
+  );
+
+  if (canSeedFromFilters) {
+    return (
+      <>
+        {button}
+        <AlertFormModal
+          open={modalOpen}
+          defaultFrequency={ALERT_TRIGGER_KINDS.AFTER_SCAN}
+          providers={providers}
+          uniqueRegions={uniqueRegions}
+          uniqueServices={uniqueServices}
+          uniqueResourceTypes={uniqueResourceTypes}
+          uniqueCategories={uniqueCategories}
+          uniqueGroups={uniqueGroups}
+          initialFindingsFilters={portableFilterBag}
+          selectedFindingsFilterChips={selectedFindingsFilterChips}
+          defaultName={defaultName}
+          onOpenChange={setModalOpen}
+          onSubmit={submitAlert}
+        />
+      </>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex"
+          tabIndex={0}
+          title={DISABLED_FILTER_TOOLTIP}
+        >
+          {button}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-xs">
+        {DISABLED_FILTER_TOOLTIP}
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/ui/app/(prowler)/findings/__tests__/page.test.tsx
+++ b/ui/app/(prowler)/findings/__tests__/page.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Findings from "../page";
+
+vi.mock("@/actions/finding-groups", () => ({
+  adaptFindingGroupsResponse: vi.fn(() => []),
+  getFindingGroups: vi.fn(),
+  getLatestFindingGroups: vi.fn(() => ({ data: [], errors: [], meta: {} })),
+}));
+
+vi.mock("@/actions/findings", () => ({
+  getLatestMetadataInfo: vi.fn(() => ({
+    data: {
+      attributes: {
+        categories: [],
+        groups: [],
+        regions: [],
+        resource_types: [],
+        services: [],
+      },
+    },
+  })),
+  getMetadataInfo: vi.fn(),
+}));
+
+vi.mock("@/actions/providers", () => ({
+  getProviders: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock("@/actions/scans", () => ({
+  getScan: vi.fn(),
+  getScans: vi.fn(() => ({ data: [] })),
+}));
+
+vi.mock("@/app/(prowler)/alerts/_components", () => ({
+  SeedFromFindingsButton: () => <button>Create Alert</button>,
+}));
+
+vi.mock("@/components/findings/findings-filters", () => ({
+  FindingsFilters: ({ trailingControls }: { trailingControls?: ReactNode }) => (
+    <section aria-label="Findings filters">
+      <span>Findings filters</span>
+      {trailingControls}
+    </section>
+  ),
+}));
+
+vi.mock("@/components/findings/table", () => ({
+  FindingsGroupTable: () => <div>Findings table</div>,
+  SkeletonTableFindings: () => <div>Loading findings</div>,
+}));
+
+vi.mock("@/components/ui", () => ({
+  ContentLayout: ({ children }: ComponentProps<"main">) => (
+    <main>{children}</main>
+  ),
+}));
+
+vi.mock("@/contexts", () => ({
+  FilterTransitionWrapper: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/lib", () => ({
+  applyDefaultMutedFilter: vi.fn((filters: Record<string, string>) => filters),
+  createScanDetailsMapping: vi.fn(() => []),
+  extractFiltersAndQuery: vi.fn(() => ({ filters: {}, query: "" })),
+  extractSortAndKey: vi.fn(() => ({ encodedSort: undefined })),
+  hasDateOrScanFilter: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/findings-scan-filters", () => ({
+  resolveFindingScanDateFilters: vi.fn(({ filters }) => filters),
+}));
+
+describe("Findings page alerts controls", () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_IS_CLOUD_ENV;
+  });
+
+  it("should hide the create alert control when Cloud is disabled", async () => {
+    // Given / When
+    render(await Findings({ searchParams: Promise.resolve({}) }));
+
+    // Then
+    expect(
+      screen.queryByRole("button", { name: /create alert/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render the create alert control when Cloud is enabled", async () => {
+    // Given
+    process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "true";
+
+    // When
+    render(await Findings({ searchParams: Promise.resolve({}) }));
+
+    // Then
+    expect(screen.getByRole("button", { name: /create alert/i })).toBeVisible();
+  });
+});

--- a/ui/app/(prowler)/findings/page.tsx
+++ b/ui/app/(prowler)/findings/page.tsx
@@ -8,6 +8,8 @@ import {
 import { getLatestMetadataInfo, getMetadataInfo } from "@/actions/findings";
 import { getProviders } from "@/actions/providers";
 import { getScan, getScans } from "@/actions/scans";
+import { SeedFromFindingsButton } from "@/app/(prowler)/alerts/_components";
+import { isAlertsEnabled } from "@/app/(prowler)/alerts/_lib/env";
 import { FindingsFilters } from "@/components/findings/findings-filters";
 import {
   FindingsGroupTable,
@@ -80,6 +82,7 @@ export default async function Findings({
     completedScans || [],
     providersData,
   ) as { [uid: string]: ScanEntity }[];
+  const showAlertsControls = isAlertsEnabled();
 
   return (
     <ContentLayout title="Findings" icon="lucide:tag">
@@ -94,6 +97,20 @@ export default async function Findings({
             uniqueResourceTypes={uniqueResourceTypes}
             uniqueCategories={uniqueCategories}
             uniqueGroups={uniqueGroups}
+            trailingControls={
+              showAlertsControls ? (
+                <SeedFromFindingsButton
+                  filterBag={filters}
+                  providers={providersData?.data || []}
+                  scans={scanDetails}
+                  uniqueRegions={uniqueRegions}
+                  uniqueServices={uniqueServices}
+                  uniqueResourceTypes={uniqueResourceTypes}
+                  uniqueCategories={uniqueCategories}
+                  uniqueGroups={uniqueGroups}
+                />
+              ) : undefined
+            }
           />
         </div>
         <Suspense fallback={<SkeletonTableFindings />}>


### PR DESCRIPTION
## Summary
- Adds the Findings CTA for creating a custom alert from active filters.
- Keeps Findings filters generic by using `trailingControls` for the alerts-specific button.
- Renders the CTA only when `NEXT_PUBLIC_IS_CLOUD_ENV === "true"`.

## Chain
- Main PR: #11003
- Previous PR: #11006
- Next branch: `feat/PROWLER-1418-alerts-navigation-tests`

## Validation
- `cd ui && pnpm run healthcheck`
- `pnpm exec vitest run app/(prowler)/alerts/_components/__tests__/seed-from-findings-button.test.tsx app/(prowler)/findings/__tests__/page.test.tsx` (2 files / 7 tests passed).