### PR TITLE
fix(vercel): exclude API token from serialization and repr

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `zone_waf_enabled` check for Cloudflare provider now appends a plan-aware hint to the FAIL `status_extended`: a possible-false-positive note on paid plans (Pro, Business, Enterprise) where the legacy `waf` zone setting can read `off` even though WAF managed rulesets are deployed via the dashboard, and a "not available on the Cloudflare Free plan" note on Free zones [(#9896)](https://github.com/prowler-cloud/prowler/pull/9896)
 - Google Workspace Gmail checks sharing a single resource row, causing the service field to be overwritten by the last check executed [(#11169)](https://github.com/prowler-cloud/prowler/pull/11169)
 - Google Workspace Drive and Calendar services missing server-side policy filters [(#11195)](https://github.com/prowler-cloud/prowler/pull/11195)
+- `VercelSession.token` is now excluded from serialization and representation to prevent the Vercel API token from leaking through `.dict()`, `.json()` or logs [(#11198)](https://github.com/prowler-cloud/prowler/pull/11198)
 
 ---
 

--- a/prowler/providers/vercel/models.py
+++ b/prowler/providers/vercel/models.py
@@ -9,7 +9,7 @@ from prowler.providers.common.models import ProviderOutputOptions
 class VercelSession(BaseModel):
     """Vercel API session information."""
 
-    token: str
+    token: str = Field(exclude=True, repr=False)
     team_id: Optional[str] = None
     base_url: str = "https://api.vercel.com"
     http_session: Any = Field(default=None, exclude=True)

--- a/tests/providers/vercel/vercel_provider_test.py
+++ b/tests/providers/vercel/vercel_provider_test.py
@@ -222,3 +222,52 @@ class TestVercelProviderTestConnection:
 
         with pytest.raises(VercelCredentialsError):
             VercelProvider.test_connection(raise_on_exception=True)
+
+
+class TestVercelSessionTokenSecurity:
+    """The Vercel API token must never leak through serialization or repr."""
+
+    def test_token_is_still_accessible_as_attribute(self):
+        session = VercelSession(token=API_TOKEN, team_id=TEAM_ID)
+
+        assert session.token == API_TOKEN
+
+    def test_token_excluded_from_dict(self):
+        session = VercelSession(token=API_TOKEN, team_id=TEAM_ID)
+
+        serialized = session.dict()
+
+        assert "token" not in serialized
+        assert API_TOKEN not in str(serialized)
+        assert serialized["team_id"] == TEAM_ID
+
+    def test_token_excluded_from_model_dump(self):
+        session = VercelSession(token=API_TOKEN, team_id=TEAM_ID)
+
+        serialized = session.model_dump()
+
+        assert "token" not in serialized
+        assert API_TOKEN not in str(serialized)
+
+    def test_token_excluded_from_json(self):
+        session = VercelSession(token=API_TOKEN, team_id=TEAM_ID)
+
+        serialized = session.json()
+
+        assert "token" not in serialized
+        assert API_TOKEN not in serialized
+
+    def test_token_excluded_from_model_dump_json(self):
+        session = VercelSession(token=API_TOKEN, team_id=TEAM_ID)
+
+        serialized = session.model_dump_json()
+
+        assert "token" not in serialized
+        assert API_TOKEN not in serialized
+
+    def test_token_excluded_from_repr_and_str(self):
+        session = VercelSession(token=API_TOKEN, team_id=TEAM_ID)
+
+        assert API_TOKEN not in repr(session)
+        assert API_TOKEN not in str(session)
+        assert "token" not in repr(session)


### PR DESCRIPTION
### Description

`VercelSession.token` was stored in plaintext while only `http_session` was excluded from serialization. As a result, any `.dict()`, `.json()` or log of a `VercelSession` instance would leak the Vercel API token, which the whole authentication relies on.

This applies the same hardening already used for the Scaleway provider (`secret_key`): the field is now declared as `token: str = Field(exclude=True, repr=False)`, so it is kept required and still accessible internally, but is no longer emitted through serialization or representation.

### Changes

- `prowler/providers/vercel/models.py`: `VercelSession.token` now uses `Field(exclude=True, repr=False)`. `Field` was already imported, no new imports added.

### Why it is safe

- `exclude` / `repr=False` only affect serialization and repr, not input nor attribute access.
- The only consumer of the token (`prowler/providers/vercel/lib/service/service.py`, `provider.session.token`) reads it via attribute access, so behaviour is unchanged.
- Verified at runtime: `VercelSession(token=...)` builds correctly, `session.token` is still readable, and the token is absent from `repr()`, `.dict()` and `.json()`.

### Context

Flagged during the review of the Scaleway provider PR (#11166) as a
separate, out of scope change.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
