### PR TITLE
chore(ui): upgrade pnpm to 11 and harden supply-chain defaults

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -11,7 +11,12 @@ envs = "wt step copy-ignored"
 [[pre-start]]
 deps = "uv sync"
 
-# Block 3: reminder - last visible output before `wt switch` returns.
+# Block 3: prepare pnpm via corepack (matches the pinned packageManager).
+[[pre-start]]
+corepack-enable = "corepack enable"
+corepack-install = "cd ui && corepack install"
+
+# Block 4: reminder - last visible output before `wt switch` returns.
 # Hooks can't mutate the parent shell, so venv activation is manual.
 [[pre-start]]
 reminder = "echo '>> Reminder: activate the venv in this shell with: source .venv/bin/activate'"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -14,6 +14,8 @@ deps = "uv sync"
 # Block 3: prepare pnpm via corepack.
 [[pre-start]]
 corepack-enable = "corepack enable"
+
+[[pre-start]]
 corepack-install = "cd ui && corepack install"
 
 # Block 4: reminder - last visible output before `wt switch` returns.

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -11,7 +11,7 @@ envs = "wt step copy-ignored"
 [[pre-start]]
 deps = "uv sync"
 
-# Block 3: prepare pnpm via corepack (matches the pinned packageManager).
+# Block 3: prepare pnpm via corepack.
 [[pre-start]]
 corepack-enable = "corepack enable"
 corepack-install = "cd ui && corepack install"

--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '24.13.0'
+          node-version-file: 'ui/.nvmrc'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   UI_WORKING_DIR: ./ui
-  NODE_VERSION: "24.13.0"
 
 permissions: {}
 
@@ -93,11 +92,11 @@ jobs:
             ui/vitest.config.ts
             ui/vitest.setup.ts
 
