### PR TITLE
[CHAIN] fix(ui): simplify attack paths graph interactions

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,14 +1,14 @@
-name: 'UI: Tests'
+name: "UI: Tests"
 
 on:
   push:
     branches:
-      - 'master'
-      - 'v5.*'
+      - "master"
+      - "v5.*"
   pull_request:
     branches:
-      - 'master'
-      - 'v5.*'
+      - "master"
+      - "v5.*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   UI_WORKING_DIR: ./ui
-  NODE_VERSION: '24.13.0'
+  NODE_VERSION: "24.13.0"
 
 permissions: {}
 
@@ -135,7 +135,7 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true' && steps.critical-changes.outputs.any_changed == 'true'
         run: |
           echo "Critical paths changed - running ALL unit tests"
-          pnpm run test:run
+          pnpm run test:unit
 
       - name: Run unit tests (related to changes only)
         if: steps.check-changes.outputs.any_changed == 'true' && steps.critical-changes.outputs.any_changed != 'true' && steps.changed-source.outputs.all_changed_files != ''
@@ -144,7 +144,7 @@ jobs:
           echo "${STEPS_CHANGED_SOURCE_OUTPUTS_ALL_CHANGED_FILES}"
           # Convert space-separated to vitest related format (remove ui/ prefix for relative paths)
           CHANGED_FILES=$(echo "${STEPS_CHANGED_SOURCE_OUTPUTS_ALL_CHANGED_FILES}" | tr ' ' '\n' | sed 's|^ui/||' | tr '\n' ' ')
-          pnpm exec vitest related $CHANGED_FILES --run
+          pnpm exec vitest related $CHANGED_FILES --run --project unit
         env:
           STEPS_CHANGED_SOURCE_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-source.outputs.all_changed_files }}
 
@@ -152,7 +152,7 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true' && steps.critical-changes.outputs.any_changed != 'true' && steps.changed-source.outputs.all_changed_files == ''
         run: |
           echo "Only test files changed - running ALL unit tests"
