### PR TITLE
refactor(mcp): align /health with IETF health-check format

### DIFF
--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -79,6 +79,7 @@ jobs:
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             files.pythonhosted.org:443

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -211,6 +211,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+      start_period: 60s
 
 volumes:
   outputs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,6 +176,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+      start_period: 60s
 
 volumes:
   output:

--- a/mcp_server/prowler_mcp_server/server.py
+++ b/mcp_server/prowler_mcp_server/server.py
@@ -41,12 +41,22 @@ async def setup_main_server():
         logger.error(f"Failed to import Prowler Documentation server: {e}")
 
 
-# Add health check endpoint
+# Response follows the IETF Health Check Response Format
+# (draft-inadarei-api-health-check-06). `version` is the contract version of
+# this endpoint; `releaseId` is the package build version.
 @prowler_mcp_server.custom_route("/health", methods=["GET"])
-async def health_check(request) -> JSONResponse:
+async def health_check(_request) -> JSONResponse:
     """Health check endpoint."""
     return JSONResponse(
-        {"status": "healthy", "service": "prowler-mcp-server", "version": __version__}
+        {
+            "status": "pass",
+            "version": "1",
+            "releaseId": __version__,
+            "serviceId": "prowler-mcp-server",
+            "description": "Prowler MCP Server",
+        },
+        media_type="application/health+json",
+        headers={"Cache-Control": "no-store"},
     )
 
 

--- a/mcp_server/pyproject.toml
+++ b/mcp_server/pyproject.toml
@@ -2,6 +2,11 @@
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=61.0", "wheel"]
 
