### PR TITLE
refactor(ui): rename roles menu item

### DIFF
--- a/ui/lib/menu-list.ts
+++ b/ui/lib/menu-list.ts
@@ -127,7 +127,7 @@ export const getMenuList = ({ pathname }: MenuListOptions): GroupProps[] => {
             },
             { href: "/scans", label: "Scan Jobs", icon: Timer },
             { href: "/integrations", label: "Integrations", icon: Puzzle },
-            { href: "/roles", label: "Roles", icon: UserCog },
+            { href: "/roles", label: "Access Control", icon: UserCog },
             { href: "/lighthouse/config", label: "Lighthouse AI", icon: Cog },
           ],
           defaultOpen: true,


### PR DESCRIPTION
## Context
- Replaces the stale closed PR branch view with a single commit on top of current master.

## Description
- Rename the Roles navigation label to Access Control.

## Steps to review
- Check the Configuration navigation label.

## Checklist
- [x] The branch contains one commit on top of current master.
- [x] Focused UI menu tests pass.