### PR TITLE
fix(azure): support sovereign clouds across all authentication methods

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🐞 Fixed
 
 - `entra_users_mfa_capable` and `entra_break_glass_account_fido2_security_key_registered` report a preventive FAIL per affected user (with the missing permission named) when the M365 service principal lacks `AuditLog.Read.All`, instead of mass false positives [(#10907)](https://github.com/prowler-cloud/prowler/pull/10907)
+- Azure provider authentication against sovereign clouds (`AzureChinaCloud`, `AzureUSGovernment`) now works for every authentication method; `ClientSecretCredential`, `InteractiveBrowserCredential`, `verify_client`, the `SubscriptionClient` calls in `test_connection` and `get_locations`, and the `GraphServiceClient` and `LogsQueryClient` in the service base all derive their endpoints from `region_config` instead of hardcoding public-cloud hosts [(#11147)](https://github.com/prowler-cloud/prowler/pull/11147)
 
 ---
 

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -507,6 +507,7 @@ class AzureProvider(Provider):
                             tenant_id=azure_credentials["tenant_id"],
                             client_id=azure_credentials["client_id"],
                             client_secret=azure_credentials["client_secret"],
+                            authority=region_config.authority,
                         )
                         return credentials
                     except ClientAuthenticationError as error:
@@ -579,7 +580,10 @@ class AzureProvider(Provider):
                 )
         else:
             try:
-                credentials = InteractiveBrowserCredential(tenant_id=tenant_id)
+                credentials = InteractiveBrowserCredential(
+                    tenant_id=tenant_id,
+                    authority=region_config.authority,
+                )
             except Exception as error:
                 logger.critical(
                     "Failed to retrieve azure credentials using browser authentication"

--- a/prowler/providers/azure/azure_provider.py
+++ b/prowler/providers/azure/azure_provider.py
@@ -241,7 +241,10 @@ class AzureProvider(Provider):
         azure_credentials = None
         if tenant_id and client_id and client_secret:
             azure_credentials = self.validate_static_credentials(
-                tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
+                tenant_id=tenant_id,
+                client_id=client_id,
+                client_secret=client_secret,
+                region_config=self._region_config,
             )
 
         # Set up the Azure session
@@ -410,6 +413,8 @@ class AzureProvider(Provider):
                 authority=config["authority"],
                 base_url=config["base_url"],
                 credential_scopes=config["credential_scopes"],
+                graph_scope=config["graph_scope"],
+                logs_endpoint=config["logs_endpoint"],
             )
         except ArgumentTypeError as validation_error:
             logger.error(
@@ -666,6 +671,7 @@ class AzureProvider(Provider):
                     tenant_id=tenant_id,
                     client_id=client_id,
                     client_secret=client_secret,
+                    region_config=region_config,
                 )
 
             # Set up the Azure session
@@ -679,7 +685,11 @@ class AzureProvider(Provider):
                 region_config,
             )
             # Create a SubscriptionClient
-            subscription_client = SubscriptionClient(credentials)
+            subscription_client = SubscriptionClient(
+                credentials,
+                base_url=region_config.base_url,
+                credential_scopes=region_config.credential_scopes,
+            )
 
             # Get info from the subscriptions
             available_subscriptions = []
@@ -1043,7 +1053,11 @@ class AzureProvider(Provider):
             }
         """
         credentials = self.session
-        subscription_client = SubscriptionClient(credentials)
+        subscription_client = SubscriptionClient(
+            credentials,
+            base_url=self.region_config.base_url,
+            credential_scopes=self.region_config.credential_scopes,
+        )
         locations = {}
 
         for subscription_id, display_name in self._identity.subscriptions.items():
@@ -1088,7 +1102,10 @@ class AzureProvider(Provider):
 
     @staticmethod
     def validate_static_credentials(
-        tenant_id: str = None, client_id: str = None, client_secret: str = None
+        tenant_id: str = None,
+        client_id: str = None,
+        client_secret: str = None,
+        region_config: AzureRegionConfig = None,
     ) -> dict:
         """
         Validates the static credentials for the Azure provider.
@@ -1097,6 +1114,9 @@ class AzureProvider(Provider):
             tenant_id (str): The Azure Active Directory tenant ID.
             client_id (str): The Azure client ID.
             client_secret (str): The Azure client secret.
