### PR TITLE
fix(api): make findings GIN index migration idempotent

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
-## [1.27.1] (Prowler v5.26.1)
+## [1.28.0] (Prowler UNRELEASED)
 
 ### 🚀 Added
 
@@ -11,6 +11,10 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🔄 Changed
 
 - Remove orphaned `gin_resources_search_idx` declaration from `Resource.Meta.indexes` (DB index dropped in `0072_drop_unused_indexes`) [(#11001)](https://github.com/prowler-cloud/prowler/pull/11001)
+
+---
+
+## [1.27.1] (Prowler v5.26.1)
 
 ### 🐞 Fixed
 

--- a/api/src/backend/api/migrations/0092_findings_arrays_gin_index_parent.py
+++ b/api/src/backend/api/migrations/0092_findings_arrays_gin_index_parent.py
@@ -7,8 +7,10 @@ PARENT_TABLE = "findings"
 
 def create_parent_and_attach(apps, schema_editor):
     with schema_editor.connection.cursor() as cursor:
+        # Idempotent: the parent index may already exist if it was created
+        # manually on an environment before this migration ran.
         cursor.execute(
-            f"CREATE INDEX {INDEX_NAME} ON ONLY {PARENT_TABLE} "
+            f"CREATE INDEX IF NOT EXISTS {INDEX_NAME} ON ONLY {PARENT_TABLE} "
             f"USING gin (categories, resource_services, resource_regions, resource_types)"
         )
         cursor.execute(
@@ -19,7 +21,22 @@ def create_parent_and_attach(apps, schema_editor):
         )
         for (partition,) in cursor.fetchall():
             child_idx = f"{partition.replace('.', '_')}_{INDEX_NAME}"
-            cursor.execute(f"ALTER INDEX {INDEX_NAME} ATTACH PARTITION {child_idx}")
+            # ALTER INDEX ... ATTACH PARTITION has no IF NOT ATTACHED clause,
+            # so check pg_inherits first to keep the migration re-runnable.
+            cursor.execute(
+                """
+                SELECT 1
+                FROM pg_inherits i
+                JOIN pg_class p ON p.oid = i.inhparent
+                JOIN pg_class c ON c.oid = i.inhrelid
+                WHERE p.relname = %s AND c.relname = %s
+                """,
+                [INDEX_NAME, child_idx],
+            )
+            if cursor.fetchone() is None:
+                cursor.execute(
+                    f"ALTER INDEX {INDEX_NAME} ATTACH PARTITION {child_idx}"
+                )
 
 
 def drop_parent_index(apps, schema_editor):

--- a/api/src/backend/api/migrations/0092_findings_arrays_gin_index_parent.py
+++ b/api/src/backend/api/migrations/0092_findings_arrays_gin_index_parent.py
@@ -34,9 +34,7 @@ def create_parent_and_attach(apps, schema_editor):
                 [INDEX_NAME, child_idx],
             )
             if cursor.fetchone() is None:
-                cursor.execute(
-                    f"ALTER INDEX {INDEX_NAME} ATTACH PARTITION {child_idx}"
-                )
+                cursor.execute(f"ALTER INDEX {INDEX_NAME} ATTACH PARTITION {child_idx}")
 
 
 def drop_parent_index(apps, schema_editor):


### PR DESCRIPTION
### Description

Make migration `0092_findings_arrays_gin_index_parent` idempotent: `CREATE INDEX IF NOT EXISTS` for the parent, and skip `ATTACH PARTITION` for children already attached (checked via `pg_inherits`). Re-runs cleanly on envs where the index was created manually.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.