### PR TITLE
chore(ci): drop views.py version bump/verify steps in favor of pyproject.toml-derived RELEASE_ID

### DIFF
--- a/.github/workflows/api-bump-version.yml
+++ b/.github/workflows/api-bump-version.yml
@@ -123,7 +123,6 @@ jobs:
           set -e
 
           sed -i "s|version = \"${CURRENT_API_VERSION}\"|version = \"${NEXT_API_VERSION}\"|" api/pyproject.toml
-          sed -i "s|spectacular_settings.VERSION = \"${CURRENT_API_VERSION}\"|spectacular_settings.VERSION = \"${NEXT_API_VERSION}\"|" api/src/backend/api/v1/views.py
           sed -i "s|  version: ${CURRENT_API_VERSION}|  version: ${NEXT_API_VERSION}|" api/src/backend/api/specs/v1.yaml
 
           echo "Files modified:"
@@ -182,7 +181,6 @@ jobs:
           set -e
 
           sed -i "s|version = \"${CURRENT_API_VERSION}\"|version = \"${FIRST_API_PATCH_VERSION}\"|" api/pyproject.toml
-          sed -i "s|spectacular_settings.VERSION = \"${CURRENT_API_VERSION}\"|spectacular_settings.VERSION = \"${FIRST_API_PATCH_VERSION}\"|" api/src/backend/api/v1/views.py
           sed -i "s|  version: ${CURRENT_API_VERSION}|  version: ${FIRST_API_PATCH_VERSION}|" api/src/backend/api/specs/v1.yaml
 
           echo "Files modified:"
@@ -265,7 +263,6 @@ jobs:
           set -e
 
           sed -i "s|version = \"${CURRENT_API_VERSION}\"|version = \"${NEXT_API_PATCH_VERSION}\"|" api/pyproject.toml
-          sed -i "s|spectacular_settings.VERSION = \"${CURRENT_API_VERSION}\"|spectacular_settings.VERSION = \"${NEXT_API_PATCH_VERSION}\"|" api/src/backend/api/v1/views.py
           sed -i "s|  version: ${CURRENT_API_VERSION}|  version: ${NEXT_API_PATCH_VERSION}|" api/src/backend/api/specs/v1.yaml
 
           echo "Files modified:"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -299,17 +299,6 @@ jobs:
         fi
         echo "✓ api/pyproject.toml prowler dependency: $CURRENT_PROWLER_REF"
 
-    - name: Verify API version in api/src/backend/api/v1/views.py
-      if: ${{ env.HAS_API_CHANGES == 'true' }}
-      run: |
-        CURRENT_API_VERSION=$(grep 'spectacular_settings.VERSION = ' api/src/backend/api/v1/views.py | sed -E 's/.*spectacular_settings.VERSION = "([^"]+)".*/\1/' | tr -d '[:space:]')
-        API_VERSION_TRIMMED=$(echo "$API_VERSION" | tr -d '[:space:]')
-        if [ "$CURRENT_API_VERSION" != "$API_VERSION_TRIMMED" ]; then
-          echo "ERROR: API version mismatch in views.py (expected: '$API_VERSION_TRIMMED', found: '$CURRENT_API_VERSION')"
-          exit 1
-        fi
-        echo "✓ api/src/backend/api/v1/views.py version: $CURRENT_API_VERSION"
-
     - name: Verify API version in api/src/backend/api/specs/v1.yaml
       if: ${{ env.HAS_API_CHANGES == 'true' }}
       run: |


### PR DESCRIPTION
> **Depends on #11200** — do not merge before #11200 lands. If this merges first, releases between the two PRs would stop verifying/bumping the literal in `views.py` while it still lives there, and the OpenAPI schema would publish a stale version. Reviewers, please hold until #11200 is merged.

### Context

PR #11200 introduces `RELEASE_ID` in a new `api/src/backend/config/version.py` (reads `[project].version` from `api/pyproject.toml`) and replaces the literal `spectacular_settings.VERSION = "1.28.0"` in `api/src/backend/api/v1/views.py` with `spectacular_settings.VERSION = RELEASE_ID`.

After #11200 lands, the existing release workflows misbehave:

- `prepare-release.yml` hard-fails the release (`exit 1`) because the grep for the literal returns the variable name `RELEASE_ID`, mismatching the expected `X.Y.Z`.
- `api-bump-version.yml` `sed` lines silently no-op (cosmetic dead code).

Bumping `api/pyproject.toml` is now sufficient — `views.py` derives its version from it at import time.

### Description

- `.github/workflows/prepare-release.yml` — removed the `Verify API version in api/src/backend/api/v1/views.py` step (between the `pyproject.toml` prowler-dep verify and the `v1.yaml` verify steps).
- `.github/workflows/api-bump-version.yml` — removed the three `sed -i "s|spectacular_settings.VERSION = ...|...|" api/src/backend/api/v1/views.py` lines (one per bump job: minor, first-patch, next-patch).
- `api/src/backend/api/specs/v1.yaml` handling is unchanged — that file still carries a literal version that #11200 does not touch, so both its `sed` (in `api-bump-version.yml`) and its verify step (in `prepare-release.yml`) remain.

### Steps to review

- For a `5.X.0` (minor) release dispatch, confirm `prepare-release.yml` no longer attempts to verify `api/src/backend/api/v1/views.py` (the step between the `pyproject.toml` prowler-dep check and the `v1.yaml` check is gone).
- For a release with API changes, confirm `api-bump-version.yml` bumps only `api/pyproject.toml` and `api/src/backend/api/specs/v1.yaml` — `views.py` is no longer touched.
- Confirm `v1.yaml` is still both bumped (in `api-bump-version.yml`) and verified (in `prepare-release.yml`).

### Checklist

- [x] Review if the code is being covered by tests. *(N/A — release workflow changes; validated by the next release dispatch.)*
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings *(N/A — workflow YAML only.)*
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) *(N/A.)*
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. *(N/A — CI-only change.)*

#### API
- [x] All issue/task requirements work as expected on the API *(workflow-only; behaviour validated by the next release dispatch.)*
- [x] Verify if API specs need to be regenerated. *(No — `v1.yaml` bump still wired.)*
- [x] Check if version updates are required (e.g., specs, uv, etc.). *(No.)*
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. *(N/A — CI-only change.)*

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.