+            region_config (AzureRegionConfig): The region configuration used to
+                build the per-cloud login endpoint and Graph scope. Defaults to
+                the public-cloud configuration when not provided.
 
         Raises:
             AzureNotValidTenantIdError: If the provided Azure Tenant ID is not valid.
@@ -1133,8 +1153,13 @@ class AzureProvider(Provider):
                 message="The provided Azure Client Secret is not valid.",
             )
 
+        if region_config is None:
+            region_config = AzureProvider.setup_region_config("AzureCloud")
+
         try:
-            AzureProvider.verify_client(tenant_id, client_id, client_secret)
+            AzureProvider.verify_client(
+                tenant_id, client_id, client_secret, region_config
+            )
             return {
                 "tenant_id": tenant_id,
                 "client_id": client_id,
@@ -1166,7 +1191,9 @@ class AzureProvider(Provider):
             )
 
     @staticmethod
-    def verify_client(tenant_id, client_id, client_secret) -> None:
+    def verify_client(
+        tenant_id, client_id, client_secret, region_config: AzureRegionConfig = None
+    ) -> None:
         """
         Verifies the Azure client credentials using the specified tenant ID, client ID, and client secret.
 
@@ -1174,6 +1201,9 @@ class AzureProvider(Provider):
             tenant_id (str): The Azure Active Directory tenant ID.
             client_id (str): The Azure client ID.
             client_secret (str): The Azure client secret.
+            region_config (AzureRegionConfig): The region configuration used to
+                build the per-cloud login endpoint and Graph scope. Defaults to
+                the public-cloud configuration when not provided.
 
         Raises:
             AzureNotValidTenantIdError: If the provided Azure Tenant ID is not valid.
@@ -1183,7 +1213,13 @@ class AzureProvider(Provider):
         Returns:
             None
         """
-        url = f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+        if region_config is None:
+            region_config = AzureProvider.setup_region_config("AzureCloud")
+        # `authority` is None for the public cloud and a bare host (e.g.
+        # `login.chinacloudapi.cn`) for sovereign clouds, mirroring the
+        # `AzureAuthorityHosts` constants used by azure-identity.
+        login_endpoint = region_config.authority or "login.microsoftonline.com"
+        url = f"https://{login_endpoint}/{tenant_id}/oauth2/v2.0/token"
         headers = {
             "Content-Type": "application/x-www-form-urlencoded",
             "Accept": "application/json",
@@ -1192,7 +1228,7 @@ class AzureProvider(Provider):
             "grant_type": "client_credentials",
             "client_id": client_id,
             "client_secret": client_secret,
-            "scope": "https://graph.microsoft.com/.default",
+            "scope": region_config.graph_scope,
         }
         response = requests.post(url, headers=headers, data=data).json()
         if "access_token" not in response.keys() and "error_codes" in response.keys():

--- a/prowler/providers/azure/lib/regions/regions.py
+++ b/prowler/providers/azure/lib/regions/regions.py
@@ -4,6 +4,16 @@ AZURE_CHINA_CLOUD = "https://management.chinacloudapi.cn"
 AZURE_US_GOV_CLOUD = "https://management.usgovcloudapi.net"
 AZURE_GENERIC_CLOUD = "https://management.azure.com"
 
+AZURE_PUBLIC_LOGIN_ENDPOINT = "login.microsoftonline.com"
+
+AZURE_GENERIC_GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+AZURE_CHINA_GRAPH_SCOPE = "https://microsoftgraph.chinacloudapi.cn/.default"
+AZURE_US_GOV_GRAPH_SCOPE = "https://graph.microsoft.us/.default"
+
+AZURE_GENERIC_LOGS_ENDPOINT = "https://api.loganalytics.io"
+AZURE_CHINA_LOGS_ENDPOINT = "https://api.loganalytics.azure.cn"
+AZURE_US_GOV_LOGS_ENDPOINT = "https://api.loganalytics.us"
+
 
 def get_regions_config(region):
     allowed_regions = {
@@ -11,16 +21,22 @@ def get_regions_config(region):
             "authority": None,
             "base_url": AZURE_GENERIC_CLOUD,
             "credential_scopes": [AZURE_GENERIC_CLOUD + "/.default"],
+            "graph_scope": AZURE_GENERIC_GRAPH_SCOPE,
+            "logs_endpoint": AZURE_GENERIC_LOGS_ENDPOINT,
         },
         "AzureChinaCloud": {
             "authority": AzureAuthorityHosts.AZURE_CHINA,
             "base_url": AZURE_CHINA_CLOUD,
             "credential_scopes": [AZURE_CHINA_CLOUD + "/.default"],
+            "graph_scope": AZURE_CHINA_GRAPH_SCOPE,
+            "logs_endpoint": AZURE_CHINA_LOGS_ENDPOINT,
         },
         "AzureUSGovernment": {
             "authority": AzureAuthorityHosts.AZURE_GOVERNMENT,
             "base_url": AZURE_US_GOV_CLOUD,
             "credential_scopes": [AZURE_US_GOV_CLOUD + "/.default"],
+            "graph_scope": AZURE_US_GOV_GRAPH_SCOPE,
+            "logs_endpoint": AZURE_US_GOV_LOGS_ENDPOINT,
         },
     }
     return allowed_regions[region]

