### PR TITLE
ci(ui-e2e): reduce Playwright artifact retention to 7 days

### DIFF
--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -270,7 +270,7 @@ jobs:
         with:
           name: playwright-report
           path: ui/playwright-report/
-          retention-days: 30
+          retention-days: 7
 
       - name: Cleanup services
         if: always()


### PR DESCRIPTION
### Context
Although `prowler` is a public repo (free Actions minutes), workflows here mirror to the private `prowler-cloud` where artifact storage IS billable. The Phase 1.2 audit on `prowler-cloud` flagged `retention-days: 30` on Playwright reports as a major contributor to the 21k+ GiB-h of artifact storage. Companion change to PR #4021 in `prowler-cloud` (which dropped retention on `ui-e2e-cloud-tests.yml`).

### Description
Drops `retention-days: 30` -> `retention-days: 7` on the `actions/upload-artifact` step in `ui-e2e-tests-v2.yml`. Playwright HTML reports + traces are typically only consulted within a few days of a failing run; 7 days is ample headroom and cuts retention by ~76%.

### Steps to review
- Confirm only the `retention-days:` value changed (line 273); rest of the `Upload test reports` step intact.

### Checklist
- [ ] SDK / CLI
- [ ] API
- [x] UI

### License
By submitting this pull request, you confirm that you have read and agree to the terms of the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).