### PR TITLE
refactor(ui): align /api/health with IETF health-check format

### DIFF
--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -80,6 +80,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             registry.npmjs.org:443
             dl-cdn.alpinelinux.org:443
             fonts.googleapis.com:443

--- a/ui/app/api/health/route.test.ts
+++ b/ui/app/api/health/route.test.ts
@@ -3,8 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GET } from "./route";
 
 interface HealthResponse {
-  status: "healthy";
-  service: "prowler-ui";
+  status: "pass";
+  version: string;
+  releaseId: string;
+  serviceId: "prowler-ui";
+  description: string;
 }
 
 const parseHealthResponse = async (response: Response) =>
@@ -16,12 +19,9 @@ describe("GET /api/health", () => {
     vi.unstubAllGlobals();
   });
 
-  it("should return a healthy response when the Next.js route handler responds", async () => {
+  it("should return an IETF-shaped healthy response when the Next.js route handler responds", async () => {
     // Given
-    const expectedBody: HealthResponse = {
-      status: "healthy",
-      service: "prowler-ui",
-    };
+    vi.stubEnv("NEXT_PUBLIC_PROWLER_RELEASE_VERSION", "1.28.0");
 
     // When
     const response = await GET();
@@ -29,8 +29,30 @@ describe("GET /api/health", () => {
 
     // Then
     expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe(
+      "application/health+json",
+    );
     expect(response.headers.get("Cache-Control")).toBe("no-store");
-    expect(body).toEqual(expectedBody);
+    expect(body).toEqual({
+      status: "pass",
+      version: "1",
+      releaseId: "1.28.0",
+      serviceId: "prowler-ui",
+      description: "Prowler UI",
+    });
+  });
+
+  it("should fall back to 'unknown' when the release version env var is missing", async () => {
+    // Given
+    vi.stubEnv("NEXT_PUBLIC_PROWLER_RELEASE_VERSION", "");
+
+    // When
+    const response = await GET();
+    const body = await parseHealthResponse(response);
+
+    // Then
+    expect(response.status).toBe(200);
+    expect(body.releaseId).toBe("unknown");
   });
 
   it("should not call fetch while evaluating UI liveness", async () => {
@@ -60,10 +82,8 @@ describe("GET /api/health", () => {
 
     // Then
     expect(response.status).toBe(200);
-    expect(body).toEqual({
-      status: "healthy",
-      service: "prowler-ui",
-    });
+    expect(body.status).toBe("pass");
+    expect(body.serviceId).toBe("prowler-ui");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/ui/app/api/health/route.ts
+++ b/ui/app/api/health/route.ts
@@ -1,13 +1,18 @@
-const healthResponse = {
-  status: "healthy",
-  service: "prowler-ui",
-} as const;
-
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  return Response.json(healthResponse, {
+  const body = {
+    status: "pass",
+    version: "1",
+    releaseId: process.env.NEXT_PUBLIC_PROWLER_RELEASE_VERSION || "unknown",
+    serviceId: "prowler-ui",
+    description: "Prowler UI",
+  };
+
+  return new Response(JSON.stringify(body), {
+    status: 200,
     headers: {
+      "Content-Type": "application/health+json",
       "Cache-Control": "no-store",
     },
   });


### PR DESCRIPTION
### Context

The API recently shipped dedicated `/health/live` and `/health/ready` endpoints in #11200, settling on the IETF Health Check Response Format (`draft-inadarei-api-health-check-06`): `application/health+json`, canonical `pass | fail | warn` status vocabulary, and `serviceId` / `releaseId` / `version` / `description` fields.

The UI shipped `/api/health` earlier in #11145 with a non-IETF payload (`{ "status": "healthy", "service": "prowler-ui" }`). Functionally it works for liveness probes (load balancers only look at the 2xx status code), but the body diverges from the API contract for anyone parsing health responses (monitoring tooling, dashboards, API gateways, future Ops automation).

This PR aligns the UI's payload and `Content-Type` with the IETF shape adopted by the API.

### Description

Changes:

- `status: "pass"` (canonical IETF, was `"healthy"`).
- `serviceId: "prowler-ui"` (renamed from `service`).
- Adds `version: "1"`, `description: "Prowler UI"`.
- Adds `releaseId`, populated from `NEXT_PUBLIC_PROWLER_RELEASE_VERSION` (already propagated as a build-arg in `ui/Dockerfile`), with `"unknown"` as fallback when the env var is absent (dev / local without the build-arg).
- Response `Content-Type: application/health+json` so the media type matches the body shape.
- `Cache-Control: no-store` is preserved on purpose (see deltas table below).
- Updates unit tests to assert the new payload, the `Content-Type`, and the `releaseId` fallback path. Suite grows from 3 to 4 tests.

The endpoint contract (no auth, no CSRF, live-only, no `fetch`, no read of `PROWLER_API_HEALTH_URL`, `force-dynamic` to disable static optimisation) is unchanged.

#### Why this PR does NOT mirror the API 1:1

The IETF draft scopes itself to HTTP APIs and does not target UI / SSR frontends. Several of the API's hardening layers exist only because the API directly opens connections to PostgreSQL, Valkey and Neo4j; the UI does not. The intentional deltas:

| Aspect | API (#11200) | UI (this PR) | Why the delta |
| --- | --- | --- | --- |
| Endpoints | `/health/live` + `/health/ready` | Single `/api/health` (live-only) | UI has no infra dependencies of its own. A UI readiness probe would just proxy the API's `/health/ready`. Out of scope here; could be added later as `/api/ready` if Ops decides UI traffic should be drained during API outages. |
| `Cache-Control` | `max-age=3, must-revalidate` | `no-store` | The API uses `max-age=3` to coordinate with its 3-second in-process readiness cache that bounds real PG/Valkey/Neo4j hits. The UI has no equivalent cache, so the stricter `no-store` is the correct default and aligns with the most common UI-frontend guidance (Kubernetes docs, Node.js Reference Architecture). |
| Per-IP throttle | `ScopedRateThrottle` (120/60 rpm) | None | The API throttle bounds real datastore hits per IP. With no dependency checks, the UI endpoint has nothing to amplify; bursts cost microseconds each (see latency below). |
| In-process cache | 3s TTL with `threading.Lock` | None | Nothing to cache. |
| Path | `/health/*` mounted at root | `/api/health` under Next.js route handlers | Next.js route handlers conventionally live under `app/api/*`. Probe consumers do not care about the path string. |
| OpenAPI exclusion | Yes (excluded from DRF schema) | N/A | Next.js does not publish an OpenAPI schema. |

All deltas are in the direction of "less machinery because no dependency surface", not "weaker semantics".

### Steps to review

#### 1. Unit tests

```bash
cd ui && pnpm run test:unit app/api/health/route.test.ts
```

Expected: 4 tests pass.

#### 2. Full UI quality gate

```bash
cd ui && pnpm run healthcheck
```

Runs `typecheck` + `lint:check`.

#### 3. Live endpoint

Boot the UI locally (`cd ui && pnpm dev`) and hit the endpoint. Real response captured from a `pnpm dev` run on this branch:

```http
GET /api/health HTTP/1.1
Host: 127.0.0.1:3001
```

```http
HTTP/1.1 200 OK
Content-Type: application/health+json
Cache-Control: no-store
```

```json
{
  "status": "pass",
  "version": "1",
  "releaseId": "v5.8.1",
  "serviceId": "prowler-ui",
  "description": "Prowler UI"
}
```

Security headers from the global middleware (`Content-Security-Policy`, `X-Content-Type-Options`, `Referrer-Policy`) are still emitted and have been omitted above for readability.

#### 4. Cross-method behaviour

```bash
$ curl -sS -I http://127.0.0.1:3001/api/health | head -1
HTTP/1.1 200 OK

$ curl -sS -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:3001/api/health
405
```

HEAD returns 200 with headers and no body (Next.js handles HEAD automatically for `GET` route handlers). Anything other than GET / HEAD returns `405 Method Not Allowed`.

#### 5. Latency and concurrency

Local `pnpm dev` server, single hit and 10 parallel requests:

<details>

<summary>Raw curl output</summary>

```bash
$ curl -sS -o /dev/null -w "time=%{time_total}s  size=%{size_download}\n" http://127.0.0.1:3001/api/health
time=0.005619s  size=104

$ for i in $(seq 1 10); do
    curl -sS -o /dev/null -w "i=$i status=%{http_code} time=%{time_total}s\n" http://127.0.0.1:3001/api/health &
  done; wait
i=4  status=200 time=0.006637s
i=3  status=200 time=0.008710s
i=2  status=200 time=0.012038s
i=1  status=200 time=0.016765s
i=6  status=200 time=0.021497s
i=7  status=200 time=0.025841s
i=8  status=200 time=0.028838s
i=5  status=200 time=0.031094s
i=9  status=200 time=0.033498s
i=10 status=200 time=0.036188s
```

</details>

Single hit ~5.6 ms, worst-case under sustained burst ~36 ms. Plenty of headroom relative to the 3-second timeout recommended by every probe configuration guide.

#### 6. Liveness invariants

The unit tests assert the endpoint is strictly process-local:

- `should not call fetch while evaluating UI liveness` (stubs global `fetch` and asserts zero calls).
- `should not depend on external health URLs` (also stubs `PROWLER_API_HEALTH_URL` and asserts `fetch` is never called).
- `should fall back to 'unknown' when the release version env var is missing` (covers the dev path where the build-arg is not propagated).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. (not applicable, no new dependencies)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) (not applicable, JSON-only endpoint)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) (not applicable, JSON-only endpoint)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) (not applicable, JSON-only endpoint)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API (not applicable, UI-only change)
- [x] Endpoint response output (see "Steps to review" above)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (not applicable, no DB queries)
- [ ] Performance test results (not applicable; latency captured in "Steps to review")
- [x] Any other relevant evidence of the implementation (live curl, real headers, real body)
- [ ] Verify if API specs need to be regenerated. (not applicable, no DRF schema in UI)
- [ ] Check if version updates are required (e.g., specs, uv, etc.). (not applicable)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.