### PR TITLE
docs(skills): require changelog confirmation

### DIFF
--- a/skills/prowler-changelog/SKILL.md
+++ b/skills/prowler-changelog/SKILL.md
@@ -132,6 +132,19 @@ Before editing any `CHANGELOG.md`, always inspect the active release boundary:
 
 **Do not trust the current topmost matching section name.** A released block can contain the same section heading (`### 🚀 Added`, `### 🔄 Changed`, etc.). Always anchor edits to the `Prowler UNRELEASED` version block first.
 
+## Mandatory Human Confirmation Gate
+
+Before creating or editing any changelog file (`CHANGELOG.md`), the agent MUST stop and get explicit user confirmation. This applies even when the changelog gate is failing, the required edit seems obvious, or the user asked to "fix the changelog".
+
+Present the proposed changelog action before writing:
+
+1. Target file path.
+2. Target version block and section.
+3. Exact entry to add, move, remove, or rewrite.
+4. Reason the changelog is needed.
+
+Only proceed after an explicit approval such as "confirm", "approved", "sí", or equivalent. If the user rejects or does not answer, do not edit or create the changelog. Offer alternatives such as adding `no-changelog` when appropriate.
+
 ## Adding a Changelog Entry
 
 ### Step 1: Determine Affected Component(s)


### PR DESCRIPTION
### Context

The changelog skill should behave like a harness gate: whenever an agent needs to create or edit a changelog, the human must explicitly approve the exact proposed changelog change before the file is touched.

### Description

- Adds a mandatory human confirmation gate to `skills/prowler-changelog/SKILL.md`.
- Requires agents to present the target path, version block/section, exact change, and reason before editing any `CHANGELOG.md`.
- Preserves the existing unreleased-block preflight and PR-link-only rules.

### Steps to review

1. Review `skills/prowler-changelog/SKILL.md`.
2. Confirm the new confirmation gate appears after the mandatory changelog preflight.
3. Confirm existing preflight and PR-link rules remain unchanged.

Validation performed:

- [x] Fresh reviewer pass found no blockers.
- [x] Commit hooks passed.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue%20is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue%20is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.