### PR TITLE
fix: PR number in changelog entry for #10529

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### 🐞 Fixed
 
-- Oracle cloud identity scans now scan known or supplied regions to better support non ashburn tenancies [(#10528)](https://github.com/prowler-cloud/prowler/pull/10529)
+- Oracle cloud identity scans now scan known or supplied regions to better support non ashburn tenancies [(#10529)](https://github.com/prowler-cloud/prowler/pull/10529)
 
 ---
 


### PR DESCRIPTION
### Context

The changelog entry for the Oracle cloud identity scan fix in `prowler/CHANGELOG.md` shows `(#10528)` as the visible label while the link itself targets PR #10529. This corrects the displayed number so it matches the actual PR.

### Description

Single-character change in `prowler/CHANGELOG.md`: the visible label `(#10528)` is updated to `(#10529)` so it agrees with the URL that already points to PR #10529.

### Steps to review

1. Open `prowler/CHANGELOG.md`.
2. Confirm the Oracle cloud identity entry now reads ``[(#10529)](https://github.com/prowler-cloud/prowler/pull/10529)``.

### Checklist

- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.
- [ ] Review if the code is being covered by tests. _(N/A — docs-only change)_
- [ ] Review if code is being documented. _(N/A — docs-only change)_
- [ ] Review if backport is needed. _(N/A — typo fix in unreleased section)_
- [ ] Review if is needed to change the Readme.md. _(N/A)_

#### SDK/CLI
- Are there new checks included in this PR? **No**

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.