### PR TITLE
fix(googleworkspace): use per-service resources for Gmail

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `entra_emergency_access_exclusion` check for M365 provider now scopes the exclusion requirement to enabled Conditional Access policies with a `Block` grant control instead of every enabled policy, focusing on the lockout-relevant policy set [(#10849)](https://github.com/prowler-cloud/prowler/pull/10849)
 - AWS IAM customer-managed policy checks no longer emit `FAIL` on unattached policies unless `--scan-unused-services` is enabled [(#11150)](https://github.com/prowler-cloud/prowler/pull/11150)
 
+### 🐞 Fixed
+
+- Google Workspace Gmail checks sharing a single resource row, causing the service field to be overwritten by the last check executed [(#11169)](https://github.com/prowler-cloud/prowler/pull/11169)
+
 ---
 
 ## [5.26.2] (Prowler UNRELEASED)

--- a/prowler/providers/googleworkspace/services/gmail/gmail_anomalous_attachment_protection_enabled/gmail_anomalous_attachment_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_anomalous_attachment_protection_enabled/gmail_anomalous_attachment_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_anomalous_attachment_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.enable_anomalous_attachment_protection

--- a/prowler/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled.py
@@ -18,7 +18,10 @@ class gmail_auto_forwarding_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             forwarding_enabled = gmail_client.policies.enable_auto_forwarding

--- a/prowler/providers/googleworkspace/services/gmail/gmail_comprehensive_mail_storage_enabled/gmail_comprehensive_mail_storage_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_comprehensive_mail_storage_enabled/gmail_comprehensive_mail_storage_enabled.py
@@ -18,7 +18,10 @@ class gmail_comprehensive_mail_storage_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             storage_enabled = gmail_client.policies.comprehensive_mail_storage_enabled

--- a/prowler/providers/googleworkspace/services/gmail/gmail_domain_spoofing_protection_enabled/gmail_domain_spoofing_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_domain_spoofing_protection_enabled/gmail_domain_spoofing_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_domain_spoofing_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.detect_domain_name_spoofing

--- a/prowler/providers/googleworkspace/services/gmail/gmail_employee_name_spoofing_protection_enabled/gmail_employee_name_spoofing_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_employee_name_spoofing_protection_enabled/gmail_employee_name_spoofing_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_employee_name_spoofing_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.detect_employee_name_spoofing

--- a/prowler/providers/googleworkspace/services/gmail/gmail_encrypted_attachment_protection_enabled/gmail_encrypted_attachment_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_encrypted_attachment_protection_enabled/gmail_encrypted_attachment_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_encrypted_attachment_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.enable_encrypted_attachment_protection

--- a/prowler/providers/googleworkspace/services/gmail/gmail_enhanced_pre_delivery_scanning_enabled/gmail_enhanced_pre_delivery_scanning_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_enhanced_pre_delivery_scanning_enabled/gmail_enhanced_pre_delivery_scanning_enabled.py
@@ -18,7 +18,10 @@ class gmail_enhanced_pre_delivery_scanning_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             scanning_enabled = (

--- a/prowler/providers/googleworkspace/services/gmail/gmail_external_image_scanning_enabled/gmail_external_image_scanning_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_external_image_scanning_enabled/gmail_external_image_scanning_enabled.py
@@ -18,7 +18,10 @@ class gmail_external_image_scanning_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             scanning_enabled = gmail_client.policies.enable_external_image_scanning

--- a/prowler/providers/googleworkspace/services/gmail/gmail_groups_spoofing_protection_enabled/gmail_groups_spoofing_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_groups_spoofing_protection_enabled/gmail_groups_spoofing_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_groups_spoofing_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.detect_groups_spoofing

--- a/prowler/providers/googleworkspace/services/gmail/gmail_inbound_domain_spoofing_protection_enabled/gmail_inbound_domain_spoofing_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_inbound_domain_spoofing_protection_enabled/gmail_inbound_domain_spoofing_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_inbound_domain_spoofing_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.detect_inbound_domain_spoofing

--- a/prowler/providers/googleworkspace/services/gmail/gmail_mail_delegation_disabled/gmail_mail_delegation_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_mail_delegation_disabled/gmail_mail_delegation_disabled.py
@@ -18,7 +18,10 @@ class gmail_mail_delegation_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             delegation_enabled = gmail_client.policies.enable_mail_delegation

--- a/prowler/providers/googleworkspace/services/gmail/gmail_per_user_outbound_gateway_disabled/gmail_per_user_outbound_gateway_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_per_user_outbound_gateway_disabled/gmail_per_user_outbound_gateway_disabled.py
@@ -18,7 +18,10 @@ class gmail_per_user_outbound_gateway_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             gateway_allowed = gmail_client.policies.allow_per_user_outbound_gateway

--- a/prowler/providers/googleworkspace/services/gmail/gmail_pop_imap_access_disabled/gmail_pop_imap_access_disabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_pop_imap_access_disabled/gmail_pop_imap_access_disabled.py
@@ -18,7 +18,10 @@ class gmail_pop_imap_access_disabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             pop_enabled = gmail_client.policies.enable_pop_access

--- a/prowler/providers/googleworkspace/services/gmail/gmail_script_attachment_protection_enabled/gmail_script_attachment_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_script_attachment_protection_enabled/gmail_script_attachment_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_script_attachment_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.enable_script_attachment_protection

--- a/prowler/providers/googleworkspace/services/gmail/gmail_shortener_scanning_enabled/gmail_shortener_scanning_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_shortener_scanning_enabled/gmail_shortener_scanning_enabled.py
@@ -18,7 +18,10 @@ class gmail_shortener_scanning_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             scanning_enabled = gmail_client.policies.enable_shortener_scanning

--- a/prowler/providers/googleworkspace/services/gmail/gmail_unauthenticated_email_protection_enabled/gmail_unauthenticated_email_protection_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_unauthenticated_email_protection_enabled/gmail_unauthenticated_email_protection_enabled.py
@@ -18,7 +18,10 @@ class gmail_unauthenticated_email_protection_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             enabled = gmail_client.policies.detect_unauthenticated_emails

--- a/prowler/providers/googleworkspace/services/gmail/gmail_untrusted_link_warnings_enabled/gmail_untrusted_link_warnings_enabled.py
+++ b/prowler/providers/googleworkspace/services/gmail/gmail_untrusted_link_warnings_enabled/gmail_untrusted_link_warnings_enabled.py
@@ -18,7 +18,10 @@ class gmail_untrusted_link_warnings_enabled(Check):
         if gmail_client.policies_fetched:
             report = CheckReportGoogleWorkspace(
                 metadata=self.metadata(),
-                resource=gmail_client.provider.domain_resource,
+                resource=gmail_client.policies,
+                resource_id="gmailPolicies",
+                resource_name="Gmail Policies",
+                customer_id=gmail_client.provider.identity.customer_id,
             )
 
             warnings_enabled = (

--- a/tests/providers/googleworkspace/services/gmail/gmail_anomalous_attachment_protection_enabled/gmail_anomalous_attachment_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_anomalous_attachment_protection_enabled/gmail_anomalous_attachment_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -38,7 +37,7 @@ class TestGmailAnomalousAttachmentProtectionEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "WARNING" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_no_action(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_auto_forwarding_disabled/gmail_auto_forwarding_disabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -35,10 +34,13 @@ class TestGmailAutoForwardingDisabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "disabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
-            assert findings[0].resource_id == CUSTOMER_ID
+            assert findings[0].resource_name == "Gmail Policies"
+            assert findings[0].resource_id == "gmailPolicies"
             assert findings[0].customer_id == CUSTOMER_ID
-            assert findings[0].resource == mock_provider.domain_resource.dict()
+            assert (
+                findings[0].resource
+                == GmailPolicies(enable_auto_forwarding=False).dict()
+            )
 
     def test_fail_disabled(self):
         mock_provider = set_mocked_googleworkspace_provider()

--- a/tests/providers/googleworkspace/services/gmail/gmail_comprehensive_mail_storage_enabled/gmail_comprehensive_mail_storage_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_comprehensive_mail_storage_enabled/gmail_comprehensive_mail_storage_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -37,7 +36,7 @@ class TestGmailComprehensiveMailStorageEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "enabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_disabled(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_domain_spoofing_protection_enabled/gmail_domain_spoofing_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_domain_spoofing_protection_enabled/gmail_domain_spoofing_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -38,7 +37,7 @@ class TestGmailDomainSpoofingProtectionEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "SPAM_FOLDER" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_no_action(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_employee_name_spoofing_protection_enabled/gmail_employee_name_spoofing_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_employee_name_spoofing_protection_enabled/gmail_employee_name_spoofing_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -38,7 +37,7 @@ class TestGmailEmployeeNameSpoofingProtectionEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "SPAM_FOLDER" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_no_action(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_encrypted_attachment_protection_enabled/gmail_encrypted_attachment_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_encrypted_attachment_protection_enabled/gmail_encrypted_attachment_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -38,7 +37,7 @@ class TestGmailEncryptedAttachmentProtectionEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "QUARANTINE" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_no_action(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_enhanced_pre_delivery_scanning_enabled/gmail_enhanced_pre_delivery_scanning_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_enhanced_pre_delivery_scanning_enabled/gmail_enhanced_pre_delivery_scanning_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -37,7 +36,7 @@ class TestGmailEnhancedPreDeliveryScanningEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "enabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_disabled(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_external_image_scanning_enabled/gmail_external_image_scanning_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_external_image_scanning_enabled/gmail_external_image_scanning_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -35,7 +34,7 @@ class TestGmailExternalImageScanningEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "enabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_disabled(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_groups_spoofing_protection_enabled/gmail_groups_spoofing_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_groups_spoofing_protection_enabled/gmail_groups_spoofing_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -39,7 +38,7 @@ class TestGmailGroupsSpoofingProtectionEnabled:
             assert findings[0].status == "PASS"
             assert "all groups" in findings[0].status_extended
             assert "SPAM_FOLDER" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_pass_private_groups_only(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_inbound_domain_spoofing_protection_enabled/gmail_inbound_domain_spoofing_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_inbound_domain_spoofing_protection_enabled/gmail_inbound_domain_spoofing_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -38,7 +37,7 @@ class TestGmailInboundDomainSpoofingProtectionEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "QUARANTINE" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_no_action(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_mail_delegation_disabled/gmail_mail_delegation_disabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_mail_delegation_disabled/gmail_mail_delegation_disabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -35,7 +34,7 @@ class TestGmailMailDelegationDisabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "disabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_delegation_enabled(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_per_user_outbound_gateway_disabled/gmail_per_user_outbound_gateway_disabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_per_user_outbound_gateway_disabled/gmail_per_user_outbound_gateway_disabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -35,7 +34,7 @@ class TestGmailPerUserOutboundGatewayDisabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "disabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_disabled(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_pop_imap_access_disabled/gmail_pop_imap_access_disabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_pop_imap_access_disabled/gmail_pop_imap_access_disabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -37,7 +36,7 @@ class TestGmailPopImapAccessDisabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "disabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_both_enabled(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_script_attachment_protection_enabled/gmail_script_attachment_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_script_attachment_protection_enabled/gmail_script_attachment_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -38,7 +37,7 @@ class TestGmailScriptAttachmentProtectionEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "QUARANTINE" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_no_action(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_shortener_scanning_enabled/gmail_shortener_scanning_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_shortener_scanning_enabled/gmail_shortener_scanning_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -35,7 +34,7 @@ class TestGmailShortenerScanningEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "enabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_disabled(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_unauthenticated_email_protection_enabled/gmail_unauthenticated_email_protection_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_unauthenticated_email_protection_enabled/gmail_unauthenticated_email_protection_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -38,7 +37,7 @@ class TestGmailUnauthenticatedEmailProtectionEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "WARNING" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_no_action(self):

--- a/tests/providers/googleworkspace/services/gmail/gmail_untrusted_link_warnings_enabled/gmail_untrusted_link_warnings_enabled_test.py
+++ b/tests/providers/googleworkspace/services/gmail/gmail_untrusted_link_warnings_enabled/gmail_untrusted_link_warnings_enabled_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from prowler.providers.googleworkspace.services.gmail.gmail_service import GmailPolicies
 from tests.providers.googleworkspace.googleworkspace_fixtures import (
     CUSTOMER_ID,
-    DOMAIN,
     set_mocked_googleworkspace_provider,
 )
 
@@ -37,7 +36,7 @@ class TestGmailUntrustedLinkWarningsEnabled:
             assert len(findings) == 1
             assert findings[0].status == "PASS"
             assert "enabled" in findings[0].status_extended
-            assert findings[0].resource_name == DOMAIN
+            assert findings[0].resource_name == "Gmail Policies"
             assert findings[0].customer_id == CUSTOMER_ID
 
     def test_fail_disabled(self):


### PR DESCRIPTION
### Context

All Google Workspace checks currently share a single provider-level resource (`provider.domain_resource`) whose `id` is the `customer_id`. Because the API uses `resource_id` to key the `resources` table, all 33 GWS checks across Calendar, Drive, Directory, and Gmail map to the same database row. The `service` field is overwritten by every subsequent finding, so only one service survives per scan, visible as a single service entry in the Findings filter dropdown.

The fix follows the M365 pattern: per-service resource models with distinct `resource_id`s.

PR #11161 covered Calendar (3 checks) and Drive (11 checks). This PR continues the same work for Gmail (17 checks). Directory will follow in a separate PR.
### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, Poetry, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
