### PR TITLE
docs(cloudflare): add pre-configured token creation links

### DIFF
--- a/docs/user-guide/providers/cloudflare/authentication.mdx
+++ b/docs/user-guide/providers/cloudflare/authentication.mdx
@@ -44,6 +44,15 @@ User API Tokens are the recommended authentication method because they:
 Create a **User API Token**, not an Account API Token. User API Tokens are created from the profile settings and offer finer permission control.
 </Note>
 
+**Quick Setup:** Use these pre-configured links to open the Cloudflare Dashboard with the required permissions already selected:
+
+- [Create User API Token](https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=%5B%7B%22key%22%3A%22account_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22read%22%7D%5D&accountId=%2A&zoneId=all&name=Prowler%20Security%20Scanner) — creates a **User API Token** (recommended). Opens the **Create Custom Token** form prefilled with the four required read-only scopes (`Account Settings`, `Zone`, `Zone Settings`, `DNS`) and the name `Prowler Security Scanner`. Adjust **Account Resources** and **Zone Resources** to match the accounts and zones you want to scan, then click **Create Token**.
+- [Create Account-Owned API Token](https://dash.cloudflare.com/?to=/:account/api-tokens&permissionGroupKeys=%5B%7B%22key%22%3A%22account_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22read%22%7D%5D&name=Prowler%20Security%20Scanner) — creates an [account-owned token](https://developers.cloudflare.com/fundamentals/api/how-to/account-owned-token-template/) instead. Use this for automation or CI/CD where the token should not depend on a specific user account remaining active. Requires the **Super Administrator** or **Administrator** role on the account.
+
+<Note>
+Template URLs only pre-fill the token creation form. Review the permissions, configure resources, and click **Create Token** to complete the process.
+</Note>
+
 ### Step 1: Create a User API Token
 
 1. Log into the [Cloudflare Dashboard](https://dash.cloudflare.com).

--- a/docs/user-guide/providers/cloudflare/getting-started-cloudflare.mdx
+++ b/docs/user-guide/providers/cloudflare/getting-started-cloudflare.mdx
@@ -14,6 +14,15 @@ Set up authentication for Cloudflare with the [Cloudflare Authentication](/user-
 - Grant the required read-only permissions (`Account Settings:Read`, `Zone:Read`, `Zone Settings:Read`, `DNS:Read`)
 - Identify the Cloudflare Account ID to use as the provider identifier
 
+<Note>
+**Quick Setup:** Use these pre-configured links to create a token with the required permissions already selected:
+
+- [Create User API Token](https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=%5B%7B%22key%22%3A%22account_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22read%22%7D%5D&accountId=%2A&zoneId=all&name=Prowler%20Security%20Scanner) — creates a User API Token (recommended).
+- [Create Account-Owned API Token](https://dash.cloudflare.com/?to=/:account/api-tokens&permissionGroupKeys=%5B%7B%22key%22%3A%22account_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22zone_settings%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22dns%22%2C%22type%22%3A%22read%22%7D%5D&name=Prowler%20Security%20Scanner) — creates an [account-owned token](https://developers.cloudflare.com/fundamentals/api/how-to/account-owned-token-template/), better suited for automation and CI/CD.
+
+Both links open the Cloudflare Dashboard with the four required read-only scopes (`Account Settings`, `Zone`, `Zone Settings`, `DNS`) and the name `Prowler Security Scanner` prefilled. See [Cloudflare Authentication](/user-guide/providers/cloudflare/authentication#api-token-recommended) for the equivalent manual steps.
+</Note>
+
 <CardGroup cols={2}>
   <Card title="Prowler Cloud" icon="cloud" href="#prowler-cloud">
     Onboard Cloudflare using Prowler Cloud


### PR DESCRIPTION
### Context

The Cloudflare provider's authentication and getting-started guides instruct users to create an API Token by manually walking through the Cloudflare Dashboard and selecting four read-only permissions (`Account Settings`, `Zone`, `Zone Settings`, `DNS`). This is error-prone — users frequently miss a permission, mis-scope a zone, or copy a name with typos, and only discover the problem when Prowler fails with an authentication / permission-denied error.

The GitHub provider already solves this with pre-configured token creation links in `docs/user-guide/providers/github/authentication.mdx` (see the "Quick Setup" callout near the Fine-Grained PAT section).

Cloudflare added equivalent support for prefilled token creation URLs — documented in [Account-owned token template](https://developers.cloudflare.com/fundamentals/api/how-to/account-owned-token-template/) — covering both User API Tokens (via `/profile/api-tokens?permissionGroupKeys=…&accountId=*&zoneId=all&name=…`) and account-owned tokens (via `/?to=/:account/api-tokens?permissionGroupKeys=…&name=…`).

### Description

Adds a "Quick Setup" callout to both Cloudflare provider docs, mirroring the GitHub provider's pattern. Each callout offers two pre-configured links:

- **Create User API Token** — uses Cloudflare's user-token URL format. Matches the existing Prowler recommendation for User API Tokens.
- **Create Account-Owned API Token** — uses the account-owned token template format. Offered as the alternative for automation and CI/CD where the token should not depend on a specific user remaining active.

Both links prefill:
- The four required read-only permissions (`account_settings`, `zone`, `zone_settings`, `dns`)
- A default token name (`Prowler Security Scanner`)

A short `<Note>` clarifies that template URLs only pre-fill the form — users still confirm scopes, configure resources, and click **Create Token** to complete the flow (consistent with Cloudflare's own documentation).

Files changed:
- `docs/user-guide/providers/cloudflare/authentication.mdx` — Quick Setup block added at the top of the `API Token (Recommended)` section, before the existing manual Step 1.
- `docs/user-guide/providers/cloudflare/getting-started-cloudflare.mdx` — Quick Setup `<Note>` added inside Prerequisites, linking back to the authentication guide for the manual steps.

No content was removed; the manual steps remain intact as the fallback path.

### Steps to review

1. Render the two changed `.mdx` files in the docs preview.
2. Click the **Create User API Token** link in either doc. Verify the Cloudflare Dashboard opens at `https://dash.cloudflare.com/profile/api-tokens` with all four read-only scopes (`Account Settings`, `Zone`, `Zone Settings`, `DNS`) and the name `Prowler Security Scanner` already populated in the Create Custom Token form.
3. Click the **Create Account-Owned API Token** link. Verify the Dashboard opens at `https://dash.cloudflare.com/?to=/:account/api-tokens` (Account → API Tokens) with the same four scopes and name prefilled, and that Cloudflare prompts for account selection if multiple accounts are accessible.
4. Confirm the rendered formatting matches the existing GitHub "Quick Setup" callout style.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me

</details>


- [x] Review if the code is being covered by tests. — _Docs-only change, no code paths added._
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings — _N/A (docs)._
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — _Not needed; change is scoped to the Cloudflare provider docs._
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. — _Docs-only; no CHANGELOG entry needed._

#### SDK/CLI
- Are there new checks included in this PR? **No**
    - No permission changes required.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
