### PR TITLE
feat(azure): add aks_cluster_auto_upgrade_enabled check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `identity_storage_service_level_admins_scoped` check for OCI provider CIS 3.1 control 1.15, ensuring storage service-level administrators exclude delete permissions [(#11523)](https://github.com/prowler-cloud/prowler/pull/11523)
 - `cosmosdb_account_automatic_failover_enabled` check for Azure provider [(#11031)](https://github.com/prowler-cloud/prowler/pull/11031)
 - `cosmosdb_account_backup_policy_continuous` check for Azure provider [(#11032)](https://github.com/prowler-cloud/prowler/pull/11032)
+- `aks_cluster_auto_upgrade_enabled` check for Azure provider [(#11027)](https://github.com/prowler-cloud/prowler/pull/11027)
 - Jira timeout preventing the calls from hanging indefinitely when the Jira endpoint is unreachable or slow [(#11602)](https://github.com/prowler-cloud/prowler/pull/11602)
 - TLS certificate verification in the `codepipeline_project_repo_private` check, which previously used an unverified SSL context, leaving the repository-visibility probe open to MITM tampering [(#11603)](https://github.com/prowler-cloud/prowler/pull/11603)
 

--- a/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
+++ b/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
@@ -1,0 +1,34 @@
+{
+  "Provider": "azure",
+  "CheckID": "aks_cluster_auto_upgrade_enabled",
+  "CheckTitle": "AKS cluster has automatic upgrade channel configured",
+  "CheckType": [],
+  "ServiceName": "aks",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "container",
+  "Description": "**Azure Kubernetes Service** clusters are evaluated for **automatic upgrade** configuration. An upgrade channel ensures the cluster automatically receives Kubernetes version updates and security patches.",
+  "Risk": "Without auto-upgrade, clusters run outdated Kubernetes versions with **known CVEs**. Manual upgrades are often delayed, leaving clusters vulnerable to exploits targeting patched vulnerabilities.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "",
+      "Url": "https://hub.prowler.com/check/aks_cluster_auto_upgrade_enabled"
+    }
+  },
+  "Categories": [
+    "vulnerabilities"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
+++ b/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
@@ -7,7 +7,7 @@
   "SubServiceName": "",
   "ResourceIdTemplate": "",
   "Severity": "medium",
-  "ResourceType": "NotDefined",
+  "ResourceType": "microsoft.containerservice/managedclusters",
   "ResourceGroup": "container",
   "Description": "**Azure Kubernetes Service** clusters are evaluated for **automatic upgrade** configuration. An upgrade channel ensures the cluster automatically receives Kubernetes version updates and security patches.",
   "Risk": "Without auto-upgrade, clusters run outdated Kubernetes versions with **known CVEs**. Manual upgrades are often delayed, leaving clusters vulnerable to exploits targeting patched vulnerabilities.",

--- a/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
+++ b/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
@@ -1,7 +1,7 @@
 {
   "Provider": "azure",
   "CheckID": "aks_cluster_auto_upgrade_enabled",
-  "CheckTitle": "AKS cluster has automatic upgrade channel configured",
+  "CheckTitle": "AKS cluster has automatic upgrade enabled",
   "CheckType": [],
   "ServiceName": "aks",
   "SubServiceName": "",
@@ -9,10 +9,13 @@
   "Severity": "medium",
   "ResourceType": "microsoft.containerservice/managedclusters",
   "ResourceGroup": "container",
-  "Description": "**Azure Kubernetes Service** clusters are evaluated for **automatic upgrade** configuration. An upgrade channel ensures the cluster automatically receives Kubernetes version updates and security patches.",
-  "Risk": "Without auto-upgrade, clusters run outdated Kubernetes versions with **known CVEs**. Manual upgrades are often delayed, leaving clusters vulnerable to exploits targeting patched vulnerabilities.",
+  "Description": "**AKS clusters** are evaluated for an **automatic upgrade channel** other than `none`. Automatic upgrades keep the Kubernetes control plane and node pools on supported patch/minor versions and reduce version drift across clusters.",
+  "Risk": "Without automatic upgrades, AKS clusters can remain on unsupported or vulnerable Kubernetes versions. Delayed patching increases exposure to **known CVEs**, control plane/node defects, and exploit chains that can affect workload **confidentiality**, **integrity**, and **availability**.",
   "RelatedUrl": "",
-  "AdditionalURLs": [],
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-cluster",
+    "https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions"
+  ],
   "Remediation": {
     "Code": {
       "CLI": "az aks update --resource-group <RESOURCE_GROUP> --name <CLUSTER_NAME> --auto-upgrade-channel patch",
@@ -26,9 +29,10 @@
     }
   },
   "Categories": [
-    "vulnerabilities"
+    "vulnerabilities",
+    "cluster-security"
   ],
   "DependsOn": [],
   "RelatedTo": [],
-  "Notes": ""
+  "Notes": "Automatic upgrade channels can change cluster versions during Azure-managed upgrade windows. Select a channel that matches the workload change tolerance and use planned maintenance windows, staging validation, and documented rollback procedures for production clusters."
 }

--- a/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
+++ b/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.metadata.json
@@ -15,13 +15,13 @@
   "AdditionalURLs": [],
   "Remediation": {
     "Code": {
-      "CLI": "",
+      "CLI": "az aks update --resource-group <RESOURCE_GROUP> --name <CLUSTER_NAME> --auto-upgrade-channel patch",
       "NativeIaC": "",
       "Other": "",
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "",
+      "Text": "Configure an AKS automatic upgrade channel so clusters receive Kubernetes version updates and security patches without relying only on manual upgrade processes. Use `patch` or `stable` for conservative production upgrades, reserve faster channels such as `rapid` for environments that can absorb quicker version changes, and avoid `none` unless a documented exception and manual patching process exists.",
       "Url": "https://hub.prowler.com/check/aks_cluster_auto_upgrade_enabled"
     }
   },

--- a/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.py
+++ b/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.py
@@ -1,0 +1,29 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.aks.aks_client import aks_client
+
+
+class aks_cluster_auto_upgrade_enabled(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+
+        for subscription_name, clusters in aks_client.clusters.items():
+            for cluster in clusters.values():
+                report = Check_Report_Azure(
+                    metadata=self.metadata(), resource=cluster
+                )
+                report.subscription = subscription_name
+
+                if cluster.auto_upgrade_channel is not None:
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"Cluster '{cluster.name}' has auto-upgrade channel."
+                    )
+                else:
+                    report.status = "FAIL"
+                    report.status_extended = (
+                        f"Cluster '{cluster.name}' does not have auto-upgrade configured."
+                    )
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.py
+++ b/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.py
@@ -3,7 +3,7 @@ from prowler.providers.azure.services.aks.aks_client import aks_client
 
 
 class aks_cluster_auto_upgrade_enabled(Check):
-    def execute(self) -> Check_Report_Azure:
+    def execute(self) -> list[Check_Report_Azure]:
         findings = []
 
         for subscription_name, clusters in aks_client.clusters.items():

--- a/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.py
+++ b/prowler/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled.py
@@ -8,21 +8,20 @@ class aks_cluster_auto_upgrade_enabled(Check):
 
         for subscription_name, clusters in aks_client.clusters.items():
             for cluster in clusters.values():
-                report = Check_Report_Azure(
-                    metadata=self.metadata(), resource=cluster
-                )
+                report = Check_Report_Azure(metadata=self.metadata(), resource=cluster)
                 report.subscription = subscription_name
 
-                if cluster.auto_upgrade_channel is not None:
+                auto_upgrade_channel = (
+                    (cluster.auto_upgrade_channel or "").strip().lower()
+                )
+                if auto_upgrade_channel and auto_upgrade_channel != "none":
                     report.status = "PASS"
                     report.status_extended = (
                         f"Cluster '{cluster.name}' has auto-upgrade channel."
                     )
                 else:
                     report.status = "FAIL"
-                    report.status_extended = (
-                        f"Cluster '{cluster.name}' does not have auto-upgrade configured."
-                    )
+                    report.status_extended = f"Cluster '{cluster.name}' does not have auto-upgrade configured."
 
                 findings.append(report)
 

--- a/prowler/providers/azure/services/aks/aks_service.py
+++ b/prowler/providers/azure/services/aks/aks_service.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from azure.mgmt.containerservice import ContainerServiceClient
 
@@ -55,6 +55,42 @@ class AKS(AzureService):
                                         )
                                     ],
                                     rbac_enabled=getattr(cluster, "enable_rbac", False),
+                                    auto_upgrade_channel=getattr(
+                                        getattr(cluster, "auto_upgrade_profile", None),
+                                        "upgrade_channel",
+                                        None,
+                                    ),
+                                    defender_enabled=bool(
+                                        getattr(
+                                            getattr(
+                                                getattr(
+                                                    getattr(cluster, "security_profile", None),
+                                                    "defender",
+                                                    None,
+                                                ),
+                                                "security_monitoring",
+                                                None,
+                                            ),
+                                            "enabled",
+                                            False,
+                                        )
+                                    ),
+                                    azure_monitor_enabled=bool(
+                                        getattr(
+                                            getattr(
+                                                getattr(cluster, "azure_monitor_profile", None),
+                                                "metrics",
+                                                None,
+                                            ),
+                                            "enabled",
+                                            False,
+                                        )
+                                    )
+                                    if getattr(cluster, "azure_monitor_profile", None)
+                                    else False,
+                                    local_accounts_disabled=getattr(
+                                        cluster, "disable_local_accounts", False
+                                    ),
                                 )
                             }
                         )
@@ -82,3 +118,7 @@ class Cluster:
     agent_pool_profiles: List[ManagedClusterAgentPoolProfile]
     rbac_enabled: bool
     location: str
+    auto_upgrade_channel: Optional[str] = None
+    defender_enabled: bool = False
+    azure_monitor_enabled: bool = False
+    local_accounts_disabled: bool = False

--- a/prowler/providers/azure/services/aks/aks_service.py
+++ b/prowler/providers/azure/services/aks/aks_service.py
@@ -64,7 +64,11 @@ class AKS(AzureService):
                                         getattr(
                                             getattr(
                                                 getattr(
-                                                    getattr(cluster, "security_profile", None),
+                                                    getattr(
+                                                        cluster,
+                                                        "security_profile",
+                                                        None,
+                                                    ),
                                                     "defender",
                                                     None,
                                                 ),
@@ -75,19 +79,27 @@ class AKS(AzureService):
                                             False,
                                         )
                                     ),
-                                    azure_monitor_enabled=bool(
-                                        getattr(
+                                    azure_monitor_enabled=(
+                                        bool(
                                             getattr(
-                                                getattr(cluster, "azure_monitor_profile", None),
-                                                "metrics",
-                                                None,
-                                            ),
-                                            "enabled",
-                                            False,
+                                                getattr(
+                                                    getattr(
+                                                        cluster,
+                                                        "azure_monitor_profile",
+                                                        None,
+                                                    ),
+                                                    "metrics",
+                                                    None,
+                                                ),
+                                                "enabled",
+                                                False,
+                                            )
                                         )
-                                    )
-                                    if getattr(cluster, "azure_monitor_profile", None)
-                                    else False,
+                                        if getattr(
+                                            cluster, "azure_monitor_profile", None
+                                        )
+                                        else False
+                                    ),
                                     local_accounts_disabled=getattr(
                                         cluster, "disable_local_accounts", False
                                     ),

--- a/prowler/providers/azure/services/aks/aks_service.py
+++ b/prowler/providers/azure/services/aks/aks_service.py
@@ -100,8 +100,10 @@ class AKS(AzureService):
                                         )
                                         else False
                                     ),
-                                    local_accounts_disabled=getattr(
-                                        cluster, "disable_local_accounts", False
+                                    local_accounts_disabled=bool(
+                                        getattr(
+                                            cluster, "disable_local_accounts", False
+                                        )
                                     ),
                                 )
                             }

--- a/tests/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled_test.py
+++ b/tests/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled_test.py
@@ -1,0 +1,83 @@
+from unittest import mock
+
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_ID,
+    set_mocked_azure_provider,
+)
+
+
+class Test_aks_cluster_auto_upgrade_enabled:
+    def test_no_subscriptions(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled.aks_client",
+                new=aks_client,
+            ),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled import (
+                aks_cluster_auto_upgrade_enabled,
+            )
+
+            aks_client.clusters = {}
+
+            check = aks_cluster_auto_upgrade_enabled()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_pass(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled.aks_client",
+                new=aks_client,
+            ),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled import (
+                aks_cluster_auto_upgrade_enabled,
+            )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            cluster = Cluster(id="/sub/rg/cluster1", name="test-cluster", public_fqdn="test.azmk8s.io", private_fqdn=None, network_policy=None, agent_pool_profiles=[], rbac_enabled=True, location="eastus", auto_upgrade_channel="stable")
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+
+            check = aks_cluster_auto_upgrade_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+
+    def test_fail(self):
+        aks_client = mock.MagicMock
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled.aks_client",
+                new=aks_client,
+            ),
+        ):
+            from prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled import (
+                aks_cluster_auto_upgrade_enabled,
+            )
+            from prowler.providers.azure.services.aks.aks_service import Cluster
+
+            cluster = Cluster(id="/sub/rg/cluster1", name="test-cluster", public_fqdn="test.azmk8s.io", private_fqdn=None, network_policy=None, agent_pool_profiles=[], rbac_enabled=True, location="eastus", auto_upgrade_channel=None)
+            aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
+
+            check = aks_cluster_auto_upgrade_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"

