### PR TITLE
fix(ui): render inline code without literal backticks in finding drawer

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Trimmed unused npm dependencies [(#11115)](https://github.com/prowler-cloud/prowler/pull/11115)
 - Attack Paths graph now uses React Flow with improved layout, interactions, export, minimap, and browser test coverage [(#10686)](https://github.com/prowler-cloud/prowler/pull/10686)
 
+---
+
+## [1.26.2] (Prowler 5.26.2)
+
 ### 🐞 Fixed
 
 - Finding drawer no longer renders literal backticks around inline code in Risk, Description and Remediation sections [(#11142)](https://github.com/prowler-cloud/prowler/pull/11142)
@@ -21,7 +25,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Role form Cancel buttons now return to Roles [(#11125)](https://github.com/prowler-cloud/prowler/pull/11125)
 - Shared select dropdowns stay constrained and scrollable inside modals [(#11125)](https://github.com/prowler-cloud/prowler/pull/11125)
-
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Trimmed unused npm dependencies [(#11115)](https://github.com/prowler-cloud/prowler/pull/11115)
 - Attack Paths graph now uses React Flow with improved layout, interactions, export, minimap, and browser test coverage [(#10686)](https://github.com/prowler-cloud/prowler/pull/10686)
 
+### 🐞 Fixed
+
+- Finding drawer no longer renders literal backticks around inline code in Risk, Description and Remediation sections [(#11142)](https://github.com/prowler-cloud/prowler/pull/11142)
+
 ---
 
 ## [1.26.1] (Prowler 5.26.1)

--- a/ui/components/findings/markdown-container.test.tsx
+++ b/ui/components/findings/markdown-container.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MarkdownContainer } from "./markdown-container";
+
+describe("MarkdownContainer", () => {
+  it("renders bold and inline code as semantic elements", () => {
+    render(
+      <MarkdownContainer>
+        {"**Bedrock API keys** are evaluated, configured to `never expire`."}
+      </MarkdownContainer>,
+    );
+
+    const code = screen.getByText("never expire");
+    expect(code.tagName).toBe("CODE");
+    expect(screen.getByText("Bedrock API keys").tagName).toBe("STRONG");
+  });
+
+  it("neutralizes the @tailwindcss/typography backtick pseudo-elements on inline code", () => {
+    const { container } = render(
+      <MarkdownContainer>{"text `code` text"}</MarkdownContainer>,
+    );
+
+    const wrapper = container.firstElementChild;
+    expect(wrapper).not.toBeNull();
+    const className = wrapper?.className ?? "";
+
+    // The prose plugin from @tailwindcss/typography adds ::before/::after
+    // pseudo-elements with literal backticks on every <code> tag. Without
+    // these overrides the drawer renders `never expire` with visible
+    // backticks, which is the bug PROWLER-1729 fixes.
+    expect(className).toMatch(/prose-code:before:content-none/);
+    expect(className).toMatch(/prose-code:after:content-none/);
+  });
+});

--- a/ui/components/findings/markdown-container.tsx
+++ b/ui/components/findings/markdown-container.tsx
@@ -5,7 +5,7 @@ interface MarkdownContainerProps {
 }
 
 export const MarkdownContainer = ({ children }: MarkdownContainerProps) => (
-  <div className="prose prose-sm dark:prose-invert max-w-none break-words whitespace-normal">
+  <div className="prose prose-sm dark:prose-invert prose-code:before:content-none prose-code:after:content-none max-w-none break-words whitespace-normal">
     <ReactMarkdown>{children}</ReactMarkdown>
   </div>
 );


### PR DESCRIPTION
### Context

In the Finding detail drawer, markdown inline code in the *Description*, *Risk* and *Remediation* sections was rendering the literal backtick characters around the code text instead of just the styled code span.

Example with the Bedrock check `bedrock_api_key_no_long_term_credentials`, whose metadata description reads:

> The finding identifies keys that are long-lived, set to expire far in the future, or configured to \`never expire\`, and distinguishes them from keys that have already expired.

The drawer was showing visible backticks around `never expire` instead of rendering it as inline code.

### Description

`MarkdownContainer` (`ui/components/findings/markdown-container.tsx`) wraps `<ReactMarkdown>` in a `<div>` that uses the `prose` class from `@tailwindcss/typography`. The plugin's default styles add `::before` and `::after` pseudo-elements with literal backtick content on every inline `<code>` element:

```css
.prose :where(code)::before { content: "\`"; }
.prose :where(code)::after  { content: "\`"; }
```

React-markdown correctly parses the backticks into `<code>` elements, but the prose plugin then re-injects the characters via CSS, producing the literal backticks seen in the UI.

The fix adds `prose-code:before:content-none prose-code:after:content-none` on the wrapper so inline code renders as the styled `<code>` span without the surrounding backticks. The change is contained to `MarkdownContainer`, which is consumed by the finding drawer for:

- Finding Overview > Risk
- Finding Overview > Description
- Remediation > Recommendation
- Remediation > Other steps

All four surfaces benefit from the same fix.

### Steps to review

1. Open any finding whose check metadata contains inline code, e.g. `bedrock_api_key_no_long_term_credentials`.
2. In the *Finding Overview* tab the Description sentence ending in \`never expire\` should now render the code span without visible backticks (only the monospace styling).
3. The *Risk* section and the *Remediation* tab should keep rendering bold, lists, links and inline code consistently.
4. Run \`pnpm vitest run --project unit components/findings/markdown-container.test.tsx\` (covers both the bold/code parsing and the prose override).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[PROWLER-1729]: https://prowlerpro.atlassian.net/browse/PROWLER-1729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