### PR TITLE
fix(ci): bump harden-runner to v2.19.3 so issue-triage jobs stop failing on ubuntu-slim

### DIFF
--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -66,7 +66,7 @@ jobs:
       title: ${{ steps.compute-text.outputs.title }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 
@@ -135,7 +135,7 @@ jobs:
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 
@@ -870,7 +870,7 @@ jobs:
       total_count: ${{ steps.missing_tool.outputs.total_count }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 
@@ -982,7 +982,7 @@ jobs:
       success: ${{ steps.parse_results.outputs.success }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 
@@ -1091,7 +1091,7 @@ jobs:
       activated: ${{ (steps.check_membership.outputs.is_team_member == 'true') && (steps.check_rate_limit.outputs.rate_limit_ok == 'true') }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 
@@ -1164,7 +1164,7 @@ jobs:
       process_safe_outputs_temporary_id_map: ${{ steps.process_safe_outputs.outputs.temporary_id_map }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
 


### PR DESCRIPTION
### Context

The AI Issue Triage agentic workflow (`gh-aw`-generated, `.github/workflows/issue-triage.lock.yml`) has never completed successfully: no run in its history ends in `success`. Every job ends in `failure` at the final `Post Harden the runner` step.

`gh-aw` workflows run on `runs-on: ubuntu-slim` (unprivileged container, agent working dir `/home/agent`). `step-security/harden-runner` **v2.16.0** (pinned in #10480) does not handle `ubuntu-slim`: its post-step runs `sudo chown -R <user> /home/agent` with an empty user and fails:

```
chown: invalid user: 'undefined'
##[error]Command failed: sudo chown -R  /home/agent
Error: EACCES: permission denied, open '/home/agent/post_event.json'
```

That post-step failure marks the whole job as `failure` even when every other step succeeds (observed in run `25991532865`, job `conclusion`, step 22 `Post Harden the runner` -> failure). Harden-runner **v2.19.1+** detects `ubuntu-slim` runners and exits the post-step cleanly with an informational log instead of failing.

No tracked issue — discovered while reviewing the workflow's run history.

### Description

Bump `step-security/harden-runner` `v2.16.0` -> `v2.19.3` (pinned by SHA `ab7a9404c0f3da075243ca237b5fac12c98deaa5`) in all 6 occurrences of `.github/workflows/issue-triage.lock.yml`. No other files changed.

Honest scope note: this removes the **confirmed** blocker (the harden-runner post-step failure). It is necessary but not proven sufficient — since no successful run exists, the rest of the pipeline (per-issue concurrency `cancel-in-progress`, the `is_team_member` activation gate, the agent engine) is unverified. Expect this to move the workflow from "always fails in the harden-runner post-step" to "the agent actually attempts to run", where any remaining issue will surface.

`issue-triage.lock.yml` is generated by `gh-aw`. This is a direct patch to the lock; a future `gh aw compile` with the current `gh-aw` version would re-pin v2.16.0. Long-term fix is upgrading `gh-aw` (or overriding the harden-runner version in its config) and recompiling. No dependencies required.

### Steps to review

1. Confirm the diff only touches `.github/workflows/issue-triage.lock.yml` and only changes the harden-runner pin (6 lines, v2.16.0 -> v2.19.3).
2. Verify the pinned SHA `ab7a9404c0f3da075243ca237b5fac12c98deaa5` resolves to harden-runner tag `v2.19.3`.
3. Verify v2.19.1+ includes ubuntu-slim handling (harden-runner release notes).
4. After merge: trigger a real triage on a test issue (`ai-issue-review` + `status/needs-triage` labels) and inspect the run to confirm jobs no longer fail at `Post Harden the runner`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests. (N/A — CI workflow change, no test harness)
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings (N/A — no code)
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) (N/A)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. (N/A — CI-only change)

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