--- a/prowler/providers/azure/lib/service/service.py
+++ b/prowler/providers/azure/lib/service/service.py
@@ -47,10 +47,24 @@ class AzureService:
         clients = {}
         try:
             if "GraphServiceClient" in str(service):
-                clients.update({identity.tenant_domain: service(credentials=session)})
+                clients.update(
+                    {
+                        identity.tenant_domain: service(
+                            credentials=session,
+                            scopes=[region_config.graph_scope],
+                        )
+                    }
+                )
             elif "LogsQueryClient" in str(service):
                 for subscription_id, display_name in identity.subscriptions.items():
-                    clients.update({subscription_id: service(credential=session)})
+                    clients.update(
+                        {
+                            subscription_id: service(
+                                credential=session,
+                                endpoint=region_config.logs_endpoint,
+                            )
+                        }
+                    )
             else:
                 for subscription_id, display_name in identity.subscriptions.items():
                     clients.update(

--- a/prowler/providers/azure/models.py
+++ b/prowler/providers/azure/models.py
@@ -20,6 +20,8 @@ class AzureRegionConfig(BaseModel):
     authority: Optional[str] = None
     base_url: str = ""
     credential_scopes: list = []
+    graph_scope: str = "https://graph.microsoft.com/.default"
+    logs_endpoint: str = "https://api.loganalytics.io"
 
 
 class AzureSubscription(BaseModel):

--- a/tests/providers/azure/azure_provider_test.py
+++ b/tests/providers/azure/azure_provider_test.py
@@ -721,3 +721,292 @@ class TestAzureProviderSetupIdentitySubscriptions:
             first_id: shared_name,
             second_id: shared_name,
         }
