### PR TITLE
feat(m365/entra): add entra_app_registration_no_password_credentials check

### DIFF
--- a/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.metadata.json
+++ b/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.metadata.json
@@ -1,0 +1,39 @@
+{
+  "Provider": "m365",
+  "CheckID": "entra_app_registration_no_password_credentials",
+  "CheckTitle": "Application registrations should not use password credentials (client secrets)",
+  "CheckType": [
+    "Software and Configuration Checks/Identity and Access Management"
+  ],
+  "ServiceName": "entra",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "Other",
+  "ResourceGroup": "",
+  "Description": "**Application registrations** should authenticate using certificates (`keyCredentials`), federated identity credentials, or managed identities instead of password credentials (client secrets).\n\nThis check audits the current state of application registrations and surfaces those that hold one or more entries in `passwordCredentials`. Both expired and active entries are flagged, since expired entries represent credential clutter that should be cleaned up.",
+  "Risk": "Client secrets are bearer credentials that are easy to leak (committed to repositories, copied into CI variables, shared via chat). Once leaked they can be used from anywhere on the internet until rotated. This harms **confidentiality** and **integrity** by enabling unauthorized access to tenant resources.",
+  "RelatedUrl": "https://learn.microsoft.com/en-us/graph/api/resources/application",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/graph/api/resources/passwordcredential",
+    "https://learn.microsoft.com/en-us/entra/identity-platform/certificate-credentials"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Open the Azure portal and go to Microsoft Entra ID > App registrations\n2. Select the application with password credentials\n3. Navigate to Certificates & secrets\n4. Under Client secrets, remove existing password credentials\n5. Under Certificates, upload a certificate for authentication\n6. Update application code to use certificate-based authentication",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Migrate application registrations from password credentials (client secrets) to certificate-based authentication, federated identity credentials, or managed identities. Remove all existing password credentials after migration.",
+      "Url": "https://hub.prowler.com/check/entra_app_registration_no_password_credentials"
+    }
+  },
+  "Categories": [],
+  "DependsOn": [],
+  "RelatedTo": [
+    "entra_default_app_management_policy_enabled"
+  ],
+  "Notes": "This check audits the current state of application registrations. The related check entra_default_app_management_policy_enabled verifies the policy that prevents new secrets from being added."
+}

--- a/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.py
+++ b/prowler/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials.py
@@ -1,0 +1,46 @@
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.entra.entra_client import entra_client
+
+
+class entra_app_registration_no_password_credentials(Check):
+    """Ensure application registrations do not use password credentials (client secrets).
+
+    Customer-owned applications should authenticate using certificates, federated
+    identity credentials, or managed identities instead of long-lived shared secrets.
+
+    - PASS: The application has no password credentials.
+    - FAIL: The application has one or more password credentials.
+    """
+
+    def execute(self) -> list[CheckReportM365]:
+        findings = []
+
+        if not entra_client.app_registrations:
+            return findings
+
+        for app in entra_client.app_registrations.values():
+            report = CheckReportM365(
+                metadata=self.metadata(),
+                resource=app,
+                resource_name=app.name,
+                resource_id=app.id,
+            )
+
+            if app.password_credentials:
+                count = len(app.password_credentials)
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"App registration '{app.name}' (appId: {app.app_id}) "
+                    f"has {count} password credential(s) (client secret(s)). "
+                    f"Migrate to certificates or federated identity credentials."
+                )
+            else:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"App registration '{app.name}' (appId: {app.app_id}) "
+                    f"does not use password credentials."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -90,6 +90,7 @@ class Entra(M365Service):
                 self._get_directory_sync_settings(),
                 self._get_authentication_method_configurations(),
                 self._get_service_principals(),
+                self._get_app_registrations(),
             )
         )
 
@@ -106,6 +107,7 @@ class Entra(M365Service):
             str, AuthenticationMethodConfiguration
         ] = attributes[9]
         self.service_principals: Dict[str, "ServicePrincipal"] = attributes[10]
