### PR TITLE
revert(ci): drop workflow-level paths on required-check workflows

### DIFF
--- a/.github/workflows/api-code-quality.yml
+++ b/.github/workflows/api-code-quality.yml
@@ -5,20 +5,10 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-tests.yml'
-      - '.github/workflows/api-code-quality.yml'
-      - '.github/actions/setup-python-poetry/**'
   pull_request:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-tests.yml'
-      - '.github/workflows/api-code-quality.yml'
-      - '.github/actions/setup-python-poetry/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -5,18 +5,10 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-tests.yml'
-      - '.github/actions/setup-python-poetry/**'
   pull_request:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-tests.yml'
-      - '.github/actions/setup-python-poetry/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-code-quality.yml
+++ b/.github/workflows/sdk-code-quality.yml
@@ -5,26 +5,10 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - '.github/workflows/sdk-tests.yml'
-      - '.github/workflows/sdk-code-quality.yml'
-      - '.github/actions/setup-python-poetry/**'
   pull_request:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - '.github/workflows/sdk-tests.yml'
-      - '.github/workflows/sdk-code-quality.yml'
-      - '.github/actions/setup-python-poetry/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -5,24 +5,10 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - '.github/workflows/sdk-tests.yml'
-      - '.github/actions/setup-python-poetry/**'
   pull_request:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'poetry.lock'
-      - '.github/workflows/sdk-tests.yml'
-      - '.github/actions/setup-python-poetry/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,16 +5,10 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'ui/**'
-      - '.github/workflows/ui-tests.yml'
   pull_request:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'ui/**'
-      - '.github/workflows/ui-tests.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Context

PR #11007 (commit `beea27aa0`) added workflow-level `paths:` filters to 8 workflows. Five of them have job names that are enrolled as required-status-checks on `master`: `sdk-tests (3.10/3.11/3.12)`, `sdk-code-quality (3.10/3.11/3.12)`, `ui-tests`, `api-tests (3.12)`, `api-code-quality (3.12)`. Result: any PR that doesn't touch matching paths leaves those required checks pending forever, blocking the PR.

Concrete victim today: PR #11049 (`chore(pyproject): revert API changes`) has 7 pending required checks because it only touches `api/pyproject.toml` / `api/poetry.lock`.

Same problem propagated to `prowler-cloud` via the workflow mirror, where `api-tests (3.12)` and `api-code-quality (3.12)` are also required.

### Description

Removes the `paths:` block from `push:` and `pull_request:` triggers in 5 files. Each workflow's pre-existing internal `tj-actions/changed-files` skip logic remains intact, so jobs short-circuit when their domain didn't change while still reporting the required check (as `success` or `skipped`).

Files:
- `.github/workflows/sdk-tests.yml`
- `.github/workflows/sdk-code-quality.yml`
- `.github/workflows/ui-tests.yml`
- `.github/workflows/api-tests.yml`
- `.github/workflows/api-code-quality.yml`

Workflows whose checks are NOT required (`sdk-security`, `sdk-check-duplicate-test-names`, `api-security`, four `*-container-checks`) keep their workflow-level paths — they continue to save minutes without breaking anything.

### Steps to review

- Confirm the `paths:` block is gone from both `push:` and `pull_request:` in each of the 5 files.
- Confirm `branches:` filter is intact on each trigger.
- Confirm no other content changed in the affected files.
- Confirm internal `tj-actions/changed-files` references are preserved (so jobs still short-circuit when their domain didn't change).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- [x] Workflow change affects SDK/CLI required checks (`sdk-tests`, `sdk-code-quality`).
- Are there new checks included in this PR? No

#### UI
- [x] Workflow change affects UI required check (`ui-tests`).
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] Workflow change affects API required checks (`api-tests`, `api-code-quality`).
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.