+[dependency-groups]
+dev = [
+  "pytest==8.3.5"
+]
+
 [project]
 dependencies = [
   "fastmcp==2.14.0",
@@ -15,6 +20,9 @@ version = "0.5.0"
 
 [project.scripts]
 prowler-mcp = "prowler_mcp_server.main:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.uv]
 package = true

--- a/mcp_server/tests/test_health.py
+++ b/mcp_server/tests/test_health.py
@@ -1,0 +1,46 @@
+"""Tests for the Prowler MCP Server health endpoint."""
+
+from starlette.testclient import TestClient
+
+from prowler_mcp_server import __version__
+from prowler_mcp_server.server import app
+
+
+def test_health_returns_ietf_pass_response():
+    """GET /health returns 200 with the IETF health-check body and headers."""
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/health+json"
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json() == {
+        "status": "pass",
+        "version": "1",
+        "releaseId": __version__,
+        "serviceId": "prowler-mcp-server",
+        "description": "Prowler MCP Server",
+    }
+
+
+def test_health_release_id_matches_package_version():
+    """The endpoint must surface the current package __version__ as releaseId.
+
+    Drift between the response and the installed package would mislead any
+    monitoring tool that uses releaseId to identify the running build.
+    """
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.json()["releaseId"] == __version__
+
+
+def test_health_rejects_non_get_methods():
+    """The endpoint only exposes GET; other verbs return 405."""
+    client = TestClient(app)
+
+    response = client.post("/health")
+
+    assert response.status_code == 405

--- a/mcp_server/uv.lock
+++ b/mcp_server/uv.lock
@@ -444,6 +444,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -677,6 +686,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathable"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -704,6 +722,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prometheus-client"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -721,11 +748,19 @@ dependencies = [
     { name = "httpx" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = "==2.14.0" },
     { name = "httpx", specifier = "==0.28.1" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = "==8.3.5" }]
 
 [[package]]
 name = "py-key-value-aio"
@@ -904,6 +939,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/99/25f4898cf420efb6f45f519de018f4faea5391114a8618b16736ef3029f1/pyperclip-1.10.0.tar.gz", hash = "sha256:180c8346b1186921c75dfd14d9048a6b5d46bfc499778811952c6dd6eb1ca6be", size = 12193, upload-time = "2025-09-18T00:54:00.384Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/bc/22540e73c5f5ae18f02924cd3954a6c9a4aa6b713c841a94c98335d333a1/pyperclip-1.10.0-py3-none-any.whl", hash = "sha256:596fbe55dc59263bff26e61d2afbe10223e2fccb5210c9c96a28d6887cfcc7ec", size = 11062, upload-time = "2025-09-18T00:53:59.252Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Context

The API recently shipped dedicated `/health/live` and `/health/ready` endpoints in #11200, settling on the IETF Health Check Response Format (`draft-inadarei-api-health-check-06`): `application/health+json`, canonical `pass | fail | warn` status vocabulary, and `serviceId` / `releaseId` / `version` / `description` fields. The UI followed suit in #11204 (refactor of the original #11145 endpoint).

The MCP server (`/health`, originally added in #8905 and patched in #8967) is still on the pre-standard payload:

```json
{ "status": "healthy", "service": "prowler-mcp-server", "version": "0.5.0" }
```

This diverges from what the API and the UI now expose. Unlike the UI, the MCP server **is** an HTTP API in IETF's sense (it speaks MCP over HTTP plus this `/health` route), so the draft applies directly and not by analogy.

This PR aligns the MCP `/health` payload and headers with the IETF shape, adds tests (the MCP package had none) and tightens the docker-compose probe with a `start_period`.

### Description

Endpoint changes (`mcp_server/prowler_mcp_server/server.py`):

- `status: "pass"` (canonical IETF, was `"healthy"`).
- `serviceId: "prowler-mcp-server"` (renamed from `service`).
- `releaseId: __version__` (the package build version, renamed from the old `version` field).
- New `version: "1"` representing the endpoint contract version (decoupled from the package version, matching the API).
- New `description: "Prowler MCP Server"`.
- Response `Content-Type: application/health+json` so the media type matches the body shape.
- Response `Cache-Control: no-store` (MCP has no in-process readiness cache to coordinate with).
- Unused `request` parameter renamed to `_request` so vulture does not flag it; the parameter is required by Starlette's route signature but is not read.

Test infrastructure (`mcp_server/tests/`):

- The MCP package had zero tests before this PR. Adds `pytest` as a dev dependency (`[dependency-groups]`) and a minimal `tests/` layout with `[tool.pytest.ini_options] testpaths = ["tests"]`.
- Three tests cover the new contract: payload + headers, `releaseId` drift against `__version__`, and method rejection (405 on non-GET). Run with `uv run pytest`.

Infrastructure wiring (`docker-compose.yml`, `docker-compose-dev.yml`):

- Adds `start_period: 60s` to the `mcp-server` healthcheck. FastMCP imports all sub-servers (Hub, App, Documentation) at boot; the previous config could mark the container unhealthy before that completed under load. The `wget /health` probe itself is unchanged.

There is no Helm chart for `mcp-server` in `contrib/k8s/helm`, so no K8s probe wiring to update.

#### Why this PR does NOT mirror the API 1:1

Even though the MCP is an API and the IETF draft applies directly, several of the API's hardening layers (#11200) target risks the MCP does not face. The intentional deltas:

| Aspect | API (#11200) | MCP (this PR) | Why the delta |
| --- | --- | --- | --- |
| Endpoints | `/health/live` + `/health/ready` | Single `/health` (live-only) | MCP has no own infra to ping. Sub-servers call the Prowler API and Hub lazily per tool invocation, not at boot, so there is nothing to probe in a readiness sense. If Ops later wants MCP traffic drained when the API is down, a `/health/ready` can be added behind a `fetch` to the API. |
| `Cache-Control` | `max-age=3, must-revalidate` | `no-store` | The API uses `max-age=3` to coordinate with its 3-second in-process readiness cache that bounds real PG / Valkey / Neo4j hits. The MCP has no equivalent cache, so the stricter `no-store` is the right default (same rationale as the UI in #11204). |
| Per-IP throttle | `ScopedRateThrottle` (120 / 60 rpm) | None | The MCP container is internal to the compose network and only exposes port 8000 to UI / API services. There is no real datastore hit to amplify per IP. |
| In-process cache | 3s TTL with `threading.Lock` | None | Nothing to cache. |
| OpenAPI exclusion | Yes (excluded from DRF schema) | N/A | FastMCP does not publish an OpenAPI schema for `custom_route` handlers. |

### Steps to review

All of the checks below were executed end-to-end on this branch; the outputs are real captures, not instructions for the reviewer.

#### 1. Unit tests

```bash
$ cd mcp_server && uv sync --group dev && uv run pytest -v
```

Real output:

```
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.10.0
collected 3 items

tests/test_health.py::test_health_returns_ietf_pass_response PASSED      [ 33%]
tests/test_health.py::test_health_release_id_matches_package_version PASSED [ 66%]
tests/test_health.py::test_health_rejects_non_get_methods PASSED         [100%]

============================== 3 passed in 0.60s ===============================
```

#### 2. Live endpoint via uvicorn

```bash
$ PROWLER_MCP_TRANSPORT_MODE=http uv run uvicorn prowler_mcp_server.server:app --host 127.0.0.1 --port 8001
```

```http
GET /health HTTP/1.1
Host: 127.0.0.1:8001
```

```http
HTTP/1.1 200 OK
Server: uvicorn
Content-Type: application/health+json
Cache-Control: no-store
Content-Length: 119
```

```json
{
  "status": "pass",
  "version": "1",
  "releaseId": "0.5.0",
  "serviceId": "prowler-mcp-server",
  "description": "Prowler MCP Server"
}
```

#### 3. Cross-method behaviour

```bash
$ curl -sS -I http://127.0.0.1:8001/health | head -1
HTTP/1.1 200 OK

$ curl -sS -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1:8001/health
405
```

#### 4. Latency and concurrency

<details>

<summary>Raw curl output (single hit + 10 parallel requests)</summary>

```bash
$ curl -sS -o /dev/null -w "time=%{time_total}s  size=%{size_download}\n" http://127.0.0.1:8001/health
time=0.001148s  size=119

$ for i in $(seq 1 10); do
    curl -sS -o /dev/null -w "i=$i status=%{http_code} time=%{time_total}s\n" http://127.0.0.1:8001/health &
  done; wait
i=1 status=200 time=0.001519s
i=4 status=200 time=0.001602s
i=2 status=200 time=0.001763s
i=3 status=200 time=0.001827s
i=5 status=200 time=0.001869s
i=8 status=200 time=0.001210s
i=7 status=200 time=0.001186s
i=6 status=200 time=0.001088s
i=9 status=200 time=0.001076s
i=10 status=200 time=0.000464s
```

</details>

Single hit ~1.1 ms, worst case under burst ~1.9 ms.

#### 5. End-to-end with `docker-compose-dev.yml`

The probe was exercised inside an actual Docker container built from this branch with `--build`, not just from a host-side uvicorn.

```bash
$ docker compose -f docker-compose-dev.yml -p prowler-mcp-healthtest up -d --build mcp-server
$ docker compose -f docker-compose-dev.yml -p prowler-mcp-healthtest ps mcp-server
NAME                                  STATUS
prowler-mcp-healthtest-mcp-server-1   Up 10 seconds (healthy)
```

Container reached `healthy` within ~10 s of starting (well inside the new 60 s `start_period`).

The probe Docker actually applied to the container:

```bash
$ docker inspect --format '{{json .Config.Healthcheck}}' prowler-mcp-healthtest-mcp-server-1
```

```json
{
  "Test": ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8000/health || exit 1"],
  "Interval": 10000000000,
  "Timeout": 5000000000,
  "StartPeriod": 60000000000,
  "Retries": 3
}
```

(nanoseconds, so `StartPeriod: 60000000000` = 60 s.)

Health state, including the probe's exit code, as reported by Docker:

```bash
$ docker inspect --format '{{json .State.Health}}' prowler-mcp-healthtest-mcp-server-1
```

```json
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "ExitCode": 0,
      "Output": ""
    }
  ]
}
```

`ExitCode: 0` means `wget /health` inside the container hit the new endpoint and got a 2xx, so the `application/health+json` payload is what Docker is gating on.

`docker compose config` also parses cleanly, with the new field surfaced:

```bash
$ docker compose -f docker-compose-dev.yml -p prowler-mcp-healthtest config | yq '.services."mcp-server".healthcheck'
interval: 10s
retries: 3
start_period: 1m0s
test:
- CMD-SHELL
- wget -q -O /dev/null http://127.0.0.1:8000/health || exit 1
timeout: 5s
```

Curl from the host into the container (port 8000 mapped):

```http
HTTP/1.1 200 OK
Server: uvicorn
Content-Type: application/health+json
Cache-Control: no-store
Content-Length: 119

{"status":"pass","version":"1","releaseId":"0.5.0","serviceId":"prowler-mcp-server","description":"Prowler MCP Server"}
```

Tear down was clean (`docker compose down -v`).

#### 6. Drift invariant

The test `test_health_release_id_matches_package_version` asserts that whatever `__init__.py` ships as `__version__` is exactly what the endpoint surfaces as `releaseId`. This is the same invariant the API enforces with its `test_version.py` against `pyproject.toml`. (Note: the MCP package currently ships `__version__ = "0.5.0"` while the CHANGELOG lists `0.7.0` UNRELEASED. The drift is preexisting and out of scope here; the test will keep both consistent going forward.)

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No.

#### UI
- [ ] All issue/task requirements work as expected on the UI (not applicable, MCP-only change)
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (not applicable)
- [ ] Screenshots/Video (not applicable)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API (MCP `/health` endpoint behaviour verified above, including end-to-end inside a Docker container)
- [x] Endpoint response output (see "Steps to review" above)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (not applicable, no DB queries)
- [ ] Performance test results (latency captured in "Steps to review")
- [x] Any other relevant evidence of the implementation (`docker inspect` health state + healthcheck config, real)
- [ ] Verify if API specs need to be regenerated. (not applicable; FastMCP custom_route is not in any OpenAPI schema)
- [ ] Check if version updates are required (e.g., specs, uv, etc.). (no, this PR introduces `releaseId` driven by `__version__` and a test that keeps them in lockstep)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.