### PR TITLE
[CHAIN] feat(ui): gate alerts navigation and public pages

### DIFF
--- a/ui/app/(auth)/alerts/__tests__/public-pages.test.tsx
+++ b/ui/app/(auth)/alerts/__tests__/public-pages.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigationMocks = vi.hoisted(() => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: navigationMocks.notFound,
+}));
+
+vi.mock("@/app/(auth)/alerts/_components/alert-public-action", () => ({
+  ALERT_PUBLIC_ACTIONS: {
+    CONFIRM: "confirm",
+    UNSUBSCRIBE: "unsubscribe",
+  },
+  AlertPublicAction: ({
+    action,
+    token,
+  }: {
+    action: string;
+    token: string | null;
+  }) => (
+    <div>
+      <span>Public alerts action</span>
+      <span>{action}</span>
+      <span>{token}</span>
+    </div>
+  ),
+}));
+
+import AlertsConfirmPage from "../confirm/page";
+import AlertsUnsubscribePage from "../unsubscribe/page";
+
+const unreadableSearchParams = {
+  then: () => {
+    throw new Error("search params should not be read");
+  },
+} as unknown as Promise<{ token?: string }>;
+
+describe("alerts public pages", () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_IS_CLOUD_ENV;
+    navigationMocks.notFound.mockClear();
+  });
+
+  it("should not render the confirm page when Cloud is disabled", async () => {
+    // Given / When / Then
+    await expect(
+      AlertsConfirmPage({ searchParams: unreadableSearchParams }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(navigationMocks.notFound).toHaveBeenCalledOnce();
+  });
+
+  it("should not render the unsubscribe page when Cloud is disabled", async () => {
+    // Given / When / Then
+    await expect(
+      AlertsUnsubscribePage({ searchParams: unreadableSearchParams }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(navigationMocks.notFound).toHaveBeenCalledOnce();
+  });
+
+  it("should render the confirm action when Cloud is enabled", async () => {
+    // Given
+    process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "true";
+
+    // When
+    render(
+      await AlertsConfirmPage({
+        searchParams: Promise.resolve({ token: "confirm-token" }),
+      }),
+    );
+
+    // Then
+    expect(screen.getByText("Public alerts action")).toBeInTheDocument();
+    expect(screen.getByText("confirm")).toBeInTheDocument();
+    expect(screen.getByText("confirm-token")).toBeInTheDocument();
+  });
+
+  it("should render the unsubscribe action when Cloud is enabled", async () => {
+    // Given
+    process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "true";
+
+    // When
+    render(
+      await AlertsUnsubscribePage({
+        searchParams: Promise.resolve({ token: "unsubscribe-token" }),
+      }),
+    );
+
+    // Then
+    expect(screen.getByText("Public alerts action")).toBeInTheDocument();
+    expect(screen.getByText("unsubscribe")).toBeInTheDocument();
+    expect(screen.getByText("unsubscribe-token")).toBeInTheDocument();
+  });
+});

--- a/ui/app/(auth)/alerts/_components/alert-public-action.tsx
+++ b/ui/app/(auth)/alerts/_components/alert-public-action.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { CheckCircle2, Loader2, XCircleIcon } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+import {
+  confirmRecipient,
+  unsubscribeRecipient,
+} from "@/app/(prowler)/alerts/_actions";
+import type { AlertPublicResponse } from "@/app/(prowler)/alerts/_types";
+import { Button, Card, CardContent } from "@/components/shadcn";
+
+// NOT FOR THE MVP: this UI supports public confirm/unsubscribe email links.
+// The MVP assumes recipients belong to the tenant and are already confirmed.
+export const ALERT_PUBLIC_ACTIONS = {
+  CONFIRM: "confirm",
+  UNSUBSCRIBE: "unsubscribe",
+} as const;
+export type AlertPublicActionKind =
+  (typeof ALERT_PUBLIC_ACTIONS)[keyof typeof ALERT_PUBLIC_ACTIONS];
+
+interface AlertPublicActionProps {
+  action: AlertPublicActionKind;
+  token: string | null;
+  idleTitle: string;
+  idleDescription: string;
+  ctaLabel: string;
+}
+
+interface AlertPublicResultProps {
+  variant: "success" | "error";
+  title: string;
+  description: string;
+  primaryHref?: string;
+  primaryLabel?: string;
+  supportHref?: string;
+}
+
+const runners: Record<
+  AlertPublicActionKind,
+  (token: string) => Promise<AlertPublicResponse>
+> = {
+  confirm: confirmRecipient,
+  unsubscribe: unsubscribeRecipient,
+};
+
+const AlertPublicResult = ({
+  variant,
+  title,
+  description,
+  primaryHref,
+  primaryLabel,
+  supportHref = "https://prowler.com/contact",
+}: AlertPublicResultProps) => (
+  <main className="flex min-h-screen items-center justify-center p-6">
+    <Card variant="base" padding="lg" className="w-full max-w-md">
+      <CardContent className="flex flex-col items-center gap-5 p-0 text-center">
+        <div
+          className={
+            variant === "success"
+              ? "bg-prowler-green-medium/10 flex h-14 w-14 items-center justify-center rounded-full"
+              : "flex h-14 w-14 items-center justify-center rounded-full bg-rose-500/10"
+          }
+        >
+          {variant === "success" ? (
+            <CheckCircle2 className="text-prowler-green-medium h-7 w-7" />
+          ) : (
+            <XCircleIcon className="h-7 w-7 text-rose-500" />
+          )}
+        </div>
+        <div className="flex flex-col gap-2">
+          <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+            {title}
+          </h1>
+          <p className="max-w-sm text-sm text-gray-600 dark:text-gray-300">
+            {description}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {primaryHref && primaryLabel && (
+            <Button asChild>
+              <Link href={primaryHref}>{primaryLabel}</Link>
+            </Button>
+          )}
+          <Button asChild variant="outline">
+            <Link href={supportHref} target="_blank" rel="noopener noreferrer">
+              Contact support
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  </main>
+);
+
+const renderResult = (
+  action: AlertPublicActionKind,
+  result: AlertPublicResponse,
+): AlertPublicResultProps => {
+  switch (result.state) {
+    case "confirmed":
+      return {
+        variant: "success",
+        title: "You're confirmed",
+        description:
+          "This address now receives Prowler Cloud alerts based on your team's alerts.",
+        primaryHref: "https://prowler.com",
+        primaryLabel: "Open Prowler Cloud",
+      };
+    case "already_confirmed":
+      return {
+        variant: "success",
+        title: "Already confirmed",
+        description:
+          "Nothing to do, this address is already subscribed to Prowler Cloud alerts.",
+      };
+    case "unsubscribed":
+      return {
+        variant: "success",
+        title: "You're unsubscribed",
+        description:
+          "We won't send you any more alert digests at this address. Pending notifications have been cancelled.",
+      };
+    case "already_unsubscribed":
+      return {
+        variant: "success",
+        title: "Already unsubscribed",
+        description:
+          "This address is already unsubscribed from Prowler Cloud alerts.",
+      };
+    case "cannot_confirm":
+      return {
+        variant: "error",
+        title: "This address can't be confirmed",
+        description:
+          "Earlier this address unsubscribed or stopped receiving deliveries. Ask your team to re-add it from the Prowler Cloud admin or contact support.",
+      };
+    case "superseded":
+      return {
+        variant: "error",
+        title: "Link superseded",
+        description:
+          "A newer confirmation email has been issued for this address. Open the most recent invitation and use that link instead.",
+      };
+    case "missing_token":
+      return {
+        variant: "error",
+        title: "Link is missing the token",
+        description:
+          "Open the original link from your email so the URL includes the token issued by Prowler Cloud.",
+      };
+    case "invalid_token":
+      return {
+        variant: "error",
+        title: "Link is invalid or expired",
+        description: `This ${action} link is no longer valid. Ask your team to resend the email.`,
+      };
+    case "not_found":
+      return {
+        variant: "error",
+        title: "Recipient not found",
+        description:
+          "We couldn't locate the recipient referenced by this link. It may have been removed.",
+      };
+    case "network_error":
+    default:
+      return {
+        variant: "error",
+        title: "We couldn't reach the server",
+        description:
+          result.message ||
+          "Try again in a few seconds. If this keeps happening, contact support.",
+      };
+  }
+};
+
+export const AlertPublicAction = ({
+  action,
+  token,
+  idleTitle,
+  idleDescription,
+  ctaLabel,
+}: AlertPublicActionProps) => {
+  const [pending, setPending] = useState(false);
+  const [result, setResult] = useState<AlertPublicResponse | null>(null);
+
+  if (!token) {
+    const view = renderResult(action, {
+      state: "missing_token",
+      message: "Token query parameter is missing.",
+    });
+    return <AlertPublicResult {...view} />;
+  }
+
+  if (result) {
+    const view = renderResult(action, result);
+    return <AlertPublicResult {...view} />;
+  }
+
+  const handleClick = async () => {
+    setPending(true);
+    const next = await runners[action](token);
+    setPending(false);
+    setResult(next);
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center p-6">
+      <Card variant="base" padding="lg" className="w-full max-w-md">
+        <CardContent className="flex flex-col items-center gap-5 p-0 text-center">
+          <div className="flex flex-col gap-2">
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+              {idleTitle}
+            </h1>
+            <p className="max-w-sm text-sm text-gray-600 dark:text-gray-300">
+              {idleDescription}
+            </p>
+          </div>
+          <Button onClick={handleClick} disabled={pending}>
+            {pending ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Working...
+              </>
+            ) : (
+              ctaLabel
+            )}
+          </Button>
+        </CardContent>
+      </Card>
+    </main>
+  );
+};

--- a/ui/app/(auth)/alerts/confirm/page.tsx
+++ b/ui/app/(auth)/alerts/confirm/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+
+import {
+  ALERT_PUBLIC_ACTIONS,
+  AlertPublicAction,
+} from "@/app/(auth)/alerts/_components/alert-public-action";
+import { isAlertsEnabled } from "@/app/(prowler)/alerts/_lib/env";
+
+// NOT FOR THE MVP: tenant-owned recipients are treated as already confirmed.
+// Keep only if we reintroduce public recipient consent links.
+interface AlertsConfirmPageProps {
+  searchParams: Promise<{ token?: string }>;
+}
+
+export default async function AlertsConfirmPage({
+  searchParams,
+}: AlertsConfirmPageProps) {
+  if (!isAlertsEnabled()) {
+    notFound();
+  }
+
+  const { token } = await searchParams;
+  return (
+    <AlertPublicAction
+      action={ALERT_PUBLIC_ACTIONS.CONFIRM}
+      token={token ?? null}
+      idleTitle="Confirm your Prowler Cloud alerts subscription"
+      idleDescription="Click the button below to confirm this email address. After confirming, alert digests for the alerts your team picked you for will start arriving here."
+      ctaLabel="Confirm subscription"
+    />
+  );
+}

--- a/ui/app/(auth)/alerts/unsubscribe/page.tsx
+++ b/ui/app/(auth)/alerts/unsubscribe/page.tsx
@@ -1,0 +1,32 @@
+import { notFound } from "next/navigation";
+
+import {
+  ALERT_PUBLIC_ACTIONS,
+  AlertPublicAction,
+} from "@/app/(auth)/alerts/_components/alert-public-action";
+import { isAlertsEnabled } from "@/app/(prowler)/alerts/_lib/env";
+
+// NOT FOR THE MVP: recipient changes are managed inside the tenant product.
+// Keep only if alert emails need public unsubscribe links.
+interface AlertsUnsubscribePageProps {
+  searchParams: Promise<{ token?: string }>;
+}
+
+export default async function AlertsUnsubscribePage({
+  searchParams,
+}: AlertsUnsubscribePageProps) {
+  if (!isAlertsEnabled()) {
+    notFound();
+  }
+
+  const { token } = await searchParams;
+  return (
+    <AlertPublicAction
+      action={ALERT_PUBLIC_ACTIONS.UNSUBSCRIBE}
+      token={token ?? null}
+      idleTitle="Unsubscribe from Prowler Cloud alerts"
+      idleDescription="Click the button below to stop receiving alert digests at this email address. Pending notifications already in flight will be cancelled."
+      ctaLabel="Unsubscribe"
+    />
+  );
+}

--- a/ui/components/ui/breadcrumbs/breadcrumb-navigation.test.tsx
+++ b/ui/components/ui/breadcrumbs/breadcrumb-navigation.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const navigationState = vi.hoisted(() => ({
+  pathname: "/alerts",
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => navigationState.pathname,
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@iconify/react", () => ({
+  Icon: ({ icon }: { icon: string }) => (
+    <span
+      data-icon={icon}
+      data-testid={icon === "lucide:bell-ring" ? "alerts-icon" : icon}
+    />
+  ),
+}));
+
+vi.mock("@heroui/breadcrumbs", () => ({
+  Breadcrumbs: ({ children }: { children: ReactNode }) => <nav>{children}</nav>,
+  BreadcrumbItem: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+import { BreadcrumbNavigation } from "./breadcrumb-navigation";
+
+describe("BreadcrumbNavigation", () => {
+  it("should show Alerts as the current canonical route", () => {
+    // Given
+    navigationState.pathname = "/alerts";
+
+    // When
+    render(
+      <BreadcrumbNavigation
+        mode="auto"
+        title="Alerts"
+        icon="lucide:bell-ring"
+      />,
+    );
+
+    // Then
+    expect(
+      screen.queryByRole("link", { name: /integrations/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Alerts")).toBeInTheDocument();
+    expect(screen.getByTestId("alerts-icon")).toBeInTheDocument();
+  });
+});

--- a/ui/components/ui/breadcrumbs/breadcrumb-navigation.tsx
+++ b/ui/components/ui/breadcrumbs/breadcrumb-navigation.tsx
@@ -43,6 +43,7 @@ export function BreadcrumbNavigation({
   const generateAutoBreadcrumbs = (): CustomBreadcrumbItem[] => {
     const pathIconMapping: Record<string, string | ReactNode> = {
       "/integrations": "lucide:puzzle",
+      "/alerts": "lucide:bell-ring",
       "/providers": "lucide:cloud",
       "/users": "lucide:users",
       "/compliance": "lucide:shield-check",

--- a/ui/components/ui/sidebar/submenu-item.tsx
+++ b/ui/components/ui/sidebar/submenu-item.tsx
@@ -19,6 +19,7 @@ interface SubmenuItemProps {
   active?: boolean;
   target?: string;
   disabled?: boolean;
+  highlight?: boolean;
   onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
 }
 
@@ -29,6 +30,7 @@ export const SubmenuItem = ({
   active,
   target,
   disabled,
+  highlight,
   onClick,
 }: SubmenuItemProps) => {
   const pathname = usePathname();
@@ -72,7 +74,14 @@ export const SubmenuItem = ({
         <span className="mr-2">
           <Icon size={16} />
         </span>
-        <p className="max-w-[170px] truncate">{label}</p>
+        <p className="flex max-w-[170px] items-center truncate">
+          <span>{label}</span>
+          {highlight && (
+            <span className="ml-2 rounded-sm bg-emerald-500 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+              NEW
+            </span>
+          )}
+        </p>
       </Link>
     </Button>
   );

--- a/ui/lib/menu-list.test.ts
+++ b/ui/lib/menu-list.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getMenuList } from "./menu-list";
+
+const findMenu = (label: string) =>
+  getMenuList({ pathname: "/alerts" })
+    .flatMap((group) => group.menus)
+    .find((menu) => menu.label === label);
+
+const findSubmenu = (label: string) =>
+  getMenuList({ pathname: "/alerts" })
+    .flatMap((group) => group.menus)
+    .flatMap((menu) => menu.submenus ?? [])
+    .find((submenu) => submenu.label === label);
+
+describe("getMenuList", () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_IS_CLOUD_ENV;
+  });
+
+  it("should hide Alerts in OSS when Cloud is disabled", () => {
+    // Given / When
+    const alerts = findSubmenu("Alerts");
+
+    // Then
+    expect(alerts).toBeUndefined();
+  });
+
+  it("should show Alerts as new under Configuration when Cloud is enabled", () => {
+    // Given
+    process.env.NEXT_PUBLIC_IS_CLOUD_ENV = "true";
+
+    // When
+    const alerts = findSubmenu("Alerts");
+
+    // Then
+    expect(alerts).toEqual(
+      expect.objectContaining({
+        href: "/alerts",
+        active: true,
+        highlight: true,
+      }),
+    );
+  });
+
+  it("should remove the new highlight from Attack Paths", () => {
+    // Given / When
+    const attackPaths = findMenu("Attack Paths");
+
+    // Then
+    expect(attackPaths).toEqual(
+      expect.not.objectContaining({ highlight: true }),
+    );
+  });
+});

--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -1,4 +1,5 @@
 import {
+  BellRing,
   CloudCog,
   Cog,
   GitBranch,
@@ -74,7 +75,6 @@ export const getMenuList = ({ pathname }: MenuListOptions): GroupProps[] => {
           label: "Attack Paths",
           icon: GitBranch,
           active: pathname.startsWith("/attack-paths"),
-          highlight: true,
         },
       ],
     },
@@ -108,6 +108,17 @@ export const getMenuList = ({ pathname }: MenuListOptions): GroupProps[] => {
           icon: Settings,
           submenus: [
             { href: "/providers", label: "Providers", icon: CloudCog },
+            ...(process.env.NEXT_PUBLIC_IS_CLOUD_ENV === "true"
+              ? [
+                  {
+                    href: "/alerts",
+                    label: "Alerts",
+                    icon: BellRing,
+                    active: pathname.startsWith("/alerts"),
+                    highlight: true,
+                  },
+                ]
+              : []),
             {
               href: "/mutelist",
               label: "Mutelist",

--- a/ui/types/components.ts
+++ b/ui/types/components.ts
@@ -21,6 +21,7 @@ export type SubmenuProps = {
   active?: boolean;
   icon: IconComponent;
   disabled?: boolean;
+  highlight?: boolean;
   onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
 };
 


### PR DESCRIPTION
## Summary
- Adds `/alerts` navigation only when `NEXT_PUBLIC_IS_CLOUD_ENV === "true"`.
- Adds public confirm/unsubscribe alert pages and gates them with `notFound()` before reading `searchParams`.
- Adds tests for menu visibility, breadcrumbs, and public page Cloud gating.

## Chain
- Main PR: #11003
- Previous PR: #11008
- Final sub-PR in the custom alerts OSS stack.

## Validation
- `cd ui && pnpm run healthcheck`
- `pnpm exec vitest run lib/menu-list.test.ts components/ui/breadcrumbs/breadcrumb-navigation.test.tsx app/(auth)/alerts/__tests__/public-pages.test.tsx` (3 files / 8 tests passed).