### PR TITLE
chore: harden npm supply chain controls

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ Please add a detailed description of how to review this PR.
 
 </details>
 
+
 - [ ] Review if the code is being covered by tests.
 - [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
 - [ ] Review if backport is needed.
@@ -30,12 +31,10 @@ Please add a detailed description of how to review this PR.
 - [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.
 
 #### SDK/CLI
-
 - Are there new checks included in this PR? Yes / No
-  - If so, do we need to update permissions for the provider? Please review this carefully.
+    - If so, do we need to update permissions for the provider? Please review this carefully.
 
 #### UI
-
 - [ ] All issue/task requirements work as expected on the UI
 - [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
 - [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
@@ -44,7 +43,6 @@ Please add a detailed description of how to review this PR.
 - [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.
 
 #### API
-
 - [ ] All issue/task requirements work as expected on the API
 - [ ] Endpoint response output (if applicable)
 - [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,6 @@ Please add a detailed description of how to review this PR.
 
 </details>
 
-
 - [ ] Review if the code is being covered by tests.
 - [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
 - [ ] Review if backport is needed.
@@ -31,17 +30,21 @@ Please add a detailed description of how to review this PR.
 - [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.
 
 #### SDK/CLI
+
 - Are there new checks included in this PR? Yes / No
-    - If so, do we need to update permissions for the provider? Please review this carefully.
+  - If so, do we need to update permissions for the provider? Please review this carefully.
 
 #### UI
+
 - [ ] All issue/task requirements work as expected on the UI
+- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
 - [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
 - [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
 - [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
 - [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.
 
 #### API
+
 - [ ] All issue/task requirements work as expected on the API
 - [ ] Endpoint response output (if applicable)
 - [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -132,6 +132,10 @@ jobs:
         if: steps.check-changes.outputs.any_changed == 'true'
         run: pnpm run healthcheck
 
+      - name: Run pnpm audit
+        if: steps.check-changes.outputs.any_changed == 'true'
+        run: pnpm run audit
+
       - name: Run unit tests (all - critical paths changed)
         if: steps.check-changes.outputs.any_changed == 'true' && steps.critical-changes.outputs.any_changed == 'true'
         run: |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,10 +10,10 @@ This repository contains the Prowler Open Source documentation powered by [Mintl
 
 ## Local Development
 
-Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview documentation changes locally:
+Install a reviewed version of the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview documentation changes locally:
 
 ```bash
-npm i -g mint
+npm install --global mint@4.2.560
 ```
 
 Run the following command at the root of your documentation (where `mint.json` is located):

--- a/docs/developer-guide/documentation.mdx
+++ b/docs/developer-guide/documentation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Contributing to Documentation"
+title: 'Contributing to Documentation'
 ---
 
 Prowler documentation is built using [Mintlify](https://www.mintlify.com/docs), allowing contributors to easily add or enhance documentation.
@@ -15,6 +15,7 @@ The Prowler documentation is organized into several sections. The main ones are:
 - **Developer Guide**: Documentation for contributors looking to extend Prowler functionality. This includes guides on creating providers, services, checks, output formats, integrations, and compliance frameworks. Provider-specific implementation details and testing strategies are also covered here.
 
 - **Troubleshooting**: Common issues, error messages, and their solutions. This section helps users resolve problems encountered during installation, configuration, or execution.
+
 
 ## AI-Driven Documentation
 
@@ -40,7 +41,6 @@ This includes the [AGENTS.md](https://github.com/prowler-cloud/prowler/blob/mast
     ```
 
     A local preview of your documentation will be available at http://localhost:3000
-
   </Step>
 
   <Step title="Make Documentation Changes">
@@ -49,14 +49,12 @@ This includes the [AGENTS.md](https://github.com/prowler-cloud/prowler/blob/mast
     For reference about formatting, check the [Mintlify documentation](https://www.mintlify.com/docs/create/text).
 
     To add new sections or files, update the [`docs/docs.json`](https://github.com/prowler-cloud/prowler/blob/master/docs/docs.json) file to include them in the navigation.
-
   </Step>
 
   <Step title="Submit Changes">
     Once documentation updates are complete, [submit a pull request for review](/developer-guide/introduction#sending-the-pull-request).
 
     The Prowler team will assess and merge contributions.
-
   </Step>
 </Steps>
 

--- a/docs/developer-guide/documentation.mdx
+++ b/docs/developer-guide/documentation.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Contributing to Documentation'
+title: "Contributing to Documentation"
 ---
 
 Prowler documentation is built using [Mintlify](https://www.mintlify.com/docs), allowing contributors to easily add or enhance documentation.
@@ -16,7 +16,6 @@ The Prowler documentation is organized into several sections. The main ones are:
 
 - **Troubleshooting**: Common issues, error messages, and their solutions. This section helps users resolve problems encountered during installation, configuration, or execution.
 
-
 ## AI-Driven Documentation
 
 As mentioned in the [Introduction](/developer-guide/introduction#ai-driven-contributions), we have specialized resources to enhance AI-driven development.
@@ -28,7 +27,7 @@ This includes the [AGENTS.md](https://github.com/prowler-cloud/prowler/blob/mast
 <Steps>
   <Step title="Install Mintlify CLI">
     ```bash
-    npm i -g mint
+    npm install --global mint@4.2.560
     ```
     For detailed instructions, check the [Mintlify documentation](https://www.mintlify.com/docs/installation).
   </Step>
@@ -41,6 +40,7 @@ This includes the [AGENTS.md](https://github.com/prowler-cloud/prowler/blob/mast
     ```
 
     A local preview of your documentation will be available at http://localhost:3000
+
   </Step>
 
   <Step title="Make Documentation Changes">
@@ -49,12 +49,14 @@ This includes the [AGENTS.md](https://github.com/prowler-cloud/prowler/blob/mast
     For reference about formatting, check the [Mintlify documentation](https://www.mintlify.com/docs/create/text).
 
     To add new sections or files, update the [`docs/docs.json`](https://github.com/prowler-cloud/prowler/blob/master/docs/docs.json) file to include them in the navigation.
+
   </Step>
 
   <Step title="Submit Changes">
     Once documentation updates are complete, [submit a pull request for review](/developer-guide/introduction#sending-the-pull-request).
 
     The Prowler team will assess and merge contributions.
+
   </Step>
 </Steps>
 

--- a/docs/getting-started/basic-usage/prowler-mcp.mdx
+++ b/docs/getting-started/basic-usage/prowler-mcp.mdx
@@ -44,13 +44,21 @@ Choose the configuration based on your deployment:
 
   <Tab title="Generic without Native HTTP Support">
     **Configuration:**
+    <Warning>
+    Avoid configuring MCP clients to run `npx mcp-remote` directly. `npx` can download and execute a new package version on each run. Install a reviewed version of `mcp-remote` in a dedicated local workspace, then point the MCP client to the installed binary.
+    </Warning>
+    ```bash
+    mkdir -p ~/.local/share/prowler-mcp-bridge
+    cd ~/.local/share/prowler-mcp-bridge
+    npm init -y
+    npm install --save-exact mcp-remote@0.1.38
+    ```
     ```json
     {
       "mcpServers": {
         "prowler": {
-          "command": "npx",
+          "command": "/absolute/path/to/.local/share/prowler-mcp-bridge/node_modules/.bin/mcp-remote",
           "args": [
-            "mcp-remote",
             "https://mcp.prowler.com/mcp", // or your self-hosted Prowler MCP Server URL
             "--header",
             "Authorization: Bearer ${PROWLER_APP_API_KEY}"
@@ -72,14 +80,20 @@ Choose the configuration based on your deployment:
     2. Go to "Developer" tab
     3. Click in "Edit Config" button
     4. Edit the `claude_desktop_config.json` file with your favorite editor
-    5. Add the following configuration:
+    5. Install a reviewed version of `mcp-remote` in a dedicated local workspace:
+    ```bash
+    mkdir -p ~/.local/share/prowler-mcp-bridge
+    cd ~/.local/share/prowler-mcp-bridge
+    npm init -y
+    npm install --save-exact mcp-remote@0.1.38
+    ```
+    6. Add the following configuration:
     ```json
     {
       "mcpServers": {
         "prowler": {
-          "command": "npx",
+          "command": "/absolute/path/to/.local/share/prowler-mcp-bridge/node_modules/.bin/mcp-remote",
           "args": [
-            "mcp-remote",
             "https://mcp.prowler.com/mcp",
             "--header",
             "Authorization: Bearer ${PROWLER_APP_API_KEY}"

--- a/docs/getting-started/basic-usage/prowler-mcp.mdx
+++ b/docs/getting-started/basic-usage/prowler-mcp.mdx
@@ -7,13 +7,16 @@ Configure your MCP client to connect to Prowler MCP Server.
 ## Step 1: Get Your API Key
 
 <Note>
-**Authentication is optional**: Prowler Hub and Prowler Documentation features work without authentication. An API key is only required for Prowler Cloud and Prowler App (Self-Managed) features.
+  **Authentication is optional**: Prowler Hub and Prowler Documentation features
+  work without authentication. An API key is only required for Prowler Cloud and
+  Prowler App (Self-Managed) features.
 </Note>
 
 To use Prowler Cloud or Prowler App (Self-Managed) features. To get the API key, please refer to the [API Keys](/user-guide/tutorials/prowler-app-api-keys) guide.
 
 <Warning>
-Keep the API key secure. Never share it publicly or commit it to version control.
+  Keep the API key secure. Never share it publicly or commit it to version
+  control.
 </Warning>
 
 ## Step 2: Configure Your MCP Host/Client
@@ -44,13 +47,24 @@ Choose the configuration based on your deployment:
 
   <Tab title="Generic without Native HTTP Support">
     **Configuration:**
+
+    <Warning>
+      Avoid configuring MCP clients to run `npx mcp-remote` directly. `npx` can download and execute a new package version on each run. Install a reviewed version of `mcp-remote` in a dedicated local workspace, then point the MCP client to the installed binary.
+    </Warning>
+
+    ```bash
+    mkdir -p ~/.local/share/prowler-mcp-bridge
+    cd ~/.local/share/prowler-mcp-bridge
+    npm init -y
+    npm install --save-exact mcp-remote@0.1.38
+    ```
+
     ```json
     {
       "mcpServers": {
         "prowler": {
-          "command": "npx",
+          "command": "/absolute/path/to/.local/share/prowler-mcp-bridge/node_modules/.bin/mcp-remote",
           "args": [
-            "mcp-remote",
             "https://mcp.prowler.com/mcp", // or your self-hosted Prowler MCP Server URL
             "--header",
             "Authorization: Bearer ${PROWLER_APP_API_KEY}"
@@ -65,6 +79,7 @@ Choose the configuration based on your deployment:
     <Info>
     The `mcp-remote` tool acts as a bridge for clients that don't support HTTP natively. Learn more at [mcp-remote on npm](https://www.npmjs.com/package/mcp-remote).
     </Info>
+
   </Tab>
 
   <Tab title="Claude Desktop">
@@ -72,14 +87,20 @@ Choose the configuration based on your deployment:
     2. Go to "Developer" tab
     3. Click in "Edit Config" button
     4. Edit the `claude_desktop_config.json` file with your favorite editor
-    5. Add the following configuration:
+    5. Install a reviewed version of `mcp-remote` in a dedicated local workspace:
+    ```bash
+    mkdir -p ~/.local/share/prowler-mcp-bridge
+    cd ~/.local/share/prowler-mcp-bridge
+    npm init -y
+    npm install --save-exact mcp-remote@0.1.38
+    ```
+    6. Add the following configuration:
     ```json
     {
       "mcpServers": {
         "prowler": {
-          "command": "npx",
+          "command": "/absolute/path/to/.local/share/prowler-mcp-bridge/node_modules/.bin/mcp-remote",
           "args": [
-            "mcp-remote",
             "https://mcp.prowler.com/mcp",
             "--header",
             "Authorization: Bearer ${PROWLER_APP_API_KEY}"
@@ -119,7 +140,6 @@ Choose the configuration based on your deployment:
     }
     ```
   </Tab>
-
 
 </Tabs>
 
@@ -185,9 +205,10 @@ STDIO mode is only available when running the MCP server locally.
 ## Step 3: Start Using Prowler MCP
 
 Restart your MCP client and start asking questions:
-- *"Show me all critical findings from my AWS accounts"*
-- *"What does the S3 bucket public access check do?"*
-- *"Onboard this new AWS account in my Prowler Organization"*
+
+- _"Show me all critical findings from my AWS accounts"_
+- _"What does the S3 bucket public access check do?"_
+- _"Onboard this new AWS account in my Prowler Organization"_
 
 ## Authentication Methods
 
@@ -229,7 +250,8 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIs...
 ```
 
 <Warning>
-JWT tokens are only valid for 30 minutes. You need to generate a new token if you want to continue using the MCP server.
+  JWT tokens are only valid for 30 minutes. You need to generate a new token if
+  you want to continue using the MCP server.
 </Warning>
 
 ## Troubleshooting
@@ -244,6 +266,7 @@ JWT tokens are only valid for 30 minutes. You need to generate a new token if yo
 ### Authentication Failures
 
 **Error: Unauthorized (401)**
+
 - Verify your API key is correct
 - Ensure the key hasn't expired
 - Check you're using the right API endpoint
@@ -251,6 +274,7 @@ JWT tokens are only valid for 30 minutes. You need to generate a new token if yo
 ### Connection Issues
 
 **Cannot Reach Server:**
+
 - Verify the server URL is correct
 - Check network connectivity
 - For local servers, ensure the server is running
@@ -277,7 +301,11 @@ JWT tokens are only valid for 30 minutes. You need to generate a new token if yo
 Now that your MCP server is configured:
 
 <CardGroup cols={1}>
-  <Card title="Tools Reference" icon="wrench" href="/getting-started/basic-usage/prowler-mcp-tools">
+  <Card
+    title="Tools Reference"
+    icon="wrench"
+    href="/getting-started/basic-usage/prowler-mcp-tools"
+  >
     Explore all available tools
   </Card>
 </CardGroup>

--- a/docs/getting-started/installation/prowler-app.mdx
+++ b/docs/getting-started/installation/prowler-app.mdx
@@ -38,7 +38,7 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
 
     - `git` installed.
     - `poetry` installed: [poetry installation](https://python-poetry.org/docs/#installation).
-    - `npm` installed: [npm installation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+    - `pnpm` installed through [Corepack](https://pnpm.io/installation#using-corepack) or the standalone [pnpm installation](https://pnpm.io/installation).
     - `Docker Compose` installed: https://docs.docker.com/compose/install/.
 
     <Warning>
@@ -97,9 +97,11 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
     ```bash
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/ui \
-    npm install \
-    npm run build \
-    npm start
+    corepack enable \
+    corepack install \
+    pnpm install --frozen-lockfile \
+    pnpm run build \
+    pnpm start
     ```
 
     > Enjoy Prowler App at http://localhost:3000 by signing up with your email and password.

--- a/docs/getting-started/installation/prowler-app.mdx
+++ b/docs/getting-started/installation/prowler-app.mdx
@@ -9,7 +9,9 @@ Prowler App offers flexible installation methods tailored to various environment
 Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detailed usage instructions.
 
 <Warning>
-  Prowler configuration is based on `.env` files. Every version of Prowler can have differences on that file, so, please, use the file that corresponds with that version or repository branch or tag.
+  Prowler configuration is based on `.env` files. Every version of Prowler can
+  have differences on that file, so, please, use the file that corresponds with
+  that version or repository branch or tag.
 </Warning>
 
 <Tabs>
@@ -38,7 +40,7 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
 
     - `git` installed.
     - `poetry` installed: [poetry installation](https://python-poetry.org/docs/#installation).
-    - `npm` installed: [npm installation](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
+    - `pnpm` installed through [Corepack](https://pnpm.io/installation#using-corepack) or the standalone [pnpm installation](https://pnpm.io/installation).
     - `Docker Compose` installed: https://docs.docker.com/compose/install/.
 
     <Warning>
@@ -97,9 +99,11 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
     ```bash
     git clone https://github.com/prowler-cloud/prowler \
     cd prowler/ui \
-    npm install \
-    npm run build \
-    npm start
+    corepack enable \
+    corepack install \
+    pnpm install --frozen-lockfile \
+    pnpm run build \
+    pnpm start
     ```
 
     > Enjoy Prowler App at http://localhost:3000 by signing up with your email and password.
@@ -107,6 +111,7 @@ Refer to the [Prowler App Tutorial](/user-guide/tutorials/prowler-app) for detai
     <Warning>
       Google and GitHub authentication is only available in [Prowler Cloud](https://prowler.com).
     </Warning>
+
   </Tab>
 </Tabs>
 
@@ -126,9 +131,10 @@ PROWLER_API_VERSION="5.26.1"
 ```
 
 <Note>
-  You can find the latest versions of Prowler App in the [Releases Github section](https://github.com/prowler-cloud/prowler/releases) or in the [Container Versions](#container-versions) section of this documentation.
+  You can find the latest versions of Prowler App in the [Releases Github
+  section](https://github.com/prowler-cloud/prowler/releases) or in the
+  [Container Versions](#container-versions) section of this documentation.
 </Note>
-
 
 #### Option 2: Using Docker Compose Pull
 
@@ -141,7 +147,8 @@ The `--policy always` flag ensures that Docker pulls the latest images even if t
 <Note>
   **What Gets Preserved During Upgrade**
 
-  Everything is preserved, nothing will be deleted after the update.
+Everything is preserved, nothing will be deleted after the update.
+
 </Note>
 
 ### Troubleshooting Installation Issues

--- a/docs/user-guide/providers/llm/getting-started-llm.mdx
+++ b/docs/user-guide/providers/llm/getting-started-llm.mdx
@@ -21,13 +21,11 @@ Before using the LLM provider, ensure the following requirements are met:
 Install promptfoo using one of the following methods:
 
 **Using npm:**
-
 ```bash
 npm install --global promptfoo@0.121.11
 ```
 
 **Using Homebrew (macOS):**
-
 ```bash
 brew install promptfoo
 ```

--- a/docs/user-guide/providers/llm/getting-started-llm.mdx
+++ b/docs/user-guide/providers/llm/getting-started-llm.mdx
@@ -21,11 +21,13 @@ Before using the LLM provider, ensure the following requirements are met:
 Install promptfoo using one of the following methods:
 
 **Using npm:**
+
 ```bash
-npm install -g promptfoo
+npm install --global promptfoo@0.121.11
 ```
 
 **Using Homebrew (macOS):**
+
 ```bash
 brew install promptfoo
 ```

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -9,6 +9,7 @@
 ### Prowler Cloud and Prowler App (Self-Managed)
 
 Full access to Prowler Cloud platform and self-managed Prowler App for:
+
 - **Findings Analysis**: Query, filter, and analyze security findings across all your cloud environments
 - **Provider Management**: Create, configure, and manage your configured Prowler providers (AWS, Azure, GCP, etc.)
 - **Scan Orchestration**: Trigger on-demand scans and schedule recurring security assessments
@@ -19,6 +20,7 @@ Full access to Prowler Cloud platform and self-managed Prowler App for:
 ### Prowler Hub
 
 Access to Prowler's comprehensive security knowledge base:
+
 - **Security Checks Catalog**: Browse and search **over 1000 security checks** across multiple Prowler providers
 - **Check Implementation**: View the Python code that powers each security check
 - **Automated Fixers**: Access remediation scripts for common security issues
@@ -28,6 +30,7 @@ Access to Prowler's comprehensive security knowledge base:
 ### Prowler Documentation
 
 Search and retrieve official Prowler documentation:
+
 - **Intelligent Search**: Full-text search across all Prowler documentation
 - **Contextual Results**: Get relevant documentation pages with highlighted snippets
 - **Document Retrieval**: Access complete markdown content of any documentation file
@@ -36,13 +39,13 @@ Search and retrieve official Prowler documentation:
 
 For comprehensive guides and tutorials, see the official documentation:
 
-| Guide | Description |
-|-------|-------------|
-| [Overview](https://docs.prowler.com/getting-started/products/prowler-mcp) | Key capabilities, use cases, and deployment options |
-| [Installation](https://docs.prowler.com/getting-started/installation/prowler-mcp) | Docker, PyPI, and source installation |
-| [Configuration](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp) | Configure Claude Desktop, Cursor, and other MCP clients |
-| [Tools Reference](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp-tools) | Complete reference of all tools |
-| [Developer Guide](https://docs.prowler.com/developer-guide/mcp-server) | How to extend with new tools |
+| Guide                                                                                     | Description                                             |
+| ----------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [Overview](https://docs.prowler.com/getting-started/products/prowler-mcp)                 | Key capabilities, use cases, and deployment options     |
+| [Installation](https://docs.prowler.com/getting-started/installation/prowler-mcp)         | Docker, PyPI, and source installation                   |
+| [Configuration](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp)         | Configure Claude Desktop, Cursor, and other MCP clients |
+| [Tools Reference](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp-tools) | Complete reference of all tools                         |
+| [Developer Guide](https://docs.prowler.com/developer-guide/mcp-server)                    | How to extend with new tools                            |
 
 ## Deployment Options
 
@@ -56,13 +59,21 @@ Prowler MCP Server can be used in three ways:
 - Managed and maintained by Prowler team
 - Always up-to-date
 
+Install a reviewed version of `mcp-remote` in a dedicated local workspace first. Avoid running `npx mcp-remote` directly because it can download and execute a new package version on each run.
+
+```bash
+mkdir -p ~/.local/share/prowler-mcp-bridge
+cd ~/.local/share/prowler-mcp-bridge
+npm init -y
+npm install --save-exact mcp-remote@0.1.38
+```
+
 ```json
 {
   "mcpServers": {
     "prowler": {
-      "command": "npx",
+      "command": "/absolute/path/to/.local/share/prowler-mcp-bridge/node_modules/.bin/mcp-remote",
       "args": [
-        "mcp-remote",
         "https://mcp.prowler.com/mcp",
         "--header",
         "Authorization: Bearer pk_YOUR_API_KEY_HERE"
@@ -117,6 +128,7 @@ For complete tool descriptions and parameters, see the [Tools Reference](https:/
 ### Tool Naming Convention
 
 All tools follow a consistent naming pattern with prefixes:
+
 - `prowler_app_*` - Prowler Cloud and App (Self-Managed) management tools
 - `prowler_hub_*` - Prowler Hub catalog and compliance tools
 - `prowler_docs_*` - Prowler documentation search and retrieval
@@ -136,6 +148,7 @@ prowler_mcp_server/
 ```
 
 **Key Features:**
+
 - **Modular Design**: Three independent sub-servers with prefixed namespacing
 - **Auto-Discovery**: Prowler App tools are automatically discovered and registered
 - **LLM Optimization**: Response models minimize token usage by excluding empty values
@@ -146,16 +159,19 @@ prowler_mcp_server/
 The Prowler MCP Server enables powerful workflows through AI assistants:
 
 **Security Operations**
+
 - "Show me all critical findings from my AWS production accounts"
 - "Register my new AWS account in Prowler and run a scheduled scan every day"
 - "List all muted findings and detect what findgings are muted by a not enough good reason in relation to their severity"
 
 **Security Research**
+
 - "Explain what the S3 bucket public access Prowler check does"
 - "Find all Prowler checks related to encryption at rest"
 - "What is the latest version of the CIS that Prowler is covering per provider?"
 
 **Documentation & Learning**
+
 - "How do I configure Prowler to scan my GCP organization?"
 - "What authentication methods does Prowler support for Azure?"
 - "How can I contribute with a new security check to Prowler?"
@@ -163,9 +179,11 @@ The Prowler MCP Server enables powerful workflows through AI assistants:
 ## Requirements
 
 **For Prowler Cloud MCP Server:**
+
 - Prowler Cloud account and API key (only for Prowler Cloud/App features)
 
 **For self-hosted STDIO/HTTP Mode:**
+
 - Python 3.12+ or Docker
 - Network access to:
   - `https://hub.prowler.com` (for Prowler Hub)

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -9,7 +9,6 @@
 ### Prowler Cloud and Prowler App (Self-Managed)
 
 Full access to Prowler Cloud platform and self-managed Prowler App for:
-
 - **Findings Analysis**: Query, filter, and analyze security findings across all your cloud environments
 - **Provider Management**: Create, configure, and manage your configured Prowler providers (AWS, Azure, GCP, etc.)
 - **Scan Orchestration**: Trigger on-demand scans and schedule recurring security assessments
@@ -20,7 +19,6 @@ Full access to Prowler Cloud platform and self-managed Prowler App for:
 ### Prowler Hub
 
 Access to Prowler's comprehensive security knowledge base:
-
 - **Security Checks Catalog**: Browse and search **over 1000 security checks** across multiple Prowler providers
 - **Check Implementation**: View the Python code that powers each security check
 - **Automated Fixers**: Access remediation scripts for common security issues
@@ -30,7 +28,6 @@ Access to Prowler's comprehensive security knowledge base:
 ### Prowler Documentation
 
 Search and retrieve official Prowler documentation:
-
 - **Intelligent Search**: Full-text search across all Prowler documentation
 - **Contextual Results**: Get relevant documentation pages with highlighted snippets
 - **Document Retrieval**: Access complete markdown content of any documentation file
@@ -39,13 +36,13 @@ Search and retrieve official Prowler documentation:
 
 For comprehensive guides and tutorials, see the official documentation:
 
-| Guide                                                                                     | Description                                             |
-| ----------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| [Overview](https://docs.prowler.com/getting-started/products/prowler-mcp)                 | Key capabilities, use cases, and deployment options     |
-| [Installation](https://docs.prowler.com/getting-started/installation/prowler-mcp)         | Docker, PyPI, and source installation                   |
-| [Configuration](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp)         | Configure Claude Desktop, Cursor, and other MCP clients |
-| [Tools Reference](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp-tools) | Complete reference of all tools                         |
-| [Developer Guide](https://docs.prowler.com/developer-guide/mcp-server)                    | How to extend with new tools                            |
+| Guide | Description |
+|-------|-------------|
+| [Overview](https://docs.prowler.com/getting-started/products/prowler-mcp) | Key capabilities, use cases, and deployment options |
+| [Installation](https://docs.prowler.com/getting-started/installation/prowler-mcp) | Docker, PyPI, and source installation |
+| [Configuration](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp) | Configure Claude Desktop, Cursor, and other MCP clients |
+| [Tools Reference](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp-tools) | Complete reference of all tools |
+| [Developer Guide](https://docs.prowler.com/developer-guide/mcp-server) | How to extend with new tools |
 
 ## Deployment Options
 
@@ -128,7 +125,6 @@ For complete tool descriptions and parameters, see the [Tools Reference](https:/
 ### Tool Naming Convention
 
 All tools follow a consistent naming pattern with prefixes:
-
 - `prowler_app_*` - Prowler Cloud and App (Self-Managed) management tools
 - `prowler_hub_*` - Prowler Hub catalog and compliance tools
 - `prowler_docs_*` - Prowler documentation search and retrieval
@@ -148,7 +144,6 @@ prowler_mcp_server/
 ```
 
 **Key Features:**
-
 - **Modular Design**: Three independent sub-servers with prefixed namespacing
 - **Auto-Discovery**: Prowler App tools are automatically discovered and registered
 - **LLM Optimization**: Response models minimize token usage by excluding empty values
@@ -159,19 +154,16 @@ prowler_mcp_server/
 The Prowler MCP Server enables powerful workflows through AI assistants:
 
 **Security Operations**
-
 - "Show me all critical findings from my AWS production accounts"
 - "Register my new AWS account in Prowler and run a scheduled scan every day"
 - "List all muted findings and detect what findgings are muted by a not enough good reason in relation to their severity"
 
 **Security Research**
-
 - "Explain what the S3 bucket public access Prowler check does"
 - "Find all Prowler checks related to encryption at rest"
 - "What is the latest version of the CIS that Prowler is covering per provider?"
 
 **Documentation & Learning**
-
 - "How do I configure Prowler to scan my GCP organization?"
 - "What authentication methods does Prowler support for Azure?"
 - "How can I contribute with a new security check to Prowler?"
@@ -179,11 +171,9 @@ The Prowler MCP Server enables powerful workflows through AI assistants:
 ## Requirements
 
 **For Prowler Cloud MCP Server:**
-
 - Prowler Cloud account and API key (only for Prowler Cloud/App features)
 
 **For self-hosted STDIO/HTTP Mode:**
-
 - Python 3.12+ or Docker
 - Network access to:
   - `https://hub.prowler.com` (for Prowler Hub)

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,7 +1,6 @@
 # Prowler UI - AI Agent Ruleset
 
 > **Skills Reference**: For detailed patterns, use these skills:
->
 > - [`prowler-ui`](../skills/prowler-ui/SKILL.md) - Prowler-specific UI patterns
 > - [`prowler-test-ui`](../skills/prowler-test-ui/SKILL.md) - Playwright E2E testing (comprehensive)
 > - [`typescript`](../skills/typescript/SKILL.md) - Const types, flat interfaces
@@ -19,35 +18,35 @@
 
 When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
-| Action                                                         | Skill               |
-| -------------------------------------------------------------- | ------------------- |
-| Add changelog entry for a PR or feature                        | `prowler-changelog` |
-| App Router / Server Actions                                    | `nextjs-16`         |
-| Building AI chat features                                      | `ai-sdk-5`          |
-| Committing changes                                             | `prowler-commit`    |
-| Create PR that requires changelog entry                        | `prowler-changelog` |
-| Creating Zod schemas                                           | `zod-4`             |
-| Creating a git commit                                          | `prowler-commit`    |
-| Creating/modifying Prowler UI components                       | `prowler-ui`        |
-| Fixing bug                                                     | `tdd`               |
-| Implementing feature                                           | `tdd`               |
-| Modifying component                                            | `tdd`               |
-| Refactoring code                                               | `tdd`               |
-| Review changelog format and conventions                        | `prowler-changelog` |
-| Testing hooks or utilities                                     | `vitest`            |
-| Update CHANGELOG.md in any component                           | `prowler-changelog` |
-| Using Zustand stores                                           | `zustand-5`         |
-| Working on Prowler UI structure (actions/adapters/types/hooks) | `prowler-ui`        |
-| Working on task                                                | `tdd`               |
-| Working with Prowler UI test helpers/pages                     | `prowler-test-ui`   |
-| Working with Tailwind classes                                  | `tailwind-4`        |
-| Writing Playwright E2E tests                                   | `playwright`        |
-| Writing Prowler UI E2E tests                                   | `prowler-test-ui`   |
-| Writing React component tests                                  | `vitest`            |
-| Writing React components                                       | `react-19`          |
-| Writing TypeScript types/interfaces                            | `typescript`        |
-| Writing Vitest tests                                           | `vitest`            |
-| Writing unit tests for UI                                      | `vitest`            |
+| Action | Skill |
+|--------|-------|
+| Add changelog entry for a PR or feature | `prowler-changelog` |
+| App Router / Server Actions | `nextjs-16` |
+| Building AI chat features | `ai-sdk-5` |
+| Committing changes | `prowler-commit` |
+| Create PR that requires changelog entry | `prowler-changelog` |
+| Creating Zod schemas | `zod-4` |
+| Creating a git commit | `prowler-commit` |
+| Creating/modifying Prowler UI components | `prowler-ui` |
+| Fixing bug | `tdd` |
+| Implementing feature | `tdd` |
+| Modifying component | `tdd` |
+| Refactoring code | `tdd` |
+| Review changelog format and conventions | `prowler-changelog` |
+| Testing hooks or utilities | `vitest` |
+| Update CHANGELOG.md in any component | `prowler-changelog` |
+| Using Zustand stores | `zustand-5` |
+| Working on Prowler UI structure (actions/adapters/types/hooks) | `prowler-ui` |
+| Working on task | `tdd` |
+| Working with Prowler UI test helpers/pages | `prowler-test-ui` |
+| Working with Tailwind classes | `tailwind-4` |
+| Writing Playwright E2E tests | `playwright` |
+| Writing Prowler UI E2E tests | `prowler-test-ui` |
+| Writing React component tests | `vitest` |
+| Writing React components | `react-19` |
+| Writing TypeScript types/interfaces | `typescript` |
+| Writing Vitest tests | `vitest` |
+| Writing unit tests for UI | `vitest` |
 
 ---
 
@@ -138,8 +137,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 const schema = z.object({
-  email: z.email(), // Zod 4: z.email() not z.string().email()
-  id: z.uuid(), // Zod 4: z.uuid() not z.string().uuid()
+  email: z.email(),  // Zod 4: z.email() not z.string().email()
+  id: z.uuid(),      // Zod 4: z.uuid() not z.string().uuid()
 });
 
 const form = useForm({ resolver: zodResolver(schema) });
@@ -164,12 +163,8 @@ const useStore = create(
 ```typescript
 export class FeaturePage extends BasePage {
   readonly submitBtn = this.page.getByRole("button", { name: "Submit" });
-  async goto() {
-    await super.goto("/path");
-  }
-  async submit() {
-    await this.submitBtn.click();
-  }
+  async goto() { await super.goto("/path"); }
+  async submit() { await this.submitBtn.click(); }
 }
 
 test("action works", { tag: ["@critical", "@feature"] }, async ({ page }) => {

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,6 +1,7 @@
 # Prowler UI - AI Agent Ruleset
 
 > **Skills Reference**: For detailed patterns, use these skills:
+>
 > - [`prowler-ui`](../skills/prowler-ui/SKILL.md) - Prowler-specific UI patterns
 > - [`prowler-test-ui`](../skills/prowler-test-ui/SKILL.md) - Playwright E2E testing (comprehensive)
 > - [`typescript`](../skills/typescript/SKILL.md) - Const types, flat interfaces
@@ -18,35 +19,35 @@
 
 When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 
-| Action | Skill |
-|--------|-------|
-| Add changelog entry for a PR or feature | `prowler-changelog` |
-| App Router / Server Actions | `nextjs-16` |
-| Building AI chat features | `ai-sdk-5` |
-| Committing changes | `prowler-commit` |
-| Create PR that requires changelog entry | `prowler-changelog` |
-| Creating Zod schemas | `zod-4` |
-| Creating a git commit | `prowler-commit` |
-| Creating/modifying Prowler UI components | `prowler-ui` |
-| Fixing bug | `tdd` |
-| Implementing feature | `tdd` |
-| Modifying component | `tdd` |
-| Refactoring code | `tdd` |
-| Review changelog format and conventions | `prowler-changelog` |
-| Testing hooks or utilities | `vitest` |
-| Update CHANGELOG.md in any component | `prowler-changelog` |
-| Using Zustand stores | `zustand-5` |
-| Working on Prowler UI structure (actions/adapters/types/hooks) | `prowler-ui` |
-| Working on task | `tdd` |
-| Working with Prowler UI test helpers/pages | `prowler-test-ui` |
-| Working with Tailwind classes | `tailwind-4` |
-| Writing Playwright E2E tests | `playwright` |
-| Writing Prowler UI E2E tests | `prowler-test-ui` |
-| Writing React component tests | `vitest` |
-| Writing React components | `react-19` |
-| Writing TypeScript types/interfaces | `typescript` |
-| Writing Vitest tests | `vitest` |
-| Writing unit tests for UI | `vitest` |
+| Action                                                         | Skill               |
+| -------------------------------------------------------------- | ------------------- |
+| Add changelog entry for a PR or feature                        | `prowler-changelog` |
+| App Router / Server Actions                                    | `nextjs-16`         |
+| Building AI chat features                                      | `ai-sdk-5`          |
+| Committing changes                                             | `prowler-commit`    |
+| Create PR that requires changelog entry                        | `prowler-changelog` |
+| Creating Zod schemas                                           | `zod-4`             |
+| Creating a git commit                                          | `prowler-commit`    |
+| Creating/modifying Prowler UI components                       | `prowler-ui`        |
+| Fixing bug                                                     | `tdd`               |
+| Implementing feature                                           | `tdd`               |
+| Modifying component                                            | `tdd`               |
+| Refactoring code                                               | `tdd`               |
+| Review changelog format and conventions                        | `prowler-changelog` |
+| Testing hooks or utilities                                     | `vitest`            |
+| Update CHANGELOG.md in any component                           | `prowler-changelog` |
+| Using Zustand stores                                           | `zustand-5`         |
+| Working on Prowler UI structure (actions/adapters/types/hooks) | `prowler-ui`        |
+| Working on task                                                | `tdd`               |
+| Working with Prowler UI test helpers/pages                     | `prowler-test-ui`   |
+| Working with Tailwind classes                                  | `tailwind-4`        |
+| Writing Playwright E2E tests                                   | `playwright`        |
+| Writing Prowler UI E2E tests                                   | `prowler-test-ui`   |
+| Writing React component tests                                  | `vitest`            |
+| Writing React components                                       | `react-19`          |
+| Writing TypeScript types/interfaces                            | `typescript`        |
+| Writing Vitest tests                                           | `vitest`            |
+| Writing unit tests for UI                                      | `vitest`            |
 
 ---
 
@@ -137,8 +138,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 const schema = z.object({
-  email: z.email(),  // Zod 4: z.email() not z.string().email()
-  id: z.uuid(),      // Zod 4: z.uuid() not z.string().uuid()
+  email: z.email(), // Zod 4: z.email() not z.string().email()
+  id: z.uuid(), // Zod 4: z.uuid() not z.string().uuid()
 });
 
 const form = useForm({ resolver: zodResolver(schema) });
@@ -163,8 +164,12 @@ const useStore = create(
 ```typescript
 export class FeaturePage extends BasePage {
   readonly submitBtn = this.page.getByRole("button", { name: "Submit" });
-  async goto() { await super.goto("/path"); }
-  async submit() { await this.submitBtn.click(); }
+  async goto() {
+    await super.goto("/path");
+  }
+  async submit() {
+    await this.submitBtn.click();
+  }
 }
 
 test("action works", { tag: ["@critical", "@feature"] }, async ({ page }) => {
@@ -226,5 +231,6 @@ pnpm run test:e2e:ui
 - [ ] Relevant E2E tests pass
 - [ ] All UI states handled (loading, error, empty)
 - [ ] No secrets in code (use `.env.local`)
+- [ ] New npm dependencies include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and a rationale for not using existing/native alternatives.
 - [ ] Error messages sanitized
 - [ ] Server-side validation present

--- a/ui/components/shadcn/README.md
+++ b/ui/components/shadcn/README.md
@@ -109,10 +109,10 @@ export function MyComponent() {
 
 ## Adding New shadcn Components
 
-When adding new shadcn components using the CLI:
+When adding new shadcn components using the CLI, pin the reviewed CLI version instead of using `@latest`:
 
 ```bash
-npx shadcn@latest add [component-name]
+pnpm dlx shadcn@4.7.0 add [component-name]
 ```
 
 The component will be automatically added to this directory due to the configuration in `components.json`:

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,6 +28,8 @@
     "test:e2e:headed": "playwright test --project=auth --project=sign-up --project=providers --project=invitations --project=scans --headed",
     "test:e2e:report": "playwright show-report",
     "test:e2e:install": "playwright install",
+    "audit": "pnpm audit --audit-level critical",
+    "audit:high": "pnpm audit --audit-level high",
     "audit:fix": "pnpm audit fix"
   },
   "dependencies": {

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -14,20 +14,21 @@ minimumReleaseAge: 1440
 
 # --- Level 2: Explicit Build Script Allow-list ---
 # Only these packages may run install/postinstall lifecycle scripts.
-# Any unlisted package with lifecycle scripts will have them silently skipped.
-onlyBuiltDependencies:
+# Any unlisted package with lifecycle scripts fails the install.
+strictDepBuilds: true
+allowBuilds:
   # sharp: Native image processing (libvips). Installs platform-specific pre-built binary or compiles from source.
-  - sharp
+  sharp: true
   # @sentry/cli: Downloads the sentry-cli native binary for the current platform. Validates integrity via SHA256.
-  - "@sentry/cli"
+  "@sentry/cli": true
   # esbuild: Go binary. Downloads the pre-compiled binary matching the current platform/architecture.
-  - esbuild
+  esbuild: true
   # @heroui/shared-utils: Demi pattern — detects React/Next.js version at install time and copies the compatible bundle (React 18 vs 19).
-  - "@heroui/shared-utils"
+  "@heroui/shared-utils": true
   # unrs-resolver: Rust module resolver (NAPI-RS). Verifies the correct native binding is available for the platform.
-  - unrs-resolver
+  unrs-resolver: true
   # msw: Copies mockServiceWorker.js into the directories listed in package.json's `msw.workerDirectory` (here: `public/`) so the runtime worker stays in sync with the installed msw version. Pure file copy — no native binary, no network access. Required for vitest browser tests to intercept fetches via the service worker.
-  - msw
+  msw: true
 
 # --- Level 3: Trust Policy + Exotic Subdeps ---
 # Fail when a package's trust evidence is downgraded (e.g., new publisher).


### PR DESCRIPTION
### Context

This PR hardens Prowler's npm/pnpm supply-chain posture after reviewing [`lirantal/npm-security-best-practices`](https://github.com/lirantal/npm-security-best-practices) against the current Prowler repository.

The audit showed that Prowler already has a strong pnpm baseline in `ui/`:

- `ui/package.json` pins `pnpm@10.33.0` through `packageManager` with an integrity hash.
- CI and Docker builds use frozen pnpm installs.
- `ui/pnpm-workspace.yaml` already had `minimumReleaseAge`, a dependency build-script allow-list, `trustPolicy: no-downgrade`, and `blockExoticSubdeps: true`.
- The UI package is private and does not publish npm packages, so npm publisher controls such as npm OIDC/provenance are not directly applicable today.

The same audit identified a few gaps worth addressing now:

- Dependency build scripts were allow-listed but not enforced as a hard failure.
- UI CI had no non-mutating npm vulnerability audit gate.
- Some docs still encouraged `npm install`, floating global npm installs, or direct `npx` execution.
- PR guidance did not explicitly require package-health evidence for new UI npm dependencies.

No issue linked; this is maintenance hardening requested from the audit follow-up.

### Description

This PR implements the following hardening changes:

#### 1. Harden pnpm Dependency Build Scripts

Updated `ui/pnpm-workspace.yaml` to make dependency lifecycle-script policy stricter:

- Added `strictDepBuilds: true` so unreviewed dependency build scripts fail installation instead of being silently skipped or only warned about.
- Migrated from `onlyBuiltDependencies` to pnpm's newer `allowBuilds` map style for pnpm 10.33.
- Preserved the reviewed allow-list for packages that currently need install/build scripts:
  - `sharp`
  - `@sentry/cli`
  - `esbuild`
  - `@heroui/shared-utils`
  - `unrs-resolver`
  - `msw`

Why: lifecycle scripts are a recurring npm supply-chain attack vector. The repo already had the right allow-list idea; this makes the policy fail closed.

#### 3. Add a Non-Mutating UI Audit Gate

Updated `ui/package.json` and `.github/workflows/ui-tests.yml`:

- Added `pnpm run audit` as a CI-safe, non-mutating audit command.
- Added `pnpm run audit:high` for strict/manual high-severity visibility.
- Added a UI workflow step that runs `pnpm run audit` after install and healthcheck.

Current behavior:

- `pnpm run audit` uses `--audit-level critical` and passes with the current baseline.
- `pnpm run audit:high` is available for maintainers to run stricter checks during remediation work.

Why: this adds CI visibility without immediately blocking all UI PRs on the existing dependency baseline. The stricter command is available for follow-up remediation; once the baseline is addressed, the CI gate can be raised.

#### 4. Prefer pnpm/Corepack in Source Install Docs

Updated `docs/getting-started/installation/prowler-app.mdx`:

- Replaced stale UI source-install instructions that used `npm install`, `npm run build`, and `npm start`.
- Documented `pnpm` through Corepack and `pnpm install --frozen-lockfile`.

Why: Prowler UI is pinned to pnpm and relies on pnpm-specific supply-chain controls. Using npm bypasses those controls and can produce a different dependency resolution path.

#### 5. Harden Dynamic npm Tool Execution in Docs

Updated docs that previously encouraged floating or dynamic npm execution:

- `docs/getting-started/basic-usage/prowler-mcp.mdx`
- `mcp_server/README.md`
- `docs/README.md`
- `docs/developer-guide/documentation.mdx`
- `docs/user-guide/providers/llm/getting-started-llm.mdx`
- `ui/components/shadcn/README.md`

Changes include:

- Replacing direct `npx mcp-remote` MCP client examples with a dedicated local workspace and exact `mcp-remote@0.1.38` install.
- Pinning global npm CLI examples:
  - `mint@4.2.560`
  - `promptfoo@0.121.11`
- Replacing `npx shadcn@latest` with `pnpm dlx shadcn@4.7.0`.

Why: direct `npx` and floating `@latest` examples can download and execute newly published code at runtime. Pinning makes the review target explicit and reduces supply-chain surprise.

#### 7. Add Package-Health Review Expectations

Updated:

- `.github/pull_request_template.md`
- `ui/AGENTS.md`

New guidance asks contributors to include package-health evidence when adding or updating UI npm dependencies, including:

- Maintenance status
- Popularity/adoption
- Known vulnerabilities
- License
- Release age
- Rationale for not using existing or native alternatives

Why: every direct dependency expands Prowler UI's transitive attack surface. This makes dependency additions easier to review and aligns PR expectations with npm supply-chain best practices.

### Steps to review

1. Review `ui/pnpm-workspace.yaml` and confirm the build-script allow-list matches packages that need install/build scripts.
2. Review `ui/package.json` and `.github/workflows/ui-tests.yml` for the audit commands and CI audit step.
3. Review the docs changes for pnpm/Corepack usage, pinned npm CLI versions, and safer `mcp-remote` guidance.
4. Review `.github/pull_request_template.md` and `ui/AGENTS.md` for the package-health checklist wording.

Validation run locally:

```bash
git diff --check
cd ui && pnpm install --frozen-lockfile --prefer-offline
cd ui && pnpm run audit
cd ui && pnpm run healthcheck
```

Additional evidence:

```bash
cd ui && pnpm run audit:high
```

`audit:high` is intentionally not wired into CI in this PR because it would block on the current dependency baseline. The CI gate uses the critical threshold for now so it introduces audit visibility without immediately blocking all UI changes. The stricter command is available for follow-up remediation.

Commit hooks also ran successfully when committing, including UI build, `zizmor`, TruffleHog, and the repository pre-commit checks.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

