### PR TITLE
fix(api): correct service principal for Bedrock AgentCore attack paths

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the **Prowler API** are documented in this file.
 
 - Remove orphaned `gin_resources_search_idx` declaration from `Resource.Meta.indexes` (DB index dropped in `0072_drop_unused_indexes`) [(#11001)](https://github.com/prowler-cloud/prowler/pull/11001)
 
+---
+
+## [1.27.2] (Prowler UNRELEASED)
+
 ### 🐞 Fixed
 
 - Attack Paths: BEDROCK-001 and BEDROCK-002 now target roles trusting `bedrock-agentcore.amazonaws.com` instead of `bedrock.amazonaws.com`, eliminating false positives against regular Bedrock service roles (Agents, Knowledge Bases, model invocation) [(#11141)](https://github.com/prowler-cloud/prowler/pull/11141)

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 ### 🐞 Fixed
 
-- Attack Paths: BEDROCK-001 and BEDROCK-002 now target roles trusting `bedrock-agentcore.amazonaws.com` instead of `bedrock.amazonaws.com`, eliminating false positives against regular Bedrock service roles (Agents, Knowledge Bases, model invocation)
+- Attack Paths: BEDROCK-001 and BEDROCK-002 now target roles trusting `bedrock-agentcore.amazonaws.com` instead of `bedrock.amazonaws.com`, eliminating false positives against regular Bedrock service roles (Agents, Knowledge Bases, model invocation) [(#11141)](https://github.com/prowler-cloud/prowler/pull/11141)
 
 ---
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the **Prowler API** are documented in this file.
 
 - Remove orphaned `gin_resources_search_idx` declaration from `Resource.Meta.indexes` (DB index dropped in `0072_drop_unused_indexes`) [(#11001)](https://github.com/prowler-cloud/prowler/pull/11001)
 
+### 🐞 Fixed
+
+- Attack Paths: BEDROCK-001 and BEDROCK-002 now target roles trusting `bedrock-agentcore.amazonaws.com` instead of `bedrock.amazonaws.com`, eliminating false positives against regular Bedrock service roles (Agents, Knowledge Bases, model invocation)
+
 ---
 
 ## [1.27.1] (Prowler v5.26.1)

--- a/api/src/backend/api/attack_paths/queries/aws.py
+++ b/api/src/backend/api/attack_paths/queries/aws.py
@@ -484,8 +484,8 @@ AWS_BEDROCK_PRIVESC_PASSROLE_CODE_INTERPRETER = AttackPathsQueryDefinition(
                 OR action = '*'
             )
 
-        // Find roles that trust Bedrock service (can be passed to Bedrock)
-        MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'bedrock.amazonaws.com'}})
+        // Find roles that trust the Bedrock AgentCore service (can be passed to a code interpreter)
+        MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'bedrock-agentcore.amazonaws.com'}})
         WHERE any(resource IN stmt_passrole.resource WHERE
             resource = '*'
             OR target_role.arn CONTAINS resource
@@ -536,8 +536,8 @@ AWS_BEDROCK_PRIVESC_INVOKE_CODE_INTERPRETER = AttackPathsQueryDefinition(
                 OR action = '*'
             )
 
-        // Find roles that trust Bedrock service (already attached to existing code interpreters)
-        MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'bedrock.amazonaws.com'}})
+        // Find roles that trust the Bedrock AgentCore service (already attached to existing code interpreters)
+        MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'bedrock-agentcore.amazonaws.com'}})
 
         WITH collect(path_principal) + collect(path_target) AS paths
         UNWIND paths AS p


### PR DESCRIPTION
### Context

The `BEDROCK-001` and `BEDROCK-002` Attack Paths queries (`api/src/backend/api/attack_paths/queries/aws.py`) were producing false positives in accounts that have no custom Bedrock AgentCore Code Interpreter — they were matching IAM roles used for regular Bedrock workloads (model invocation, Bedrock Agents, Knowledge Bases) instead of the AgentCore execution roles the attack actually targets.

Per the [pathfinding.cloud BEDROCK-001 spec](https://github.com/DataDog/pathfinding.cloud/blob/main/data/paths/bedrock/bedrock-001.yaml) and the [Sonrai disclosure](https://sonraisecurity.com/blog/aws-agentcore-privilege-escalation-bedrock-scp-fix/), the prerequisite is *“a role must exist that trusts `bedrock-agentcore.amazonaws.com` to assume it”* — a different service principal from `bedrock.amazonaws.com`.

### Description

Both queries' `path_target` matched `AWSPrincipal {arn: 'bedrock.amazonaws.com'}`. Changed to `'bedrock-agentcore.amazonaws.com'` in `aws.py:488` (BEDROCK-001) and `aws.py:540` (BEDROCK-002). No other behavior change; the patterns, permissions, and deduplication logic are untouched.

### Steps to review

1. Confirm the trust principal change at `api/src/backend/api/attack_paths/queries/aws.py:488` and `:540`.
2. Cross-check against the upstream spec at https://github.com/DataDog/pathfinding.cloud/blob/main/data/paths/bedrock/bedrock-001.yaml — `prerequisites.admin` and `prerequisites.lateral` both require trust of `bedrock-agentcore.amazonaws.com`.
3. Run the BEDROCK-001 query against a stage account that has:
   - A principal with `iam:PassRole` + the three `bedrock-agentcore:*` actions
   - At least one role trusting `bedrock.amazonaws.com` (regular Bedrock) — should no longer match
   - Optionally, a role trusting `bedrock-agentcore.amazonaws.com` — should match
4. Verify the changelog entry under `api/CHANGELOG.md` → `[1.28.0]` → `🐞 Fixed`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [ ] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — not required.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. — API CHANGELOG updated.

#### SDK/CLI
- Are there new checks included in this PR? **No**
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI — N/A
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) — N/A
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) — N/A
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) — N/A
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. — N/A

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable) — query runs through the existing Attack Paths runner; no endpoint shape change.
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — N/A (openCypher, not SQL).
- [ ] Performance test results (if applicable) — N/A; same query shape, only literal value changed.
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated. — not required.
- [x] Check if version updates are required (e.g., specs, Poetry, etc.). — not required.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
`