+
+
+class TestAzureProviderSovereignCloudSupport:
+    """Sovereign-cloud authentication coverage across AzureCloud,
+    AzureChinaCloud and AzureUSGovernment for every authentication code path
+    Prowler exposes. Pinned to issue #8425."""
+
+    REGION_CASES = [
+        (
+            "AzureCloud",
+            None,
+            "https://management.azure.com",
+            ["https://management.azure.com/.default"],
+            "https://graph.microsoft.com/.default",
+            "https://api.loganalytics.io",
+            "login.microsoftonline.com",
+        ),
+        (
+            "AzureChinaCloud",
+            "login.chinacloudapi.cn",
+            "https://management.chinacloudapi.cn",
+            ["https://management.chinacloudapi.cn/.default"],
+            "https://microsoftgraph.chinacloudapi.cn/.default",
+            "https://api.loganalytics.azure.cn",
+            "login.chinacloudapi.cn",
+        ),
+        (
+            "AzureUSGovernment",
+            "login.microsoftonline.us",
+            "https://management.usgovcloudapi.net",
+            ["https://management.usgovcloudapi.net/.default"],
+            "https://graph.microsoft.us/.default",
+            "https://api.loganalytics.us",
+            "login.microsoftonline.us",
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        "region,authority,base_url,credential_scopes,graph_scope,logs_endpoint,_login_endpoint",
+        REGION_CASES,
+    )
+    def test_setup_region_config_per_cloud(
+        self,
+        region,
+        authority,
+        base_url,
+        credential_scopes,
+        graph_scope,
+        logs_endpoint,
+        _login_endpoint,
+    ):
+        config = AzureProvider.setup_region_config(region)
+
+        assert config == AzureRegionConfig(
+            name=region,
+            authority=authority,
+            base_url=base_url,
+            credential_scopes=credential_scopes,
+            graph_scope=graph_scope,
+            logs_endpoint=logs_endpoint,
+        )
+
+    @pytest.mark.parametrize(
+        "region,authority,_base_url,_credential_scopes,_graph_scope,_logs_endpoint,_login_endpoint",
+        REGION_CASES,
+    )
+    def test_setup_session_static_credentials_passes_authority(
+        self,
+        region,
+        authority,
+        _base_url,
+        _credential_scopes,
+        _graph_scope,
+        _logs_endpoint,
+        _login_endpoint,
+    ):
+        with patch(
+            "prowler.providers.azure.azure_provider.ClientSecretCredential"
+        ) as mock_client_secret_credential:
+            azure_credentials = {
+                "tenant_id": str(uuid4()),
+                "client_id": str(uuid4()),
+                "client_secret": "fake-secret-value",
+            }
+            region_config = AzureProvider.setup_region_config(region)
+
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                tenant_id=azure_credentials["tenant_id"],
+                azure_credentials=azure_credentials,
+                region_config=region_config,
+            )
+
+            mock_client_secret_credential.assert_called_once_with(
+                tenant_id=azure_credentials["tenant_id"],
+                client_id=azure_credentials["client_id"],
+                client_secret=azure_credentials["client_secret"],
+                authority=authority,
+            )
+
+    @pytest.mark.parametrize(
+        "region,authority,_base_url,_credential_scopes,_graph_scope,_logs_endpoint,_login_endpoint",
+        REGION_CASES,
+    )
+    def test_setup_session_browser_auth_passes_authority(
+        self,
+        region,
+        authority,
+        _base_url,
+        _credential_scopes,
+        _graph_scope,
+        _logs_endpoint,
+        _login_endpoint,
+    ):
+        with patch(
+            "prowler.providers.azure.azure_provider.InteractiveBrowserCredential"
+        ) as mock_interactive_browser_credential:
+            tenant_id = str(uuid4())
+            region_config = AzureProvider.setup_region_config(region)
+
+            AzureProvider.setup_session(
+                az_cli_auth=False,
+                sp_env_auth=False,
+                browser_auth=True,
+                managed_identity_auth=False,
+                tenant_id=tenant_id,
+                azure_credentials=None,
+                region_config=region_config,
+            )
+
+            mock_interactive_browser_credential.assert_called_once_with(
+                tenant_id=tenant_id,
+                authority=authority,
+            )
+
+    @pytest.mark.parametrize(
+        "region,authority,_base_url,_credential_scopes,_graph_scope,_logs_endpoint,_login_endpoint",
+        REGION_CASES,
+    )
+    def test_setup_session_default_credential_passes_authority(
+        self,
+        region,
+        authority,
+        _base_url,
+        _credential_scopes,
+        _graph_scope,
+        _logs_endpoint,
+        _login_endpoint,
+    ):
+        with patch(
+            "prowler.providers.azure.azure_provider.DefaultAzureCredential"
+        ) as mock_default_credential:
+            region_config = AzureProvider.setup_region_config(region)
+
+            AzureProvider.setup_session(
+                az_cli_auth=True,
+                sp_env_auth=False,
+                browser_auth=False,
+                managed_identity_auth=False,
+                tenant_id=None,
+                azure_credentials=None,
+                region_config=region_config,
+            )
+
+            _, called_kwargs = mock_default_credential.call_args
+            assert called_kwargs["authority"] == authority
+            assert called_kwargs["exclude_cli_credential"] is False
+            assert called_kwargs["exclude_environment_credential"] is True
+            assert called_kwargs["exclude_managed_identity_credential"] is True
+
+    @pytest.mark.parametrize(
+        "region,_authority,_base_url,_credential_scopes,graph_scope,_logs_endpoint,login_endpoint",
+        REGION_CASES,
+    )
+    def test_verify_client_uses_per_cloud_endpoints(
+        self,
+        region,
+        _authority,
+        _base_url,
+        _credential_scopes,
+        graph_scope,
+        _logs_endpoint,
+        login_endpoint,
+    ):
+        tenant_id = str(uuid4())
+        client_id = str(uuid4())
+        client_secret = "fake-secret"
+        region_config = AzureProvider.setup_region_config(region)
+
+        with patch("prowler.providers.azure.azure_provider.requests.post") as mock_post:
+            mock_post.return_value = MagicMock()
+            mock_post.return_value.json.return_value = {"access_token": "fake-token"}
+
+            AzureProvider.verify_client(
+                tenant_id, client_id, client_secret, region_config
+            )
+
+            mock_post.assert_called_once()
+            args, kwargs = mock_post.call_args
+            assert args[0] == (
+                f"https://{login_endpoint}/{tenant_id}/oauth2/v2.0/token"
+            )
+            assert kwargs["data"]["scope"] == graph_scope
+            assert kwargs["data"]["client_id"] == client_id
+            assert kwargs["data"]["client_secret"] == client_secret
+
+    @pytest.mark.parametrize(
+        "region,_authority,base_url,credential_scopes,_graph_scope,_logs_endpoint,_login_endpoint",
+        REGION_CASES,
+    )
+    def test_test_connection_passes_base_url_to_subscription_client(
+        self,
+        region,
+        _authority,
+        base_url,
+        credential_scopes,
+        _graph_scope,
+        _logs_endpoint,
+        _login_endpoint,
+    ):
+        subscription_client_instance = MagicMock()
+        subscription_client_instance.subscriptions = MagicMock()
+        subscription_client_instance.subscriptions.list = MagicMock(return_value=[])
+        subscription_client_class = MagicMock(return_value=subscription_client_instance)
+
+        with (
+            patch(
+                "prowler.providers.azure.azure_provider.AzureProvider.setup_session"
+            ) as mock_setup_session,
+            patch(
+                "prowler.providers.azure.azure_provider.SubscriptionClient",
+                subscription_client_class,
+            ),
+        ):
+            mock_setup_session.return_value = MagicMock()
+
+            AzureProvider.test_connection(
+                az_cli_auth=True,
+                region=region,
+                raise_on_exception=False,
+            )
+
+            subscription_client_class.assert_called_once()
+            _, kwargs = subscription_client_class.call_args
+            assert kwargs["base_url"] == base_url
+            assert kwargs["credential_scopes"] == credential_scopes
+
+    @pytest.mark.parametrize(
+        "region,_authority,base_url,credential_scopes,_graph_scope,_logs_endpoint,_login_endpoint",
+        REGION_CASES,
+    )
+    def test_get_locations_passes_base_url_to_subscription_client(
+        self,
+        region,
+        _authority,
+        base_url,
+        credential_scopes,
+        _graph_scope,
+        _logs_endpoint,
+        _login_endpoint,
+    ):
+        subscription_client_instance = MagicMock()
+        subscription_client_instance.subscriptions = MagicMock()
+        subscription_client_instance.subscriptions.list_locations = MagicMock(
+            return_value=[]
+        )
+        subscription_client_class = MagicMock(return_value=subscription_client_instance)
+
+        with (
+            patch.object(AzureProvider, "__init__", return_value=None),
+            patch(
+                "prowler.providers.azure.azure_provider.SubscriptionClient",
+                subscription_client_class,
+            ),
+        ):
+            azure_provider = AzureProvider()
+            azure_provider._session = MagicMock()
+            azure_provider._region_config = AzureProvider.setup_region_config(region)
+            azure_provider._identity = AzureIdentityInfo(subscriptions={})
+
+            azure_provider.get_locations()
+
+            subscription_client_class.assert_called_once()
+            _, kwargs = subscription_client_class.call_args
+            assert kwargs["base_url"] == base_url
+            assert kwargs["credential_scopes"] == credential_scopes

