### PR TITLE
fix(ui): enforce 100-char limit on mute rule name input

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 - Attack Paths graph now uses React Flow with improved layout, interactions, export, minimap, and browser test coverage [(#10686)](https://github.com/prowler-cloud/prowler/pull/10686)
 - SAML ACS URL is only shown if the email domain is configured [(#11144)](https://github.com/prowler-cloud/prowler/pull/11144)
 
+### 🐞 Fixed
+
+- Mute Findings modal now enforces the 100-character limit on the rule name input with a live counter and inline error, matching the existing reason field behaviour [(#11158)](https://github.com/prowler-cloud/prowler/pull/11158)
+
 ---
 
 ## [1.26.2] (Prowler 5.26.2)

--- a/ui/components/findings/mute-findings-modal.test.tsx
+++ b/ui/components/findings/mute-findings-modal.test.tsx
@@ -106,6 +106,11 @@ describe("MuteFindingsModal", () => {
     expect(
       screen.getByText("Explain why these findings are being muted"),
     ).toBeInTheDocument();
+    expect(screen.getByText("0/100 characters")).toBeInTheDocument();
+    expect(screen.getByLabelText("Rule Name")).toHaveAttribute(
+      "maxLength",
+      "100",
+    );
     expect(screen.getByText("0/500 characters")).toBeInTheDocument();
     expect(screen.getByLabelText("Reason")).toHaveAttribute("maxLength", "500");
   });
@@ -181,6 +186,25 @@ describe("MuteFindingsModal", () => {
     expect(screen.getByText("500/500 characters")).toBeInTheDocument();
     expect(
       screen.getByText("Reason must be 500 characters or fewer"),
+    ).toBeInTheDocument();
+  });
+
+  it("clamps oversized rule name input and shows a local validation error", () => {
+    render(
+      <MuteFindingsModal
+        isOpen
+        onOpenChange={vi.fn()}
+        findingIds={["finding-1"]}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Rule Name"), {
+      target: { value: "a".repeat(101) },
+    });
+
+    expect(screen.getByText("100/100 characters")).toBeInTheDocument();
+    expect(
+      screen.getByText("Name must be 100 characters or fewer"),
     ).toBeInTheDocument();
   });
 });

--- a/ui/components/findings/mute-findings-modal.tsx
+++ b/ui/components/findings/mute-findings-modal.tsx
@@ -11,8 +11,12 @@ import { FormButtons } from "@/components/ui/form";
 import { Label } from "@/components/ui/form/Label";
 import { useMuteRuleAction } from "@/hooks/use-mute-rule-action";
 import {
+  enforceMuteRuleNameLimit,
   enforceMuteRuleReasonLimit,
+  getMuteRuleNameCounterText,
   getMuteRuleReasonCounterText,
+  MAX_MUTE_RULE_NAME_LENGTH,
+  MAX_MUTE_RULE_REASON_LENGTH,
 } from "@/lib/mute-rules";
 
 interface MuteFindingsModalProps {
@@ -35,6 +39,8 @@ export function MuteFindingsModal({
   preparationError = null,
 }: MuteFindingsModalProps) {
   const [state, setState] = useState<MuteRuleActionState | null>(null);
+  const [name, setName] = useState("");
+  const [nameLengthError, setNameLengthError] = useState<string>();
   const [reason, setReason] = useState("");
   const [reasonLengthError, setReasonLengthError] = useState<string>();
   const { isPending, runAction } = useMuteRuleAction();
@@ -48,8 +54,15 @@ export function MuteFindingsModal({
     isPreparing ||
     findingIds.length === 0 ||
     Boolean(preparationError);
-  const nameError = state?.errors?.name;
+  const nameError = nameLengthError || state?.errors?.name;
   const reasonError = reasonLengthError || state?.errors?.reason;
+
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const nextName = enforceMuteRuleNameLimit(event.target.value);
+
+    setName(nextName.value);
+    setNameLengthError(nextName.error);
+  };
 
   const handleReasonChange = (
     event: React.ChangeEvent<HTMLTextAreaElement>,
@@ -77,7 +90,14 @@ export function MuteFindingsModal({
           }
 
           const formData = new FormData(e.currentTarget);
+          formData.set("name", name);
           formData.set("reason", reason);
+
+          const nextName = enforceMuteRuleNameLimit(name);
+          if (nextName.error) {
+            setNameLengthError(nextName.error);
+            return;
+          }
 
           const nextReason = enforceMuteRuleReasonLimit(reason);
           if (nextReason.error) {
@@ -211,6 +231,9 @@ export function MuteFindingsModal({
                     placeholder="e.g., Ignore dev environment S3 buckets"
                     required
                     disabled={isPending}
+                    value={name}
+                    onChange={handleNameChange}
+                    maxLength={MAX_MUTE_RULE_NAME_LENGTH}
                     aria-invalid={nameError ? "true" : "false"}
                     aria-describedby={
                       nameError
@@ -218,12 +241,17 @@ export function MuteFindingsModal({
                         : "mute-rule-name-description"
                     }
                   />
-                  <p
-                    id="mute-rule-name-description"
-                    className="text-text-neutral-tertiary text-xs"
-                  >
-                    A descriptive name for this mute rule
-                  </p>
+                  <div className="flex items-center justify-between gap-3">
+                    <p
+                      id="mute-rule-name-description"
+                      className="text-text-neutral-tertiary text-xs"
+                    >
+                      A descriptive name for this mute rule
+                    </p>
+                    <p className="text-text-neutral-tertiary shrink-0 text-xs">
+                      {getMuteRuleNameCounterText(name)}
+                    </p>
+                  </div>
                   {nameError ? (
                     <p
                       id="mute-rule-name-error"
@@ -250,7 +278,7 @@ export function MuteFindingsModal({
                     value={reason}
                     onChange={handleReasonChange}
                     rows={4}
-                    maxLength={500}
+                    maxLength={MAX_MUTE_RULE_REASON_LENGTH}
                     aria-invalid={reasonError ? "true" : "false"}
                     aria-describedby={
                       reasonError

--- a/ui/lib/mute-rules.ts
+++ b/ui/lib/mute-rules.ts
@@ -1,9 +1,29 @@
+export const MAX_MUTE_RULE_NAME_LENGTH = 100;
 export const MAX_MUTE_RULE_REASON_LENGTH = 500;
 
+export const MUTE_RULE_NAME_TOO_LONG_MESSAGE = `Name must be ${MAX_MUTE_RULE_NAME_LENGTH} characters or fewer`;
 export const MUTE_RULE_REASON_TOO_LONG_MESSAGE = `Reason must be ${MAX_MUTE_RULE_REASON_LENGTH} characters or fewer`;
+
+export function getMuteRuleNameCounterText(name: string): string {
+  return `${name.length}/${MAX_MUTE_RULE_NAME_LENGTH} characters`;
+}
 
 export function getMuteRuleReasonCounterText(reason: string): string {
   return `${reason.length}/${MAX_MUTE_RULE_REASON_LENGTH} characters`;
+}
+
+export function enforceMuteRuleNameLimit(name: string): {
+  value: string;
+  error?: string;
+} {
+  if (name.length <= MAX_MUTE_RULE_NAME_LENGTH) {
+    return { value: name };
+  }
+
+  return {
+    value: name.slice(0, MAX_MUTE_RULE_NAME_LENGTH),
+    error: MUTE_RULE_NAME_TOO_LONG_MESSAGE,
+  };
 }
 
 export function enforceMuteRuleReasonLimit(reason: string): {


### PR DESCRIPTION
### Context

The Mute Findings modal (`/findings`) does not enforce the 100-character limit that the API model imposes on `MuteRule.name` (`max_length=100`, `MinLengthValidator(3)` in `api/src/backend/api/models.py`). Users could type a longer rule name and the `POST /api/v1/mute-rules` request only failed after the round-trip with a generic validation error. The `reason` field already enforces its 500-character limit client-side via `enforceMuteRuleReasonLimit` + counter + inline error; this PR mirrors that pattern for the Rule Name input so feedback is immediate and consistent.

Tracks PROWLER-1734.

### Description

- `ui/lib/mute-rules.ts`: add `MAX_MUTE_RULE_NAME_LENGTH = 100`, `MUTE_RULE_NAME_TOO_LONG_MESSAGE`, `getMuteRuleNameCounterText`, `enforceMuteRuleNameLimit`. Existing reason helpers untouched; the modal now also imports `MAX_MUTE_RULE_REASON_LENGTH` from this module instead of relying on the magic number `500`.
- `ui/components/findings/mute-findings-modal.tsx`: convert the Rule Name `Input` into a controlled component with `value` / `onChange` / `maxLength=100`, render the `X/100 characters` counter and inline length error, and re-validate on submit (mirrors the existing reason flow). The local `nameLengthError` is OR'd with the server-side `state.errors.name`.
- `ui/components/findings/mute-findings-modal.test.tsx`: extend the ready-state test to assert both counters and `maxLength` attributes; add a new test that types 101 chars and asserts truncation + inline error.

No API, MCP, or SDK changes.

### Steps to review

1. `cd ui && pnpm install`
2. `pnpm run typecheck && pnpm run lint:fix && pnpm run format:write` — clean.
3. `pnpm vitest run components/findings/mute-findings-modal.test.tsx` — 5/5 pass.
4. Local stack: open `/findings`, select a finding group, click **Mute Finding Group**.
   - Counter under the Rule Name input shows `0/100 characters` initially and updates as you type.
   - Pasting more than 100 chars truncates to 100; an inline `Name must be 100 characters or fewer` appears.
   - Reason field behaviour unchanged (still 500 chars, counter, inline error).
   - Submitting a 100-char rule name now succeeds without the previous server-side `name` validation error.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.