--- a/tests/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled_test.py
+++ b/tests/providers/azure/services/aks/aks_cluster_auto_upgrade_enabled/aks_cluster_auto_upgrade_enabled_test.py
@@ -1,9 +1,26 @@
 from unittest import mock
 
+import pytest
+
+from prowler.providers.azure.services.aks.aks_service import Cluster
 from tests.providers.azure.azure_fixtures import (
     AZURE_SUBSCRIPTION_ID,
     set_mocked_azure_provider,
 )
+
+
+def build_cluster(auto_upgrade_channel):
+    return Cluster(
+        id="/sub/rg/cluster1",
+        name="test-cluster",
+        public_fqdn="test.azmk8s.io",
+        private_fqdn=None,
+        network_policy=None,
+        agent_pool_profiles=[],
+        rbac_enabled=True,
+        location="eastus",
+        auto_upgrade_channel=auto_upgrade_channel,
+    )
 
 
 class Test_aks_cluster_auto_upgrade_enabled:
@@ -46,9 +63,8 @@ class Test_aks_cluster_auto_upgrade_enabled:
             from prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled import (
                 aks_cluster_auto_upgrade_enabled,
             )
-            from prowler.providers.azure.services.aks.aks_service import Cluster
 
-            cluster = Cluster(id="/sub/rg/cluster1", name="test-cluster", public_fqdn="test.azmk8s.io", private_fqdn=None, network_policy=None, agent_pool_profiles=[], rbac_enabled=True, location="eastus", auto_upgrade_channel="stable")
+            cluster = build_cluster(auto_upgrade_channel="stable")
             aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
 
             check = aks_cluster_auto_upgrade_enabled()
