### PR TITLE
fix(ui): label finding drawer column as Provider, not Account

### DIFF
--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
@@ -676,11 +676,11 @@ export function ResourceDetailDrawerContent({
             <div className="flex items-start gap-4">
               {/* Resource info grid — 4 data columns */}
               <div className="@container flex min-w-0 flex-1 flex-col gap-4">
-                {/* Row 1: Account (cols 1-2), Resource (cols 3-5) */}
+                {/* Row 1: Provider (cols 1-2), Resource (cols 3-5) */}
                 <div className="grid min-w-0 grid-cols-1 gap-4 @md:grid-cols-5 @md:gap-x-8">
                   <div className="flex min-w-0 flex-col gap-1 @md:col-span-2">
                     <span className="text-text-neutral-secondary text-[10px] whitespace-nowrap">
-                      Account
+                      Provider
                     </span>
                     <EntityInfo
                       cloudProvider={providerType}

--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-skeleton.test.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-skeleton.test.tsx
@@ -13,7 +13,7 @@ describe("ResourceDetailSkeleton", () => {
   it("should render placeholders mirroring the resource info grid layout", () => {
     render(<ResourceDetailSkeleton />);
 
-    // Account/Resource entity placeholders + 5 info fields (dates + service +
+    // Provider/Resource entity placeholders + 5 info fields (dates + service +
     // region) + actions button = at least 7 blocks rendered.
     const blocks = screen.getAllByTestId("skeleton-block");
     expect(blocks.length).toBeGreaterThanOrEqual(7);

--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-skeleton.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-skeleton.tsx
@@ -9,7 +9,7 @@ export function ResourceDetailSkeleton() {
   return (
     <div className="flex items-start gap-4">
       <div className="@container flex min-w-0 flex-1 flex-col gap-4">
-        {/* Row 1: Account, Resource */}
+        {/* Row 1: Provider, Resource */}
         <div className="grid min-w-0 grid-cols-1 gap-4 @md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] @md:gap-x-8">
           <EntityInfoSkeleton hasIcon labelWidth="w-12" />
           <EntityInfoSkeleton labelWidth="w-14" />


### PR DESCRIPTION
### Context

The finding detail drawer reorganized in #11091 labels the cloud-account column as **Account**, but every other surface in the UI was already standardized to **Provider** in #10971.

### Description

Renames the column header from "Account" to "Provider" in the resource info grid of the finding detail drawer, plus the matching skeleton/test comments. No behavior change, no API change, no copy elsewhere is affected.

| Before | After |
|--------|-------|
| Account | Provider |

### Steps to review

1. Open any finding's detail drawer (click a row in `/findings`).
2. Verify the column above the cloud logo + UID now reads **Provider** instead of **Account**.
3. Confirm no other labels in the drawer changed.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. _(Not applicable — fix for unreleased change in #11091.)_

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. _(Not applicable — fix for unreleased change in #11091.)_

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.