-      - name: Setup Node.js ${{ env.NODE_VERSION }}
+      - name: Setup Node.js
         if: steps.check-changes.outputs.any_changed == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version-file: 'ui/.nvmrc'
 
       - name: Setup pnpm
         if: steps.check-changes.outputs.any_changed == 'true'

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,3 +1,0 @@
-public-hoist-pattern[]=*@nextui-org/*
-public-hoist-pattern[]=*@heroui/*
-save-exact=true

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -225,9 +225,9 @@ pnpm run test:e2e:ui
 
 ## QA CHECKLIST BEFORE COMMIT
 
-- [ ] `npm run typecheck` passes
-- [ ] `npm run lint:fix` passes
-- [ ] `npm run format:write` passes
+- [ ] `pnpm run typecheck` passes
+- [ ] `pnpm run lint:fix` passes
+- [ ] `pnpm run format:write` passes
 - [ ] Relevant E2E tests pass
 - [ ] All UI states handled (loading, error, empty)
 - [ ] No secrets in code (use `.env.local`)

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Compliance page now loads the most recent scan when opened from the sidebar instead of showing the "no compliance data available" alert [(#11374)](https://github.com/prowler-cloud/prowler/pull/11374)
 
+### 🔐 Security
+
+- `pnpm` upgraded to 11 with supply-chain defaults consolidated in `pnpm-workspace.yaml` and `trustPolicyExclude` entries pinned to exact versions [(#11225)](https://github.com/prowler-cloud/prowler/pull/11225)
+
 ---
 
 ## [1.28.1] (Prowler v5.28.1)

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Dark mode: pure-black canvas, pure-white primary text, and brighter border / input tokens for clearer separation between cards, tables, and inputs [(#11073)](https://github.com/prowler-cloud/prowler/pull/11073)
+- CI workflows (`ui-tests.yml`, `ui-e2e-tests-v2.yml`) now read the Node version from `ui/.nvmrc` and the pnpm version from `package.json#packageManager` instead of hardcoded values [(#11225)](https://github.com/prowler-cloud/prowler/pull/11225)
 
 ### 🐞 Fixed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔐 Security
 
 - `pnpm` upgraded to 11 with supply-chain defaults consolidated in `pnpm-workspace.yaml` and `trustPolicyExclude` entries pinned to exact versions [(#11225)](https://github.com/prowler-cloud/prowler/pull/11225)
+- `uuid` pinned to `11.1.1` via `pnpm-workspace.yaml#overrides` to clear `GHSA-w5hq-g745-h8pq` (missing bounds check in `v3`/`v5`/`v6` name-based generators with `buf`) in the transitive tree [(#11225)](https://github.com/prowler-cloud/prowler/pull/11225)
 
 ---
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,7 +1,4 @@
-# Keep in sync with ui/.nvmrc — Docker requires a literal version in FROM.
-# pnpm is provisioned via corepack from package.json's packageManager field
-# (see RUN corepack enable / corepack install below); no pnpm version is
-# redeclared in this Dockerfile.
+# Keep in sync with ui/.nvmrc.
 FROM node:24.13.0-alpine@sha256:cd6fb7efa6490f039f3471a189214d5f548c11df1ff9e5b181aa49e22c14383e AS base
 
 LABEL maintainer="https://github.com/prowler-cloud"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,3 +1,7 @@
+# Keep in sync with ui/.nvmrc — Docker requires a literal version in FROM.
+# pnpm is provisioned via corepack from package.json's packageManager field
+# (see RUN corepack enable / corepack install below); no pnpm version is
+# redeclared in this Dockerfile.
 FROM node:24.13.0-alpine@sha256:cd6fb7efa6490f039f3471a189214d5f548c11df1ff9e5b181aa49e22c14383e AS base
 
 LABEL maintainer="https://github.com/prowler-cloud"

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY scripts ./scripts
 RUN corepack install && pnpm install --frozen-lockfile
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev",
     "format:check": "./node_modules/.bin/prettier --check .",
     "format:write": "./node_modules/.bin/prettier --config .prettierrc.json --write .",
-    "healthcheck": "pnpm run typecheck && pnpm run lint:check",
+    "healthcheck": "pnpm run typecheck && pnpm run lint:check && pnpm run format:check",
     "postinstall": "node scripts/postinstall.js",
     "lint:check": "eslint . --max-warnings 40",
     "lint:fix": "eslint . --fix --max-warnings 40",

--- a/ui/package.json
+++ b/ui/package.json
@@ -164,7 +164,7 @@
   "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
   "engines": {
     "node": ">=22.13",
-    "pnpm": ">=11"
+    "pnpm": ">=11.1.3"
   },
   "msw": {
     "workerDirectory": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
     "dev": "next dev",
     "format:check": "./node_modules/.bin/prettier --check .",
     "format:write": "./node_modules/.bin/prettier --config .prettierrc.json --write .",
-    "healthcheck": "pnpm run typecheck && pnpm run lint:check && pnpm run format:check",
+    "healthcheck": "pnpm run typecheck && pnpm run lint:check",
     "postinstall": "node scripts/postinstall.js",
     "lint:check": "eslint . --max-warnings 40",
     "lint:fix": "eslint . --fix --max-warnings 40",
@@ -161,27 +161,10 @@
     "vitest": "4.0.18",
     "vitest-browser-react": "2.0.4"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-  "pnpm": {
-    "overrides": {
-      "@hono/node-server": "1.19.14",
-      "@internationalized/date": "3.10.0",
-      "@isaacs/brace-expansion": "5.0.1",
-      "@react-aria/interactions>react": "19.2.6",
-      "@react-aria/ssr>react": "19.2.6",
-      "@react-aria/ssr>react-dom": "19.2.6",
-      "@react-aria/visually-hidden>react": "19.2.6",
-      "fast-xml-parser": "5.8.0",
-      "hono": "4.12.18",
-      "lodash": "4.18.1",
-      "lodash-es": "4.18.1",
-      "minimatch@>=9 <10": "9.0.7",
-      "minimatch@>=10": "10.2.3",
-      "minimatch@<4": "3.1.4",
-      "qs": "6.14.2",
-      "rollup@>=4": "4.59.0",
-      "serialize-javascript": "7.0.5"
-    }
+  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
+  "engines": {
+    "node": ">=22.13",
+    "pnpm": ">=11"
   },
   "msw": {
     "workerDirectory": [

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
   ajv@<7: 6.14.0
   ajv@>=8: 8.18.0
   qs: 6.14.2
-  express-rate-limit: '>=8.3.1'
+  express-rate-limit: 8.5.1
 
 importers:
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -5,23 +5,27 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@hono/node-server': 1.19.14
+  '@react-types/shared': 3.26.0
   '@internationalized/date': 3.10.0
-  '@isaacs/brace-expansion': 5.0.1
-  '@react-aria/interactions>react': 19.2.6
   '@react-aria/ssr>react': 19.2.6
   '@react-aria/ssr>react-dom': 19.2.6
   '@react-aria/visually-hidden>react': 19.2.6
-  fast-xml-parser: 5.8.0
-  hono: 4.12.18
+  '@react-aria/interactions>react': 19.2.6
   lodash: 4.18.1
   lodash-es: 4.18.1
+  hono: 4.12.18
+  '@hono/node-server': 1.19.14
+  '@isaacs/brace-expansion': 5.0.1
+  fast-xml-parser: 5.8.0
+  serialize-javascript: 7.0.5
+  rollup@>=4: 4.59.0
+  minimatch@<4: 3.1.4
   minimatch@>=9 <10: 9.0.7
   minimatch@>=10: 10.2.3
-  minimatch@<4: 3.1.4
+  ajv@<7: 6.14.0
+  ajv@>=8: 8.18.0
   qs: 6.14.2
-  rollup@>=4: 4.59.0
-  serialize-javascript: 7.0.5
+  express-rate-limit: '>=8.3.1'
 
 importers:
 
@@ -369,7 +373,7 @@ importers:
         version: 17.0.0
       jsdom:
         specifier: 27.4.0
-        version: 27.4.0(@noble/hashes@1.8.0)
+        version: 27.4.0
       knip:
         specifier: 6.3.1
         version: 6.3.1(@emnapi/core@1.8.1)(@emnapi/runtime@1.10.0)
@@ -396,7 +400,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
       vitest-browser-react:
         specifier: 2.0.4
         version: 2.0.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.0.18)
@@ -2150,10 +2154,6 @@ packages:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
-  '@noble/hashes@1.8.0':
-    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
-    engines: {node: ^14.21.3 || >=16}
-
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
@@ -3824,16 +3824,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@react-types/shared@3.32.0':
-    resolution: {integrity: sha512-t+cligIJsZYFMSPFMvsJMjzlzde06tZMOIOFa1OV5Z0BcMowrb2g4mB57j/9nP28iJIRYn10xCniQts+qadrqQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-types/shared@3.34.0':
-    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   '@react-types/slider@3.8.2':
     resolution: {integrity: sha512-MQYZP76OEOYe7/yA2To+Dl0LNb0cKKnvh5JtvNvDnAvEprn1RuLiay8Oi/rTtXmc2KmBa4VdTcsXsmkbbkeN2Q==}
     peerDependencies:
@@ -4188,6 +4178,7 @@ packages:
   '@smithy/core@3.24.1':
     resolution: {integrity: sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==}
     engines: {node: '>=18.0.0'}
+    deprecated: Deprecated due to bug in browser bundling instructions https://github.com/smithy-lang/smithy-typescript/issues/2025
 
   '@smithy/credential-provider-imds@4.3.1':
     resolution: {integrity: sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ==}
@@ -4788,6 +4779,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -4958,7 +4950,7 @@ packages:
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -4966,7 +4958,7 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: 8.18.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -4974,7 +4966,7 @@ packages:
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
-      ajv: ^8.8.2
+      ajv: 8.18.0
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -6053,6 +6045,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -8284,6 +8277,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -9568,9 +9562,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.14.1(@noble/hashes@1.8.0)':
-    optionalDependencies:
-      '@noble/hashes': 1.8.0
+  '@exodus/bytes@1.14.1': {}
 
   '@extractus/feed-extractor@7.1.7':
     dependencies:
@@ -9640,7 +9632,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/tree': 3.9.2(react@19.2.6)
       '@react-types/accordion': 3.0.0-alpha.26(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -9665,7 +9657,7 @@ snapshots:
       '@react-aria/utils': 3.30.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/collections': 3.12.7(react@19.2.6)
       '@react-types/overlays': 3.9.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -9691,7 +9683,7 @@ snapshots:
       '@react-aria/i18n': 3.12.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/combobox': 3.11.1(react@19.2.6)
       '@react-types/combobox': 3.13.8(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -9743,7 +9735,7 @@ snapshots:
       '@heroui/use-aria-button': 2.2.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/focus': 3.21.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -9769,7 +9761,7 @@ snapshots:
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/button': 3.14.0(react@19.2.6)
       '@react-types/calendar': 3.7.4(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -9785,7 +9777,7 @@ snapshots:
       '@heroui/use-aria-button': 2.2.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/focus': 3.21.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -9805,7 +9797,7 @@ snapshots:
       '@react-stately/checkbox': 3.7.1(react@19.2.6)
       '@react-stately/toggle': 3.9.1(react@19.2.6)
       '@react-types/checkbox': 3.10.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -9842,7 +9834,7 @@ snapshots:
       '@react-aria/i18n': 3.12.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/datepicker': 3.15.1(react@19.2.6)
       '@react-types/datepicker': 3.13.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -9865,7 +9857,7 @@ snapshots:
       '@react-stately/datepicker': 3.15.1(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/datepicker': 3.13.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -9875,7 +9867,7 @@ snapshots:
       '@heroui/react-rsc-utils': 2.1.9(react@19.2.6)
       '@heroui/system-rsc': 2.3.19(@heroui/theme@2.4.22(tailwindcss@4.1.18))(react@19.2.6)
       '@heroui/theme': 2.4.22(tailwindcss@4.1.18)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -9920,7 +9912,7 @@ snapshots:
       '@heroui/theme': 2.4.22(tailwindcss@4.1.18)
       '@react-stately/form': 3.2.1(react@19.2.6)
       '@react-types/form': 3.7.15(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -9974,7 +9966,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/textfield': 3.18.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/textfield': 3.12.5(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -10017,7 +10009,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/listbox': 3.14.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/list': 3.13.0(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@tanstack/react-virtual': 3.11.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -10038,7 +10030,7 @@ snapshots:
       '@react-aria/menu': 3.19.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/tree': 3.9.2(react@19.2.6)
       '@react-types/menu': 3.10.4(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -10103,7 +10095,7 @@ snapshots:
       '@react-stately/numberfield': 3.10.1(react@19.2.6)
       '@react-types/button': 3.14.0(react@19.2.6)
       '@react-types/numberfield': 3.8.14(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -10173,7 +10165,7 @@ snapshots:
       '@react-aria/visually-hidden': 3.8.27(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/radio': 3.11.1(react@19.2.6)
       '@react-types/radio': 3.9.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -10288,7 +10280,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/overlays': 3.29.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/visually-hidden': 3.8.27(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -10378,7 +10370,7 @@ snapshots:
   '@heroui/system-rsc@2.3.19(@heroui/theme@2.4.22(tailwindcss@4.1.18))(react@19.2.6)':
     dependencies:
       '@heroui/theme': 2.4.22(tailwindcss@4.1.18)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       clsx: 1.2.1
       react: 19.2.6
 
@@ -10428,7 +10420,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/tabs': 3.10.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/tabs': 3.8.5(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       framer-motion: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -10489,7 +10481,7 @@ snapshots:
       '@react-aria/selection': 3.25.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/tree': 3.9.2(react@19.2.6)
       '@react-types/accordion': 3.0.0-alpha.26(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
     transitivePeerDependencies:
       - react-dom
@@ -10500,7 +10492,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.30.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/button': 3.14.0(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
     transitivePeerDependencies:
       - react-dom
@@ -10511,7 +10503,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.30.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/link': 3.6.4(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
     transitivePeerDependencies:
       - react-dom
@@ -10539,7 +10531,7 @@ snapshots:
       '@react-stately/menu': 3.9.7(react@19.2.6)
       '@react-types/button': 3.14.0(react@19.2.6)
       '@react-types/overlays': 3.9.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -10548,7 +10540,7 @@ snapshots:
       '@react-aria/focus': 3.21.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/overlays': 3.29.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -11119,9 +11111,6 @@ snapshots:
       next: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       third-party-capital: 1.0.20
-
-  '@noble/hashes@1.8.0':
-    optional: true
 
   '@nodable/entities@2.1.0': {}
 
@@ -12150,7 +12139,7 @@ snapshots:
       '@react-aria/link': 3.8.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/breadcrumbs': 3.7.16(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12162,7 +12151,7 @@ snapshots:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/toggle': 3.9.1(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12177,7 +12166,7 @@ snapshots:
       '@react-stately/calendar': 3.8.4(react@19.2.6)
       '@react-types/button': 3.14.0(react@19.2.6)
       '@react-types/calendar': 3.7.4(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12193,7 +12182,7 @@ snapshots:
       '@react-stately/form': 3.2.2(react@19.2.6)
       '@react-stately/toggle': 3.9.1(react@19.2.6)
       '@react-types/checkbox': 3.10.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12214,7 +12203,7 @@ snapshots:
       '@react-stately/form': 3.2.2(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
       '@react-types/combobox': 3.13.8(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12237,7 +12226,7 @@ snapshots:
       '@react-types/calendar': 3.8.1(react@19.2.6)
       '@react-types/datepicker': 3.13.2(react@19.2.6)
       '@react-types/dialog': 3.5.22(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12248,7 +12237,7 @@ snapshots:
       '@react-aria/overlays': 3.29.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/dialog': 3.5.22(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12257,7 +12246,7 @@ snapshots:
     dependencies:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       clsx: 2.1.1
       react: 19.2.6
@@ -12267,7 +12256,7 @@ snapshots:
     dependencies:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       clsx: 2.1.1
       react: 19.2.6
@@ -12278,7 +12267,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/form': 3.2.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12288,7 +12277,7 @@ snapshots:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/form': 3.2.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12306,7 +12295,7 @@ snapshots:
       '@react-stately/selection': 3.20.7(react@19.2.6)
       '@react-types/checkbox': 3.10.2(react@19.2.6)
       '@react-types/grid': 3.3.6(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12319,7 +12308,7 @@ snapshots:
       '@internationalized/string': 3.2.7
       '@react-aria/ssr': 3.9.10(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12332,7 +12321,7 @@ snapshots:
       '@internationalized/string': 3.2.7
       '@react-aria/ssr': 3.9.10(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12345,7 +12334,7 @@ snapshots:
       '@internationalized/string': 3.2.7
       '@react-aria/ssr': 3.9.10(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12355,7 +12344,7 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/flags': 3.1.2
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12365,7 +12354,7 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/flags': 3.1.2
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.18
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12373,7 +12362,7 @@ snapshots:
   '@react-aria/label@3.7.21(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@react-aria/utils': 3.30.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12381,7 +12370,7 @@ snapshots:
   '@react-aria/label@3.7.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12389,7 +12378,7 @@ snapshots:
   '@react-aria/landmark@3.0.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12400,7 +12389,7 @@ snapshots:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/link': 3.6.5(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12414,7 +12403,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/list': 3.13.0(react@19.2.6)
       '@react-types/listbox': 3.7.4(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12428,7 +12417,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/list': 3.13.2(react@19.2.6)
       '@react-types/listbox': 3.7.4(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12451,7 +12440,7 @@ snapshots:
       '@react-stately/tree': 3.9.2(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
       '@react-types/menu': 3.10.4(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12470,7 +12459,7 @@ snapshots:
       '@react-stately/tree': 3.9.4(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
       '@react-types/menu': 3.10.5(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12486,7 +12475,7 @@ snapshots:
       '@react-stately/numberfield': 3.10.1(react@19.2.6)
       '@react-types/button': 3.14.0(react@19.2.6)
       '@react-types/numberfield': 3.8.14(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12502,7 +12491,7 @@ snapshots:
       '@react-stately/overlays': 3.6.19(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
       '@react-types/overlays': 3.9.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12518,7 +12507,7 @@ snapshots:
       '@react-stately/overlays': 3.6.21(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
       '@react-types/overlays': 3.9.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12529,7 +12518,7 @@ snapshots:
       '@react-aria/label': 3.7.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/progress': 3.5.15(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12544,7 +12533,7 @@ snapshots:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/radio': 3.11.1(react@19.2.6)
       '@react-types/radio': 3.9.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12556,7 +12545,7 @@ snapshots:
       '@react-aria/interactions': 3.25.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.30.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/selection': 3.20.7(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12568,7 +12557,7 @@ snapshots:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/selection': 3.20.7(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12580,7 +12569,7 @@ snapshots:
       '@react-aria/label': 3.7.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/slider': 3.7.1(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/slider': 3.8.2(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12592,7 +12581,7 @@ snapshots:
       '@react-aria/live-announcer': 3.4.4
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12611,7 +12600,7 @@ snapshots:
     dependencies:
       '@react-aria/toggle': 3.12.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/toggle': 3.9.1(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/switch': 3.5.15(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12631,7 +12620,7 @@ snapshots:
       '@react-stately/table': 3.15.0(react@19.2.6)
       '@react-types/checkbox': 3.10.2(react@19.2.6)
       '@react-types/grid': 3.3.5(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/table': 3.13.3(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12644,7 +12633,7 @@ snapshots:
       '@react-aria/selection': 3.27.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/tabs': 3.8.5(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/tabs': 3.3.20(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12658,7 +12647,7 @@ snapshots:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/form': 3.2.2(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/textfield': 3.12.5(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12672,7 +12661,7 @@ snapshots:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/form': 3.2.2(react@19.2.6)
       '@react-stately/utils': 3.11.0(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/textfield': 3.12.6(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12686,7 +12675,7 @@ snapshots:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/toast': 3.1.2(react@19.2.6)
       '@react-types/button': 3.14.1(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12697,7 +12686,7 @@ snapshots:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/toggle': 3.9.3(react@19.2.6)
       '@react-types/checkbox': 3.10.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12707,7 +12696,7 @@ snapshots:
       '@react-aria/focus': 3.21.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/i18n': 3.12.13(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12717,7 +12706,7 @@ snapshots:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-stately/tooltip': 3.5.7(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/tooltip': 3.4.20(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12728,7 +12717,7 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@19.2.6)
       '@react-stately/flags': 3.1.2
       '@react-stately/utils': 3.10.8(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       clsx: 2.1.1
       react: 19.2.6
@@ -12739,7 +12728,7 @@ snapshots:
       '@react-aria/ssr': 3.9.10(react@19.2.6)
       '@react-stately/flags': 3.1.2
       '@react-stately/utils': 3.11.0(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.18
       clsx: 2.1.1
       react: 19.2.6
@@ -12759,7 +12748,7 @@ snapshots:
     dependencies:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.18
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12768,7 +12757,7 @@ snapshots:
     dependencies:
       '@react-aria/interactions': 3.26.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -12778,7 +12767,7 @@ snapshots:
       '@internationalized/date': 3.10.0
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/calendar': 3.7.4(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12787,19 +12776,19 @@ snapshots:
       '@react-stately/form': 3.2.2(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/checkbox': 3.10.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
   '@react-stately/collections@3.12.7(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
   '@react-stately/collections@3.12.8(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12812,7 +12801,7 @@ snapshots:
       '@react-stately/select': 3.9.0(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/combobox': 3.13.8(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12824,7 +12813,7 @@ snapshots:
       '@react-stately/overlays': 3.6.21(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/datepicker': 3.13.2(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12834,13 +12823,13 @@ snapshots:
 
   '@react-stately/form@3.2.1(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
   '@react-stately/form@3.2.2(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12849,7 +12838,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/selection': 3.20.7(react@19.2.6)
       '@react-types/grid': 3.3.6(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12858,7 +12847,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/selection': 3.20.7(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12867,7 +12856,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/selection': 3.20.7(react@19.2.6)
       '@react-stately/utils': 3.11.0(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12875,7 +12864,7 @@ snapshots:
     dependencies:
       '@react-stately/overlays': 3.6.21(react@19.2.6)
       '@react-types/menu': 3.10.4(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12883,7 +12872,7 @@ snapshots:
     dependencies:
       '@react-stately/overlays': 3.6.21(react@19.2.6)
       '@react-types/menu': 3.10.5(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12915,7 +12904,7 @@ snapshots:
       '@react-stately/form': 3.2.2(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/radio': 3.9.1(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12926,7 +12915,7 @@ snapshots:
       '@react-stately/overlays': 3.6.21(react@19.2.6)
       '@react-stately/utils': 3.11.0(react@19.2.6)
       '@react-types/select': 3.12.0(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12934,14 +12923,14 @@ snapshots:
     dependencies:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/utils': 3.11.0(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
   '@react-stately/slider@3.7.1(react@19.2.6)':
     dependencies:
       '@react-stately/utils': 3.10.8(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/slider': 3.8.2(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12954,7 +12943,7 @@ snapshots:
       '@react-stately/selection': 3.20.7(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/grid': 3.3.5(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/table': 3.13.3(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12962,7 +12951,7 @@ snapshots:
   '@react-stately/tabs@3.8.5(react@19.2.6)':
     dependencies:
       '@react-stately/list': 3.13.2(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@react-types/tabs': 3.3.20(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
@@ -12977,7 +12966,7 @@ snapshots:
     dependencies:
       '@react-stately/utils': 3.10.8(react@19.2.6)
       '@react-types/checkbox': 3.10.2(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -12985,7 +12974,7 @@ snapshots:
     dependencies:
       '@react-stately/utils': 3.11.0(react@19.2.6)
       '@react-types/checkbox': 3.10.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -13001,7 +12990,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/selection': 3.20.7(react@19.2.6)
       '@react-stately/utils': 3.10.8(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -13010,7 +12999,7 @@ snapshots:
       '@react-stately/collections': 3.12.8(react@19.2.6)
       '@react-stately/selection': 3.20.7(react@19.2.6)
       '@react-stately/utils': 3.11.0(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
 
@@ -13027,57 +13016,57 @@ snapshots:
   '@react-stately/virtualizer@4.4.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@react-aria/utils': 3.32.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       '@swc/helpers': 0.5.21
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
   '@react-types/accordion@3.0.0-alpha.26(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/breadcrumbs@3.7.16(react@19.2.6)':
     dependencies:
       '@react-types/link': 3.6.5(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/button@3.14.0(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/button@3.14.1(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/calendar@3.7.4(react@19.2.6)':
     dependencies:
       '@internationalized/date': 3.10.0
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/calendar@3.8.1(react@19.2.6)':
     dependencies:
       '@internationalized/date': 3.10.0
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/checkbox@3.10.1(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/checkbox@3.10.2(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/combobox@3.13.8(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/datepicker@3.13.1(react@19.2.6)':
@@ -13085,7 +13074,7 @@ snapshots:
       '@internationalized/date': 3.10.0
       '@react-types/calendar': 3.8.1(react@19.2.6)
       '@react-types/overlays': 3.9.2(react@19.2.6)
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/datepicker@3.13.2(react@19.2.6)':
@@ -13093,134 +13082,126 @@ snapshots:
       '@internationalized/date': 3.10.0
       '@react-types/calendar': 3.8.1(react@19.2.6)
       '@react-types/overlays': 3.9.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/dialog@3.5.22(react@19.2.6)':
     dependencies:
       '@react-types/overlays': 3.9.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/form@3.7.15(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/grid@3.3.5(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/grid@3.3.6(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/link@3.6.4(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/link@3.6.5(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/listbox@3.7.4(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/menu@3.10.4(react@19.2.6)':
     dependencies:
       '@react-types/overlays': 3.9.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/menu@3.10.5(react@19.2.6)':
     dependencies:
       '@react-types/overlays': 3.9.2(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/numberfield@3.8.14(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/overlays@3.9.1(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/overlays@3.9.2(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/progress@3.5.15(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/radio@3.9.1(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.32.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/select@3.12.0(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/shared@3.26.0(react@19.2.6)':
     dependencies:
       react: 19.2.6
 
-  '@react-types/shared@3.32.0(react@19.2.6)':
-    dependencies:
-      react: 19.2.6
-
-  '@react-types/shared@3.34.0(react@19.2.6)':
-    dependencies:
-      react: 19.2.6
-
   '@react-types/slider@3.8.2(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/switch@3.5.15(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/table@3.13.3(react@19.2.6)':
     dependencies:
       '@react-types/grid': 3.3.5(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/tabs@3.3.20(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/textfield@3.12.5(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/textfield@3.12.6(react@19.2.6)':
     dependencies:
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@react-types/tooltip@3.4.20(react@19.2.6)':
     dependencies:
       '@react-types/overlays': 3.9.1(react@19.2.6)
-      '@react-types/shared': 3.34.0(react@19.2.6)
+      '@react-types/shared': 3.26.0(react@19.2.6)
       react: 19.2.6
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
@@ -14295,7 +14276,7 @@ snapshots:
       '@vitest/mocker': 4.0.18(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(vite@7.3.2(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.9.0))
       playwright: 1.56.1
       tinyrainbow: 3.1.0
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -14311,7 +14292,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
       ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
@@ -14331,7 +14312,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.1.0
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
     optionalDependencies:
       '@vitest/browser': 4.0.18(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(vite@7.3.2(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.9.0))(vitest@4.0.18)
 
@@ -15967,9 +15948,9 @@ snapshots:
 
   hono@4.12.18: {}
 
-  html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
+  html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.14.1(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.14.1
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -16263,15 +16244,15 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.4.0(@noble/hashes@1.8.0):
+  jsdom@27.4.0:
     dependencies:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
-      '@exodus/bytes': 1.14.1(@noble/hashes@1.8.0)
+      '@exodus/bytes': 1.14.1
       cssstyle: 5.3.7
       data-urls: 6.0.1
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
+      html-encoding-sniffer: 6.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
@@ -18523,12 +18504,12 @@ snapshots:
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0)
     optionalDependencies:
       '@types/react': 19.2.8
       '@types/react-dom': 19.2.3(@types/react@19.2.8)
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0(@noble/hashes@1.8.0))(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(terser@5.47.1)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(vite@7.3.2(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.9.0))
@@ -18554,7 +18535,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 24.10.8
       '@vitest/browser-playwright': 4.0.18(msw@2.13.4(@types/node@24.10.8)(typescript@5.5.4))(playwright@1.56.1)(vite@7.3.2(@types/node@24.10.8)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.47.1)(yaml@2.9.0))(vitest@4.0.18)
-      jsdom: 27.4.0(@noble/hashes@1.8.0)
+      jsdom: 27.4.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   ajv@>=8: 8.18.0
   qs: 6.14.2
   express-rate-limit: 8.5.1
+  uuid: 11.1.1
 
 importers:
 
@@ -8266,18 +8267,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@13.0.2:
-    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vary@1.1.2:
@@ -10950,7 +10941,7 @@ snapshots:
   '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.45(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))':
     dependencies:
       '@langchain/core': 1.1.45(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
-      uuid: 10.0.0
+      uuid: 11.1.1
 
   '@langchain/langgraph-sdk@1.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(ws@8.20.1)':
     dependencies:
@@ -10959,7 +10950,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       p-queue: 9.2.0
       p-retry: 7.1.1
-      uuid: 13.0.2
+      uuid: 11.1.1
     optionalDependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -10977,7 +10968,7 @@ snapshots:
       '@langchain/langgraph-sdk': 1.9.2(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.4.0(@opentelemetry/api@1.9.0))(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(ws@8.20.1)
       '@langchain/protocol': 0.0.15
       '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
+      uuid: 11.1.1
       zod: 4.4.3
     optionalDependencies:
       zod-to-json-schema: 3.25.1(zod@4.4.3)
@@ -13497,7 +13488,7 @@ snapshots:
     dependencies:
       '@sentry/bundler-plugin-core': 4.7.0
       unplugin: 1.0.1
-      uuid: 9.0.1
+      uuid: 11.1.1
       webpack: 5.104.1(lightningcss@1.30.2)(postcss@8.5.14)
     transitivePeerDependencies:
       - encoding
@@ -16685,7 +16676,7 @@ snapshots:
       roughjs: 4.6.6
       stylis: 4.3.6
       ts-dedent: 2.2.0
-      uuid: 13.0.2
+      uuid: 11.1.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -18435,11 +18426,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@10.0.0: {}
-
-  uuid@13.0.2: {}
-
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   vary@1.1.2: {}
 

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,29 +1,20 @@
-# Canonical home for pnpm 11+ configuration. In pnpm 11 .npmrc accepts only
-# auth/registry keys and package.json no longer reads its `pnpm` field — every
-# other setting lives here (or in ~/.config/pnpm/config.yaml at the global level).
-#
+# pnpm 11+ workspace config. .npmrc is auth/registry only; everything else lives here.
 # Reference: https://pnpm.io/supply-chain-security
 
 packages: []
 
-# --- Engine enforcement ---
 # Refuse to install on Node/pnpm outside the `engines` block in package.json.
-# Replaces engine-strict=true (a pnpm 10 .npmrc key; .npmrc-only is auth/registry in v11).
 engineStrict: true
 
-# --- npm-style ergonomics (migrated from .npmrc) ---
-# Hoist NextUI / HeroUI families to root node_modules so legacy peer-dep
-# patterns continue to resolve.
+# Hoist NextUI / HeroUI families so legacy peer-dep patterns resolve.
 publicHoistPattern:
   - "*@nextui-org/*"
   - "*@heroui/*"
 
-# Default `pnpm add` to exact versions — matches the convention used across
-# package.json today (no carets/tildes).
+# Default `pnpm add` to exact versions — matches package.json convention.
 saveExact: true
 
-# --- Dependency overrides (migrated from package.json#pnpm.overrides) ---
-# pnpm 11 no longer reads the `pnpm` field in package.json; same versions, same ordering.
+# --- Dependency overrides ---
 overrides:
   "@react-types/shared": "3.26.0"
   "@internationalized/date": "3.10.0"
@@ -45,15 +36,13 @@ overrides:
   "ajv@<7": "6.14.0"
   "ajv@>=8": "8.18.0"
   "qs": "6.14.2"
-  # express-rate-limit 8.2.2 was a one-off release that dropped provenance
-  # attestation; 8.3.1+ restored it (continuous through latest 8.5.2). Force the
-  # transitive resolution to a version that satisfies `trustPolicy: no-downgrade`.
-  "express-rate-limit": ">=8.3.1"
+  # 8.2.2 dropped provenance attestation; 8.3.1+ restored it. Pinned to skip 8.2.2
+  # under `trustPolicy: no-downgrade`.
+  "express-rate-limit": "8.5.1"
 
 # --- Level 1: Minimum Release Age ---
 # Packages must be published for at least 1 day before they can be installed.
 # Prevents installing compromised packages during the detection window.
-# (pnpm 11 default: 1440. Explicit value kept as defense-in-depth + documentation.)
 minimumReleaseAge: 1440
 
 # Bypasses the minimum release age for specific packages.
@@ -64,7 +53,6 @@ minimumReleaseAge: 1440
 # --- Level 2: Explicit Build Script Allow-list ---
 # Only these packages may run install/postinstall lifecycle scripts.
 # Any unlisted package with lifecycle scripts fails the install.
-# (pnpm 11 default: strictDepBuilds=true. Explicit value kept as defense-in-depth.)
 strictDepBuilds: true
 allowBuilds:
   # sharp: Native image processing (libvips). Installs platform-specific pre-built binary or compiles from source.
@@ -82,29 +70,16 @@ allowBuilds:
 
 # --- Level 3: Trust Policy + Exotic Subdeps ---
 # Fail when a package's trust evidence is downgraded (e.g., new publisher).
-# Intentionally stricter than the upstream default (`off`) — keep as-is.
 trustPolicy: no-downgrade
-# Documented exceptions for packages where the "trust downgrade" pnpm 11 reports
-# is a false positive — i.e. the project simply doesn't use provenance for its
-# real releases, so there's no actual regression. Each entry must be justified.
-# Review periodically: when a package starts publishing with provenance again,
-# remove the entry.
+# False positives — packages that don't publish provenance for real releases.
+# Pin to the version range that lacks provenance so a bump fails until reviewed.
 trustPolicyExclude:
-  # next-auth: 725 versions published, only `0.0.0-manual.2824fa11` (a one-off
-  # manual test release) has provenance. None of the real beta or stable
-  # releases use provenance — there is nothing to downgrade *from*. Tracked
-  # upstream as a long-standing publishing-pipeline gap, not a takeover.
-  - "next-auth"
-  # langium: provenance is published intermittently across majors (1.2, 1.3,
-  # 2.0, 2.1, 3.0, 4.2+ have it; 3.1–3.x do not). Our pin sits in the
-  # provenance-less 3.x band; the package is a transitive dep, not direct.
-  - "langium"
-  # semver: legacy major 6.x never had provenance (provenance attestations
-  # started in semver 7.5.1+). Pulled transitively via
-  # @vitejs/plugin-react -> @babel/core -> @babel/helper-compilation-targets.
-  # Upgrading the chain to a version using semver 7+ is not in our control.
-  - "semver"
+  # next-auth: only one one-off manual test release (`0.0.0-manual.2824fa11`) has
+  # provenance; real beta/stable releases don't. Scoped to current beta line.
+  - "next-auth@5.0.0-beta.30"
+  # semver: legacy major 6.x never had provenance (added in 7.5.1+). Pinned
+  # to the exact 6.x version pulled transitively (via @babel/helper-compilation-targets).
+  - "semver@6.3.1"
 
 # Block transitive dependencies from using exotic specifiers (git URLs, tarballs).
-# (pnpm 11 default: blockExoticSubdeps=true. Explicit value kept as defense-in-depth.)
 blockExoticSubdeps: true

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -39,6 +39,11 @@ overrides:
   # 8.2.2 dropped provenance attestation; 8.3.1+ restored it. Pinned to skip 8.2.2
   # under `trustPolicy: no-downgrade`.
   "express-rate-limit": "8.5.1"
+  # GHSA-w5hq-g745-h8pq: missing bounds check in v3/v5/v6 with buf, fixed in
+  # 11.1.1. Transitive consumers (@sentry/webpack-plugin@9, @langchain/langgraph@10)
+  # use the random v4 generator only, so the bug isn't reachable in practice,
+  # but the override unifies the tree on a patched version.
+  "uuid": "11.1.1"
 
 # --- Level 1: Minimum Release Age ---
 # Packages must be published for at least 1 day before they can be installed.

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -6,9 +6,8 @@ packages: []
 # Refuse to install on Node/pnpm outside the `engines` block in package.json.
 engineStrict: true
 
-# Hoist NextUI / HeroUI families so legacy peer-dep patterns resolve.
+# Hoist the HeroUI family so its legacy peer-dep pattern resolves.
 publicHoistPattern:
-  - "*@nextui-org/*"
   - "*@heroui/*"
 
 # Default `pnpm add` to exact versions — matches package.json convention.

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -1,10 +1,59 @@
+# Canonical home for pnpm 11+ configuration. In pnpm 11 .npmrc accepts only
+# auth/registry keys and package.json no longer reads its `pnpm` field — every
+# other setting lives here (or in ~/.config/pnpm/config.yaml at the global level).
+#
 # Reference: https://pnpm.io/supply-chain-security
 
 packages: []
 
+# --- Engine enforcement ---
+# Refuse to install on Node/pnpm outside the `engines` block in package.json.
+# Replaces engine-strict=true (a pnpm 10 .npmrc key; .npmrc-only is auth/registry in v11).
+engineStrict: true
+
+# --- npm-style ergonomics (migrated from .npmrc) ---
+# Hoist NextUI / HeroUI families to root node_modules so legacy peer-dep
+# patterns continue to resolve.
+publicHoistPattern:
+  - "*@nextui-org/*"
+  - "*@heroui/*"
+
+# Default `pnpm add` to exact versions — matches the convention used across
+# package.json today (no carets/tildes).
+saveExact: true
+
+# --- Dependency overrides (migrated from package.json#pnpm.overrides) ---
+# pnpm 11 no longer reads the `pnpm` field in package.json; same versions, same ordering.
+overrides:
+  "@react-types/shared": "3.26.0"
+  "@internationalized/date": "3.10.0"
+  "@react-aria/ssr>react": "19.2.6"
+  "@react-aria/ssr>react-dom": "19.2.6"
+  "@react-aria/visually-hidden>react": "19.2.6"
+  "@react-aria/interactions>react": "19.2.6"
+  "lodash": "4.18.1"
+  "lodash-es": "4.18.1"
+  "hono": "4.12.18"
+  "@hono/node-server": "1.19.14"
+  "@isaacs/brace-expansion": "5.0.1"
+  "fast-xml-parser": "5.8.0"
+  "serialize-javascript": "7.0.5"
+  "rollup@>=4": "4.59.0"
+  "minimatch@<4": "3.1.4"
+  "minimatch@>=9 <10": "9.0.7"
+  "minimatch@>=10": "10.2.3"
+  "ajv@<7": "6.14.0"
+  "ajv@>=8": "8.18.0"
+  "qs": "6.14.2"
+  # express-rate-limit 8.2.2 was a one-off release that dropped provenance
+  # attestation; 8.3.1+ restored it (continuous through latest 8.5.2). Force the
+  # transitive resolution to a version that satisfies `trustPolicy: no-downgrade`.
+  "express-rate-limit": ">=8.3.1"
+
 # --- Level 1: Minimum Release Age ---
 # Packages must be published for at least 1 day before they can be installed.
 # Prevents installing compromised packages during the detection window.
+# (pnpm 11 default: 1440. Explicit value kept as defense-in-depth + documentation.)
 minimumReleaseAge: 1440
 
 # Bypasses the minimum release age for specific packages.
@@ -15,6 +64,7 @@ minimumReleaseAge: 1440
 # --- Level 2: Explicit Build Script Allow-list ---
 # Only these packages may run install/postinstall lifecycle scripts.
 # Any unlisted package with lifecycle scripts fails the install.
+# (pnpm 11 default: strictDepBuilds=true. Explicit value kept as defense-in-depth.)
 strictDepBuilds: true
 allowBuilds:
   # sharp: Native image processing (libvips). Installs platform-specific pre-built binary or compiles from source.
@@ -32,8 +82,29 @@ allowBuilds:
 
 # --- Level 3: Trust Policy + Exotic Subdeps ---
 # Fail when a package's trust evidence is downgraded (e.g., new publisher).
+# Intentionally stricter than the upstream default (`off`) — keep as-is.
 trustPolicy: no-downgrade
-trustPolicyExclude: []
+# Documented exceptions for packages where the "trust downgrade" pnpm 11 reports
+# is a false positive — i.e. the project simply doesn't use provenance for its
+# real releases, so there's no actual regression. Each entry must be justified.
+# Review periodically: when a package starts publishing with provenance again,
+# remove the entry.
+trustPolicyExclude:
+  # next-auth: 725 versions published, only `0.0.0-manual.2824fa11` (a one-off
+  # manual test release) has provenance. None of the real beta or stable
+  # releases use provenance — there is nothing to downgrade *from*. Tracked
+  # upstream as a long-standing publishing-pipeline gap, not a takeover.
+  - "next-auth"
+  # langium: provenance is published intermittently across majors (1.2, 1.3,
+  # 2.0, 2.1, 3.0, 4.2+ have it; 3.1–3.x do not). Our pin sits in the
+  # provenance-less 3.x band; the package is a transitive dep, not direct.
+  - "langium"
+  # semver: legacy major 6.x never had provenance (provenance attestations
+  # started in semver 7.5.1+). Pulled transitively via
+  # @vitejs/plugin-react -> @babel/core -> @babel/helper-compilation-targets.
+  # Upgrading the chain to a version using semver 7+ is not in our control.
+  - "semver"
 
 # Block transitive dependencies from using exotic specifiers (git URLs, tarballs).
+# (pnpm 11 default: blockExoticSubdeps=true. Explicit value kept as defense-in-depth.)
 blockExoticSubdeps: true


### PR DESCRIPTION
### Context

The UI workspace was on pnpm 10.33.0 with supply-chain configuration spread across three files (`ui/.npmrc`, `ui/package.json#pnpm`, `ui/pnpm-workspace.yaml`). pnpm 11 dropped support for `pnpm` and most `.npmrc` keys, so the migration was needed to stay on a supported release line while consolidating the security defaults in a single place. While at it, several `trustPolicyExclude` entries were open-ended package names — a bump to a malicious version of those would silently pass the trust check.

### Description

- Bump pnpm `10.33.0` → `11.1.3` (Node ≥22.13 required by pnpm 11; aligned with `ui/.nvmrc`).
- Migrate `pnpm.overrides` from `package.json` and the security-relevant keys from `.npmrc` into `ui/pnpm-workspace.yaml` (pnpm 11 only reads `auth/registry` from `.npmrc`, so `ui/.npmrc` is deleted).
- Centralize versions: CI workflows (`ui-e2e-tests-v2.yml`, `ui-tests.yml`) read Node from `ui/.nvmrc` and pnpm from `package.json#packageManager` instead of hardcoding values.
- Pin `express-rate-limit` to exact `8.5.1` in `overrides` — version `8.2.2` dropped provenance attestation, so without a pin pnpm 11's `trustPolicy: no-downgrade` rejects the transitive (`@modelcontextprotocol/sdk` → `express-rate-limit`).
- Tighten `trustPolicyExclude`: entries are now pinned to the exact resolved version (`next-auth@5.0.0-beta.30`, `semver@6.3.1`). A bump now fails until reviewed.
- `langium` removed from `trustPolicyExclude` (no longer in the dep tree after pnpm 11 re-resolution).
- Add `corepack enable` / `corepack install` pre-start hook in `.config/wt.toml`; document the Node version sync requirement in `ui/Dockerfile`.
- `engineStrict: true` plus `engines.node`/`engines.pnpm` in `package.json` refuse installs outside the supported versions.

### Steps to review

1. `cd ui && pnpm install` — should succeed with no `--trust-policy-exclude` flag and resolve `express-rate-limit@8.5.1`, `next-auth@5.0.0-beta.30`, `semver@6.3.1`.
2. Confirm `pnpm-lock.yaml` header reflects the overrides (`express-rate-limit: 8.5.1`).
3. Try installing with Node <22.13 — should fail because of `engineStrict` (the floor required by pnpm 11). Anything ≥22.13 still installs; `.nvmrc` pins 24.13.0 to keep Docker and CI in lockstep with the team default, not as a strict equality requirement.
4. Inspect `ui/pnpm-workspace.yaml` — all supply-chain settings (`engineStrict`, `publicHoistPattern`, `saveExact`, `overrides`, `minimumReleaseAge`, `strictDepBuilds`/`allowBuilds`, `trustPolicy`/`trustPolicyExclude`, `blockExoticSubdeps`) are now in one file.
5. `git grep -n "node-version" .github/workflows/ui-*.yml` — should show only `node-version-file: ui/.nvmrc` (no hardcoded number).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)

- [x] All issue/task requirements work as expected on the UI
- [x] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
