### PR TITLE
fix(ui): contain finding drawer horizontal scroll to the tab bar on mobile

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - Mute Findings modal now enforces the 100-character limit on the rule name input with a live counter and inline error, matching the existing reason field behaviour [(#11158)](https://github.com/prowler-cloud/prowler/pull/11158)
+- Finding detail drawer no longer scrolls horizontally on mobile; the section tab bar is now its own horizontal scroll container with a visible thin scrollbar, so the drawer body stays put while the tabs scroll [(#11199)](https://github.com/prowler-cloud/prowler/pull/11199)
 
 ### 🔐 Security
 

--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
@@ -681,7 +681,7 @@ export function ResourceDetailDrawerContent({
       </div>
 
       {/* Resource card */}
-      <div className="border-border-neutral-secondary bg-bg-neutral-secondary minimal-scrollbar flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto rounded-lg border p-4">
+      <div className="border-border-neutral-secondary bg-bg-neutral-secondary minimal-scrollbar flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-x-hidden overflow-y-auto rounded-lg border p-4">
         {/* Resource info — shows loading when currentFinding is not yet available */}
         {!currentResource && !f ? (
           <ResourceDetailSkeleton />
@@ -833,7 +833,7 @@ export function ResourceDetailDrawerContent({
           defaultValue="overview"
           className="mt-2 flex min-h-fit w-full flex-1 flex-col md:min-h-0"
         >
-          <div className="mb-4 flex items-center justify-between">
+          <div className="mb-4 flex min-w-0 items-center justify-between">
             <TabsList>
               <TabsTrigger value="overview">Finding Overview</TabsTrigger>
               <TabsTrigger value="remediation">Remediation</TabsTrigger>

--- a/ui/components/shadcn/tabs/tabs.tsx
+++ b/ui/components/shadcn/tabs/tabs.tsx
@@ -44,9 +44,16 @@ function buildTriggerClassName(): string {
 
 /**
  * Build list className
+ *
+ * The tab bar is its own horizontal scroll container: when the triggers don't
+ * fit (e.g. narrow mobile widths) they scroll within the list instead of
+ * forcing the surrounding drawer/page content to overflow horizontally.
+ * Triggers keep their intrinsic size (`shrink-0`) and stay on a single line
+ * (`whitespace-nowrap`) so a partially-visible tab plus the thin scrollbar
+ * make it obvious that more tabs are reachable by scrolling.
  */
 function buildListClassName(): string {
-  return "inline-flex w-full items-center border-[#E9E9F0] dark:border-[#171D30]";
+  return "minimal-scrollbar inline-flex w-full max-w-full min-w-0 items-center overflow-x-auto overflow-y-hidden border-[#E9E9F0] dark:border-[#171D30] [&>button]:shrink-0 [&>button]:whitespace-nowrap";
 }
 
 function Tabs({

--- a/ui/styles/globals.css
+++ b/ui/styles/globals.css
@@ -345,6 +345,7 @@
   /* Webkit browsers (Chrome, Safari, Edge) */
   .minimal-scrollbar::-webkit-scrollbar {
     width: 6px;
+    height: 6px; /* visible thumb for horizontal scroll containers (e.g. tab bars) */
   }
 
   .minimal-scrollbar::-webkit-scrollbar-track {


### PR DESCRIPTION
### Context

On mobile, the finding detail drawer scrolled horizontally as a whole: the resource info, status card and body text were all pushed sideways and clipped at the left edge.

Root cause: the section tab bar has five triggers (Finding Overview, Remediation, Findings for this resource, Scans, Events) that don't fit on a narrow screen. `TabsList` had no dedicated scroll container, so the overflow leaked up to the resource card — whose `overflow-y-auto` implicitly resolves `overflow-x` to `auto` — and the entire drawer body scrolled horizontally instead.

### Description

Contain the horizontal scroll to the tab bar only, and make it visually obvious that the tabs are scrollable:

- **`components/shadcn/tabs/tabs.tsx`** — `TabsList` is now its own horizontal scroll container (`overflow-x-auto`, `min-w-0`, `max-w-full`). Triggers keep their intrinsic size (`shrink-0`) and stay on a single line (`whitespace-nowrap`) so a partially-visible tab plus the thin scrollbar signal that more tabs are reachable.
- **`resource-detail-drawer-content.tsx`** — the resource card is pinned to `overflow-x-hidden` + `min-w-0` (and the tab-bar wrapper to `min-w-0`) so no child can force the drawer body to scroll sideways.
- **`styles/globals.css`** — `.minimal-scrollbar` now sets a `6px` scrollbar `height` in addition to `width`, so the horizontal scrollbar is actually visible on WebKit (it previously only set `width`, making horizontal bars 0px tall and invisible).

The fix is shared via the `TabsList` primitive, so the resource detail tab bar benefits from the same containment on narrow widths. Desktop is unchanged (no scrollbar appears when the tabs fit).

### Steps to review

1. Open a finding detail drawer at a mobile width (X < 640px).
2. Confirm the drawer body (badges, resource info, status card, body text) no longer scrolls horizontally and nothing is clipped at the left edge.
3. Confirm the section tab bar scrolls horizontally on its own, with a visible thin scrollbar and a partially-visible tab hinting there's more.
4. Confirm desktop (X > 1024px) is unchanged.

### Checklist

- [x] Review if the code is being covered by tests.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