@@ -56,7 +72,8 @@ class Test_aks_cluster_auto_upgrade_enabled:
             assert len(result) == 1
             assert result[0].status == "PASS"
 
-    def test_fail(self):
+    @pytest.mark.parametrize("auto_upgrade_channel", [None, "", "none", "None"])
+    def test_fail(self, auto_upgrade_channel):
         aks_client = mock.MagicMock
 
         with (
@@ -72,9 +89,8 @@ class Test_aks_cluster_auto_upgrade_enabled:
             from prowler.providers.azure.services.aks.aks_cluster_auto_upgrade_enabled.aks_cluster_auto_upgrade_enabled import (
                 aks_cluster_auto_upgrade_enabled,
             )
-            from prowler.providers.azure.services.aks.aks_service import Cluster
 
-            cluster = Cluster(id="/sub/rg/cluster1", name="test-cluster", public_fqdn="test.azmk8s.io", private_fqdn=None, network_policy=None, agent_pool_profiles=[], rbac_enabled=True, location="eastus", auto_upgrade_channel=None)
+            cluster = build_cluster(auto_upgrade_channel=auto_upgrade_channel)
             aks_client.clusters = {AZURE_SUBSCRIPTION_ID: {cluster.id: cluster}}
 
             check = aks_cluster_auto_upgrade_enabled()


### PR DESCRIPTION
## Summary

Adds a check that verifies AKS clusters have an auto-upgrade channel configured. Clusters without auto-upgrade drift on unpatched Kubernetes versions and miss CVE patches, increasing exposure to known vulnerabilities.

## What's added

- New check: `aks_cluster_auto_upgrade_enabled` — FAIL when `auto_upgrade_channel` is None or empty
- AKS service-layer additions (`auto_upgrade_channel`, `defender_enabled`, `azure_monitor_enabled`, `local_accounts_disabled`) shared across the AKS check group

## Context

Split from #10809 per @jfagoagas's review request to submit one PR per check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Azure AKS security check to report whether cluster auto-upgrade is enabled (passes when set to an active channel; fails when unset, empty, or set to “none”).
* **Tests**
  * Added unit tests covering: no clusters present, auto-upgrade enabled, and auto-upgrade disabled/“none” cases.
* **Documentation**
  * Updated the changelog to include the new AKS auto-upgrade check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->