--- a/tests/providers/azure/lib/regions/regions_test.py
+++ b/tests/providers/azure/lib/regions/regions_test.py
@@ -2,8 +2,14 @@ from azure.identity import AzureAuthorityHosts
 
 from prowler.providers.azure.lib.regions.regions import (
     AZURE_CHINA_CLOUD,
+    AZURE_CHINA_GRAPH_SCOPE,
+    AZURE_CHINA_LOGS_ENDPOINT,
     AZURE_GENERIC_CLOUD,
+    AZURE_GENERIC_GRAPH_SCOPE,
+    AZURE_GENERIC_LOGS_ENDPOINT,
     AZURE_US_GOV_CLOUD,
+    AZURE_US_GOV_GRAPH_SCOPE,
+    AZURE_US_GOV_LOGS_ENDPOINT,
     get_regions_config,
 )
 
@@ -20,16 +26,22 @@ class Test_azure_regions:
                 "authority": None,
                 "base_url": AZURE_GENERIC_CLOUD,
                 "credential_scopes": [AZURE_GENERIC_CLOUD + "/.default"],
+                "graph_scope": AZURE_GENERIC_GRAPH_SCOPE,
+                "logs_endpoint": AZURE_GENERIC_LOGS_ENDPOINT,
             },
             "AzureChinaCloud": {
                 "authority": AzureAuthorityHosts.AZURE_CHINA,
                 "base_url": AZURE_CHINA_CLOUD,
                 "credential_scopes": [AZURE_CHINA_CLOUD + "/.default"],
+                "graph_scope": AZURE_CHINA_GRAPH_SCOPE,
+                "logs_endpoint": AZURE_CHINA_LOGS_ENDPOINT,
             },
             "AzureUSGovernment": {
                 "authority": AzureAuthorityHosts.AZURE_GOVERNMENT,
                 "base_url": AZURE_US_GOV_CLOUD,
                 "credential_scopes": [AZURE_US_GOV_CLOUD + "/.default"],
+                "graph_scope": AZURE_US_GOV_GRAPH_SCOPE,
+                "logs_endpoint": AZURE_US_GOV_LOGS_ENDPOINT,
             },
         }
 

