### PR TITLE
fix(ui): preserve scans provider wizard flow

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Trimmed unused npm dependencies [(#11115)](https://github.com/prowler-cloud/prowler/pull/11115)
 
+### 🐞 Fixed
+
+- Launch Scan first-provider wizard continues after provider creation instead of resetting the Scans page [(#11136)](https://github.com/prowler-cloud/prowler/pull/11136)
+
 ---
 
 ## [1.26.1] (Prowler 5.26.1)
@@ -16,7 +20,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Role form Cancel buttons now return to Roles [(#11125)](https://github.com/prowler-cloud/prowler/pull/11125)
 - Shared select dropdowns stay constrained and scrollable inside modals [(#11125)](https://github.com/prowler-cloud/prowler/pull/11125)
-
 
 ---
 

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -4,16 +4,11 @@ import { getAllProviders } from "@/actions/providers";
 import { getScans } from "@/actions/scans";
 import { auth } from "@/auth.config";
 import { MutedFindingsConfigButton } from "@/components/providers";
-import {
-  NoProvidersAdded,
-  NoProvidersConnected,
-  ScansFilters,
-} from "@/components/scans";
-import { LaunchScanWorkflow } from "@/components/scans/launch-workflow";
+import { ScansFilters } from "@/components/scans";
+import { ScansLaunchSection } from "@/components/scans/scans-launch-section";
 import { SkeletonTableScans } from "@/components/scans/table";
 import { ScansTableWithPolling } from "@/components/scans/table/scans";
 import { ContentLayout } from "@/components/ui";
-import { CustomBanner } from "@/components/ui/custom/custom-banner";
 import {
   createProviderDetailsMapping,
   extractProviderUIDs,
@@ -93,44 +88,30 @@ export default async function Scans({
     ? createProviderDetailsMapping(providerUIDs, providersData)
     : [];
 
-  if (thereIsNoProviders) {
-    return (
-      <ContentLayout title="Scans" icon="lucide:timer">
-        <NoProvidersAdded />
-      </ContentLayout>
-    );
-  }
-
   return (
     <ContentLayout title="Scans" icon="lucide:timer">
       <>
-        <>
-          {!hasManageScansPermission ? (
-            <CustomBanner
-              title={"Access Denied"}
-              message={"You don't have permission to launch the scan."}
+        <ScansLaunchSection
+          providers={providerInfo}
+          hasManageScansPermission={hasManageScansPermission}
+          thereIsNoProviders={thereIsNoProviders}
+          thereIsNoProvidersConnected={thereIsNoProvidersConnected}
+        />
+        {!thereIsNoProviders && (
+          <div className="flex flex-col gap-6">
+            <ScansFilters
+              providerUIDs={providerUIDs}
+              providerDetails={providerDetails}
+              completedScans={completedScans}
             />
-          ) : thereIsNoProvidersConnected ? (
-            <>
-              <NoProvidersConnected />
-            </>
-          ) : (
-            <LaunchScanWorkflow providers={providerInfo} />
-          )}
-        </>
-        <div className="flex flex-col gap-6">
-          <ScansFilters
-            providerUIDs={providerUIDs}
-            providerDetails={providerDetails}
-            completedScans={completedScans}
-          />
-          <div className="flex items-center justify-end">
-            <MutedFindingsConfigButton />
+            <div className="flex items-center justify-end">
+              <MutedFindingsConfigButton />
+            </div>
+            <Suspense fallback={<SkeletonTableScans />}>
+              <SSRDataTableScans searchParams={resolvedSearchParams} />
+            </Suspense>
           </div>
-          <Suspense fallback={<SkeletonTableScans />}>
-            <SSRDataTableScans searchParams={resolvedSearchParams} />
-          </Suspense>
-        </div>
+        )}
       </>
     </ContentLayout>
   );

--- a/ui/app/(prowler)/scans/page.tsx
+++ b/ui/app/(prowler)/scans/page.tsx
@@ -76,11 +76,15 @@ export default async function Scans({
   const thereIsNoProviders =
     !providersData?.data || providersData.data.length === 0;
 
-  const thereIsNoProvidersConnected = providersData?.data?.every(
-    (provider: ProviderProps) => !provider.attributes.connection.connected,
+  const thereIsNoProvidersConnected = Boolean(
+    providersData?.data?.every(
+      (provider: ProviderProps) => !provider.attributes.connection.connected,
+    ),
   );
 
-  const hasManageScansPermission = session?.user?.permissions?.manage_scans;
+  const hasManageScansPermission = Boolean(
+    session?.user?.permissions?.manage_scans,
+  );
 
   // Extract provider UIDs and create provider details mapping for filtering
   const providerUIDs = providersData ? extractProviderUIDs(providersData) : [];

--- a/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
+++ b/ui/components/scans/launch-workflow/launch-scan-workflow-form.tsx
@@ -11,23 +11,15 @@ import { Button } from "@/components/shadcn";
 import { CustomInput } from "@/components/ui/custom";
 import { Form } from "@/components/ui/form";
 import { toast } from "@/components/ui/toast";
-import { onDemandScanFormSchema } from "@/types";
+import { onDemandScanFormSchema, ScanProviderInfo } from "@/types";
 
 import { SCAN_LAUNCHED_EVENT } from "../table/scans/scans-table-with-polling";
 import { SelectScanProvider } from "./select-scan-provider";
 
-type ProviderInfo = {
-  providerId: string;
-  alias: string;
-  providerType: string;
-  uid: string;
-  connected: boolean;
-};
-
 export const LaunchScanWorkflow = ({
   providers,
 }: {
-  providers: ProviderInfo[];
+  providers: ScanProviderInfo[];
 }) => {
   const formSchema = z.object({
     ...onDemandScanFormSchema().shape,

--- a/ui/components/scans/launch-workflow/select-scan-provider.tsx
+++ b/ui/components/scans/launch-workflow/select-scan-provider.tsx
@@ -11,18 +11,13 @@ import {
 } from "@/components/shadcn";
 import { EntityInfo } from "@/components/ui/entities";
 import { FormControl, FormField, FormMessage } from "@/components/ui/form";
+import { ScanProviderInfo } from "@/types";
 
 interface SelectScanProviderProps<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > {
-  providers: {
-    providerId: string;
-    alias: string;
-    providerType: string;
-    uid: string;
-    connected: boolean;
-  }[];
+  providers: ScanProviderInfo[];
   control: Control<TFieldValues>;
   name: TName;
 }

--- a/ui/components/scans/no-providers-added.tsx
+++ b/ui/components/scans/no-providers-added.tsx
@@ -7,8 +7,21 @@ import { Button, Card, CardContent } from "@/components/shadcn";
 
 import { InfoIcon } from "../icons/Icons";
 
-export const NoProvidersAdded = () => {
+interface NoProvidersAddedProps {
+  onOpenWizard?: () => void;
+}
+
+export const NoProvidersAdded = ({ onOpenWizard }: NoProvidersAddedProps) => {
   const [open, setOpen] = useState(false);
+
+  const handleOpenWizard = () => {
+    if (onOpenWizard) {
+      onOpenWizard();
+      return;
+    }
+
+    setOpen(true);
+  };
 
   return (
     <>
@@ -32,14 +45,16 @@ export const NoProvidersAdded = () => {
               aria-label="Open Add Provider modal"
               className="w-full max-w-xs justify-center"
               size="lg"
-              onClick={() => setOpen(true)}
+              onClick={handleOpenWizard}
             >
               Get Started
             </Button>
           </CardContent>
         </Card>
       </div>
-      <ProviderWizardModal open={open} onOpenChange={setOpen} />
+      {!onOpenWizard && (
+        <ProviderWizardModal open={open} onOpenChange={setOpen} />
+      )}
     </>
   );
 };

--- a/ui/components/scans/no-providers-added.tsx
+++ b/ui/components/scans/no-providers-added.tsx
@@ -1,60 +1,38 @@
 "use client";
 
-import { useState } from "react";
-
-import { ProviderWizardModal } from "@/components/providers/wizard";
 import { Button, Card, CardContent } from "@/components/shadcn";
 
 import { InfoIcon } from "../icons/Icons";
 
 interface NoProvidersAddedProps {
-  onOpenWizard?: () => void;
+  onOpenWizard: () => void;
 }
 
-export const NoProvidersAdded = ({ onOpenWizard }: NoProvidersAddedProps) => {
-  const [open, setOpen] = useState(false);
+export const NoProvidersAdded = ({ onOpenWizard }: NoProvidersAddedProps) => (
+  <div className="flex min-h-screen items-center justify-center">
+    <Card variant="base" className="mx-auto w-full max-w-3xl">
+      <CardContent className="flex flex-col items-center gap-4 p-6 text-center sm:p-8">
+        <div className="flex flex-col items-center gap-4">
+          <InfoIcon className="h-10 w-10 text-gray-800 dark:text-white" />
+          <h2 className="text-2xl font-bold text-gray-800 dark:text-white">
+            No Providers Configured
+          </h2>
+        </div>
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-md leading-relaxed text-gray-600 dark:text-gray-300">
+            No providers have been configured. Start by setting up a provider.
+          </p>
+        </div>
 
-  const handleOpenWizard = () => {
-    if (onOpenWizard) {
-      onOpenWizard();
-      return;
-    }
-
-    setOpen(true);
-  };
-
-  return (
-    <>
-      <div className="flex min-h-screen items-center justify-center">
-        <Card variant="base" className="mx-auto w-full max-w-3xl">
-          <CardContent className="flex flex-col items-center gap-4 p-6 text-center sm:p-8">
-            <div className="flex flex-col items-center gap-4">
-              <InfoIcon className="h-10 w-10 text-gray-800 dark:text-white" />
-              <h2 className="text-2xl font-bold text-gray-800 dark:text-white">
-                No Providers Configured
-              </h2>
-            </div>
-            <div className="flex flex-col items-center gap-3">
-              <p className="text-md leading-relaxed text-gray-600 dark:text-gray-300">
-                No providers have been configured. Start by setting up a
-                provider.
-              </p>
-            </div>
-
-            <Button
-              aria-label="Open Add Provider modal"
-              className="w-full max-w-xs justify-center"
-              size="lg"
-              onClick={handleOpenWizard}
-            >
-              Get Started
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-      {!onOpenWizard && (
-        <ProviderWizardModal open={open} onOpenChange={setOpen} />
-      )}
-    </>
-  );
-};
+        <Button
+          aria-label="Open Add Provider modal"
+          className="w-full max-w-xs justify-center"
+          size="lg"
+          onClick={onOpenWizard}
+        >
+          Get Started
+        </Button>
+      </CardContent>
+    </Card>
+  </div>
+);

--- a/ui/components/scans/scans-launch-section.test.tsx
+++ b/ui/components/scans/scans-launch-section.test.tsx
@@ -56,9 +56,7 @@ describe("ScansLaunchSection", () => {
     );
 
     // Then
-    expect(screen.getByRole("dialog", { name: "" })).toHaveTextContent(
-      "Provider wizard",
-    );
+    expect(screen.getByRole("dialog")).toHaveTextContent("Provider wizard");
     expect(screen.getByText("Launch scan workflow")).toBeInTheDocument();
   });
 });

--- a/ui/components/scans/scans-launch-section.test.tsx
+++ b/ui/components/scans/scans-launch-section.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ScansLaunchSection } from "./scans-launch-section";
+
+vi.mock("@/components/providers/wizard", () => ({
+  ProviderWizardModal: ({ open }: { open: boolean }) =>
+    open ? <div role="dialog">Provider wizard</div> : null,
+}));
+
+vi.mock("@/components/scans/launch-workflow", () => ({
+  LaunchScanWorkflow: () => <div>Launch scan workflow</div>,
+}));
+
+vi.mock("@/components/scans/no-providers-connected", () => ({
+  NoProvidersConnected: () => <div>No providers connected</div>,
+}));
+
+vi.mock("@/components/ui/custom/custom-banner", () => ({
+  CustomBanner: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+const connectedProvider = {
+  providerId: "provider-1",
+  alias: "Production",
+  providerType: "aws",
+  uid: "123456789012",
+  connected: true,
+};
+
+describe("ScansLaunchSection", () => {
+  it("should keep the provider wizard open when providers data refreshes after adding the first provider", async () => {
+    // Given
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ScansLaunchSection
+        providers={[]}
+        hasManageScansPermission
+        thereIsNoProviders
+        thereIsNoProvidersConnected
+      />,
+    );
+
+    // When
+    await user.click(
+      screen.getByRole("button", { name: /open add provider modal/i }),
+    );
+    rerender(
+      <ScansLaunchSection
+        providers={[connectedProvider]}
+        hasManageScansPermission
+        thereIsNoProviders={false}
+        thereIsNoProvidersConnected={false}
+      />,
+    );
+
+    // Then
+    expect(screen.getByRole("dialog", { name: "" })).toHaveTextContent(
+      "Provider wizard",
+    );
+    expect(screen.getByText("Launch scan workflow")).toBeInTheDocument();
+  });
+});

--- a/ui/components/scans/scans-launch-section.tsx
+++ b/ui/components/scans/scans-launch-section.tsx
@@ -7,20 +7,13 @@ import { LaunchScanWorkflow } from "@/components/scans/launch-workflow";
 import { NoProvidersAdded } from "@/components/scans/no-providers-added";
 import { NoProvidersConnected } from "@/components/scans/no-providers-connected";
 import { CustomBanner } from "@/components/ui/custom/custom-banner";
-
-export interface ScanProviderInfo {
-  providerId: string;
-  alias: string;
-  providerType: string;
-  uid: string;
-  connected: boolean;
-}
+import { ScanProviderInfo } from "@/types";
 
 interface ScansLaunchSectionProps {
   providers: ScanProviderInfo[];
-  hasManageScansPermission?: boolean;
+  hasManageScansPermission: boolean;
   thereIsNoProviders: boolean;
-  thereIsNoProvidersConnected?: boolean;
+  thereIsNoProvidersConnected: boolean;
 }
 
 export function ScansLaunchSection({

--- a/ui/components/scans/scans-launch-section.tsx
+++ b/ui/components/scans/scans-launch-section.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+import { ProviderWizardModal } from "@/components/providers/wizard";
+import { LaunchScanWorkflow } from "@/components/scans/launch-workflow";
+import { NoProvidersAdded } from "@/components/scans/no-providers-added";
+import { NoProvidersConnected } from "@/components/scans/no-providers-connected";
+import { CustomBanner } from "@/components/ui/custom/custom-banner";
+
+export interface ScanProviderInfo {
+  providerId: string;
+  alias: string;
+  providerType: string;
+  uid: string;
+  connected: boolean;
+}
+
+interface ScansLaunchSectionProps {
+  providers: ScanProviderInfo[];
+  hasManageScansPermission?: boolean;
+  thereIsNoProviders: boolean;
+  thereIsNoProvidersConnected?: boolean;
+}
+
+export function ScansLaunchSection({
+  providers,
+  hasManageScansPermission,
+  thereIsNoProviders,
+  thereIsNoProvidersConnected,
+}: ScansLaunchSectionProps) {
+  const [isProviderWizardOpen, setIsProviderWizardOpen] = useState(false);
+
+  return (
+    <>
+      {thereIsNoProviders ? (
+        <NoProvidersAdded onOpenWizard={() => setIsProviderWizardOpen(true)} />
+      ) : !hasManageScansPermission ? (
+        <CustomBanner
+          title={"Access Denied"}
+          message={"You don't have permission to launch the scan."}
+        />
+      ) : thereIsNoProvidersConnected ? (
+        <NoProvidersConnected />
+      ) : (
+        <LaunchScanWorkflow providers={providers} />
+      )}
+      <ProviderWizardModal
+        open={isProviderWizardOpen}
+        onOpenChange={setIsProviderWizardOpen}
+      />
+    </>
+  );
+}

--- a/ui/types/scans.ts
+++ b/ui/types/scans.ts
@@ -45,10 +45,18 @@ export interface ScanRelationships {
   task: RelationshipWrapper;
 }
 
-export interface ScanProviderInfo {
+export interface ScanResultProviderInfo {
   provider: ProviderType;
   uid: string;
   alias: string;
+}
+
+export interface ScanProviderInfo {
+  providerId: string;
+  alias: string;
+  providerType: string;
+  uid: string;
+  connected: boolean;
 }
 
 export interface ScanProps {
@@ -56,7 +64,7 @@ export interface ScanProps {
   id: string;
   attributes: ScanAttributes;
   relationships: ScanRelationships;
-  providerInfo?: ScanProviderInfo;
+  providerInfo?: ScanResultProviderInfo;
 }
 
 export interface ScanEntityProviderInfo {
@@ -77,7 +85,7 @@ export interface ScanEntity {
 }
 
 export interface ExpandedScanData extends ScanProps {
-  providerInfo: ScanProviderInfo;
+  providerInfo: ScanResultProviderInfo;
 }
 
 export interface IncludedResource {


### PR DESCRIPTION
### Context


https://github.com/user-attachments/assets/7f67b599-26ab-4e0b-bb59-64bad81e245c



The `/scans` first-provider onboarding flow was reset after creating a provider from **Launch Scan → Get Started**. The page refreshed with providers data and unmounted the local modal state before users could continue through the wizard.

### Description

- Adds a stable `ScansLaunchSection` client boundary to own the provider wizard modal state across `/scans` server refreshes.
- Keeps the existing `NoProvidersAdded` standalone behavior while allowing `/scans` to control modal opening from a stable parent.
- Adds regression coverage for preserving the wizard after providers data refreshes.

### Steps to review

1. Open `/scans` with no configured providers.
2. Click **Get Started**.
3. Select a provider, enter provider data, and click **Next**.
4. Verify the provider wizard remains open and continues to the next wizard step instead of resetting the `/scans` page.

Validation performed:

- [x] `pnpm test:run scans-launch-section.test.tsx`
- [x] Commit hooks passed: UI TypeScript Check, ESLint, Unit Tests, Build
- [x] Manual desktop verification using screen recording evidence: `/Users/alanbuscaglia/Desktop/Screen Recording 2026-05-12 at 14.19.43.mov`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
