### PR TITLE
feat(m365): add check for app registrations using password credentials

### DIFF
--- a/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.metadata.json
+++ b/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.metadata.json
@@ -1,0 +1,41 @@
+{
+  "Provider": "m365",
+  "CheckID": "entra_app_registration_no_password_credentials",
+  "CheckTitle": "Application registrations should not use password credentials (client secrets)",
+  "CheckType": [],
+  "ServiceName": "entra",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "IAM",
+  "Description": "Microsoft Entra application registrations should not have password credentials (client secrets). Client secrets are bearer credentials that are easy to leak (committed to repos, copied into CI variables, shared via chat). Applications should authenticate using certificates, federated identity credentials, or managed identities.",
+  "Risk": "Client secrets can be used from anywhere on the internet once leaked. Unlike certificates, they cannot be scoped to a specific machine and are harder to rotate across distributed systems. Both expired and active secrets represent credential clutter that increases attack surface.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/entra/identity-platform/certificate-credentials",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/graph/api/resources/passwordcredential?view=graph-rest-1.0",
+    "https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation",
+    "https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Navigate to Microsoft Entra admin center (https://entra.microsoft.com)\n2. Go to Applications > App registrations\n3. Select the flagged application\n4. Go to Certificates & secrets\n5. Delete all client secrets under the 'Client secrets' tab\n6. Add a certificate or configure federated identity credentials instead",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Migrate application authentication from client secrets to certificates, federated identity credentials, or managed identities. Enable the default app management policy to prevent new secrets from being added.",
+      "Url": "https://hub.prowler.com/check/entra_app_registration_no_password_credentials"
+    }
+  },
+  "Categories": [
+    "identity-access",
+    "e3"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "entra_default_app_management_policy_enabled"
+  ],
+  "Notes": "This check audits the current state of password credentials on app registrations. The related check entra_default_app_management_policy_enabled audits the tenant-wide policy that prevents new secrets from being added. Both expired and active password credentials trigger a FAIL."
+}

--- a/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.py
+++ b/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.py
@@ -1,0 +1,56 @@
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.entra.entra_client import entra_client
+
+
+class entra_app_registration_no_password_credentials(Check):
+    """
+    Ensure that application registrations do not use password credentials (client secrets).
+
+    This check evaluates application registrations in Microsoft Entra ID to identify
+    those with password credentials (client secrets). Applications should authenticate
+    using certificates, federated identity credentials, or managed identities instead.
+
+    - PASS: The application has no password credentials.
+    - FAIL: The application has one or more password credentials that should be removed.
+    """
+
+    def execute(self) -> list[CheckReportM365]:
+        findings = []
+
+        for app_id, app in entra_client.app_registrations.items():
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=app,
+                resource_name=app.name or app.app_id,
+                resource_id=app_id,
+            )
+
+            num_secrets = len(app.password_credentials)
+            if num_secrets > 0:
+                report.status = "FAIL"
+                secret_details = []
+                for cred in app.password_credentials:
+                    detail = cred.display_name or cred.key_id
+                    if cred.end_date_time:
+                        detail += f" (expires: {cred.end_date_time})"
+                    secret_details.append(detail)
+
+                if num_secrets > 5:
+                    displayed = ", ".join(secret_details[:5])
+                    displayed += f" (and {num_secrets - 5} more)"
+                else:
+                    displayed = ", ".join(secret_details)
+
+                report.status_extended = (
+                    f"App registration {app.name} has {num_secrets} "
+                    f"password credential(s) (client secrets): {displayed}."
+                )
+            else:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"App registration {app.name} does not use password credentials."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -83,6 +83,7 @@ class Entra(M365Service):
                 self._get_oauth_apps(),
                 self._get_directory_sync_settings(),
                 self._get_authentication_method_configurations(),
+                self._get_app_registrations(),
             )
         )
 
@@ -98,6 +99,7 @@ class Entra(M365Service):
         self.authentication_method_configurations: Dict[
             str, AuthenticationMethodConfiguration
         ] = attributes[9]
+        self.app_registrations: Dict[str, AppRegistration] = attributes[10]
         self.user_accounts_status = {}
 
         if created_loop:
@@ -1055,6 +1057,53 @@ OAuthAppInfo
             )
         return authentication_method_configurations
 
+    async def _get_app_registrations(self):
+        """Retrieve application registrations from Microsoft Entra.
+
+        Fetches all application registrations and their password credentials
+        to identify apps using client secrets instead of certificates or
+        federated identity credentials.
+
+        Returns:
+            Dict[str, AppRegistration]: Dictionary of app registrations keyed by app ID.
+        """
+        logger.info("Entra - Getting app registrations...")
+        app_registrations = {}
+        try:
+            apps_data = await self.client.applications.get()
+            if apps_data and apps_data.value:
+                for app in apps_data.value:
+                    app_id = getattr(app, "app_id", None) or getattr(app, "id", "")
+                    display_name = getattr(app, "display_name", "") or ""
+                    object_id = getattr(app, "id", "")
+
+                    password_creds = []
+                    for cred in getattr(app, "password_credentials", []) or []:
+                        password_creds.append(
+                            PasswordCredential(
+                                key_id=str(getattr(cred, "key_id", "")),
+                                display_name=getattr(cred, "display_name", None),
+                                start_date_time=str(getattr(cred, "start_date_time", ""))
+                                if getattr(cred, "start_date_time", None)
+                                else None,
+                                end_date_time=str(getattr(cred, "end_date_time", ""))
+                                if getattr(cred, "end_date_time", None)
+                                else None,
+                            )
+                        )
+
+                    app_registrations[object_id] = AppRegistration(
+                        id=object_id,
+                        app_id=app_id,
+                        name=display_name,
+                        password_credentials=password_creds,
+                    )
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+        return app_registrations
+
 
 class ConditionalAccessPolicyState(Enum):
     ENABLED = "enabled"
