### PR TITLE
chore: remove pre-push from default install hook types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 #   P40 — security scanners
 #   P50 — dependency validation
 
-default_install_hook_types: [pre-commit, pre-push]
+default_install_hook_types: [pre-commit]
 
 repos:
   ## GENERAL (prek built-in — no external repo needed)
@@ -62,12 +62,7 @@ repos:
       - id: autoflake
         name: "SDK - autoflake"
         files: { glob: ["{prowler,tests,dashboard,util,scripts}/**/*.py"] }
-        args:
-          [
-            "--in-place",
-            "--remove-all-unused-imports",
-            "--remove-unused-variable",
-          ]
+        args: ["--in-place", "--remove-all-unused-imports", "--remove-unused-variable"]
         priority: 20
 
   - repo: https://github.com/pycqa/isort
@@ -179,8 +174,7 @@ repos:
         language: system
         types: [python]
         files: '.*\.py'
-        exclude:
-          { glob: ["{contrib,skills}/**", "**/.venv/**", "**/*_test.py"] }
+        exclude: { glob: ["{contrib,skills}/**", "**/.venv/**", "**/*_test.py"] }
         priority: 40
 
       - id: safety
@@ -190,16 +184,7 @@ repos:
         entry: safety check --policy-file .safety-policy.yml
         language: system
         pass_filenames: false
-        files:
-          {
-            glob:
-              [
-                "**/pyproject.toml",
-                "**/poetry.lock",
-                "**/requirements*.txt",
-                ".safety-policy.yml",
-              ],
-          }
+        files: { glob: ["**/pyproject.toml", "**/poetry.lock", "**/requirements*.txt", ".safety-policy.yml"] }
         priority: 40
 
       - id: vulture

--- a/docs/developer-guide/introduction.mdx
+++ b/docs/developer-guide/introduction.mdx
@@ -134,6 +134,22 @@ prek installed at `.git/hooks/pre-commit`
 If pre-commit hooks were previously installed, run `prek install --overwrite` to replace the existing hook. Otherwise, both tools will run on each commit.
 </Warning>
 
+#### Enable TruffleHog as a Pre-Push Hook
+
+By default, only `pre-commit` hooks are installed. To enable [`TruffleHog`](https://github.com/trufflesecurity/trufflehog) secret scanning on every push, install the `pre-push` hook type explicitly:
+
+```shell
+prek install --hook-type pre-push
+```
+
+Successful installation should produce the following output:
+
+```shell
+prek installed at `.git/hooks/pre-push`
+```
+
+Once installed, TruffleHog runs before each push and blocks the operation when verified secrets are detected.
+
 ### Code Quality and Security Checks
 
 Before merging pull requests, several automated checks and utilities ensure code security and updated dependencies:


### PR DESCRIPTION
### Context

Pre-push hooks were running every push, slowing down the developer workflow even for routine pushes. The only check we still want enforced before pushing is secret detection (`trufflehog`); everything else (formatters, linters, security scanners) already runs at `pre-commit` time.

### Description

- Drop `pre-push` from `default_install_hook_types` so `prek install` only registers `pre-commit` hooks by default.
- Keep `trufflehog` declared with `stages: ["pre-commit", "pre-push"]` so it remains available when developers opt in to the `pre-push` hook type (`prek install --hook-type pre-push`).
- Minor formatting cleanup: collapse a few multi-line `args` / `files` mappings onto single lines for readability.
- Update `docs/developer-guide/introduction.mdx` with a new **Enable TruffleHog as a Pre-Push Hook** subsection documenting the opt-in `prek install --hook-type pre-push` workflow.

No runtime behavior of Prowler changes — this only affects local developer tooling.

### Steps to review

1. Inspect the diff in `.pre-commit-config.yaml` and `docs/developer-guide/introduction.mdx`.
2. Reinstall hooks locally:
   ```bash
   poetry run prek install
   ```
3. Confirm only `pre-commit` is installed:
   ```bash
   ls -la .git/hooks/ | grep -E 'pre-(commit|push)'
   ```
4. Optionally enable trufflehog on push (per the new docs section):
   ```bash
   poetry run prek install --hook-type pre-push
   ```
5. Verify a normal `git push` no longer triggers the previous pre-push hook chain, and that with the opt-in installed, TruffleHog runs on push.
6. Render `docs/developer-guide/introduction.mdx` and confirm the new subsection appears under **Pre-Commit Hooks**.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests. _(N/A — dev tooling config + docs only)_
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings _(N/A — no Python code changes)_
- [x] Review if backport is needed. _(No)_
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) _(No)_
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. _(N/A — internal dev tooling, no user-facing change)_

#### SDK/CLI
- Are there new checks included in this PR? **No**

#### UI
- [ ] N/A

#### API
- [ ] N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.