### PR TITLE
ci(pr-conflict-checker): restore persist-credentials so base ref fetch works on private mirrors

### DIFF
--- a/.github/workflows/pr-conflict-checker.yml
+++ b/.github/workflows/pr-conflict-checker.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
-          persist-credentials: false
+          # zizmor: ignore[artipacked]
+          persist-credentials: true # Required by tj-actions/changed-files to fetch PR branch
 
       - name: Fetch PR base ref for tj-actions/changed-files
         env:


### PR DESCRIPTION
### Context

Set 5 of #11007 introduced an explicit `git fetch --depth=1 origin <base>` step in three PR helper workflows (`pr-conflict-checker`, `pr-check-changelog`, `pr-check-compliance-mapping`) when shrinking `fetch-depth: 0 → 1`. The other two workflows correctly kept `persist-credentials: true` so the fetch had auth; `pr-conflict-checker.yml` was left at `persist-credentials: false`.

This works on the public `prowler` repo (anonymous fetch is allowed), but breaks on the private `prowler-cloud` mirror where the same code returns 401. Currently blocking PR `prowler-cloud#4021`.

### Description

Aligns `pr-conflict-checker.yml` with its two siblings — `persist-credentials: true` plus the matching `# zizmor: ignore[artipacked]` comment. One file, two lines.

### Steps to review

1. Confirm the resulting `Checkout PR head` block matches the pattern already in `pr-check-changelog.yml` (lines 41-46) and `pr-check-compliance-mapping.yml`.
2. Confirm the rest of `pr-conflict-checker.yml` is untouched — the `Fetch PR base ref for tj-actions/changed-files` step added in #11007 stays as-is.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

CI-only change. SDK/CLI, UI, and API checklists do not apply.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.