@@ -1486,3 +1535,21 @@ class OAuthApp(BaseModel):
     is_admin_consented: bool = False
     last_used_time: Optional[str] = None
     app_origin: str = ""
+
+
+class PasswordCredential(BaseModel):
+    """Model for a password credential (client secret) on an app registration."""
+
+    key_id: str = ""
+    display_name: Optional[str] = None
+    start_date_time: Optional[str] = None
+    end_date_time: Optional[str] = None
+
+
+class AppRegistration(BaseModel):
+    """Model for a Microsoft Entra application registration."""
+
+    id: str
+    app_id: str = ""
+    name: str = ""
+    password_credentials: List[PasswordCredential] = []

--- a/tests/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials_test.py
+++ b/tests/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials_test.py
@@ -1,0 +1,234 @@
+from unittest import mock
+from uuid import uuid4
+
+from prowler.providers.m365.services.entra.entra_service import (
+    AppRegistration,
+    PasswordCredential,
+)
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_entra_app_registration_no_password_credentials:
+    def test_no_app_registrations(self):
+        """No app registrations in tenant: no findings."""
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {}
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_app_no_password_credentials(self):
+        """App with no password credentials: expected PASS."""
+        app_id = str(uuid4())
+        app_name = "Test App Clean"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                app_id: AppRegistration(
+                    id=app_id,
+                    app_id=str(uuid4()),
+                    name=app_name,
+                    password_credentials=[],
+                )
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"App registration {app_name} does not use password credentials."
+            )
+            assert result[0].resource_name == app_name
+            assert result[0].resource_id == app_id
+
+    def test_app_with_one_password_credential(self):
+        """App with one password credential: expected FAIL."""
+        app_id = str(uuid4())
+        app_name = "Test App With Secret"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                app_id: AppRegistration(
+                    id=app_id,
+                    app_id=str(uuid4()),
+                    name=app_name,
+                    password_credentials=[
+                        PasswordCredential(
+                            key_id=str(uuid4()),
+                            display_name="My Secret",
+                            start_date_time="2024-01-01T00:00:00Z",
+                            end_date_time="2025-01-01T00:00:00Z",
+                        ),
+                    ],
+                )
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "1 password credential(s)" in result[0].status_extended
+            assert "My Secret" in result[0].status_extended
+            assert result[0].resource_name == app_name
+            assert result[0].resource_id == app_id
+
+    def test_app_with_multiple_password_credentials(self):
+        """App with multiple password credentials: expected FAIL."""
+        app_id = str(uuid4())
+        app_name = "Test App Multiple Secrets"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                app_id: AppRegistration(
+                    id=app_id,
+                    app_id=str(uuid4()),
+                    name=app_name,
+                    password_credentials=[
+                        PasswordCredential(
+                            key_id=str(uuid4()),
+                            display_name="Secret 1",
+                            end_date_time="2025-06-01T00:00:00Z",
+                        ),
+                        PasswordCredential(
+                            key_id=str(uuid4()),
+                            display_name="Secret 2",
+                            end_date_time="2025-12-01T00:00:00Z",
+                        ),
+                    ],
+                )
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "2 password credential(s)" in result[0].status_extended
+            assert result[0].resource_name == app_name
+
+    def test_multiple_apps_mixed(self):
+        """Multiple apps: one clean, one with secrets."""
+        app_id_pass = str(uuid4())
+        app_name_pass = "Clean App"
+        app_id_fail = str(uuid4())
+        app_name_fail = "App With Secret"
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                app_id_pass: AppRegistration(
+                    id=app_id_pass,
+                    app_id=str(uuid4()),
+                    name=app_name_pass,
+                    password_credentials=[],
+                ),
+                app_id_fail: AppRegistration(
+                    id=app_id_fail,
+                    app_id=str(uuid4()),
+                    name=app_name_fail,
+                    password_credentials=[
+                        PasswordCredential(
+                            key_id=str(uuid4()),
+                            display_name="Legacy Secret",
+                        ),
+                    ],
+                ),
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 2
+
+            result_pass = next(r for r in result if r.resource_id == app_id_pass)
+            result_fail = next(r for r in result if r.resource_id == app_id_fail)
+
+            assert result_pass.status == "PASS"
+            assert result_fail.status == "FAIL"
+            assert "Legacy Secret" in result_fail.status_extended


### PR DESCRIPTION
## Summary

- Adds new check `entra_app_registration_no_password_credentials` that flags application registrations with client secrets (password credentials)
- Extends `entra_service.py` with `_get_app_registrations()` method and `AppRegistration`/`PasswordCredential` models
- Applications should authenticate using certificates, federated identity credentials, or managed identities instead of shared secrets

## Changes

- `entra_service.py`: Added `_get_app_registrations` async method, `AppRegistration` and `PasswordCredential` Pydantic models, wired into init gather
- New check directory with check class, metadata JSON, and `__init__.py`
- 5 test cases: empty tenant, clean app, single secret, multiple secrets, mixed apps

## Test plan

- [x] No app registrations returns empty findings
- [x] App without password credentials returns PASS
- [x] App with one password credential returns FAIL with secret details
- [x] App with multiple password credentials returns FAIL with count
- [x] Mixed apps return correct PASS/FAIL per app

Closes #11064

🤖 Generated with [Claude Code](https://claude.com/claude-code)