-          pnpm run test:run
+          pnpm run test:unit
 
       - name: Cache Playwright browsers
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Attack Paths graph: extract shared primitives across `FindingNode`, `ResourceNode`, and `InternetNode` (hidden handles, label truncation, fill/border resolution) without forcing a generic node renderer [(#10705)](https://github.com/prowler-cloud/prowler/pull/10705)
-- Attack Paths graph: viewport now auto-fits when entering or exiting the filtered view (clicking a finding or "Back to Full View") so the focused subgraph is centered, and the minimap viewport indicator stands out against the dark theme
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Attack Paths graph: extract shared primitives across `FindingNode`, `ResourceNode`, and `InternetNode` (hidden handles, label truncation, fill/border resolution) without forcing a generic node renderer [(#10705)](https://github.com/prowler-cloud/prowler/pull/10705)
+- Attack Paths graph: viewport now auto-fits when entering or exiting the filtered view (clicking a finding or "Back to Full View") so the focused subgraph is centered, and the minimap viewport indicator stands out against the dark theme
 
 ---
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -463,6 +463,13 @@ const GraphCanvas = ({
     ...node,
     selected: node.id === selectedNodeId,
     hidden: hiddenFindingIds.has(node.id),
+    className: cn(
+      node.className,
+      isFindingNode(node.data.graphNode.labels) ||
+        resourcesWithFindings.has(node.id)
+        ? "cursor-pointer"
+        : "cursor-default",
+    ),
     data: {
       ...node.data,
       hasFindings: resourcesWithFindings.has(node.id),

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -206,8 +206,14 @@ const GraphCanvas = ({
   onInitialFilter,
   ref,
 }: GraphCanvasProps) => {
-  const { zoomIn, zoomOut, fitView, getZoom, getNodes, getNodesBounds } =
-    useReactFlow();
+  const {
+    zoomIn,
+    zoomOut,
+    fitView,
+    getZoom,
+    getNodes,
+    getNodesBounds,
+  } = useReactFlow();
   const { resolvedTheme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const hasInitialized = useRef(false);

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -26,12 +26,13 @@ import { cn } from "@/lib/utils";
 import type { AttackPathGraphData, GraphNode } from "@/types/attack-paths";
 
 import {
+  computeFilteredSubgraph,
   getNodeBorderColor,
   getNodeColor,
   getPathEdges,
   GRAPH_EDGE_HIGHLIGHT_COLOR,
+  resolveHiddenFindingIds,
 } from "../../_lib";
-import { computeFilteredSubgraph } from "../../_lib/graph-utils";
 import { isFindingNode, layoutWithDagre } from "../../_lib/layout";
 import { FindingNode } from "./nodes/finding-node";
 import { InternetNode } from "./nodes/internet-node";
@@ -199,7 +200,7 @@ const scheduleMeasuredFit = (
 const GraphCanvas = ({
   data,
   selectedNodeId,
-  isFilteredView,
+  isFilteredView = false,
   initialNodeId,
   expandedResources,
   onNodeClick,
@@ -426,23 +427,12 @@ const GraphCanvas = ({
   resourceToFindingsRef.current = resourceToFindings;
 
   // Tier 1: compute which finding nodes are hidden (not expanded)
-  const hiddenFindingIds = new Set<string>();
-  if (!isFilteredView) {
-    findingNodeIds.forEach((findingId) => {
-      // A finding is visible only if at least one of its connected resources is expanded
-      const connectedResources = findingToResources.get(findingId);
-      if (!connectedResources) {
-        hiddenFindingIds.add(findingId);
-        return;
-      }
-      const anyExpanded = Array.from(connectedResources).some((resId) =>
-        expanded.has(resId),
-      );
-      if (!anyExpanded) {
-        hiddenFindingIds.add(findingId);
-      }
-    });
-  }
+  const hiddenFindingIds = resolveHiddenFindingIds({
+    expandedResources: expanded,
+    findingNodeIds,
+    findingToResources,
+    isFilteredView,
+  });
 
   const layoutNodeIds = new Set(
     nodes
@@ -483,7 +473,12 @@ const GraphCanvas = ({
   const enrichedEdges = rfEdges.map((edge) => {
     const sourceHidden = hiddenFindingIds.has(edge.source);
     const targetHidden = hiddenFindingIds.has(edge.target);
-    const isHighlighted = highlightedEdgeIds.has(edge.id);
+    const pathKey =
+      typeof edge.data === "object" && edge.data && "pathKey" in edge.data
+        ? String((edge.data as { pathKey?: string }).pathKey)
+        : `${edge.source}-${edge.target}`;
+    const isHighlighted =
+      highlightedEdgeIds.has(edge.id) || highlightedEdgeIds.has(pathKey);
 
     return {
       ...edge,

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -383,64 +383,6 @@ const GraphCanvas = ({
     );
   }, [expanded, fitView, getNodes]);
 
-  useEffect(() => {
-    const previous = previousExpandedRef.current;
-    previousExpandedRef.current = expanded;
-    if (previous === expanded) return;
-    const newResourceIds = Array.from(expanded).filter(
-      (id) => !previous.has(id),
-    );
-    // Only fit on growth — collapsing intentionally leaves the user's
-    // current framing alone.
-    if (newResourceIds.length === 0) return;
-
-    const newFindingIds = new Set<string>();
-    for (const resourceId of newResourceIds) {
-      const findings = resourceToFindingsRef.current.get(resourceId);
-      if (!findings) continue;
-      findings.forEach((id) => newFindingIds.add(id));
-    }
-    if (newFindingIds.size === 0) return;
-
-    // Findings transition from hidden to visible on expand, and React Flow
-    // measures them asynchronously. Poll before checking whether their full
-    // bounding boxes sit entirely past a viewport edge; collapsing and
-    // partially clipped findings preserve the user's current frame.
-    let frame = 0;
-    let attempts = 0;
-    const MAX_ATTEMPTS = 30;
-    const tryFit = () => {
-      const targets = getNodes().filter((n) => newFindingIds.has(n.id));
-      const allMeasured =
-        targets.length === newFindingIds.size &&
-        targets.every((n) => (n.measured?.width ?? 0) > 0);
-      if (allMeasured || attempts >= MAX_ATTEMPTS) {
-        const containerEl = containerRef.current;
-        if (!containerEl) return;
-        const { width, height } = containerEl.getBoundingClientRect();
-        if (width === 0 || height === 0) return;
-        const { x, y, zoom } = getViewport();
-        const minX = -x / zoom;
-        const minY = -y / zoom;
-        const maxX = minX + width / zoom;
-        const maxY = minY + height / zoom;
-        const anyOutside = targets.some((node) => {
-          const nx = node.position.x;
-          const ny = node.position.y;
-          const nw = node.measured?.width ?? 0;
-          const nh = node.measured?.height ?? 0;
-          return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
-        });
-        if (anyOutside) fitView(AUTO_FIT_OPTIONS);
-        return;
-      }
-      attempts += 1;
-      frame = requestAnimationFrame(tryFit);
-    };
-    frame = requestAnimationFrame(tryFit);
-    return () => cancelAnimationFrame(frame);
-  }, [expanded, fitView, getNodes, getViewport]);
-
   const nodes = effectiveData.nodes ?? [];
   const edges = effectiveData.edges ?? [];
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -386,9 +386,6 @@ const GraphCanvas = ({
   const nodes = effectiveData.nodes ?? [];
   const edges = effectiveData.edges ?? [];
 
-  // Derive RF nodes and edges from data (pure computation in render body — D4)
-  const { rfNodes, rfEdges } = layoutWithDagre(nodes, edges);
-
   // Pre-compute which resources have findings connected (O(n+e))
   const findingNodeIds = new Set<string>();
   const resourceToFindings = new Map<string, Set<string>>();
@@ -446,6 +443,21 @@ const GraphCanvas = ({
       }
     });
   }
+
+  const layoutNodeIds = new Set(
+    nodes
+      .filter((node) => !hiddenFindingIds.has(node.id))
+      .map((node) => node.id),
+  );
+  const layoutNodes = nodes.filter((node) => layoutNodeIds.has(node.id));
+  const layoutEdges = edges.filter(
+    (edge) => layoutNodeIds.has(edge.source) && layoutNodeIds.has(edge.target),
+  );
+
+  // Derive RF nodes and edges from visible data only. Hidden finding nodes are
+  // excluded before Dagre runs so the initial tier-1 graph does not reserve
+  // empty space for findings that the user has not expanded yet.
+  const { rfNodes, rfEdges } = layoutWithDagre(layoutNodes, layoutEdges);
 
   // Path highlight: compute highlighted edge IDs
   const activeHighlightNodeId = hoveredNodeId ?? selectedNodeId;

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -383,6 +383,48 @@ const GraphCanvas = ({
     );
   }, [expanded, fitView, getNodes]);
 
+  useEffect(() => {
+    const previous = previousExpandedRef.current;
+    previousExpandedRef.current = expanded;
+    if (previous === expanded) return;
+    // Only fit on growth — collapsing intentionally leaves the user's
+    // framing alone.
+    const newResourceIds = Array.from(expanded).filter(
+      (id) => !previous.has(id),
+    );
+    if (newResourceIds.length === 0) return;
+
+    const newFindingIds = new Set<string>();
+    for (const resourceId of newResourceIds) {
+      const findings = resourceToFindingsRef.current.get(resourceId);
+      if (!findings) continue;
+      findings.forEach((id) => newFindingIds.add(id));
+    }
+    if (newFindingIds.size === 0) return;
+
+    const frame = requestAnimationFrame(() => {
+      const containerEl = containerRef.current;
+      if (!containerEl) return;
+      const { width, height } = containerEl.getBoundingClientRect();
+      if (width === 0 || height === 0) return;
+      const { x, y, zoom } = getViewport();
+      const minX = -x / zoom;
+      const minY = -y / zoom;
+      const maxX = minX + width / zoom;
+      const maxY = minY + height / zoom;
+      const anyOutside = getNodes().some((node) => {
+        if (!newFindingIds.has(node.id)) return false;
+        const nx = node.position.x;
+        const ny = node.position.y;
+        const nw = node.measured?.width ?? 0;
+        const nh = node.measured?.height ?? 0;
+        return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
+      });
+      if (anyOutside) fitView(AUTO_FIT_OPTIONS);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [expanded, fitView, getNodes, getViewport]);
+
   const nodes = effectiveData.nodes ?? [];
   const edges = effectiveData.edges ?? [];
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/attack-path-graph.tsx
@@ -387,11 +387,11 @@ const GraphCanvas = ({
     const previous = previousExpandedRef.current;
     previousExpandedRef.current = expanded;
     if (previous === expanded) return;
-    // Only fit on growth — collapsing intentionally leaves the user's
-    // framing alone.
     const newResourceIds = Array.from(expanded).filter(
       (id) => !previous.has(id),
     );
+    // Only fit on growth — collapsing intentionally leaves the user's
+    // current framing alone.
     if (newResourceIds.length === 0) return;
 
     const newFindingIds = new Set<string>();
@@ -402,26 +402,42 @@ const GraphCanvas = ({
     }
     if (newFindingIds.size === 0) return;
 
-    const frame = requestAnimationFrame(() => {
-      const containerEl = containerRef.current;
-      if (!containerEl) return;
-      const { width, height } = containerEl.getBoundingClientRect();
-      if (width === 0 || height === 0) return;
-      const { x, y, zoom } = getViewport();
-      const minX = -x / zoom;
-      const minY = -y / zoom;
-      const maxX = minX + width / zoom;
-      const maxY = minY + height / zoom;
-      const anyOutside = getNodes().some((node) => {
-        if (!newFindingIds.has(node.id)) return false;
-        const nx = node.position.x;
-        const ny = node.position.y;
-        const nw = node.measured?.width ?? 0;
-        const nh = node.measured?.height ?? 0;
-        return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
-      });
-      if (anyOutside) fitView(AUTO_FIT_OPTIONS);
-    });
+    // Findings transition from hidden to visible on expand, and React Flow
+    // measures them asynchronously. Poll before checking whether their full
+    // bounding boxes sit entirely past a viewport edge; collapsing and
+    // partially clipped findings preserve the user's current frame.
+    let frame = 0;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 30;
+    const tryFit = () => {
+      const targets = getNodes().filter((n) => newFindingIds.has(n.id));
+      const allMeasured =
+        targets.length === newFindingIds.size &&
+        targets.every((n) => (n.measured?.width ?? 0) > 0);
+      if (allMeasured || attempts >= MAX_ATTEMPTS) {
+        const containerEl = containerRef.current;
+        if (!containerEl) return;
+        const { width, height } = containerEl.getBoundingClientRect();
+        if (width === 0 || height === 0) return;
+        const { x, y, zoom } = getViewport();
+        const minX = -x / zoom;
+        const minY = -y / zoom;
+        const maxX = minX + width / zoom;
+        const maxY = minY + height / zoom;
+        const anyOutside = targets.some((node) => {
+          const nx = node.position.x;
+          const ny = node.position.y;
+          const nw = node.measured?.width ?? 0;
+          const nh = node.measured?.height ?? 0;
+          return nx + nw < minX || nx > maxX || ny + nh < minY || ny > maxY;
+        });
+        if (anyOutside) fitView(AUTO_FIT_OPTIONS);
+        return;
+      }
+      attempts += 1;
+      frame = requestAnimationFrame(tryFit);
+    };
+    frame = requestAnimationFrame(tryFit);
     return () => cancelAnimationFrame(frame);
   }, [expanded, fitView, getNodes, getViewport]);
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.test.tsx
@@ -55,7 +55,7 @@ describe("GraphLegend", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: /edges/i })).toBeInTheDocument();
 
-    expect(screen.getByText("Provider / account root")).toBeInTheDocument();
+    expect(screen.getByText("Provider")).toBeInTheDocument();
     expect(screen.getByText("S3 Bucket")).toBeInTheDocument();
     expect(screen.getByText("VPC")).toBeInTheDocument();
     expect(screen.queryByText("Storage")).not.toBeInTheDocument();

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.test.tsx
@@ -99,6 +99,35 @@ describe("GraphLegend", () => {
     expect(screen.getByText("Node with findings")).toBeInTheDocument();
   });
 
+  it("should keep unattached findings visible in the legend", () => {
+    // Given - Findings have no connected resource and stay visible in the full graph
+    const findingsOnlyGraphData: AttackPathGraphData = {
+      nodes: [
+        {
+          id: "finding-critical",
+          labels: ["ProwlerFinding"],
+          properties: { check_title: "Critical finding", severity: "critical" },
+        },
+        {
+          id: "finding-high",
+          labels: ["ProwlerFinding"],
+          properties: { check_title: "High finding", severity: "high" },
+        },
+      ],
+      relationships: [],
+    };
+
+    // When
+    render(<GraphLegend data={findingsOnlyGraphData} />);
+
+    // Then
+    expect(
+      screen.getByRole("heading", { name: /findings by risk/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+  });
+
   it("should list policy and role node types separately", () => {
     // Given - A graph whose visible nodes are all identity-related, but distinct
     const identityGraphData: AttackPathGraphData = {

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.tsx
@@ -22,6 +22,7 @@ import {
   GRAPH_NODE_BORDER_COLORS,
   GRAPH_NODE_COLORS,
 } from "../../_lib/graph-colors";
+import { resolveHiddenFindingIds } from "../../_lib/graph-utils";
 import { NODE_CATEGORY, resolveNodeVisual } from "../../_lib/node-visuals";
 
 const LEGEND_PREVIEW = {
@@ -234,19 +235,12 @@ const resolveLegendState = (
     }
   }
 
-  const hiddenFindingIds = new Set<string>();
-  if (!isFilteredView) {
-    for (const findingId of Array.from(findingNodeIds)) {
-      const connectedResources = findingToResources.get(findingId);
-      const isVisible = connectedResources
-        ? Array.from(connectedResources).some((resourceId) =>
-            expandedResources.has(resourceId),
-          )
-        : false;
-
-      if (!isVisible) hiddenFindingIds.add(findingId);
-    }
-  }
+  const hiddenFindingIds = resolveHiddenFindingIds({
+    expandedResources,
+    findingNodeIds,
+    findingToResources,
+    isFilteredView,
+  });
 
   const visibleNodes = data.nodes.filter(
     (node) => !hiddenFindingIds.has(node.id),

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.tsx
@@ -116,7 +116,7 @@ const buildVisualItem = (
 });
 
 const providerRootItem = buildVisualItem(
-  "Provider / account root",
+  "Provider",
   "Cloud account, tenant, project, organization, or cluster entry point.",
   buildNode(["AWSAccount"], { name: "Provider root" }),
   GRAPH_NODE_COLORS.awsAccount,

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/finding-node.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/finding-node.test.tsx
@@ -32,7 +32,7 @@ const buildNodeProps = (graphNode: GraphNode): NodeProps =>
   }) as unknown as NodeProps;
 
 describe("FindingNode", () => {
-  it("positions graph handles for vertical top-to-bottom edges", () => {
+  it("positions graph handles for horizontal left-to-right edges", () => {
     // Given
     const props = buildNodeProps(
       buildFindingNode("critical", "Root key exposed"),
@@ -44,8 +44,10 @@ describe("FindingNode", () => {
     // Then
     expect(hiddenHandlesMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        sourcePosition: Position.Bottom,
-        targetPosition: Position.Top,
+        sourcePosition: Position.Right,
+        sourceStyle: { left: 97, top: 26 },
+        targetPosition: Position.Left,
+        targetStyle: { left: 53, top: 26 },
       }),
       undefined,
     );

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/finding-node.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/finding-node.tsx
@@ -21,8 +21,8 @@ const BADGE_SIZE = 44;
 const BADGE_RADIUS = BADGE_SIZE / 2;
 const BADGE_CENTER_X = NODE_WIDTH / 2;
 const BADGE_CENTER_Y = 26;
-const BADGE_BOTTOM_Y = BADGE_CENTER_Y + BADGE_RADIUS;
-const BADGE_TOP_Y = BADGE_CENTER_Y - BADGE_RADIUS;
+const BADGE_LEFT_X = BADGE_CENTER_X - BADGE_RADIUS;
+const BADGE_RIGHT_X = BADGE_CENTER_X + BADGE_RADIUS;
 const ICON_SIZE = 28;
 const ICON_X = BADGE_CENTER_X - ICON_SIZE / 2;
 const ICON_Y = BADGE_CENTER_Y - ICON_SIZE / 2;
@@ -76,11 +76,10 @@ export const FindingNode = ({ data, selected }: NodeProps) => {
   return (
     <>
       <HiddenHandles
-        sourcePosition={Position.Bottom}
-        sourceStyle={{ top: BADGE_BOTTOM_Y }}
-        style={{ left: BADGE_CENTER_X }}
-        targetPosition={Position.Top}
-        targetStyle={{ top: BADGE_TOP_Y }}
+        sourcePosition={Position.Right}
+        sourceStyle={{ left: BADGE_RIGHT_X, top: BADGE_CENTER_Y }}
+        targetPosition={Position.Left}
+        targetStyle={{ left: BADGE_LEFT_X, top: BADGE_CENTER_Y }}
       />
       <svg width={NODE_WIDTH} height={NODE_HEIGHT} className="overflow-visible">
         <circle

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/hidden-handles.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/hidden-handles.tsx
@@ -12,10 +12,10 @@ interface HiddenHandlesProps {
 }
 
 export const HiddenHandles = ({
-  sourcePosition = Position.Bottom,
+  sourcePosition = Position.Right,
   sourceStyle,
   style,
-  targetPosition = Position.Top,
+  targetPosition = Position.Left,
   targetStyle,
 }: HiddenHandlesProps) => (
   <>

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/resource-node.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/resource-node.test.tsx
@@ -32,7 +32,7 @@ const buildNodeProps = (graphNode: GraphNode): NodeProps =>
   }) as unknown as NodeProps;
 
 describe("ResourceNode", () => {
-  it("positions graph handles for vertical top-to-bottom edges", () => {
+  it("positions graph handles for horizontal left-to-right edges", () => {
     // Given
     const props = buildNodeProps(buildGraphNode("S3Bucket", "logs"));
 
@@ -42,8 +42,10 @@ describe("ResourceNode", () => {
     // Then
     expect(hiddenHandlesMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        sourcePosition: Position.Bottom,
-        targetPosition: Position.Top,
+        sourcePosition: Position.Right,
+        sourceStyle: { left: 90, top: 26 },
+        targetPosition: Position.Left,
+        targetStyle: { left: 46, top: 26 },
       }),
       undefined,
     );

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/resource-node.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/nodes/resource-node.tsx
@@ -22,8 +22,8 @@ const BADGE_SIZE = 44;
 const BADGE_RADIUS = BADGE_SIZE / 2;
 const BADGE_CENTER_X = NODE_WIDTH / 2;
 const BADGE_CENTER_Y = 26;
-const BADGE_BOTTOM_Y = BADGE_CENTER_Y + BADGE_RADIUS;
-const BADGE_TOP_Y = BADGE_CENTER_Y - BADGE_RADIUS;
+const BADGE_LEFT_X = BADGE_CENTER_X - BADGE_RADIUS;
+const BADGE_RIGHT_X = BADGE_CENTER_X + BADGE_RADIUS;
 const ICON_SIZE = 28;
 const ICON_X = BADGE_CENTER_X - ICON_SIZE / 2;
 const ICON_Y = BADGE_CENTER_Y - ICON_SIZE / 2;
@@ -63,11 +63,10 @@ export const ResourceNode = ({ data, selected }: NodeProps) => {
   return (
     <>
       <HiddenHandles
-        sourcePosition={Position.Bottom}
-        sourceStyle={{ top: BADGE_BOTTOM_Y }}
-        style={{ left: BADGE_CENTER_X }}
-        targetPosition={Position.Top}
-        targetStyle={{ top: BADGE_TOP_Y }}
+        sourcePosition={Position.Right}
+        sourceStyle={{ left: BADGE_RIGHT_X, top: BADGE_CENTER_Y }}
+        targetPosition={Position.Left}
+        targetStyle={{ left: BADGE_LEFT_X, top: BADGE_CENTER_Y }}
       />
       <svg width={NODE_WIDTH} height={NODE_HEIGHT} className="overflow-visible">
         {glowRadius > 0 && (

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_hooks/use-graph-state.test.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_hooks/use-graph-state.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useGraphStore } from "./use-graph-state";
+
+describe("useGraphStore", () => {
+  beforeEach(() => {
+    useGraphStore.getState().reset();
+  });
+
+  it("keeps only one expanded findings resource open at a time", () => {
+    // Given
+    const store = useGraphStore.getState();
+
+    // When
+    store.toggleExpandedResource("resource-a");
+    useGraphStore.getState().toggleExpandedResource("resource-b");
+
+    // Then
+    expect(Array.from(useGraphStore.getState().expandedResources)).toEqual([
+      "resource-b",
+    ]);
+  });
+
+  it("closes the expanded findings resource when toggled again", () => {
+    // Given
+    const store = useGraphStore.getState();
+
+    // When
+    store.toggleExpandedResource("resource-a");
+    useGraphStore.getState().toggleExpandedResource("resource-a");
+
+    // Then
+    expect(useGraphStore.getState().expandedResources.size).toBe(0);
+  });
+});

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_hooks/use-graph-state.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_hooks/use-graph-state.ts
@@ -72,12 +72,9 @@ export const useGraphStore = create<GraphStore>((set) => ({
     }),
   toggleExpandedResource: (resourceId) =>
     set((state) => {
-      const next = new Set(state.expandedResources);
-      if (next.has(resourceId)) {
-        next.delete(resourceId);
-      } else {
-        next.add(resourceId);
-      }
+      const next = state.expandedResources.has(resourceId)
+        ? new Set<string>()
+        : new Set([resourceId]);
       return { expandedResources: next };
     }),
   reset: () => set(initialState),

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/graph-colors.test.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/graph-colors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GRAPH_ALERT_BORDER_COLOR,
+  GRAPH_EDGE_HIGHLIGHT_COLOR,
+  resolveNodeColors,
+} from "./graph-colors";
+
+describe("resolveNodeColors", () => {
+  it("prioritizes selected state over hasFindings for the border color", () => {
+    const selectedColors = resolveNodeColors({
+      labels: ["EC2Instance"],
+      selected: true,
+      hasFindings: true,
+    });
+
+    const alertOnlyColors = resolveNodeColors({
+      labels: ["EC2Instance"],
+      selected: false,
+      hasFindings: true,
+    });
+
+    expect(selectedColors.borderColor).toBe(GRAPH_EDGE_HIGHLIGHT_COLOR);
+    expect(alertOnlyColors.borderColor).toBe(GRAPH_ALERT_BORDER_COLOR);
+  });
+});

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/graph-colors.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/graph-colors.ts
@@ -151,10 +151,10 @@ export const resolveNodeColors = ({
   hasFindings,
 }: ResolveNodeColorsParams): NodeColorResult => {
   const fillColor = getNodeColor(labels, properties);
-  const borderColor = hasFindings
-    ? GRAPH_ALERT_BORDER_COLOR
-    : selected
-      ? GRAPH_EDGE_HIGHLIGHT_COLOR
+  const borderColor = selected
+    ? GRAPH_EDGE_HIGHLIGHT_COLOR
+    : hasFindings
+      ? GRAPH_ALERT_BORDER_COLOR
       : getNodeBorderColor(labels, properties);
   return { fillColor, borderColor };
 };

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/graph-utils.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/graph-utils.ts
@@ -4,6 +4,42 @@
 
 import type { AttackPathGraphData } from "@/types/attack-paths";
 
+export const resolveHiddenFindingIds = ({
+  expandedResources,
+  findingNodeIds,
+  findingToResources,
+  isFilteredView,
+}: {
+  expandedResources: ReadonlySet<string>;
+  findingNodeIds: ReadonlySet<string>;
+  findingToResources: ReadonlyMap<string, ReadonlySet<string>>;
+  isFilteredView: boolean;
+}): Set<string> => {
+  const hiddenFindingIds = new Set<string>();
+
+  if (isFilteredView) {
+    return hiddenFindingIds;
+  }
+
+  findingNodeIds.forEach((findingId) => {
+    const connectedResources = findingToResources.get(findingId);
+
+    if (!connectedResources) {
+      return;
+    }
+
+    const anyExpanded = Array.from(connectedResources).some((resourceId) =>
+      expandedResources.has(resourceId),
+    );
+
+    if (!anyExpanded) {
+      hiddenFindingIds.add(findingId);
+    }
+  });
+
+  return hiddenFindingIds;
+};
+
 /**
  * Compute a filtered subgraph containing only the path through the target node.
  * This follows the directed graph structure of attack paths:

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/index.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/index.ts
@@ -12,7 +12,11 @@ export {
   GRAPH_SELECTION_COLOR,
   resolveNodeColors,
 } from "./graph-colors";
-export { computeFilteredSubgraph, getPathEdges } from "./graph-utils";
+export {
+  computeFilteredSubgraph,
+  getPathEdges,
+  resolveHiddenFindingIds,
+} from "./graph-utils";
 export { layoutWithDagre } from "./layout";
 export {
   NODE_CATEGORY,

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.test.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.test.ts
@@ -72,7 +72,7 @@ describe("layoutWithDagre", () => {
     expect(a).toEqual(b);
   });
 
-  it("spreads sibling nodes horizontally to use wide graph space", () => {
+  it("places connected children to the right and stacks siblings within the horizontal rank", () => {
     const rootNode: GraphNode = {
       id: "root",
       labels: ["AWSAccount"],
@@ -106,6 +106,9 @@ describe("layoutWithDagre", () => {
       })),
     );
 
+    const rootPosition = rfNodes.find(
+      (candidate) => candidate.id === "root",
+    )?.position;
     const siblingPositions = siblingNodes.map((node) => {
       const rfNode = rfNodes.find((candidate) => candidate.id === node.id);
 
@@ -121,10 +124,14 @@ describe("layoutWithDagre", () => {
       Math.max(...siblingPositions.map((position) => position.y)) -
       Math.min(...siblingPositions.map((position) => position.y));
 
-    expect(xSpread).toBeGreaterThan(ySpread);
+    expect(rootPosition).toBeDefined();
+    siblingPositions.forEach((position) => {
+      expect(position.x).toBeGreaterThan(rootPosition?.x ?? 0);
+    });
+    expect(ySpread).toBeGreaterThan(xSpread);
   });
 
-  it("connects edges through top and bottom node sides for vertical layout", () => {
+  it("connects edges through right and left node sides for horizontal layout", () => {
     const { rfNodes } = layoutWithDagre(
       [findingNode, resourceNode],
       [
@@ -138,8 +145,8 @@ describe("layoutWithDagre", () => {
     );
 
     rfNodes.forEach((node) => {
-      expect(node.sourcePosition).toBe(Position.Bottom);
-      expect(node.targetPosition).toBe(Position.Top);
+      expect(node.sourcePosition).toBe(Position.Right);
+      expect(node.targetPosition).toBe(Position.Left);
     });
   });
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.test.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.test.ts
@@ -29,7 +29,6 @@ describe("layoutWithDagre", () => {
     expect(result.rfNodes).toEqual([]);
     expect(result.rfEdges).toEqual([]);
   });
-
   it("assigns node types and dimensions from labels", () => {
     const { rfNodes } = layoutWithDagre(
       [findingNode, resourceNode, internetNode],
@@ -233,7 +232,7 @@ describe("layoutWithDagre", () => {
     });
   });
 
-  it("builds rf edge IDs as `${source}-${target}` after layout", () => {
+  it("preserves the original edge id when the graph has a single edge", () => {
     const { rfEdges } = layoutWithDagre(
       [findingNode, resourceNode],
       [
@@ -246,6 +245,31 @@ describe("layoutWithDagre", () => {
       ],
     );
 
-    expect(rfEdges[0]?.id).toBe("resource-1-finding-1");
+    expect(rfEdges[0]?.id).toBe("ignored-by-rf");
+  });
+
+  it("preserves parallel edges between the same nodes with unique ids", () => {
+    const { rfEdges } = layoutWithDagre(
+      [resourceNode, findingNode],
+      [
+        {
+          id: "edge-1",
+          source: "resource-1",
+          target: "finding-1",
+          type: "HAS_FINDING",
+        },
+        {
+          id: "edge-2",
+          source: "resource-1",
+          target: "finding-1",
+          type: "HAS_FINDING",
+        },
+      ],
+    );
+
+    expect(rfEdges).toHaveLength(2);
+    expect(rfEdges.map((edge) => edge.id)).toEqual(["edge-1", "edge-2"]);
+    expect(rfEdges.every((edge) => edge.source === "resource-1")).toBe(true);
+    expect(rfEdges.every((edge) => edge.target === "finding-1")).toBe(true);
   });
 });

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.ts
@@ -63,7 +63,7 @@ export const layoutWithDagre = (
   nodes: GraphNode[],
   edges: GraphEdge[],
 ): { rfNodes: Node<NodeData>[]; rfEdges: Edge[] } => {
-  const g = new Graph();
+  const g = new Graph({ multigraph: true });
   g.setGraph({
     rankdir: "LR",
     nodesep: 80,
@@ -90,10 +90,16 @@ export const layoutWithDagre = (
     }
 
     if (sourceId && targetId) {
-      g.setEdge(sourceId, targetId, {
-        originalSource: edge.source,
-        originalTarget: edge.target,
-      });
+      g.setEdge(
+        sourceId,
+        targetId,
+        {
+          id: edge.id,
+          originalSource: edge.source,
+          originalTarget: edge.target,
+        },
+        edge.id,
+      );
     }
   });
 
@@ -121,31 +127,35 @@ export const layoutWithDagre = (
   });
 
   // Build RF edges from dagre edges (using layout order, not original)
-  const rfEdges: Edge[] = g.edges().map((e: { v: string; w: string }) => {
-    const edgeData = g.edge(e) as {
-      originalSource: string;
-      originalTarget: string;
-    };
+  const rfEdges: Edge[] = g
+    .edges()
+    .map((e: { v: string; w: string; name?: string }) => {
+      const edgeData = g.edge(e) as {
+        id?: string;
+        originalSource: string;
+        originalTarget: string;
+      };
 
-    // Check if either end is a finding node
-    const sourceNode = nodes.find((n) => n.id === e.v);
-    const targetNode = nodes.find((n) => n.id === e.w);
-    const hasFinding =
-      isFindingNode(sourceNode?.labels ?? []) ||
-      isFindingNode(targetNode?.labels ?? []);
+      // Check if either end is a finding node
+      const sourceNode = nodes.find((n) => n.id === e.v);
+      const targetNode = nodes.find((n) => n.id === e.w);
+      const hasFinding =
+        isFindingNode(sourceNode?.labels ?? []) ||
+        isFindingNode(targetNode?.labels ?? []);
 
-    return {
-      id: `${e.v}-${e.w}`,
-      source: e.v,
-      target: e.w,
-      animated: hasFinding,
-      className: hasFinding ? "finding-edge" : "resource-edge",
-      data: {
-        originalSource: edgeData.originalSource,
-        originalTarget: edgeData.originalTarget,
-      },
-    };
-  });
+      return {
+        id: edgeData.id ?? e.name ?? `${e.v}-${e.w}`,
+        source: e.v,
+        target: e.w,
+        animated: hasFinding,
+        className: hasFinding ? "finding-edge" : "resource-edge",
+        data: {
+          pathKey: `${e.v}-${e.w}`,
+          originalSource: edgeData.originalSource,
+          originalTarget: edgeData.originalTarget,
+        },
+      };
+    });
 
   return { rfNodes, rfEdges };
 };

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.ts
@@ -65,7 +65,7 @@ export const layoutWithDagre = (
 ): { rfNodes: Node<NodeData>[]; rfEdges: Edge[] } => {
   const g = new Graph();
   g.setGraph({
-    rankdir: "TB",
+    rankdir: "LR",
     nodesep: 80,
     ranksep: 150,
     marginx: 50,
@@ -112,8 +112,8 @@ export const layoutWithDagre = (
         x: dagreNode.x - width / 2,
         y: dagreNode.y - height / 2,
       },
-      sourcePosition: Position.Bottom,
-      targetPosition: Position.Top,
+      sourcePosition: Position.Right,
+      targetPosition: Position.Left,
       data: { graphNode: node },
       width,
       height,

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/node-visuals.test.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/node-visuals.test.ts
@@ -4,6 +4,7 @@ import {
   Braces,
   CircleAlert,
   FileKey2,
+  Globe2,
   Info,
   KeyRound,
   Route,

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/node-visuals.test.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/_lib/node-visuals.test.ts
@@ -4,7 +4,6 @@ import {
   Braces,
   CircleAlert,
   FileKey2,
-  Globe2,
   Info,
   KeyRound,
   Route,

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -262,7 +262,9 @@ describe("running a query", () => {
 });
 
 describe("exploring the graph", () => {
-  test("clicking a finding opens the filtered view", async ({ mountWith }) => {
+  test("clicking a finding opens the filtered view and finding details", async ({
+    mountWith,
+  }) => {
     const graph = await mountWith();
     await graph.executeQuery();
     await graph.waitForLayoutStable(3);
@@ -270,40 +272,48 @@ describe("exploring the graph", () => {
 
     expect(graph.isInFilteredView).toBe(false);
     await graph.clickFirstFindingNode();
+
     expect(graph.isInFilteredView).toBe(true);
+    expect(getFindingByIdMock).toHaveBeenCalledTimes(1);
     expect(graph.hasNodeDetailsModal).toBe(false);
+    expect(graph.hasNodeActionDialog).toBe(false);
   });
 
-  test("clicking a resource with findings opens the action selector", async ({
+  test("clicking a resource with findings directly reveals related finding nodes", async ({
     mountWith,
   }) => {
     const graph = await mountWith();
     await graph.executeQuery();
     await graph.waitForLayoutStable(3);
 
+    expect(graph.findingNodes.length).toBe(0);
     expect(graph.hasNodeDetailsModal).toBe(false);
 
     await graph.clickFirstResourceNode();
-
-    expect(graph.hasNodeActionDialog).toBe(true);
-    expect(graph.hasNodeDetailsModal).toBe(false);
-  });
-
-  test("choosing Show findings reveals related finding nodes", async ({
-    mountWith,
-  }) => {
-    const graph = await mountWith();
-    await graph.executeQuery();
-    await graph.waitForLayoutStable(3);
-
-    await graph.clickFirstResourceNode();
-    await graph.chooseShowFindingsAction();
 
     expect(graph.findingNodes.length).toBeGreaterThan(0);
     expect(graph.hasNodeDetailsModal).toBe(false);
+    expect(graph.hasNodeActionDialog).toBe(false);
   });
 
-  test("choosing Show findings re-fits around the resource and its findings", async ({
+  test("clicking an expanded resource with findings hides its related finding nodes", async ({
+    mountWith,
+  }) => {
+    const graph = await mountWith();
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    await graph.clickFirstResourceNode();
+    expect(graph.findingNodes.length).toBeGreaterThan(0);
+
+    await graph.clickFirstResourceNode();
+
+    expect(graph.findingNodes.length).toBe(0);
+    expect(graph.hasNodeDetailsModal).toBe(false);
+    expect(graph.hasNodeActionDialog).toBe(false);
+  });
+
+  test("clicking a resource with findings re-fits around the resource and its findings", async ({
     mountWith,
   }) => {
     const graph = await mountWith();
@@ -313,7 +323,6 @@ describe("exploring the graph", () => {
     const initialViewport = graph.viewportTransform;
 
     await graph.clickFirstResourceNode();
-    await graph.chooseShowFindingsAction();
 
     expect(graph.findingNodes.length).toBeGreaterThan(0);
     await graph.waitFor(
@@ -330,7 +339,7 @@ describe("exploring the graph", () => {
       2000,
     );
   });
-  test("expanded resources offer Hide findings in the action selector", async ({
+  test("clicking an expanded resource re-fits the remaining visible graph", async ({
     mountWith,
   }) => {
     const graph = await mountWith();
@@ -338,35 +347,12 @@ describe("exploring the graph", () => {
     await graph.waitForLayoutStable(3);
 
     await graph.clickFirstResourceNode();
-    await graph.chooseShowFindingsAction();
-    expect(graph.findingNodes.length).toBeGreaterThan(0);
-
-    await graph.clickFirstResourceNode();
-
-    expect(graph.hasNodeActionDialog).toBe(true);
-    expect(graph.containsText(/Hide findings/i)).toBe(true);
-
-    await graph.chooseHideFindingsAction();
-
-    expect(graph.findingNodes.length).toBe(0);
-  });
-
-  test("choosing Hide findings re-fits the remaining visible graph", async ({
-    mountWith,
-  }) => {
-    const graph = await mountWith();
-    await graph.executeQuery();
-    await graph.waitForLayoutStable(3);
-
-    await graph.clickFirstResourceNode();
-    await graph.chooseShowFindingsAction();
     expect(graph.findingNodes.length).toBeGreaterThan(0);
     await graph.waitForTransition();
 
     const expandedViewport = graph.viewportTransform;
 
     await graph.clickFirstResourceNode();
-    await graph.chooseHideFindingsAction();
 
     expect(graph.findingNodes.length).toBe(0);
     await graph.waitFor(
@@ -383,7 +369,6 @@ describe("exploring the graph", () => {
     await graph.waitForLayoutStable(16);
 
     await graph.clickFirstResourceNode();
-    await graph.chooseShowFindingsAction();
     expect(graph.findingNodes.length).toBeGreaterThan(0);
     await graph.waitForTransition();
 
@@ -398,20 +383,7 @@ describe("exploring the graph", () => {
     expect(graph.findingNodes.length).toBeGreaterThan(0);
     expect(graph.viewportTransform).toBeTruthy();
   });
-  test("choosing View node details opens node details in a modal", async ({
-    mountWith,
-  }) => {
-    const graph = await mountWith();
-    await graph.executeQuery();
-    await graph.waitForLayoutStable(3);
-
-    await graph.clickFirstResourceNode();
-    await graph.chooseViewNodeDetailsAction();
-
-    expect(graph.hasNodeDetailsModal).toBe(true);
-  });
-
-  test("clicking a resource without findings opens node details in a modal", async ({
+  test("clicking a resource without findings does nothing", async ({
     mountWith,
   }) => {
     const graph = await mountWith();
@@ -419,30 +391,14 @@ describe("exploring the graph", () => {
     await graph.waitForLayoutStable(3);
 
     expect(graph.hasNodeDetailsModal).toBe(false);
+    expect(graph.hasNodeActionDialog).toBe(false);
+    expect(graph.findingNodes.length).toBe(0);
 
     await graph.clickFirstResourceNodeWithoutFindings();
 
-    expect(graph.hasNodeDetailsModal).toBe(true);
-  });
-
-  test("clicking a parent node in filtered view asks whether to go back or view details", async ({
-    mountWith,
-  }) => {
-    const graph = await mountWith();
-    await graph.executeQuery();
-    await graph.waitForLayoutStable(3);
-    await graph.expandAllFindings();
-    await graph.clickFirstFindingNode();
-    expect(graph.isInFilteredView).toBe(true);
-
-    await graph.clickFirstResourceNode();
-
-    expect(graph.hasNodeActionDialog).toBe(true);
-    expect(graph.containsText(/Back to full graph/i)).toBe(true);
-
-    await graph.chooseBackToFullGraphAction();
-
-    expect(graph.isInFilteredView).toBe(false);
+    expect(graph.findingNodes.length).toBe(0);
+    expect(graph.hasNodeDetailsModal).toBe(false);
+    expect(graph.hasNodeActionDialog).toBe(false);
   });
 
   test("exiting the filtered view restores the full graph", async ({

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -17,6 +17,7 @@ import { worker } from "@/__tests__/msw/worker";
 import { render } from "@/__tests__/render-browser";
 
 import { useGraphStore } from "./_hooks/use-graph-state";
+import { isFindingNode, layoutWithDagre } from "./_lib/layout";
 import AttackPathsPage from "./attack-paths-page";
 import { fixtures, type PageFixture } from "./attack-paths-page.fixtures";
 import { AttackPathPageHarness } from "./attack-paths-page.harness";
@@ -188,6 +189,47 @@ describe("running a query", () => {
     }
     expect(graph.findingNodes.length).toBe(0);
     expect(graph.resourceNodes.length).toBe(0);
+  });
+
+  test("hidden findings do not reserve layout space until expanded", async ({
+    mountWith,
+  }) => {
+    // Given - a graph whose findings are hidden in the initial tier-1 view.
+    // The initial rendered positions should match a layout computed from only
+    // visible resources/edges, not from hidden finding nodes.
+    const fixture = fixtures.typical();
+    if (!fixture.queryResult) throw new Error("Expected graph fixture data");
+
+    const visibleNodes = fixture.queryResult.nodes.filter(
+      (node) => !isFindingNode(node.labels),
+    );
+    const visibleNodeIds = new Set(visibleNodes.map((node) => node.id));
+    const visibleEdges = (fixture.queryResult.relationships ?? [])
+      .filter(
+        (edge) =>
+          visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target),
+      )
+      .map((edge) => ({
+        ...edge,
+        type: edge.label,
+      }));
+    const expectedPositions = Object.fromEntries(
+      layoutWithDagre(visibleNodes, visibleEdges).rfNodes.map((node) => [
+        node.id,
+        node.position,
+      ]),
+    );
+
+    const graph = await mountWith(fixture);
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    // Then - hidden findings do not influence initial resource coordinates.
+    for (const node of visibleNodes) {
+      expect(graph.nodePositionsById[node.id]).toEqual(
+        expectedPositions[node.id],
+      );
+    }
   });
 
   test("self-loops, cycles, long labels, unicode, and duplicate edges all render", async ({

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -487,7 +487,6 @@ describe("auto-fitting the viewport", () => {
       await graph.zoomIn();
       await graph.waitForTransition(80);
     }
-
     // Hidden findings are not measured by the initial declarative fit, so
     // their positions can sit outside the framed viewport. Expanding the
     // resources should re-fit so the user does not have to hunt for the

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -10,13 +10,32 @@
  * If you find yourself reaching for a DOM query in a test, push it into the harness.
  */
 
-import { beforeEach, describe, expect, test as base } from "vitest";
+import { beforeEach, describe, expect, test as base, vi } from "vitest";
 
 import { handlersForFixture } from "@/__tests__/msw/handlers/attack-paths";
 import { worker } from "@/__tests__/msw/worker";
 import { render } from "@/__tests__/render-browser";
 
+const { getFindingByIdMock } = vi.hoisted(() => ({
+  getFindingByIdMock: vi.fn(),
+}));
+
+vi.mock("@/actions/findings", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/actions/findings")>(
+      "@/actions/findings",
+    );
+
+  getFindingByIdMock.mockImplementation(actual.getFindingById);
+
+  return {
+    ...actual,
+    getFindingById: getFindingByIdMock,
+  };
+});
+
 import { useGraphStore } from "./_hooks/use-graph-state";
+import { getPathEdges } from "./_lib";
 import { isFindingNode, layoutWithDagre } from "./_lib/layout";
 import AttackPathsPage from "./attack-paths-page";
 import { fixtures, type PageFixture } from "./attack-paths-page.fixtures";
@@ -31,6 +50,7 @@ interface Fixtures {
 // one (selection, filtered view, expanded resources, etc.).
 beforeEach(() => {
   useGraphStore.getState().reset();
+  getFindingByIdMock.mockClear();
 });
 
 const test = base.extend<Fixtures>({
@@ -122,8 +142,9 @@ describe("running a query", () => {
 
     const edgeIds = graph.renderedEdgeIds;
     expect(edgeIds.length).toBeGreaterThan(0);
+    expect(new Set(edgeIds).size).toBe(edgeIds.length);
     for (const id of edgeIds) {
-      expect(id).toMatch(/^[\w-]+-[\w-]+$/);
+      expect(id.length).toBeGreaterThan(0);
     }
   });
 
@@ -176,18 +197,14 @@ describe("running a query", () => {
     expect(graph.resourceNodes.length).toBe(3);
   });
 
-  test("findings without a connected resource are hidden by default", async ({
+  test("findings without a connected resource stay visible in the full graph", async ({
     mountWith,
   }) => {
-    // Tier 1 view: unattached findings stay hidden until the user expands
-    // their adjacent resource — none here, so nothing renders.
     const graph = await mountWith(fixtures.findingsOnly());
-    try {
-      await graph.executeQuery();
-    } catch {
-      /* expected: nothing visible, layout never stabilizes */
-    }
-    expect(graph.findingNodes.length).toBe(0);
+    await graph.executeQuery();
+    await graph.waitForLayoutStable(3);
+
+    expect(graph.findingNodes.length).toBe(3);
     expect(graph.resourceNodes.length).toBe(0);
   });
 
@@ -444,13 +461,36 @@ describe("exploring the graph", () => {
   });
 
   test("hovering a node highlights its path edges", async ({ mountWith }) => {
-    const graph = await mountWith();
+    const fixture = fixtures.typical();
+    const graph = await mountWith(fixture);
     await graph.executeQuery();
     await graph.waitForLayoutStable(3);
 
+    const hoveredNodeId = graph.resourceNodes[0]?.getAttribute("data-id");
+    expect(hoveredNodeId).toBeTruthy();
+
+    const findingIds = new Set(
+      (fixture.queryResult?.nodes ?? [])
+        .filter((node) => isFindingNode(node.labels))
+        .map((node) => node.id),
+    );
+    const visibleEdges = (fixture.queryResult?.relationships ?? [])
+      .filter(
+        (edge) => !findingIds.has(edge.source) && !findingIds.has(edge.target),
+      )
+      .map((edge) => ({ sourceId: edge.source, targetId: edge.target }));
+    const expectedPathKeys = getPathEdges(hoveredNodeId ?? "", visibleEdges);
+    const expectedHighlightedIds = (fixture.queryResult?.relationships ?? [])
+      .filter((edge) => expectedPathKeys.has(`${edge.source}-${edge.target}`))
+      .map((edge) => edge.id)
+      .sort();
+
     await graph.hoverFirstResourceNode();
     await graph.waitForTransition(120);
-    expect(graph.highlightedEdges.length).toBeGreaterThanOrEqual(0);
+
+    expect(
+      graph.highlightedEdges.map((edge) => edge.dataset.id ?? "").sort(),
+    ).toEqual(expectedHighlightedIds);
 
     await graph.unhoverNodes();
     await graph.waitForTransition(120);
@@ -489,7 +529,9 @@ describe("exploring the graph", () => {
     await graph.expandAllFindings();
 
     await graph.rapidlyClickFirstFindingNode(2);
+
     expect(graph.isInFilteredView).toBe(true);
+    expect(getFindingByIdMock).toHaveBeenCalledTimes(1);
   });
 
   test("double-clicking a node doesn't break state", async ({ mountWith }) => {

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.browser.test.tsx
@@ -271,7 +271,6 @@ describe("exploring the graph", () => {
       2000,
     );
   });
-
   test("expanded resources offer Hide findings in the action selector", async ({
     mountWith,
   }) => {
@@ -340,7 +339,6 @@ describe("exploring the graph", () => {
     expect(graph.findingNodes.length).toBeGreaterThan(0);
     expect(graph.viewportTransform).toBeTruthy();
   });
-
   test("choosing View node details opens node details in a modal", async ({
     mountWith,
   }) => {

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.browser.test.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.browser.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fixtures } from "./attack-paths-page.fixtures";
+import { AttackPathPageHarness } from "./attack-paths-page.harness";
+
+describe("AttackPathPageHarness", () => {
+  it("should fail graph node clicks when browser pointer interaction fails", async () => {
+    // Given - A rendered graph node whose pointer interaction fails
+    const harness = new AttackPathPageHarness(fixtures.typical());
+    const node = document.createElement("div");
+    node.className = "react-flow__node react-flow__node-resource";
+    node.setAttribute("data-id", "ec2-1");
+    document.body.append(node);
+
+    const pointerError = new Error("pointer intercepted");
+    const clickSpy = vi
+      .spyOn(harness.user, "click")
+      .mockRejectedValue(pointerError);
+    const domClickSpy = vi.spyOn(node, "click");
+
+    // When / Then
+    await expect(harness.clickNode("ec2-1")).rejects.toThrow(
+      "pointer intercepted",
+    );
+    expect(clickSpy).toHaveBeenCalledWith(node);
+    expect(domClickSpy).not.toHaveBeenCalled();
+  });
+
+  it("should dispatch rapid finding clicks synchronously for race tests", async () => {
+    // Given - A rendered finding node and a harness rapid-click helper
+    const harness = new AttackPathPageHarness(fixtures.typical());
+    const finding = document.createElement("button");
+    finding.className = "react-flow__node react-flow__node-finding";
+    finding.setAttribute("data-id", "f-1");
+    document.body.append(finding);
+
+    const userClickSpy = vi.spyOn(harness.user, "click");
+    const domClickSpy = vi.spyOn(finding, "click");
+    vi.spyOn(harness, "waitForTransition").mockResolvedValue();
+
+    // When
+    await harness.rapidlyClickFirstFindingNode(2);
+
+    // Then
+    expect(userClickSpy).not.toHaveBeenCalled();
+    expect(domClickSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -539,9 +539,6 @@ export class AttackPathPageHarness {
       if (el) {
         await this.user.click(el);
         await this.waitForTransition(50);
-        if (this.hasNodeActionDialog) {
-          await this.chooseShowFindingsAction();
-        }
       }
     }
   }
@@ -585,51 +582,6 @@ export class AttackPathPageHarness {
     const btn = this.toolbar.fitButton;
     if (!btn) throw new Error("fit: toolbar not rendered");
     await this.user.click(btn);
-  }
-
-  async closeNodeDetailsModal(): Promise<void> {
-    const btn = this.q('button[aria-label="Close node details"]');
-    if (!btn) throw new Error("closeNodeDetailsModal: modal not rendered");
-    await this.user.click(btn);
-    await this.waitForTransition();
-  }
-
-  async chooseShowFindingsAction(): Promise<void> {
-    const button = Array.from(
-      document.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((btn) => /show findings/i.test(btn.textContent ?? ""));
-    if (!button) throw new Error("chooseShowFindingsAction: button not found");
-    await this.clickElement(button);
-    await this.waitForTransition();
-  }
-
-  async chooseHideFindingsAction(): Promise<void> {
-    const button = Array.from(
-      document.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((btn) => /hide findings/i.test(btn.textContent ?? ""));
-    if (!button) throw new Error("chooseHideFindingsAction: button not found");
-    await this.clickElement(button);
-    await this.waitForTransition();
-  }
-
-  async chooseViewNodeDetailsAction(): Promise<void> {
-    const button = Array.from(
-      document.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((btn) => /view node details/i.test(btn.textContent ?? ""));
-    if (!button)
-      throw new Error("chooseViewNodeDetailsAction: button not found");
-    await this.clickElement(button);
-    await this.waitForTransition();
-  }
-
-  async chooseBackToFullGraphAction(): Promise<void> {
-    const button = Array.from(
-      document.querySelectorAll<HTMLButtonElement>("button"),
-    ).find((btn) => /back to full graph/i.test(btn.textContent ?? ""));
-    if (!button)
-      throw new Error("chooseBackToFullGraphAction: button not found");
-    await this.clickElement(button);
-    await this.waitForTransition();
   }
 
   async exitFilteredView(): Promise<void> {

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -427,6 +427,33 @@ export class AttackPathPageHarness {
     return resource;
   }
 
+  async clickFirstResourceNodeWithoutFindings(): Promise<HTMLElement> {
+    const findingIds = new Set(
+      (this.fixture.queryResult?.nodes ?? [])
+        .filter((n) =>
+          n.labels.some((l) => l.toLowerCase().includes("finding")),
+        )
+        .map((n) => n.id),
+    );
+    const resourceWithFindingIds = new Set<string>();
+    for (const rel of this.fixture.queryResult?.relationships ?? []) {
+      if (findingIds.has(rel.source)) resourceWithFindingIds.add(rel.target);
+      if (findingIds.has(rel.target)) resourceWithFindingIds.add(rel.source);
+    }
+    const resource = this.resourceNodes.find((node) => {
+      const id = node.getAttribute("data-id");
+      return id && !resourceWithFindingIds.has(id);
+    });
+    if (!resource) {
+      throw new Error(
+        "clickFirstResourceNodeWithoutFindings: no resource without findings rendered",
+      );
+    }
+    await this.user.click(resource);
+    await this.waitForTransition();
+    return resource;
+  }
+
   /**
    * Click the first finding `times` times back-to-back, with no transition
    * waits between clicks. Used for rapid-click race tests.

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -311,13 +311,21 @@ export class AttackPathPageHarness {
 
   // --- Action methods ---
 
+  private async clickElement(
+    element: HTMLElement,
+    options?: { fallbackToDomClick?: boolean },
+  ): Promise<void> {
+    try {
+      await this.user.click(element);
+    } catch (error) {
+      if (!options?.fallbackToDomClick) throw error;
+      element.click();
+    }
+  }
+
   private async clickGraphElement(element: HTMLElement): Promise<void> {
     await this.closeFindingDrawerIfOpen();
-    // React Flow nodes can be visually reachable while the surrounding scroll
-    // container or overlay intercepts browser-mode pointer events in large
-    // graphs. Use a bubbling DOM click so the component's onClick path is still
-    // exercised without depending on viewport scroll physics.
-    element.click();
+    await this.user.click(element);
   }
 
   async closeFindingDrawerIfOpen(): Promise<void> {
@@ -336,7 +344,7 @@ export class AttackPathPageHarness {
     ).find((button) => /^close$/i.test(button.textContent?.trim() ?? ""));
 
     if (closeButton) {
-      closeButton.click();
+      await this.clickElement(closeButton);
       await this.waitForTransition();
     }
   }
@@ -471,13 +479,16 @@ export class AttackPathPageHarness {
   }
 
   /**
-   * Click the first finding `times` times back-to-back, with no transition
-   * waits between clicks. Used for rapid-click race tests.
+   * Dispatch same-tick clicks against the first finding node. This models the
+   * duplicate-click race before the drawer overlay can intercept later pointer
+   * actions, so it intentionally uses native DOM clicks instead of awaited
+   * user-event pointer interactions.
    */
   async rapidlyClickFirstFindingNode(times = 2): Promise<HTMLElement> {
     const [finding] = this.findingNodes;
     if (!finding)
       throw new Error("rapidlyClickFirstFindingNode: no finding rendered");
+    await this.closeFindingDrawerIfOpen();
     for (let i = 0; i < times; i++) {
       finding.click();
     }
@@ -588,7 +599,7 @@ export class AttackPathPageHarness {
       document.querySelectorAll<HTMLButtonElement>("button"),
     ).find((btn) => /show findings/i.test(btn.textContent ?? ""));
     if (!button) throw new Error("chooseShowFindingsAction: button not found");
-    button.click();
+    await this.clickElement(button);
     await this.waitForTransition();
   }
 
@@ -597,7 +608,7 @@ export class AttackPathPageHarness {
       document.querySelectorAll<HTMLButtonElement>("button"),
     ).find((btn) => /hide findings/i.test(btn.textContent ?? ""));
     if (!button) throw new Error("chooseHideFindingsAction: button not found");
-    button.click();
+    await this.clickElement(button);
     await this.waitForTransition();
   }
 
@@ -607,7 +618,7 @@ export class AttackPathPageHarness {
     ).find((btn) => /view node details/i.test(btn.textContent ?? ""));
     if (!button)
       throw new Error("chooseViewNodeDetailsAction: button not found");
-    button.click();
+    await this.clickElement(button);
     await this.waitForTransition();
   }
 
@@ -617,7 +628,7 @@ export class AttackPathPageHarness {
     ).find((btn) => /back to full graph/i.test(btn.textContent ?? ""));
     if (!button)
       throw new Error("chooseBackToFullGraphAction: button not found");
-    button.click();
+    await this.clickElement(button);
     await this.waitForTransition();
   }
 
@@ -626,7 +637,7 @@ export class AttackPathPageHarness {
 
     const btn = this.toolbar.backToFullViewButton;
     if (!btn) throw new Error("exitFilteredView: not in filtered view");
-    btn.click();
+    await this.clickElement(btn);
     await this.waitForTransition();
   }
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.harness.ts
@@ -112,6 +112,22 @@ export class AttackPathPageHarness {
     });
   }
 
+  get nodePositionsById(): Record<string, { x: number; y: number }> {
+    return Object.fromEntries(
+      this.nodes.map((el) => {
+        const id = el.getAttribute("data-id") ?? "";
+        const match = /translate\(\s*([-\d.]+)px?\s*,\s*([-\d.]+)px?\s*\)/.exec(
+          el.style.transform,
+        );
+
+        return [
+          id,
+          match ? { x: Number(match[1]), y: Number(match[2]) } : { x: 0, y: 0 },
+        ];
+      }),
+    );
+  }
+
   // --- Predicates ---
 
   get isInFilteredView(): boolean {

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
@@ -31,7 +31,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/shadcn/dialog";
-import { Modal } from "@/components/shadcn/modal/modal";
 import { useToast } from "@/components/ui";
 import type {
   AttackPathQuery,
@@ -47,7 +46,6 @@ import {
   GraphControls,
   GraphLegend,
   GraphLoading,
-  NodeDetailPanel as NodeDetailDrawer,
   QueryDescription,
   QueryExecutionError,
   QueryParametersForm,
@@ -58,29 +56,6 @@ import type { GraphHandle } from "./_components/graph/attack-path-graph";
 import { useGraphState } from "./_hooks/use-graph-state";
 import { useQueryBuilder } from "./_hooks/use-query-builder";
 import { exportGraphAsPNG } from "./_lib";
-
-const NODE_ACTION_CONTEXT = {
-  RESOURCE_FINDINGS: "resource-findings",
-  FILTERED_PARENT: "filtered-parent",
-} as const;
-
-type NodeActionContext =
-  (typeof NODE_ACTION_CONTEXT)[keyof typeof NODE_ACTION_CONTEXT];
-
-interface NodeActionBase {
-  node: GraphNode;
-  context: NodeActionContext;
-}
-
-interface ResourceFindingsNodeAction extends NodeActionBase {
-  context: typeof NODE_ACTION_CONTEXT.RESOURCE_FINDINGS;
-}
-
-interface FilteredParentNodeAction extends NodeActionBase {
-  context: typeof NODE_ACTION_CONTEXT.FILTERED_PARENT;
-}
-
-type NodeActionState = ResourceFindingsNodeAction | FilteredParentNodeAction;
 
 /**
  * Attack Paths
@@ -98,7 +73,6 @@ export default function AttackPathsPage() {
   const [queriesLoading, setQueriesLoading] = useState(true);
   const [queriesError, setQueriesError] = useState<string | null>(null);
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false);
-  const [nodeAction, setNodeAction] = useState<NodeActionState | null>(null);
   const graphRef = useRef<GraphHandle>(null);
   const fullscreenGraphRef = useRef<GraphHandle>(null);
   const findingNavigationInFlightRef = useRef(false);
@@ -334,11 +308,6 @@ export default function AttackPathsPage() {
       return;
     }
 
-    if (graphState.isFilteredView) {
-      setNodeAction({ node, context: NODE_ACTION_CONTEXT.FILTERED_PARENT });
-      return;
-    }
-
     const sourceData = graphState.fullData || graphState.data;
     const hasFindings = sourceData?.edges?.some((edge) => {
       if (edge.source !== node.id && edge.target !== node.id) return false;
@@ -350,39 +319,12 @@ export default function AttackPathsPage() {
     });
 
     if (hasFindings) {
-      setNodeAction({ node, context: NODE_ACTION_CONTEXT.RESOURCE_FINDINGS });
-      return;
+      graphState.toggleExpandedResource(node.id);
     }
-
-    finding.resetFindingDetails();
-    graphState.selectNode(node.id);
   };
 
   const handleBackToFullView = () => {
     graphState.exitFilteredView();
-  };
-
-  const handleCloseDetails = () => {
-    graphState.selectNode(null);
-  };
-
-  const handleShowNodeFindings = () => {
-    if (!nodeAction) return;
-    graphState.toggleExpandedResource(nodeAction.node.id);
-    setNodeAction(null);
-  };
-
-  const handleOpenNodeDetails = () => {
-    if (!nodeAction) return;
-    finding.resetFindingDetails();
-    graphState.selectNode(nodeAction.node.id);
-    setNodeAction(null);
-  };
-
-  const handleReturnToFullGraph = () => {
-    graphState.exitFilteredView();
-    graphState.selectNode(null);
-    setNodeAction(null);
   };
 
   const handleViewFinding = async (findingId: string) => {
@@ -394,10 +336,6 @@ export default function AttackPathsPage() {
       findingNavigationInFlightRef.current = false;
     }
   };
-
-  const actionNodeFindingsExpanded = nodeAction
-    ? graphState.expandedResources.has(nodeAction.node.id)
-    : false;
 
   const handleGraphExport = async (target: "main" | "fullscreen") => {
     const ref = target === "fullscreen" ? fullscreenGraphRef : graphRef;
@@ -586,7 +524,8 @@ export default function AttackPathsPage() {
                         </span>
                         <span className="flex-1">
                           Click a finding to focus its connected path, or click
-                          a resource to view details and reveal related findings
+                          a resource with findings to show or hide its related
+                          findings
                         </span>
                       </div>
                     )}
@@ -684,50 +623,6 @@ export default function AttackPathsPage() {
                 </>
               ) : null}
             </div>
-          )}
-
-          {/* Node Detail Drawer */}
-          {graphState.data && (
-            <NodeDetailDrawer
-              node={graphState.selectedNode}
-              allNodes={graphState.data.nodes}
-              onClose={handleCloseDetails}
-              onViewFinding={handleViewFinding}
-              viewFindingLoading={finding.findingDetailLoading}
-            />
-          )}
-
-          {nodeAction && (
-            <Modal
-              open={!!nodeAction}
-              onOpenChange={(open) => {
-                if (!open) setNodeAction(null);
-              }}
-              size="md"
-              title="Choose node action"
-              description={
-                nodeAction.context === NODE_ACTION_CONTEXT.FILTERED_PARENT
-                  ? "You're viewing a filtered path. Choose whether to return to the full graph or inspect this node."
-                  : "This node has related findings. Choose whether to reveal them in the graph or inspect the node metadata."
-              }
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-                <Button variant="outline" onClick={handleOpenNodeDetails}>
-                  View node details
-                </Button>
-                {nodeAction.context === NODE_ACTION_CONTEXT.FILTERED_PARENT ? (
-                  <Button onClick={handleReturnToFullGraph}>
-                    Back to full graph
-                  </Button>
-                ) : (
-                  <Button onClick={handleShowNodeFindings}>
-                    {actionNodeFindingsExpanded
-                      ? "Hide findings"
-                      : "Show findings"}
-                  </Button>
-                )}
-              </div>
-            </Modal>
           )}
 
           {finding.findingDetails && (

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
@@ -101,6 +101,7 @@ export default function AttackPathsPage() {
   const [nodeAction, setNodeAction] = useState<NodeActionState | null>(null);
   const graphRef = useRef<GraphHandle>(null);
   const fullscreenGraphRef = useRef<GraphHandle>(null);
+  const findingNavigationInFlightRef = useRef(false);
   const hasResetRef = useRef(false);
   const graphContainerRef = useRef<HTMLDivElement>(null);
 
@@ -317,6 +318,11 @@ export default function AttackPathsPage() {
     );
 
     if (isFinding) {
+      if (findingNavigationInFlightRef.current) {
+        return;
+      }
+
+      findingNavigationInFlightRef.current = true;
       // Findings skip the intermediate node-details modal. The finding drawer
       // is the useful destination, so open it directly from the graph click.
       graphState.enterFilteredView(node.id);
@@ -324,7 +330,7 @@ export default function AttackPathsPage() {
       // highlight it. Clear the selection right after for findings so the node
       // details modal does not open before the finding drawer.
       graphState.selectNode(null);
-      handleViewFinding(String(node.properties?.id || node.id));
+      void handleViewFinding(String(node.properties?.id || node.id));
       return;
     }
 
@@ -379,9 +385,14 @@ export default function AttackPathsPage() {
     setNodeAction(null);
   };
 
-  const handleViewFinding = (findingId: string) => {
+  const handleViewFinding = async (findingId: string) => {
     if (!findingId) return;
-    void finding.navigateToFinding(findingId);
+
+    try {
+      await finding.navigateToFinding(findingId);
+    } finally {
+      findingNavigationInFlightRef.current = false;
+    }
   };
 
   const actionNodeFindingsExpanded = nodeAction
@@ -574,8 +585,8 @@ export default function AttackPathsPage() {
                           💡
                         </span>
                         <span className="flex-1">
-                          Click on any node to filter and view its connected
-                          paths
+                          Click a finding to focus its connected path, or click
+                          a resource to view details and reveal related findings
                         </span>
                       </div>
                     )}


### PR DESCRIPTION
## 🔗 Part of Chained PRs

| Field | Value |
|-------|-------|
| **Feature Branch** | `PROWLER-1273/react-flow-migration` |
| **Main PR** | [#10686](https://github.com/prowler-cloud/prowler/pull/10686) |
| **Sub-task** | PROWLER-1273 |
| **Chain Position** | 11 of 11 |
| **Depends on** | [#11017](https://github.com/prowler-cloud/prowler/pull/11017) (PR10 — Layout highlights) 🟡 Open |

### Chain Overview

```
#10701 → #10705 → #10756 → #10800 → #10970 → #11010 → #11013 → #11014 → #11015 → #11016 → #11017 → 📍 #11020 → #10686
```

---

### Context

Final interaction-hardening slice for the Attack Paths React Flow migration chain tracked by #10686. This PR builds on #11017 and focuses on dynamic finding layout, graph correctness regressions, and a simplified click model.

---

### Description

**Changes:**
- Excludes hidden finding nodes and edges before Dagre layout so the initial graph does not reserve empty finding space.
- Reflows the graph only when findings are explicitly shown/hidden.
- Keeps only one resource's findings expanded at a time.
- Preserves parallel graph edges with unique relationship IDs.
- Keeps unattached findings visible and shares the hidden-finding rule between graph and legend.
- Makes selected node styling override finding-alert border styling.
- Simplifies graph clicks:
  - finding click opens finding details and filtered path
  - resource with findings toggles findings directly
  - resource without findings has no click action
- Narrows related unit-test workflow execution to the unit project to avoid duplicating browser tests.
- Strengthens Attack Paths unit/browser regression coverage for graph layout, legend visibility, hover highlighting, rapid finding clicks, and simplified graph interactions.

---

### Steps to review

1. Review this PR after #11017.
2. Open Attack Paths and execute a graph query.
3. Verify the initial graph is compact and does not reserve empty space for hidden findings.
4. Click a resource with findings and verify findings show directly without an intermediate action modal.
5. Click the same resource again and verify findings hide.
6. Click a resource without findings and verify no modal/details panel opens.
7. Click a finding and verify the filtered path and finding details open.
8. Verify legend entries match the currently visible graph nodes and finding sections.
9. Run focused tests if validating locally:

```bash
pnpm exec vitest run --project unit "app/(prowler)/attack-paths/(workflow)/query-builder/_hooks/use-graph-state.test.ts" "app/(prowler)/attack-paths/(workflow)/query-builder/_lib/layout.test.ts" "app/(prowler)/attack-paths/(workflow)/query-builder/_components/graph/graph-legend.test.tsx"
pnpm test:browser -- --run attack-paths-page
```

Commit hooks also passed TypeScript, ESLint, unit tests, and UI build for the latest commits.

---

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to ui/CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.