--- a/tests/providers/azure/lib/service/service_test.py
+++ b/tests/providers/azure/lib/service/service_test.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from prowler.providers.azure.lib.service.service import AzureService
+from prowler.providers.azure.models import AzureIdentityInfo, AzureRegionConfig
+
+REGION_CASES = [
+    (
+        "AzureCloud",
+        "https://graph.microsoft.com/.default",
+        "https://api.loganalytics.io",
+    ),
+    (
+        "AzureChinaCloud",
+        "https://microsoftgraph.chinacloudapi.cn/.default",
+        "https://api.loganalytics.azure.cn",
+    ),
+    (
+        "AzureUSGovernment",
+        "https://graph.microsoft.us/.default",
+        "https://api.loganalytics.us",
+    ),
+]
+
+
+def _provider_mock(region_config: AzureRegionConfig):
+    provider = MagicMock()
+    provider.identity = AzureIdentityInfo(
+        tenant_domain="tenant.onmicrosoft.com",
+        subscriptions={"sub-1": "Subscription 1"},
+    )
+    provider.session = MagicMock()
+    provider.audit_config = {}
+    provider.fixer_config = {}
+    provider.locations = {}
+    provider.region_config = region_config
+    return provider
+
+
+class TestAzureServiceSovereignClouds:
+    """Cover __set_clients__ kwargs for the Graph and Logs clients across the
+    three sovereign clouds — these are the two service slots in service.py
+    that historically defaulted to public-cloud endpoints."""
+
+    @pytest.mark.parametrize(
+        "_region,graph_scope,_logs_endpoint",
+        REGION_CASES,
+    )
+    def test_set_clients_graph_passes_per_cloud_scope(
+        self, _region, graph_scope, _logs_endpoint
+    ):
+        graph_service = MagicMock()
+        graph_service.__str__ = MagicMock(return_value="GraphServiceClient")
+        region_config = AzureRegionConfig(
+            graph_scope=graph_scope,
+            logs_endpoint=_logs_endpoint,
+        )
+
+        with patch.object(AzureService, "__init__", return_value=None):
+            service = AzureService.__new__(AzureService)
+
+        service.__set_clients__(
+            _provider_mock(region_config).identity,
+            _provider_mock(region_config).session,
+            graph_service,
+            region_config,
+        )
+
+        graph_service.assert_called_once()
+        _, kwargs = graph_service.call_args
+        assert kwargs["scopes"] == [graph_scope]
+
+    @pytest.mark.parametrize(
+        "_region,_graph_scope,logs_endpoint",
+        REGION_CASES,
+    )
+    def test_set_clients_logs_passes_per_cloud_endpoint(
+        self, _region, _graph_scope, logs_endpoint
+    ):
+        logs_service = MagicMock()
+        logs_service.__str__ = MagicMock(return_value="LogsQueryClient")
+        region_config = AzureRegionConfig(
+            graph_scope=_graph_scope,
+            logs_endpoint=logs_endpoint,
+        )
+
+        with patch.object(AzureService, "__init__", return_value=None):
+            service = AzureService.__new__(AzureService)
+
+        service.__set_clients__(
+            _provider_mock(region_config).identity,
+            _provider_mock(region_config).session,
+            logs_service,
+            region_config,
+        )
+
+        logs_service.assert_called_once()
+        _, kwargs = logs_service.call_args
+        assert kwargs["endpoint"] == logs_endpoint


### PR DESCRIPTION
### Context

Fixes #8425.

