### PR TITLE
fix(api): defer scan broker publish until transaction commits

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [1.27.1] (Prowler v5.26.1)
+
+### 🐞 Fixed
+
+- `POST /api/v1/scans` was intermittently failing with `Scan matching query does not exist` in the `scan-perform` worker; the Celery task is now published via `transaction.on_commit` so the worker cannot read the Scan before the dispatch-wide transaction commits [(#11122)](https://github.com/prowler-cloud/prowler/pull/11122)
+
+---
+
 ## [1.27.0] (Prowler v5.26.0)
 
 ### 🚀 Added

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import time
+import uuid
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
@@ -16,7 +17,7 @@ from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.saml.views import FinishACSView, LoginView
 from botocore.exceptions import ClientError, NoCredentialsError, ParamValidationError
-from celery import chain
+from celery import chain, states
 from celery.result import AsyncResult
 from config.custom_logging import BackendLogger
 from config.env import env
@@ -60,6 +61,7 @@ from django.utils.dateparse import parse_date
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control
 from django_celery_beat.models import PeriodicTask
+from django_celery_results.models import TaskResult
 from drf_spectacular.settings import spectacular_settings
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
@@ -2534,28 +2536,45 @@ class ScanViewSet(BaseRLSViewSet):
     def create(self, request, *args, **kwargs):
         input_serializer = self.get_serializer(data=request.data)
         input_serializer.is_valid(raise_exception=True)
+
+        # Broker publish is deferred to on_commit so the worker cannot read
+        # Scan before BaseRLSViewSet's dispatch-wide atomic commits.
+        pre_task_id = str(uuid.uuid4())
+
         with transaction.atomic():
             scan = input_serializer.save()
-        with transaction.atomic():
-            task = perform_scan_task.apply_async(
-                kwargs={
-                    "tenant_id": self.request.tenant_id,
-                    "scan_id": str(scan.id),
-                    "provider_id": str(scan.provider_id),
-                    # Disabled for now
-                    # checks_to_execute=scan.scanner_args.get("checks_to_execute")
-                },
+            scan.task_id = pre_task_id
+            scan.save(update_fields=["task_id"])
+
+            attack_paths_db_utils.create_attack_paths_scan(
+                tenant_id=self.request.tenant_id,
+                scan_id=str(scan.id),
+                provider_id=str(scan.provider_id),
             )
 
-        attack_paths_db_utils.create_attack_paths_scan(
-            tenant_id=self.request.tenant_id,
-            scan_id=str(scan.id),
-            provider_id=str(scan.provider_id),
-        )
+            task_result, _ = TaskResult.objects.get_or_create(
+                task_id=pre_task_id,
+                defaults={"status": states.PENDING, "task_name": "scan-perform"},
+            )
+            prowler_task, _ = Task.objects.update_or_create(
+                id=pre_task_id,
+                tenant_id=self.request.tenant_id,
+                defaults={"task_runner_task": task_result},
+            )
 
-        prowler_task = Task.objects.get(id=task.id)
-        scan.task_id = task.id
-        scan.save(update_fields=["task_id"])
+            scan_kwargs = {
+                "tenant_id": self.request.tenant_id,
+                "scan_id": str(scan.id),
+                "provider_id": str(scan.provider_id),
+                # Disabled for now
+                # checks_to_execute=scan.scanner_args.get("checks_to_execute")
+            }
+
+            transaction.on_commit(
+                lambda: perform_scan_task.apply_async(
+                    kwargs=scan_kwargs, task_id=pre_task_id
+                )
+            )
 
         self.response_serializer_class = TaskSerializer
         output_serializer = self.get_serializer(prowler_task)


### PR DESCRIPTION
### Context

`POST /api/v1/scans` was intermittently emitting `Scan matching query does not exist` from the scan worker (`scan-perform`). The error correlated with manual scans only; scheduled scans were unaffected.

### Description

`ScanViewSet.create` was wrapping the save and the Celery dispatch in two `transaction.atomic()` blocks. Because `BaseRLSViewSet.dispatch` already opens a transaction for the whole request (`api/src/backend/api/base_views.py:96`), those inner blocks resolved to `SAVEPOINT`s, not real commits. `perform_scan_task.apply_async(...)` published the message before the outer transaction committed, so a worker that picked it up on a separate connection observed nothing for that scan id and raised `Scan.DoesNotExist`.

The fix:

- Pre-generate `pre_task_id = uuid.uuid4()` and persist it on the `Scan` row inside the same atomic.
- Pre-create the `TaskResult` (PENDING) and the local `Task` row so the response can serialize them immediately.
- Move `perform_scan_task.apply_async(..., task_id=pre_task_id)` into `transaction.on_commit(...)`, which fires only after the dispatch-wide transaction commits. The worker is guaranteed to see the `Scan`.

Scheduled scans (`perform_scheduled_scan_task`) already created the `Scan` inside the worker, so they were never affected and don't change.

### Steps to review

1. Read `api/src/backend/api/v1/views.py` `ScanViewSet.create` and confirm:
   - The pre-generated `pre_task_id` is the same id stored on `scan.task_id`, on the `TaskResult.task_id`, on the local `Task.id`, and passed to `apply_async(task_id=...)`.
   - Both the `apply_async` and any side-effect publishes are inside `transaction.on_commit(...)`.
2. `RLSTask.apply_async` (`config/celery.py:119`) does `TaskResult.objects.get(task_id=result.task_id)` and `Task.objects.update_or_create(...)`. Confirm this still works when the rows were pre-created by the view: the `get` finds the existing PENDING row, and `update_or_create` updates the existing `Task`.
3. `before_task_publish` signal (`api/src/backend/api/signals.py:23`) calls `DatabaseBackend.store_result` which is idempotent (`update_or_create` semantically), so the pre-created `TaskResult` is just updated to PENDING again.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.