+        self.app_registrations: Dict[str, "AppRegistration"] = attributes[11]
         self.user_accounts_status = {}
 
         if created_loop:
@@ -1261,6 +1263,48 @@ OAuthAppInfo
             )
         return service_principals
 
+    async def _get_app_registrations(self) -> Dict[str, "AppRegistration"]:
+        logger.info("Entra - Getting app registrations...")
+        app_registrations: Dict[str, AppRegistration] = {}
+        try:
+            app_response = await self.client.applications.get()
+            while app_response:
+                for app in getattr(app_response, "value", []) or []:
+                    app_id = getattr(app, "app_id", None)
+                    obj_id = getattr(app, "id", None)
+                    if not app_id or not obj_id:
+                        continue
+
+                    password_credentials = []
+                    for cred in getattr(app, "password_credentials", []) or []:
+                        password_credentials.append(
+                            PasswordCredential(
+                                key_id=str(getattr(cred, "key_id", "")),
+                                display_name=getattr(cred, "display_name", None),
+                                end_date_time=getattr(cred, "end_date_time", None),
+                            )
+                        )
+
+                    app_registrations[obj_id] = AppRegistration(
+                        id=obj_id,
+                        app_id=app_id,
+                        name=getattr(app, "display_name", "") or "",
+                        password_credentials=password_credentials,
+                    )
+
+                next_link = getattr(app_response, "odata_next_link", None)
+                if not next_link:
+                    break
+                app_response = await self.client.applications.with_url(
+                    next_link
+                ).get()
+
+        except Exception as error:
+            logger.error(
+                f"{error.__class__.__name__}[{error.__traceback__.tb_lineno}]: {error}"
+            )
+        return app_registrations
+
 
 class ConditionalAccessPolicyState(Enum):
     ENABLED = "enabled"
@@ -1783,3 +1827,19 @@ class ServicePrincipal(BaseModel):
     password_credentials: List[PasswordCredential] = []
     key_credentials: List[KeyCredential] = []
     directory_role_template_ids: List[str] = []
+
+
+class AppRegistration(BaseModel):
+    """Model representing a Microsoft Entra ID application registration.
+
+    Attributes:
+        id: The application object's unique identifier.
+        app_id: The application (client) ID.
+        name: The application's display name.
+        password_credentials: List of password credentials (client secrets).
+    """
+
+    id: str
+    app_id: str
+    name: str
+    password_credentials: List[PasswordCredential] = []

