### PR TITLE
[CHAIN] fix(ui): re-fit attack-path viewport on filter and expand, harden minimap

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Attack Paths graph: extract shared primitives across `FindingNode`, `ResourceNode`, and `InternetNode` (hidden handles, label truncation, fill/border resolution) without forcing a generic node renderer [(#10705)](https://github.com/prowler-cloud/prowler/pull/10705)
-- Attack Paths graph: viewport now auto-fits when entering or exiting the filtered view (clicking a finding or "Back to Full View") so the focused subgraph is centered, and the minimap viewport indicator stands out against the dark theme
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Attack Paths graph: extract shared primitives across `FindingNode`, `ResourceNode`, and `InternetNode` (hidden handles, label truncation, fill/border resolution) without forcing a generic node renderer [(#10705)](https://github.com/prowler-cloud/prowler/pull/10705)
+- Attack Paths graph: viewport now auto-fits when entering or exiting the filtered view (clicking a finding or "Back to Full View") so the focused subgraph is centered, and the minimap viewport indicator stands out against the dark theme
 
 ---
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -144,18 +144,29 @@ const GraphDefs = () => (
 
 type GraphCanvasProps = Omit<AttackPathGraphProps, "className">;
 
+// Mask covers the area NOT currently in view; the cut-out rectangle is the
+// viewport. To make the viewport rectangle stand out we darken the mask and
+// give its border high contrast against the minimap background.
 const MINIMAP_COLORS = {
   light: {
     bg: "#f8fafc",
-    mask: "rgba(241, 245, 249, 0.6)",
-    maskStroke: "#cbd5e1",
+    mask: "rgba(15, 23, 42, 0.45)",
+    maskStroke: "#0f172a",
   },
   dark: {
     bg: "#0f172a",
-    mask: "rgba(15, 23, 42, 0.6)",
-    maskStroke: "#475569",
+    mask: "rgba(0, 0, 0, 0.7)",
+    maskStroke: "#cbd5e1",
   },
 } as const;
+
+const MINIMAP_VIEWPORT_STROKE_WIDTH = 3;
+
+// Animated re-fit shared by every auto-fit trigger. We deliberately do not
+// cap maxZoom — for small subgraphs (e.g. a finding's filtered view with 3
+// nodes) the user expects the result to fill the canvas; an artificial cap
+// looks like a layout error.
+const AUTO_FIT_OPTIONS = { padding: 0.2, duration: 300 } as const;
 
 const GraphCanvas = ({
   data,
@@ -211,6 +222,37 @@ const GraphCanvas = ({
       onInitialFilter(effectiveData);
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- one-time init
+
+  // --- Auto-fit on filter toggle ---
+  // Filter toggles (finding click → filtered view, "Back to Full View" →
+  // full graph) swap the data prop, which leaves the previous viewport
+  // pointing at coordinates that no longer contain the new layout. Re-fit
+  // once React Flow has applied the new layout (next animation frame).
+  //
+  // Resource expansion intentionally has NO re-fit: the declarative
+  // `fitViewOptions.includeHiddenNodes` already lays out the initial
+  // viewport around every resource AND every (still-hidden) finding, so
+  // newly revealed findings sit inside the framing the user already has.
+  // Re-fitting on each expand caused jarring layout shifts that the user
+  // experienced as visual errors.
+  const filteredFitInitRef = useRef(false);
+  const previousFilteredRef = useRef(isFilteredView);
+
+  useEffect(() => {
+    if (!filteredFitInitRef.current) {
+      filteredFitInitRef.current = true;
+      previousFilteredRef.current = isFilteredView;
+      return;
+    }
+    if (previousFilteredRef.current === isFilteredView) return;
+    previousFilteredRef.current = isFilteredView;
+    // Defer to the next animation frame so React Flow has applied the new
+    // layout (after the filter swap) before we measure for the fit.
+    const frame = requestAnimationFrame(() => {
+      fitView(AUTO_FIT_OPTIONS);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isFilteredView, fitView]);
 
   const nodes = effectiveData.nodes ?? [];
   const edges = effectiveData.edges ?? [];
@@ -351,7 +393,7 @@ const GraphCanvas = ({
         onNodeMouseEnter={handleNodeMouseEnter}
         onNodeMouseLeave={handleNodeMouseLeave}
         fitView
-        fitViewOptions={{ padding: 0.2 }}
+        fitViewOptions={{ padding: 0.2, includeHiddenNodes: true }}
         zoomOnScroll={false}
         zoomOnPinch={true}
         zoomOnDoubleClick={false}
@@ -368,6 +410,7 @@ const GraphCanvas = ({
           bgColor={minimapColors.bg}
           maskColor={minimapColors.mask}
           maskStrokeColor={minimapColors.maskStroke}
+          maskStrokeWidth={MINIMAP_VIEWPORT_STROKE_WIDTH}
           nodeColor={(node) => {
             const graphNode = (node.data as { graphNode?: GraphNode })
               .graphNode;

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -166,7 +166,15 @@ const MINIMAP_VIEWPORT_STROKE_WIDTH = 3;
 // cap maxZoom — for small subgraphs (e.g. a finding's filtered view with 3
 // nodes) the user expects the result to fill the canvas; an artificial cap
 // looks like a layout error.
-const AUTO_FIT_OPTIONS = { padding: 0.2, duration: 300 } as const;
+//
+// Padding is asymmetric: the minimap sits in the bottom-right corner of the
+// canvas (default 200×150 panel + offset), so a fit with uniform padding
+// can drop nodes underneath it. Generous bottom/right padding keeps the
+// fitted graph clear of the minimap.
+const AUTO_FIT_OPTIONS = {
+  padding: { top: "32px", left: "32px", right: "240px", bottom: "180px" },
+  duration: 300,
+} as const;
 
 const GraphCanvas = ({
   data,
@@ -179,8 +187,15 @@ const GraphCanvas = ({
   onInitialFilter,
   ref,
 }: GraphCanvasProps) => {
-  const { zoomIn, zoomOut, fitView, getZoom, getNodes, getNodesBounds } =
-    useReactFlow();
+  const {
+    zoomIn,
+    zoomOut,
+    fitView,
+    getZoom,
+    getNodes,
+    getNodesBounds,
+    getViewport,
+  } = useReactFlow();
   const { resolvedTheme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const hasInitialized = useRef(false);
@@ -223,20 +238,31 @@ const GraphCanvas = ({
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- one-time init
 
-  // --- Auto-fit on filter toggle ---
+  // --- Auto-fit triggers ---
+  //
   // Filter toggles (finding click → filtered view, "Back to Full View" →
   // full graph) swap the data prop, which leaves the previous viewport
   // pointing at coordinates that no longer contain the new layout. Re-fit
   // once React Flow has applied the new layout (next animation frame).
   //
-  // Resource expansion intentionally has NO re-fit: the declarative
-  // `fitViewOptions.includeHiddenNodes` already lays out the initial
-  // viewport around every resource AND every (still-hidden) finding, so
-  // newly revealed findings sit inside the framing the user already has.
-  // Re-fitting on each expand caused jarring layout shifts that the user
-  // experienced as visual errors.
+  // Resource expansion fits ONLY when a newly revealed finding sits
+  // entirely outside the current viewport (i.e. its full bounding box
+  // is past one of the viewport edges). This intentionally lets
+  // partially-clipped edge nodes through without re-fitting — hidden
+  // findings contribute zero size to the initial bbox, so a finding's
+  // far edge often peeks past the padded viewport on the first reveal,
+  // and a "partially outside" check would re-fit on every expand. The
+  // user's "no cabe visualmente" complaint is about findings that
+  // appear completely off-screen after the user has panned away, which
+  // the strict check captures.
   const filteredFitInitRef = useRef(false);
   const previousFilteredRef = useRef(isFilteredView);
+  const previousExpandedRef = useRef<ReadonlySet<string>>(expanded);
+  // Captured every render so the expand-fit effect can resolve a resource
+  // ID to its connected finding IDs without recomputing the lookup.
+  // The map itself is built later in this render — see assignment below
+  // the layout-derivation block.
+  const resourceToFindingsRef = useRef<Map<string, Set<string>>>(new Map());
 
   useEffect(() => {
     if (!filteredFitInitRef.current) {
@@ -253,6 +279,48 @@ const GraphCanvas = ({
     });
     return () => cancelAnimationFrame(frame);
   }, [isFilteredView, fitView]);
+
+  useEffect(() => {
+    const previous = previousExpandedRef.current;
+    previousExpandedRef.current = expanded;
+    if (previous === expanded) return;
+    // Only fit on growth — collapsing intentionally leaves the user's
+    // framing alone.
+    const newResourceIds = Array.from(expanded).filter(
+      (id) => !previous.has(id),
+    );
+    if (newResourceIds.length === 0) return;
+
+    const newFindingIds = new Set<string>();
+    for (const resourceId of newResourceIds) {
+      const findings = resourceToFindingsRef.current.get(resourceId);
+      if (!findings) continue;
+      findings.forEach((id) => newFindingIds.add(id));
+    }
+    if (newFindingIds.size === 0) return;
+
+    const frame = requestAnimationFrame(() => {
+      const containerEl = containerRef.current;
+      if (!containerEl) return;
+      const { width, height } = containerEl.getBoundingClientRect();
+      if (width === 0 || height === 0) return;
+      const { x, y, zoom } = getViewport();
+      const minX = -x / zoom;
+      const minY = -y / zoom;
+      const maxX = minX + width / zoom;
+      const maxY = minY + height / zoom;
+      const anyOutside = getNodes().some((node) => {
+        if (!newFindingIds.has(node.id)) return false;
+        const nx = node.position.x;
+        const ny = node.position.y;
+        const nw = node.measured?.width ?? 0;
+        const nh = node.measured?.height ?? 0;
+        return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
+      });
+      if (anyOutside) fitView(AUTO_FIT_OPTIONS);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [expanded, fitView, getNodes, getViewport]);
 
   const nodes = effectiveData.nodes ?? [];
   const edges = effectiveData.edges ?? [];
@@ -295,6 +363,9 @@ const GraphCanvas = ({
       findingToResources.set(edge.target, resources);
     }
   });
+
+  // Refresh the expand-fit effect's lookup with the latest mapping.
+  resourceToFindingsRef.current = resourceToFindings;
 
   // Tier 1: compute which finding nodes are hidden (not expanded)
   const hiddenFindingIds = new Set<string>();

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -172,6 +172,30 @@ const AUTO_FIT_OPTIONS = {
   duration: 300,
 } as const;
 
+const MEASURED_FIT_MAX_ATTEMPTS = 30;
+
+const scheduleMeasuredFit = (
+  isMeasured: () => boolean,
+  onMeasured: () => void,
+) => {
+  let frame = 0;
+  let attempts = 0;
+
+  const tryFit = () => {
+    if (isMeasured() || attempts >= MEASURED_FIT_MAX_ATTEMPTS) {
+      onMeasured();
+      return;
+    }
+
+    attempts += 1;
+    frame = requestAnimationFrame(tryFit);
+  };
+
+  frame = requestAnimationFrame(tryFit);
+
+  return () => cancelAnimationFrame(frame);
+};
+
 const GraphCanvas = ({
   data,
   selectedNodeId,
@@ -273,23 +297,16 @@ const GraphCanvas = ({
     // previous zoom — most visibly when leaving a filtered view in which the
     // user had zoomed in. Poll until visible nodes are measured (or give up
     // after ~500ms so we never block on a stuck observer).
-    let frame = 0;
-    let attempts = 0;
-    const MAX_ATTEMPTS = 30;
-    const tryFit = () => {
-      const visibleNodes = getNodes().filter((n) => !n.hidden);
-      const allMeasured =
-        visibleNodes.length > 0 &&
-        visibleNodes.every((n) => (n.measured?.width ?? 0) > 0);
-      if (allMeasured || attempts >= MAX_ATTEMPTS) {
-        fitView(AUTO_FIT_OPTIONS);
-        return;
-      }
-      attempts += 1;
-      frame = requestAnimationFrame(tryFit);
-    };
-    frame = requestAnimationFrame(tryFit);
-    return () => cancelAnimationFrame(frame);
+    return scheduleMeasuredFit(
+      () => {
+        const visibleNodes = getNodes().filter((n) => !n.hidden);
+        return (
+          visibleNodes.length > 0 &&
+          visibleNodes.every((n) => (n.measured?.width ?? 0) > 0)
+        );
+      },
+      () => fitView(AUTO_FIT_OPTIONS),
+    );
   }, [isFilteredView, fitView, getNodes]);
 
   useEffect(() => {
@@ -315,15 +332,16 @@ const GraphCanvas = ({
     // measures them asynchronously. Poll before checking whether their full
     // bounding boxes sit entirely past a viewport edge; collapsing and
     // partially clipped findings preserve the user's current frame.
-    let frame = 0;
-    let attempts = 0;
-    const MAX_ATTEMPTS = 30;
-    const tryFit = () => {
-      const targets = getNodes().filter((n) => newFindingIds.has(n.id));
-      const allMeasured =
-        targets.length === newFindingIds.size &&
-        targets.every((n) => (n.measured?.width ?? 0) > 0);
-      if (allMeasured || attempts >= MAX_ATTEMPTS) {
+    return scheduleMeasuredFit(
+      () => {
+        const targets = getNodes().filter((n) => newFindingIds.has(n.id));
+        return (
+          targets.length === newFindingIds.size &&
+          targets.every((n) => (n.measured?.width ?? 0) > 0)
+        );
+      },
+      () => {
+        const targets = getNodes().filter((n) => newFindingIds.has(n.id));
         const containerEl = containerRef.current;
         if (!containerEl) return;
         const { width, height } = containerEl.getBoundingClientRect();
@@ -341,13 +359,8 @@ const GraphCanvas = ({
           return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
         });
         if (anyOutside) fitView(AUTO_FIT_OPTIONS);
-        return;
-      }
-      attempts += 1;
-      frame = requestAnimationFrame(tryFit);
-    };
-    frame = requestAnimationFrame(tryFit);
-    return () => cancelAnimationFrame(frame);
+      },
+    );
   }, [expanded, fitView, getNodes, getViewport]);
 
   const nodes = effectiveData.nodes ?? [];

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -53,11 +53,7 @@ interface AttackPathGraphProps {
   selectedNodeId?: string | null;
   isFilteredView?: boolean;
   initialNodeId?: string;
-  // Tier 1 expansion state — controlled by the parent (lives in the graph
-  // store) so it survives filtered-view enter/exit. If omitted, no resource
-  // expansion is tracked and findings stay hidden in the full view.
   expandedResources?: Set<string>;
-  onResourceToggle?: (resourceId: string) => void;
   onNodeClick?: (node: GraphNode) => void;
   onInitialFilter?: (filteredData: AttackPathGraphData) => void;
   ref?: Ref<GraphHandle>;
@@ -182,7 +178,6 @@ const GraphCanvas = ({
   isFilteredView,
   initialNodeId,
   expandedResources,
-  onResourceToggle,
   onNodeClick,
   onInitialFilter,
   ref,
@@ -272,23 +267,40 @@ const GraphCanvas = ({
     }
     if (previousFilteredRef.current === isFilteredView) return;
     previousFilteredRef.current = isFilteredView;
-    // Defer to the next animation frame so React Flow has applied the new
-    // layout (after the filter swap) before we measure for the fit.
-    const frame = requestAnimationFrame(() => {
-      fitView(AUTO_FIT_OPTIONS);
-    });
+    // React Flow measures node sizes asynchronously via ResizeObserver after
+    // the data swap. A single rAF runs while measured.width is still 0, so
+    // fitView computes a degenerate bbox and the viewport keeps the user's
+    // previous zoom — most visibly when leaving a filtered view in which the
+    // user had zoomed in. Poll until visible nodes are measured (or give up
+    // after ~500ms so we never block on a stuck observer).
+    let frame = 0;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 30;
+    const tryFit = () => {
+      const visibleNodes = getNodes().filter((n) => !n.hidden);
+      const allMeasured =
+        visibleNodes.length > 0 &&
+        visibleNodes.every((n) => (n.measured?.width ?? 0) > 0);
+      if (allMeasured || attempts >= MAX_ATTEMPTS) {
+        fitView(AUTO_FIT_OPTIONS);
+        return;
+      }
+      attempts += 1;
+      frame = requestAnimationFrame(tryFit);
+    };
+    frame = requestAnimationFrame(tryFit);
     return () => cancelAnimationFrame(frame);
-  }, [isFilteredView, fitView]);
+  }, [isFilteredView, fitView, getNodes]);
 
   useEffect(() => {
     const previous = previousExpandedRef.current;
     previousExpandedRef.current = expanded;
     if (previous === expanded) return;
-    // Only fit on growth — collapsing intentionally leaves the user's
-    // framing alone.
     const newResourceIds = Array.from(expanded).filter(
       (id) => !previous.has(id),
     );
+    // Only fit on growth — collapsing intentionally leaves the user's
+    // current framing alone.
     if (newResourceIds.length === 0) return;
 
     const newFindingIds = new Set<string>();
@@ -299,26 +311,42 @@ const GraphCanvas = ({
     }
     if (newFindingIds.size === 0) return;
 
-    const frame = requestAnimationFrame(() => {
-      const containerEl = containerRef.current;
-      if (!containerEl) return;
-      const { width, height } = containerEl.getBoundingClientRect();
-      if (width === 0 || height === 0) return;
-      const { x, y, zoom } = getViewport();
-      const minX = -x / zoom;
-      const minY = -y / zoom;
-      const maxX = minX + width / zoom;
-      const maxY = minY + height / zoom;
-      const anyOutside = getNodes().some((node) => {
-        if (!newFindingIds.has(node.id)) return false;
-        const nx = node.position.x;
-        const ny = node.position.y;
-        const nw = node.measured?.width ?? 0;
-        const nh = node.measured?.height ?? 0;
-        return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
-      });
-      if (anyOutside) fitView(AUTO_FIT_OPTIONS);
-    });
+    // Findings transition from hidden to visible on expand, and React Flow
+    // measures them asynchronously. Poll before checking whether their full
+    // bounding boxes sit entirely past a viewport edge; collapsing and
+    // partially clipped findings preserve the user's current frame.
+    let frame = 0;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 30;
+    const tryFit = () => {
+      const targets = getNodes().filter((n) => newFindingIds.has(n.id));
+      const allMeasured =
+        targets.length === newFindingIds.size &&
+        targets.every((n) => (n.measured?.width ?? 0) > 0);
+      if (allMeasured || attempts >= MAX_ATTEMPTS) {
+        const containerEl = containerRef.current;
+        if (!containerEl) return;
+        const { width, height } = containerEl.getBoundingClientRect();
+        if (width === 0 || height === 0) return;
+        const { x, y, zoom } = getViewport();
+        const minX = -x / zoom;
+        const minY = -y / zoom;
+        const maxX = minX + width / zoom;
+        const maxY = minY + height / zoom;
+        const anyOutside = targets.some((node) => {
+          const nx = node.position.x;
+          const ny = node.position.y;
+          const nw = node.measured?.width ?? 0;
+          const nh = node.measured?.height ?? 0;
+          return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
+        });
+        if (anyOutside) fitView(AUTO_FIT_OPTIONS);
+        return;
+      }
+      attempts += 1;
+      frame = requestAnimationFrame(tryFit);
+    };
+    frame = requestAnimationFrame(tryFit);
     return () => cancelAnimationFrame(frame);
   }, [expanded, fitView, getNodes, getViewport]);
 
@@ -434,13 +462,6 @@ const GraphCanvas = ({
   const handleNodeClick = (_event: MouseEvent, node: Node) => {
     const graphNode = (node.data as { graphNode: GraphNode }).graphNode;
 
-    // Tier 1: clicking resource in full view toggles connected findings
-    if (!isFilteredView && !isFindingNode(graphNode.labels)) {
-      if (resourcesWithFindings.has(node.id)) {
-        onResourceToggle?.(node.id);
-      }
-    }
-
     // Always fire parent callback (handles selection + Tier 2 filtered view)
     onNodeClick?.(graphNode);
   };
@@ -465,10 +486,14 @@ const GraphCanvas = ({
         onNodeMouseLeave={handleNodeMouseLeave}
         fitView
         fitViewOptions={{ padding: 0.2, includeHiddenNodes: true }}
-        zoomOnScroll={false}
+        // Supported React Flow behavior: wheel over the graph zooms the
+        // viewport. The surrounding UX avoids using node details as inline
+        // content, so this no longer fights a below-graph details section.
+        zoomOnScroll={true}
         zoomOnPinch={true}
         zoomOnDoubleClick={false}
         panOnScroll={false}
+        preventScrolling={true}
         minZoom={0.1}
         maxZoom={10}
         proOptions={{ hideAttribution: true }}
@@ -508,7 +533,6 @@ export const AttackPathGraph = ({
   isFilteredView,
   initialNodeId,
   expandedResources,
-  onResourceToggle,
   onNodeClick,
   onInitialFilter,
   ref,
@@ -533,7 +557,6 @@ export const AttackPathGraph = ({
           isFilteredView={isFilteredView}
           initialNodeId={initialNodeId}
           expandedResources={expandedResources}
-          onResourceToggle={onResourceToggle}
           onNodeClick={onNodeClick}
           onInitialFilter={onInitialFilter}
         />

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -212,6 +212,104 @@ describe("exploring the graph", () => {
     expect(graph.isInFilteredView).toBe(false);
     await graph.clickFirstFindingNode();
     expect(graph.isInFilteredView).toBe(true);
+    expect(graph.hasNodeDetailsModal).toBe(false);
+  });
+
+  test("clicking a resource with findings opens the action selector", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    expect(graph.hasNodeDetailsModal).toBe(false);
+
+    await graph.clickFirstResourceNode();
+
+    expect(graph.hasNodeActionDialog).toBe(true);
+    expect(graph.hasNodeDetailsModal).toBe(false);
+  });
+
+  test("choosing Show findings reveals related finding nodes", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    await graph.clickFirstResourceNode();
+    await graph.chooseShowFindingsAction();
+
+    expect(graph.findingNodes.length).toBeGreaterThan(0);
+    expect(graph.hasNodeDetailsModal).toBe(false);
+  });
+
+  test("expanded resources offer Hide findings in the action selector", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    await graph.clickFirstResourceNode();
+    await graph.chooseShowFindingsAction();
+    expect(graph.findingNodes.length).toBeGreaterThan(0);
+
+    await graph.clickFirstResourceNode();
+
+    expect(graph.hasNodeActionDialog).toBe(true);
+    expect(graph.containsText(/Hide findings/i)).toBe(true);
+
+    await graph.chooseHideFindingsAction();
+
+    expect(graph.findingNodes.length).toBe(0);
+  });
+
+  test("choosing View node details opens node details in a modal", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    await graph.clickFirstResourceNode();
+    await graph.chooseViewNodeDetailsAction();
+
+    expect(graph.hasNodeDetailsModal).toBe(true);
+  });
+
+  test("clicking a resource without findings opens node details in a modal", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    expect(graph.hasNodeDetailsModal).toBe(false);
+
+    await graph.clickFirstResourceNodeWithoutFindings();
+
+    expect(graph.hasNodeDetailsModal).toBe(true);
+  });
+
+  test("clicking a parent node in filtered view asks whether to go back or view details", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+    await graph.expandAllFindings();
+    await graph.clickFirstFindingNode();
+    expect(graph.isInFilteredView).toBe(true);
+
+    await graph.clickFirstResourceNode();
+
+    expect(graph.hasNodeActionDialog).toBe(true);
+    expect(graph.containsText(/Back to full graph/i)).toBe(true);
+
+    await graph.chooseBackToFullGraphAction();
+
+    expect(graph.isInFilteredView).toBe(false);
   });
 
   test("exiting the filtered view restores the full graph", async ({
@@ -293,6 +391,14 @@ describe("auto-fitting the viewport", () => {
     const graph = await mountWith();
     await graph.executeQuery();
     await graph.waitForLayoutStable(3);
+
+    // Given - zoom into the current overview so newly revealed findings can
+    // sit entirely outside the current frame. The expand auto-fit should then
+    // recover the user instead of leaving them hunting off-screen.
+    for (let i = 0; i < 5; i++) {
+      await graph.zoomIn();
+      await graph.waitForTransition(80);
+    }
 
     // Hidden findings are not measured by the initial declarative fit, so
     // their positions can sit outside the framed viewport. Expanding the

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -287,20 +287,24 @@ describe("auto-fitting the viewport", () => {
     expect(graph.minimapMaskStrokeWidth).toBeGreaterThan(0);
   });
 
-  test("expanding resources does not re-fit the viewport", async ({
+  test("expanding resources re-fits the viewport when revealed findings fall off-screen", async ({
     mountWith,
   }) => {
     const graph = await mountWith();
     await graph.executeQuery();
     await graph.waitForLayoutStable(3);
 
+    // Hidden findings are not measured by the initial declarative fit, so
+    // their positions can sit outside the framed viewport. Expanding the
+    // resources should re-fit so the user does not have to hunt for the
+    // newly visible findings off-screen.
     const before = graph.viewportTransform;
     expect(before).toBeTruthy();
 
     await graph.expandAllFindings();
     await graph.waitForTransition();
 
-    expect(graph.viewportTransform).toBe(before);
+    expect(graph.viewportTransform).not.toBe(before);
   });
 
   test("clicking a finding re-fits the viewport for the filtered subgraph", async ({

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -276,6 +276,71 @@ describe("exploring the graph", () => {
   });
 });
 
+describe("auto-fitting the viewport", () => {
+  test("the minimap viewport indicator has a visible border", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    expect(graph.minimapMaskStrokeWidth).toBeGreaterThan(0);
+  });
+
+  test("expanding resources does not re-fit the viewport", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    const before = graph.viewportTransform;
+    expect(before).toBeTruthy();
+
+    await graph.expandAllFindings();
+    await graph.waitForTransition();
+
+    expect(graph.viewportTransform).toBe(before);
+  });
+
+  test("clicking a finding re-fits the viewport for the filtered subgraph", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+    await graph.expandAllFindings();
+
+    const beforeFilter = graph.viewportTransform;
+    expect(beforeFilter).toBeTruthy();
+
+    await graph.clickFirstFindingNode();
+    expect(graph.isInFilteredView).toBe(true);
+    await graph.waitForTransition();
+
+    expect(graph.viewportTransform).not.toBe(beforeFilter);
+  });
+
+  test("Back to Full View re-fits the viewport for the full graph", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+    await graph.expandAllFindings();
+    await graph.clickFirstFindingNode();
+    expect(graph.isInFilteredView).toBe(true);
+    await graph.waitForTransition();
+    const filterT = graph.viewportTransform;
+
+    await graph.exitFilteredView();
+    await graph.waitForLayoutStable(3);
+    await graph.waitForTransition();
+
+    expect(graph.viewportTransform).not.toBe(filterT);
+  });
+});
+
 describe("exporting the graph", () => {
   test("the export button is enabled when a graph is rendered", async ({
     mountWith,

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -244,8 +244,18 @@ export class AttackPathPageHarness {
     return !!this.nodeDetailsHeading;
   }
 
+  get nodeActionHeading(): HTMLElement | null {
+    return (
+      Array.from(
+        document.querySelectorAll<HTMLElement>("[role='dialog'] h2"),
+      ).find((heading) =>
+        /^Choose node action$/i.test(heading.textContent ?? ""),
+      ) ?? null
+    );
+  }
+
   get hasNodeActionDialog(): boolean {
-    return this.containsText(/Choose node action/i);
+    return !!this.nodeActionHeading;
   }
 
   // --- Sync helpers ---

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -231,6 +231,23 @@ export class AttackPathPageHarness {
     return document.querySelector<HTMLElement>('[role="dialog"]');
   }
 
+  get nodeDetailsHeading(): HTMLElement | null {
+    return (
+      Array.from(
+        document.querySelectorAll<HTMLElement>("[role='dialog'] h2"),
+      ).find((heading) => /^Node Details$/i.test(heading.textContent ?? "")) ??
+      null
+    );
+  }
+
+  get hasNodeDetailsModal(): boolean {
+    return !!this.nodeDetailsHeading;
+  }
+
+  get hasNodeActionDialog(): boolean {
+    return this.containsText(/Choose node action/i);
+  }
+
   // --- Sync helpers ---
 
   /** Wait until React Flow has rendered at least `expected` node elements. */
@@ -341,6 +358,33 @@ export class AttackPathPageHarness {
     return resource;
   }
 
+  async clickFirstResourceNodeWithoutFindings(): Promise<HTMLElement> {
+    const findingIds = new Set(
+      (this.fixture.queryResult?.nodes ?? [])
+        .filter((n) =>
+          n.labels.some((l) => l.toLowerCase().includes("finding")),
+        )
+        .map((n) => n.id),
+    );
+    const resourceWithFindingIds = new Set<string>();
+    for (const rel of this.fixture.queryResult?.relationships ?? []) {
+      if (findingIds.has(rel.source)) resourceWithFindingIds.add(rel.target);
+      if (findingIds.has(rel.target)) resourceWithFindingIds.add(rel.source);
+    }
+    const resource = this.resourceNodes.find((node) => {
+      const id = node.getAttribute("data-id");
+      return id && !resourceWithFindingIds.has(id);
+    });
+    if (!resource) {
+      throw new Error(
+        "clickFirstResourceNodeWithoutFindings: no resource without findings rendered",
+      );
+    }
+    await this.user.click(resource);
+    await this.waitForTransition();
+    return resource;
+  }
+
   /**
    * Click the first finding `times` times back-to-back, with no transition
    * waits between clicks. Used for rapid-click race tests.
@@ -399,6 +443,9 @@ export class AttackPathPageHarness {
       if (el) {
         await this.user.click(el);
         await this.waitForTransition(50);
+        if (this.hasNodeActionDialog) {
+          await this.chooseShowFindingsAction();
+        }
       }
     }
   }
@@ -442,6 +489,51 @@ export class AttackPathPageHarness {
     const btn = this.toolbar.fitButton;
     if (!btn) throw new Error("fit: toolbar not rendered");
     await this.user.click(btn);
+  }
+
+  async closeNodeDetailsModal(): Promise<void> {
+    const btn = this.q('button[aria-label="Close node details"]');
+    if (!btn) throw new Error("closeNodeDetailsModal: modal not rendered");
+    await this.user.click(btn);
+    await this.waitForTransition();
+  }
+
+  async chooseShowFindingsAction(): Promise<void> {
+    const button = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((btn) => /show findings/i.test(btn.textContent ?? ""));
+    if (!button) throw new Error("chooseShowFindingsAction: button not found");
+    await this.user.click(button);
+    await this.waitForTransition();
+  }
+
+  async chooseHideFindingsAction(): Promise<void> {
+    const button = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((btn) => /hide findings/i.test(btn.textContent ?? ""));
+    if (!button) throw new Error("chooseHideFindingsAction: button not found");
+    await this.user.click(button);
+    await this.waitForTransition();
+  }
+
+  async chooseViewNodeDetailsAction(): Promise<void> {
+    const button = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((btn) => /view node details/i.test(btn.textContent ?? ""));
+    if (!button)
+      throw new Error("chooseViewNodeDetailsAction: button not found");
+    await this.user.click(button);
+    await this.waitForTransition();
+  }
+
+  async chooseBackToFullGraphAction(): Promise<void> {
+    const button = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((btn) => /back to full graph/i.test(btn.textContent ?? ""));
+    if (!button)
+      throw new Error("chooseBackToFullGraphAction: button not found");
+    await this.user.click(button);
+    await this.waitForTransition();
   }
 
   async exitFilteredView(): Promise<void> {

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -200,6 +200,33 @@ export class AttackPathPageHarness {
     return this.q(AttackPathPageHarness.VIEWPORT_SEL);
   }
 
+  /**
+   * Inline `transform` of the React Flow viewport element. This is the
+   * pan/zoom matrix React Flow rewrites on every fit/zoom/pan, so comparing
+   * it before vs. after a user action is enough to assert that the viewport
+   * actually moved (or stayed put).
+   */
+  get viewportTransform(): string {
+    return this.viewport?.style.transform ?? "";
+  }
+
+  /**
+   * `stroke-width` of the minimap mask SVG. The mask cuts out the area
+   * currently in view; the cut-out's border is what indicates the viewport
+   * inside the minimap. A non-zero stroke-width means the indicator has a
+   * visible border (rather than blending into the dark theme background).
+   */
+  get minimapMaskStrokeWidth(): number {
+    const mask = this.minimap?.querySelector<SVGPathElement>(
+      ".react-flow__minimap-mask",
+    );
+    if (!mask) return 0;
+    const inline = mask.getAttribute("stroke-width");
+    if (inline) return Number.parseFloat(inline);
+    const computed = getComputedStyle(mask).strokeWidth;
+    return Number.parseFloat(computed);
+  }
+
   get fullscreenDialog(): HTMLElement | null {
     return document.querySelector<HTMLElement>('[role="dialog"]');
   }

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
@@ -67,6 +67,21 @@ const NODE_ACTION_CONTEXT = {
 type NodeActionContext =
   (typeof NODE_ACTION_CONTEXT)[keyof typeof NODE_ACTION_CONTEXT];
 
+interface NodeActionBase {
+  node: GraphNode;
+  context: NodeActionContext;
+}
+
+interface ResourceFindingsNodeAction extends NodeActionBase {
+  context: typeof NODE_ACTION_CONTEXT.RESOURCE_FINDINGS;
+}
+
+interface FilteredParentNodeAction extends NodeActionBase {
+  context: typeof NODE_ACTION_CONTEXT.FILTERED_PARENT;
+}
+
+type NodeActionState = ResourceFindingsNodeAction | FilteredParentNodeAction;
+
 /**
  * Attack Paths
  * Allows users to select a scan, build a query, and visualize the attack path graph
@@ -83,10 +98,7 @@ export default function AttackPathsPage() {
   const [queriesLoading, setQueriesLoading] = useState(true);
   const [queriesError, setQueriesError] = useState<string | null>(null);
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false);
-  const [actionNode, setActionNode] = useState<GraphNode | null>(null);
-  const [actionContext, setActionContext] = useState<NodeActionContext>(
-    NODE_ACTION_CONTEXT.RESOURCE_FINDINGS,
-  );
+  const [nodeAction, setNodeAction] = useState<NodeActionState | null>(null);
   const graphRef = useRef<GraphHandle>(null);
   const fullscreenGraphRef = useRef<GraphHandle>(null);
   const hasResetRef = useRef(false);
@@ -317,8 +329,7 @@ export default function AttackPathsPage() {
     }
 
     if (graphState.isFilteredView) {
-      setActionNode(node);
-      setActionContext(NODE_ACTION_CONTEXT.FILTERED_PARENT);
+      setNodeAction({ node, context: NODE_ACTION_CONTEXT.FILTERED_PARENT });
       return;
     }
 
@@ -333,8 +344,7 @@ export default function AttackPathsPage() {
     });
 
     if (hasFindings) {
-      setActionNode(node);
-      setActionContext(NODE_ACTION_CONTEXT.RESOURCE_FINDINGS);
+      setNodeAction({ node, context: NODE_ACTION_CONTEXT.RESOURCE_FINDINGS });
       return;
     }
 
@@ -351,22 +361,22 @@ export default function AttackPathsPage() {
   };
 
   const handleShowNodeFindings = () => {
-    if (!actionNode) return;
-    graphState.toggleExpandedResource(actionNode.id);
-    setActionNode(null);
+    if (!nodeAction) return;
+    graphState.toggleExpandedResource(nodeAction.node.id);
+    setNodeAction(null);
   };
 
   const handleOpenNodeDetails = () => {
-    if (!actionNode) return;
+    if (!nodeAction) return;
     finding.resetFindingDetails();
-    graphState.selectNode(actionNode.id);
-    setActionNode(null);
+    graphState.selectNode(nodeAction.node.id);
+    setNodeAction(null);
   };
 
   const handleReturnToFullGraph = () => {
     graphState.exitFilteredView();
     graphState.selectNode(null);
-    setActionNode(null);
+    setNodeAction(null);
   };
 
   const handleViewFinding = (findingId: string) => {
@@ -374,8 +384,8 @@ export default function AttackPathsPage() {
     void finding.navigateToFinding(findingId);
   };
 
-  const actionNodeFindingsExpanded = actionNode
-    ? graphState.expandedResources.has(actionNode.id)
+  const actionNodeFindingsExpanded = nodeAction
+    ? graphState.expandedResources.has(nodeAction.node.id)
     : false;
 
   const handleGraphExport = async (target: "main" | "fullscreen") => {
@@ -675,16 +685,16 @@ export default function AttackPathsPage() {
             />
           )}
 
-          {actionNode && (
+          {nodeAction && (
             <Modal
-              open={!!actionNode}
+              open={!!nodeAction}
               onOpenChange={(open) => {
-                if (!open) setActionNode(null);
+                if (!open) setNodeAction(null);
               }}
               size="md"
               title="Choose node action"
               description={
-                actionContext === NODE_ACTION_CONTEXT.FILTERED_PARENT
+                nodeAction.context === NODE_ACTION_CONTEXT.FILTERED_PARENT
                   ? "You're viewing a filtered path. Choose whether to return to the full graph or inspect this node."
                   : "This node has related findings. Choose whether to reveal them in the graph or inspect the node metadata."
               }
@@ -693,7 +703,7 @@ export default function AttackPathsPage() {
                 <Button variant="outline" onClick={handleOpenNodeDetails}>
                   View node details
                 </Button>
-                {actionContext === NODE_ACTION_CONTEXT.FILTERED_PARENT ? (
+                {nodeAction.context === NODE_ACTION_CONTEXT.FILTERED_PARENT ? (
                   <Button onClick={handleReturnToFullGraph}>
                     Back to full graph
                   </Button>

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, Info, Maximize2, X } from "lucide-react";
+import { ArrowLeft, Info, Maximize2 } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef, useState } from "react";
@@ -22,8 +22,6 @@ import {
   AlertDescription,
   AlertTitle,
   Button,
-  Card,
-  CardContent,
 } from "@/components/shadcn";
 import {
   Dialog,
@@ -33,9 +31,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/shadcn/dialog";
-import { Spinner } from "@/components/shadcn/spinner/spinner";
+import { Modal } from "@/components/shadcn/modal/modal";
 import { useToast } from "@/components/ui";
-import { cn } from "@/lib/utils";
 import type {
   AttackPathQuery,
   AttackPathQueryError,
@@ -50,7 +47,7 @@ import {
   GraphControls,
   GraphLegend,
   GraphLoading,
-  NodeDetailContent,
+  NodeDetailPanel as NodeDetailDrawer,
   QueryDescription,
   QueryExecutionError,
   QueryParametersForm,
@@ -62,98 +59,13 @@ import { useGraphState } from "./_hooks/use-graph-state";
 import { useQueryBuilder } from "./_hooks/use-query-builder";
 import { exportGraphAsPNG } from "./_lib";
 
-const getNodeDisplayTitle = (node: GraphNode): string => {
-  const isFinding = node.labels.some((l) =>
-    l.toLowerCase().includes("finding"),
-  );
-  return String(
-    isFinding
-      ? node.properties?.check_title || node.properties?.id || "Unknown Finding"
-      : node.properties?.name || node.properties?.id || "Unknown Resource",
-  );
-};
+const NODE_ACTION_CONTEXT = {
+  RESOURCE_FINDINGS: "resource-findings",
+  FILTERED_PARENT: "filtered-parent",
+} as const;
 
-interface NodeDetailPanelProps {
-  node: GraphNode;
-  allNodes: GraphNode[];
-  onClose: () => void;
-  headingId: string;
-  compact?: boolean;
-  onViewFinding?: (findingId: string) => void;
-  viewFindingLoading?: boolean;
-}
-
-const NodeDetailPanel = ({
-  node,
-  allNodes,
-  onClose,
-  headingId,
-  compact,
-  onViewFinding,
-  viewFindingLoading = false,
-}: NodeDetailPanelProps) => {
-  const isFinding = node.labels.some((label) =>
-    label.toLowerCase().includes("finding"),
-  );
-  const findingId = String(node.properties?.id || node.id);
-
-  return (
-    <>
-      <div className="flex items-center justify-between">
-        <div className="flex-1">
-          <h3
-            id={headingId}
-            className={
-              compact ? "text-sm font-semibold" : "text-lg font-semibold"
-            }
-          >
-            Node Details
-          </h3>
-          <p
-            className={cn(
-              "text-text-neutral-secondary",
-              compact ? "mb-4 text-xs" : "mt-1 text-sm",
-            )}
-          >
-            {getNodeDisplayTitle(node)}
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {!compact && isFinding && onViewFinding && (
-            <Button
-              variant="default"
-              size="sm"
-              onClick={() => onViewFinding(findingId)}
-              disabled={viewFindingLoading}
-              aria-label={`View finding ${findingId}`}
-            >
-              {viewFindingLoading ? (
-                <Spinner className="size-4" />
-              ) : (
-                "View Finding"
-              )}
-            </Button>
-          )}
-          <Button
-            onClick={onClose}
-            variant="ghost"
-            size="sm"
-            className={compact ? "h-6 w-6 p-0" : "h-8 w-8 p-0"}
-            aria-label="Close node details"
-          >
-            <X size={16} />
-          </Button>
-        </div>
-      </div>
-      <NodeDetailContent
-        node={node}
-        allNodes={allNodes}
-        onViewFinding={onViewFinding}
-        viewFindingLoading={viewFindingLoading}
-      />
-    </>
-  );
-};
+type NodeActionContext =
+  (typeof NODE_ACTION_CONTEXT)[keyof typeof NODE_ACTION_CONTEXT];
 
 /**
  * Attack Paths
@@ -171,10 +83,13 @@ export default function AttackPathsPage() {
   const [queriesLoading, setQueriesLoading] = useState(true);
   const [queriesError, setQueriesError] = useState<string | null>(null);
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false);
+  const [actionNode, setActionNode] = useState<GraphNode | null>(null);
+  const [actionContext, setActionContext] = useState<NodeActionContext>(
+    NODE_ACTION_CONTEXT.RESOURCE_FINDINGS,
+  );
   const graphRef = useRef<GraphHandle>(null);
   const fullscreenGraphRef = useRef<GraphHandle>(null);
   const hasResetRef = useRef(false);
-  const nodeDetailsRef = useRef<HTMLDivElement>(null);
   const graphContainerRef = useRef<HTMLDivElement>(null);
 
   const [queries, setQueries] = useState<AttackPathQuery[]>([]);
@@ -385,27 +300,46 @@ export default function AttackPathsPage() {
   };
 
   const handleNodeClick = (node: GraphNode) => {
-    // Always select the node (opens detail panel)
-    graphState.selectNode(node.id);
-
     const isFinding = node.labels.some((label) =>
       label.toLowerCase().includes("finding"),
     );
 
-    // Tier 2: clicking a finding node OR any node in filtered view → enter filtered view
-    if (isFinding || graphState.isFilteredView) {
+    if (isFinding) {
+      // Findings skip the intermediate node-details modal. The finding drawer
+      // is the useful destination, so open it directly from the graph click.
       graphState.enterFilteredView(node.id);
+      // enterFilteredView stores the filtered node as selected so the graph can
+      // highlight it. Clear the selection right after for findings so the node
+      // details modal does not open before the finding drawer.
+      graphState.selectNode(null);
+      handleViewFinding(String(node.properties?.id || node.id));
+      return;
     }
 
-    // Scroll to details section for findings
-    if (isFinding) {
-      setTimeout(() => {
-        nodeDetailsRef.current?.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
-        });
-      }, 100);
+    if (graphState.isFilteredView) {
+      setActionNode(node);
+      setActionContext(NODE_ACTION_CONTEXT.FILTERED_PARENT);
+      return;
     }
+
+    const sourceData = graphState.fullData || graphState.data;
+    const hasFindings = sourceData?.edges?.some((edge) => {
+      if (edge.source !== node.id && edge.target !== node.id) return false;
+      const otherId = edge.source === node.id ? edge.target : edge.source;
+      const otherNode = sourceData.nodes?.find(({ id }) => id === otherId);
+      return otherNode?.labels.some((label) =>
+        label.toLowerCase().includes("finding"),
+      );
+    });
+
+    if (hasFindings) {
+      setActionNode(node);
+      setActionContext(NODE_ACTION_CONTEXT.RESOURCE_FINDINGS);
+      return;
+    }
+
+    finding.resetFindingDetails();
+    graphState.selectNode(node.id);
   };
 
   const handleBackToFullView = () => {
@@ -416,10 +350,33 @@ export default function AttackPathsPage() {
     graphState.selectNode(null);
   };
 
+  const handleShowNodeFindings = () => {
+    if (!actionNode) return;
+    graphState.toggleExpandedResource(actionNode.id);
+    setActionNode(null);
+  };
+
+  const handleOpenNodeDetails = () => {
+    if (!actionNode) return;
+    finding.resetFindingDetails();
+    graphState.selectNode(actionNode.id);
+    setActionNode(null);
+  };
+
+  const handleReturnToFullGraph = () => {
+    graphState.exitFilteredView();
+    graphState.selectNode(null);
+    setActionNode(null);
+  };
+
   const handleViewFinding = (findingId: string) => {
     if (!findingId) return;
     void finding.navigateToFinding(findingId);
   };
+
+  const actionNodeFindingsExpanded = actionNode
+    ? graphState.expandedResources.has(actionNode.id)
+    : false;
 
   const handleGraphExport = async (target: "main" | "fullscreen") => {
     const ref = target === "fullscreen" ? fullscreenGraphRef : graphRef;
@@ -674,34 +631,8 @@ export default function AttackPathsPage() {
                                   expandedResources={
                                     graphState.expandedResources
                                   }
-                                  onResourceToggle={
-                                    graphState.toggleExpandedResource
-                                  }
                                 />
                               </div>
-                              {/* Node Detail Panel - Side by side */}
-                              {graphState.selectedNode && graphState.data && (
-                                <section
-                                  aria-labelledby="fullscreen-node-details-heading"
-                                  className="w-full overflow-y-auto lg:w-96"
-                                >
-                                  <Card>
-                                    <CardContent className="p-4">
-                                      <NodeDetailPanel
-                                        node={graphState.selectedNode}
-                                        allNodes={graphState.data.nodes}
-                                        onClose={handleCloseDetails}
-                                        onViewFinding={handleViewFinding}
-                                        viewFindingLoading={
-                                          finding.findingDetailLoading
-                                        }
-                                        headingId="fullscreen-node-details-heading"
-                                        compact
-                                      />
-                                    </CardContent>
-                                  </Card>
-                                </section>
-                              )}
                             </div>
                           </DialogContent>
                         </Dialog>
@@ -721,7 +652,6 @@ export default function AttackPathsPage() {
                       selectedNodeId={graphState.selectedNodeId}
                       isFilteredView={graphState.isFilteredView}
                       expandedResources={graphState.expandedResources}
-                      onResourceToggle={graphState.toggleExpandedResource}
                     />
                   </div>
 
@@ -734,21 +664,48 @@ export default function AttackPathsPage() {
             </div>
           )}
 
-          {/* Node Detail Panel - Below Graph */}
-          {graphState.selectedNode && graphState.data && (
-            <div
-              ref={nodeDetailsRef}
-              className="minimal-scrollbar rounded-large shadow-small border-border-neutral-secondary bg-bg-neutral-secondary relative z-0 flex w-full flex-col gap-4 overflow-auto border p-4"
+          {/* Node Detail Drawer */}
+          {graphState.data && (
+            <NodeDetailDrawer
+              node={graphState.selectedNode}
+              allNodes={graphState.data.nodes}
+              onClose={handleCloseDetails}
+              onViewFinding={handleViewFinding}
+              viewFindingLoading={finding.findingDetailLoading}
+            />
+          )}
+
+          {actionNode && (
+            <Modal
+              open={!!actionNode}
+              onOpenChange={(open) => {
+                if (!open) setActionNode(null);
+              }}
+              size="md"
+              title="Choose node action"
+              description={
+                actionContext === NODE_ACTION_CONTEXT.FILTERED_PARENT
+                  ? "You're viewing a filtered path. Choose whether to return to the full graph or inspect this node."
+                  : "This node has related findings. Choose whether to reveal them in the graph or inspect the node metadata."
+              }
             >
-              <NodeDetailPanel
-                node={graphState.selectedNode}
-                allNodes={graphState.data.nodes}
-                onClose={handleCloseDetails}
-                onViewFinding={handleViewFinding}
-                viewFindingLoading={finding.findingDetailLoading}
-                headingId="node-details-heading"
-              />
-            </div>
+              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+                <Button variant="outline" onClick={handleOpenNodeDetails}>
+                  View node details
+                </Button>
+                {actionContext === NODE_ACTION_CONTEXT.FILTERED_PARENT ? (
+                  <Button onClick={handleReturnToFullGraph}>
+                    Back to full graph
+                  </Button>
+                ) : (
+                  <Button onClick={handleShowNodeFindings}>
+                    {actionNodeFindingsExpanded
+                      ? "Hide findings"
+                      : "Show findings"}
+                  </Button>
+                )}
+              </div>
+            </Modal>
           )}
 
           {finding.findingDetails && (


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|-------|-------|
| **Feature Branch** | `PROWLER-1273/react-flow-migration` |
| **Main PR** | [#10686](https://github.com/prowler-cloud/prowler/pull/10686) |
| **Chain Position** | 5 (after PR4 / #10970) |

### Chain Overview

```
   ┌──────────────────────────────────────────────────────────────┐
   │ PR0  #10701  refactor(ui): normalize graph edge types        │
   └────────────────────────────┬─────────────────────────────────┘
                                │
   ┌──────────────────────────────────────────────────────────────┐
   │ PR1  #10705  refactor(ui): replace D3 with React Flow        │
   └────────────────────────────┬─────────────────────────────────┘
                                │
   ┌──────────────────────────────────────────────────────────────┐
   │ PR2  #10756  feat(ui): graph interactions + filtered view    │
   └────────────────────────────┬─────────────────────────────────┘
                                │
   ┌──────────────────────────────────────────────────────────────┐
   │ PR3  #10800  feat(ui): export, minimap, fullscreen polish    │
   └────────────────────────────┬─────────────────────────────────┘
                                │
   ┌──────────────────────────────────────────────────────────────┐
   │ PR4  #10970  test(ui): Vitest Browser coverage               │
   └────────────────────────────┬─────────────────────────────────┘
                                │
                                ▼
   ┌──────────────────────────────────────────────────────────────┐
   │ 📍 PR5  THIS PR — auto-fit + minimap                         │
   └────────────────────────────┬─────────────────────────────────┘
                                │
                                ▼
   ┌──────────────────────────────────────────────────────────────┐
   │ #10686  Main PR  feat(ui): D3 → React Flow → master          │
   └──────────────────────────────────────────────────────────────┘
```

---

### Context

Follow-up polish on the React Flow migration based on review feedback against the previously merged chained PRs.

After interacting with the graph, three viewport regressions left the user staring at empty canvas and forced manual recovery via the **Fit to Screen** toolbar button:

1. Clicking a finding to enter the filtered view kept the previous viewport pointing at the old coordinates, so the filtered subgraph rendered off-screen.
2. Pressing **Back to Full View** also kept the viewport, leaving the restored full graph misaligned.
3. Expanding a resource whose findings were laid out beyond the framed area revealed nodes the user could not see.

The minimap viewport indicator (the rectangle that shows the area currently in view) was also nearly invisible against the dark theme.

---

### Description

**Changes:**

- Auto-fit when `isFilteredView` toggles in either direction (finding click → filtered view, "Back to Full View" → full graph). Animated 300 ms re-fit, deferred to the next animation frame so React Flow has applied the new Dagre layout first.
- Auto-fit on resource expansion **only when** at least one of the newly revealed findings sits entirely past one of the viewport edges. Partially clipped edge nodes are left alone, and collapsing a resource never re-fits — the user keeps their current framing whenever nothing has actually moved off-screen.
- Auto-fit padding is asymmetric (extra room on the right and bottom) so fitted nodes never land underneath the bottom-right minimap panel.
- Minimap mask is darkened (higher contrast) and the viewport indicator's stroke colour and width are bumped, so the rectangle is visible against the dark theme background.
- Browser-mode coverage for the new behaviours under a new `auto-fitting the viewport` describe block: minimap stroke is visible, expansion re-fits when revealed findings fall off-screen, filter on/off both re-fit. New `viewportTransform` and `minimapMaskStrokeWidth` getters on `AttackPathPageHarness`.

---

### Steps to review

1. Run a query, click any finding — the filtered subgraph should animate to fill the canvas (no need to press Fit to Screen).
2. From the filtered view, click **Back to Full View** — the full graph should animate back to a fitted framing.
3. Expand a resource whose findings sit off-screen — the viewport should re-fit so the newly revealed findings are visible. Collapse the resource — the viewport should stay where it is.
4. With the dark theme active, pan/zoom the canvas — the rectangle in the minimap should clearly indicate which portion of the graph is visible.
5. `pnpm test:browser -- --run attack-paths-page` (the four `auto-fitting the viewport` tests cover the regressions).

---

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.