Issue #8425 reported that `prowler azure --sp-env-auth --azure-region AzureChinaCloud …` fails to retrieve a token. Community PR #10284 (thanks @Br1an67!) addressed two narrow symptoms — forwarding `authority` to `ClientSecretCredential` and `InteractiveBrowserCredential` — but its scope was insufficient: a first-principles audit of the Azure provider shows that sovereign-cloud (AzureChinaCloud, AzureUSGovernment) support was broken in **six other code paths** beyond the two #10284 touches. This PR picks up Br1an67's commit (preserving authorship) and finishes the job so every Azure authentication method works against every supported cloud.

### Description

Sovereign-cloud audit status before this PR (verified in `azure-identity` 1.21.0):

| # | Code path | Status before | Action |
|---|---|---|---|
| 1 | `DefaultAzureCredential` for `--az-cli-auth` / `--managed-identity-auth` | ✅ Worked | — |
| 2 | `DefaultAzureCredential` for `--sp-env-auth` | ✅ Worked (azure-identity propagates `authority` to inner `EnvironmentCredential → ClientSecretCredential`) | — |
| 3 | `ClientSecretCredential` for static credentials | ❌ Broken | Fixed by #10284 commit (cherry-picked) |
| 4 | `InteractiveBrowserCredential` for `--browser-auth` | ❌ Broken | Fixed by #10284 commit (cherry-picked) |
| 5 | `verify_client` preflight on static credentials | ❌ Hardcoded `login.microsoftonline.com` + Graph public scope | Now derived from `region_config` (authority + new `graph_scope`) |
| 6 | `SubscriptionClient(credentials)` in `test_connection` | ❌ No `base_url` / `credential_scopes` | Now passes both from `region_config` |
| 7 | `SubscriptionClient(credentials)` in `get_locations` | ❌ Same as above | Same fix |
| 8 | `GraphServiceClient` in `AzureService.__set_clients__` | ❌ Used public-cloud Graph host | Now passes per-cloud `scopes=[region_config.graph_scope]` |
| 9 | `LogsQueryClient` in `AzureService.__set_clients__` | ❌ Used public-cloud Log Analytics endpoint | Now passes `endpoint=region_config.logs_endpoint` |
| 10 | Per-service ARM management clients (KeyVault, Storage, …) | ✅ Worked | — |

To support the new endpoints, `AzureRegionConfig` (`prowler/providers/azure/models.py`) and the per-cloud table in `prowler/providers/azure/lib/regions/regions.py` grow two fields: `graph_scope` and `logs_endpoint`. `validate_static_credentials` and `verify_client` accept an optional `region_config` (defaulting to the public-cloud configuration for backwards compatibility on direct callers).

No CLI, API or UI surface changes — the existing `--azure-region` flag is still the entry point. Adding the matching Azure-cloud selector to the UI is intentionally out of scope and tracked separately.

`AzureGermanCloud` is intentionally not added (deprecated upstream in #5561; Microsoft retired it in 2021).

### Steps to review

1. Read the audit table above against the diff in `prowler/providers/azure/azure_provider.py`, `prowler/providers/azure/lib/regions/regions.py`, `prowler/providers/azure/lib/service/service.py`, and `prowler/providers/azure/models.py`.
2. Run the parametrized test suite:
   ```bash
   poetry run pytest tests/providers/azure/azure_provider_test.py tests/providers/azure/lib/ -v
   ```
   New tests cover the three clouds (`AzureCloud`, `AzureChinaCloud`, `AzureUSGovernment`) on every credential class, `verify_client`, `test_connection`, `get_locations`, and the Graph / Logs clients in the service base.
3. Public-cloud regression check (no sovereign tenant required):
   ```bash
   AZURE_SUBSCRIPTION_ID=… \
   AZURE_TENANT_ID=… AZURE_CLIENT_ID=… AZURE_CLIENT_SECRET=… \
   poetry run python prowler-cli.py azure --sp-env-auth --list-checks
   ```
4. **Sovereign-cloud end-to-end validation — help wanted**: we do not have access to an AzureChinaCloud or AzureUSGovernment tenant. Anyone subscribed to #8425 with such access, please run the original failing command and share the output:
   ```bash
   poetry run python prowler-cli.py azure --sp-env-auth --subscription-id <id> --azure-region AzureChinaCloud --verbose --log-level ERROR
   ```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues/8425)
- [x] Is it assigned to me

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - No new permissions required.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.