--- a/tests/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials_test.py
+++ b/tests/providers/m365/services/entra/entra_app_registration_no_password_credentials/entra_app_registration_no_password_credentials_test.py
@@ -1,0 +1,259 @@
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+from uuid import uuid4
+
+from prowler.providers.m365.services.entra.entra_service import (
+    AppRegistration,
+    PasswordCredential,
+)
+from tests.providers.m365.m365_fixtures import DOMAIN, set_mocked_m365_provider
+
+
+class Test_entra_app_registration_no_password_credentials:
+
+    def test_no_app_registrations(self):
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {}
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_app_registration_no_secrets(self):
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        obj_id = str(uuid4())
+        app_id = str(uuid4())
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                obj_id: AppRegistration(
+                    id=obj_id,
+                    app_id=app_id,
+                    name="CleanApp",
+                    password_credentials=[],
+                )
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert "does not use password credentials" in result[0].status_extended
+            assert result[0].resource_id == obj_id
+            assert result[0].resource_name == "CleanApp"
+
+    def test_app_registration_with_active_secret(self):
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        obj_id = str(uuid4())
+        app_id = str(uuid4())
+        future = datetime.now(timezone.utc) + timedelta(days=180)
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                obj_id: AppRegistration(
+                    id=obj_id,
+                    app_id=app_id,
+                    name="SecretApp",
+                    password_credentials=[
+                        PasswordCredential(
+                            key_id=str(uuid4()),
+                            display_name="prod-secret",
+                            end_date_time=future,
+                        )
+                    ],
+                )
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "1 password credential(s)" in result[0].status_extended
+            assert result[0].resource_id == obj_id
+            assert result[0].resource_name == "SecretApp"
+
+    def test_app_registration_with_expired_secret_still_fails(self):
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        obj_id = str(uuid4())
+        app_id = str(uuid4())
+        expired = datetime.now(timezone.utc) - timedelta(days=30)
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                obj_id: AppRegistration(
+                    id=obj_id,
+                    app_id=app_id,
+                    name="LegacyApp",
+                    password_credentials=[
+                        PasswordCredential(
+                            key_id=str(uuid4()),
+                            display_name="old-secret",
+                            end_date_time=expired,
+                        )
+                    ],
+                )
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "1 password credential(s)" in result[0].status_extended
+
+    def test_app_registration_with_multiple_secrets(self):
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        obj_id = str(uuid4())
+        app_id = str(uuid4())
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                obj_id: AppRegistration(
+                    id=obj_id,
+                    app_id=app_id,
+                    name="MultiSecretApp",
+                    password_credentials=[
+                        PasswordCredential(key_id=str(uuid4()), display_name="secret1"),
+                        PasswordCredential(key_id=str(uuid4()), display_name="secret2"),
+                        PasswordCredential(key_id=str(uuid4()), display_name="secret3"),
+                    ],
+                )
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "3 password credential(s)" in result[0].status_extended
+
+    def test_multiple_apps_mixed(self):
+        entra_client = mock.MagicMock
+        entra_client.audited_tenant = "audited_tenant"
+        entra_client.audited_domain = DOMAIN
+
+        clean_id = str(uuid4())
+        dirty_id = str(uuid4())
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials.entra_client",
+                new=entra_client,
+            ),
+        ):
+            from prowler.providers.m365.services.entra.entra_app_registration_no_password_credentials.entra_app_registration_no_password_credentials import (
+                entra_app_registration_no_password_credentials,
+            )
+
+            entra_client.app_registrations = {
+                clean_id: AppRegistration(
+                    id=clean_id,
+                    app_id=str(uuid4()),
+                    name="CleanApp",
+                    password_credentials=[],
+                ),
+                dirty_id: AppRegistration(
+                    id=dirty_id,
+                    app_id=str(uuid4()),
+                    name="DirtyApp",
+                    password_credentials=[
+                        PasswordCredential(key_id=str(uuid4()), display_name="secret1")
+                    ],
+                ),
+            }
+
+            check = entra_app_registration_no_password_credentials()
+            result = check.execute()
+
+            assert len(result) == 2
+            statuses = {r.resource_id: r.status for r in result}
+            assert statuses[clean_id] == "PASS"
+            assert statuses[dirty_id] == "FAIL"


### PR DESCRIPTION
## Summary
- Implements the `entra_app_registration_no_password_credentials` check requested in #11064
- Adds `AppRegistration` model and `_get_app_registrations()` method to the Entra service to fetch application objects and their `passwordCredentials` via Microsoft Graph
- The check audits each application registration and reports FAIL when any password credentials (client secrets) are present
- Both expired and active credentials are flagged — expired entries are credential clutter that should be cleaned up

## Details
Client secrets are bearer credentials that are easy to leak (committed to repos, copied into CI variables, shared via chat). Once leaked they can be used from anywhere until rotated. Microsoft's official guidance is to migrate away from client secrets in favor of certificate-based authentication, federated identity credentials, or managed identities.

The complementary check `entra_default_app_management_policy_enabled` verifies the *policy* that prevents *new* secrets from being added; this new check audits the *current state* and surfaces apps that already hold secrets.

## Test plan
- [x] Test: no app registrations → 0 findings
- [x] Test: app with no password credentials → PASS
- [x] Test: app with active password credential → FAIL
- [x] Test: app with expired password credential → FAIL (expired entries still count)
- [x] Test: app with multiple password credentials → FAIL with correct count
- [x] Test: mixed apps (one clean, one with secrets) → PASS + FAIL