### PR TITLE
feat(azure): add recovery_vault_backup_policy_retention_adequate check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `acmpca_certificate_authority_pqc_key_algorithm` check and new `acmpca` service for AWS provider to verify AWS Private CA certificate authorities use a post-quantum (ML-DSA) key algorithm [(#11318)](https://github.com/prowler-cloud/prowler/pull/11318)
 - `rolesanywhere_trust_anchor_pqc_pki` check and new `rolesanywhere` service for AWS provider to verify IAM Roles Anywhere trust anchors are backed by a post-quantum (ML-DSA) PKI [(#11319)](https://github.com/prowler-cloud/prowler/pull/11319)
 - Kubernetes core checks for container CPU limits, CPU requests, memory limits, memory requests, fixed image tags, liveness probes, and readiness probes [(#11373)](https://github.com/prowler-cloud/prowler/pull/11373)
+- `recovery_vault_backup_policy_retention_adequate` check for Azure provider, verifying Recovery Services backup policies retain daily backups for at least 30 days [(#11047)](https://github.com/prowler-cloud/prowler/pull/11047)
 
 ### 🔄 Changed
 

--- a/prowler/compliance/azure/hipaa_azure.json
+++ b/prowler/compliance/azure/hipaa_azure.json
@@ -430,6 +430,7 @@
         }
       ],
       "Checks": [
+        "recovery_vault_backup_policy_retention_adequate",
         "vm_backup_enabled",
         "vm_sufficient_daily_backup_retention_period",
         "storage_blob_versioning_is_enabled",

--- a/prowler/compliance/azure/iso27001_2022_azure.json
+++ b/prowler/compliance/azure/iso27001_2022_azure.json
@@ -1271,7 +1271,8 @@
       "Checks": [
         "cosmosdb_account_backup_policy_continuous",
         "mysql_flexible_server_geo_redundant_backup_enabled",
-        "postgresql_flexible_server_geo_redundant_backup_enabled"
+        "postgresql_flexible_server_geo_redundant_backup_enabled",
+        "recovery_vault_backup_policy_retention_adequate"
       ]
     },
     {

--- a/prowler/providers/azure/services/recovery/recovery_service.py
+++ b/prowler/providers/azure/services/recovery/recovery_service.py
@@ -52,6 +52,7 @@ class Recovery(AzureService):
         """
         logger.info("Recovery - Getting Recovery Services vaults...")
         vaults_dict: dict[str, dict[str, BackupVault]] = {}
+        subscription_id = "unknown"
         try:
             vaults_dict: dict[str, dict[str, BackupVault]] = {}
             for subscription_id, client in self.clients.items():
@@ -74,6 +75,13 @@ class Recovery(AzureService):
 
 
 class RecoveryBackup(AzureService):
+    """
+    Service wrapper for Azure Recovery Services backup data.
+
+    Collects the backup protected items and backup policies for each Recovery
+    Services vault discovered by the Recovery service.
+    """
+
     def __init__(
         self,
         provider: AzureProvider,

--- a/prowler/providers/azure/services/recovery/recovery_service.py
+++ b/prowler/providers/azure/services/recovery/recovery_service.py
@@ -66,21 +66,26 @@ class Recovery(AzureService):
                     vaults_dict[subscription_id][vault_obj.id] = vault_obj
         except Exception as error:
             logger.error(
-                f"Subscription ID: {subscription_id} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"Subscription ID: {subscription_id} -- "
+                f"{error.__class__.__name__}"
+                f"[{error.__traceback__.tb_lineno}]: {error}"
             )
         return vaults_dict
 
 
 class RecoveryBackup(AzureService):
     def __init__(
-        self, provider: AzureProvider, vaults: dict[str, dict[str, BackupVault]]
+        self,
+        provider: AzureProvider,
+        vaults: dict[str, dict[str, BackupVault]],
     ):
         super().__init__(RecoveryServicesBackupClient, provider)
         for subscription_id, vaults in vaults.items():
             for vault in vaults.values():
-                vault.backup_protected_items = self._get_backup_protected_items(
+                protected_items = self._get_backup_protected_items(
                     subscription_id=subscription_id, vault=vault
                 )
+                vault.backup_protected_items = protected_items
                 vault.backup_policies = self._get_backup_policies(
                     subscription_id=subscription_id, vault=vault
                 )
@@ -102,19 +107,22 @@ class RecoveryBackup(AzureService):
             )
             for item in backup_protected_items:
                 item_properties = getattr(item, "properties", None)
+                workload_type = None
+                backup_policy_id = None
+                if item_properties:
+                    workload_type = item_properties.workload_type
+                    backup_policy_id = item_properties.policy_id
                 backup_protected_items_dict[item.id] = BackupItem(
                     id=item.id,
                     name=item.name,
-                    workload_type=(
-                        item_properties.workload_type if item_properties else None
-                    ),
-                    backup_policy_id=(
-                        item_properties.policy_id if item_properties else None
-                    ),
+                    workload_type=workload_type,
+                    backup_policy_id=backup_policy_id,
                 )
         except Exception as error:
             logger.error(
-                f"Subscription ID: {subscription_id} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"Subscription ID: {subscription_id} -- "
+                f"{error.__class__.__name__}"
+                f"[{error.__traceback__.tb_lineno}]: {error}"
             )
         return backup_protected_items_dict
 
@@ -126,40 +134,44 @@ class RecoveryBackup(AzureService):
         """
         logger.info("Recovery - Getting backup policies...")
         backup_policies_dict: dict[str, BackupPolicy] = {}
-        unique_backup_policies: set[str] = set()
         try:
-            for item in vault.backup_protected_items.values():
-                if item.backup_policy_id:
-                    unique_backup_policies.add(item.backup_policy_id)
-            for policy_id in unique_backup_policies:
-                policy = self.clients[subscription_id].protection_policies.get(
-                    vault_name=vault.name,
-                    resource_group_name=vault.id.split("/")[4],
-                    policy_name=policy_id.split("/")[-1],
-                )
-                backup_policies_dict[policy_id] = BackupPolicy(
+            client = self.clients[subscription_id]
+            backup_policies = client.backup_policies.list(
+                vault_name=vault.name,
+                resource_group_name=vault.id.split("/")[4],
+            )
+            for policy in backup_policies:
+                retention_days = self._get_backup_policy_retention_days(policy)
+                backup_policies_dict[policy.id] = BackupPolicy(
                     id=policy.id,
                     name=policy.name,
-                    retention_days=getattr(
-                        getattr(
-                            getattr(
-                                getattr(
-                                    getattr(policy, "properties", None),
-                                    "retention_policy",
-                                    None,
-                                ),
-                                "daily_schedule",
-                                None,
-                            ),
-                            "retention_duration",
-                            None,
-                        ),
-                        "count",
-                        None,
-                    ),
+                    retention_days=retention_days,
                 )
         except Exception as error:
             logger.error(
-                f"Subscription ID: {subscription_id} -- {error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+                f"Subscription ID: {subscription_id} -- "
+                f"{error.__class__.__name__}"
+                f"[{error.__traceback__.tb_lineno}]: {error}"
             )
         return backup_policies_dict
+
+    @staticmethod
+    def _get_backup_policy_retention_days(policy) -> Optional[int]:
+        """Return the daily retention duration count for a backup policy."""
+        return getattr(
+            getattr(
+                getattr(
+                    getattr(
+                        getattr(policy, "properties", None),
+                        "retention_policy",
+                        None,
+                    ),
+                    "daily_schedule",
+                    None,
+                ),
+                "retention_duration",
+                None,
+            ),
+            "count",
+            None,
+        )

--- a/tests/providers/azure/services/recovery/recovery_service_test.py
+++ b/tests/providers/azure/services/recovery/recovery_service_test.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+from unittest import mock
+
+from prowler.providers.azure.services.recovery.recovery_service import (
+    BackupVault,
+    RecoveryBackup,
+)
+from tests.providers.azure.azure_fixtures import AZURE_SUBSCRIPTION_ID
+
+VAULT_ID = (
+    f"/subscriptions/{AZURE_SUBSCRIPTION_ID}/resourceGroups/rg1/"
+    "providers/Microsoft.RecoveryServices/vaults/test-vault"
+)
+POLICY_ID = f"{VAULT_ID}/backupPolicies/ShortPolicy"
+
+
+class BackupClientFake:
+    def __init__(self, policies):
+        self.backup_policies = mock.MagicMock()
+        self.backup_policies.list.return_value = policies
+
+
+class Test_RecoveryBackup_Service:
+    def test_get_backup_policies_lists_unprotected_vault_policies(self):
+        policy = SimpleNamespace(
+            id=POLICY_ID,
+            name="ShortPolicy",
+            properties=SimpleNamespace(
+                retention_policy=SimpleNamespace(
+                    daily_schedule=SimpleNamespace(
+                        retention_duration=SimpleNamespace(count=7)
+                    )
+                )
+            ),
+        )
+        client = BackupClientFake(policies=[policy])
+        vault = BackupVault(
+            id=VAULT_ID,
+            name="test-vault",
+            location="eastus",
+            backup_protected_items={},
+        )
+        recovery_backup = object.__new__(RecoveryBackup)
+        recovery_backup.clients = {AZURE_SUBSCRIPTION_ID: client}
+
+        backup_policies = recovery_backup._get_backup_policies(
+            subscription_id=AZURE_SUBSCRIPTION_ID,
+            vault=vault,
+        )
+
+        client.backup_policies.list.assert_called_once_with(
+            vault_name="test-vault",
+            resource_group_name="rg1",
+        )
+        assert list(backup_policies) == [POLICY_ID]
+        assert backup_policies[POLICY_ID].name == "ShortPolicy"
+        assert backup_policies[POLICY_ID].retention_days == 7


### PR DESCRIPTION
## Summary

Adds a check that verifies Azure Recovery Services Vault backup policies retain backups for an adequate period (>= 30 days by default). Inadequate retention can compromise recovery from incidents detected late or from ransomware events that span weeks.

## What's added

- New check: `recovery_vault_backup_policy_retention_adequate` — FAIL when retention < 30 days
- Adds the missing `recovery/__init__.py` to make the package importable

## Context

Split from #10809 per @jfagoagas's review request to submit one PR per check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the **recovery_vault_backup_policy_retention_adequate** check for the Azure provider, validating backup retention policy adequacy.

* **Tests**
  * Added a new Azure Recovery Services test covering backup policy listing and retention duration parsing.

* **Bug Fixes**
  * Improved error diagnostics during backup vault retrieval with richer exception context.
  * Updated backup policy enumeration to use direct policy listing and enhanced retention duration extraction for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->