### PR TITLE
fix(azure): skip system 'master' DB in sqlserver_tde_encrypted_with_cmk

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ---
 
+## [5.27.1] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- `sqlserver_tde_encrypted_with_cmk` check for Azure provider no longer reports a false `FAIL` for SQL Servers whose user databases are correctly encrypted with a customer-managed key, by excluding the system `master` database (always reports TDE `Disabled` and is not customer-controllable) from the TDE evaluation [(#11233)](https://github.com/prowler-cloud/prowler/pull/11233)
+
+---
+
 ## [5.27.0] (Prowler v5.27.0)
 
 ### 🚀 Added

--- a/prowler/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk.py
+++ b/prowler/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk.py
@@ -10,9 +10,13 @@ class sqlserver_tde_encrypted_with_cmk(Check):
                 subscription, subscription
             )
             for sql_server in sql_servers:
-                databases = (
-                    sql_server.databases if sql_server.databases is not None else []
-                )
+                databases = [
+                    database
+                    for database in (
+                        sql_server.databases if sql_server.databases is not None else []
+                    )
+                    if database.name.lower() != "master"
+                ]
                 if len(databases) > 0:
                     report = Check_Report_Azure(
                         metadata=self.metadata(), resource=sql_server

--- a/tests/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk_test.py
+++ b/tests/providers/azure/services/sqlserver/sqlserver_tde_encrypted_with_cmk/sqlserver_tde_encrypted_with_cmk_test.py
@@ -264,3 +264,200 @@ class Test_sqlserver_tde_encrypted_with_cmk:
             assert result[0].resource_name == sql_server_name
             assert result[0].resource_id == sql_server_id
             assert result[0].location == "location"
+
+    def test_sql_servers_master_database_disabled_user_database_enabled(self):
+        # System "master" database always reports TDE Disabled in Azure SQL
+        # and is not customer-controllable. It must not fail a server whose
+        # user databases are correctly encrypted with CMK (PROWLER-1760).
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.subscriptions = {
+            AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME
+        }
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        master_database = Database(
+            id="master_id",
+            name="master",
+            type="type",
+            location="location",
+            managed_by="managed_by",
+            tde_encryption=TransparentDataEncryption(status="Disabled"),
+        )
+        user_database = Database(
+            id="user_id",
+            name="DynamicBudgets_Intacct",
+            type="type",
+            location="location",
+            managed_by="managed_by",
+            tde_encryption=TransparentDataEncryption(status="Enabled"),
+        )
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION_ID: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    location="location",
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=[master_database, user_database],
+                    encryption_protector=EncryptionProtector(
+                        server_key_type="AzureKeyVault"
+                    ),
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.sqlserver.sqlserver_tde_encrypted_with_cmk.sqlserver_tde_encrypted_with_cmk.sqlserver_client",
+                new=sqlserver_client,
+            ),
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_tde_encrypted_with_cmk.sqlserver_tde_encrypted_with_cmk import (
+                sqlserver_tde_encrypted_with_cmk,
+            )
+
+            check = sqlserver_tde_encrypted_with_cmk()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION_DISPLAY} has TDE enabled with CMK."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+            assert result[0].location == "location"
+
+    def test_sql_servers_only_master_database(self):
+        # A server whose only database is the system "master" has no user
+        # databases to evaluate, so it must not produce a finding.
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.subscriptions = {
+            AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME
+        }
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        master_database = Database(
+            id="master_id",
+            name="MASTER",
+            type="type",
+            location="location",
+            managed_by="managed_by",
+            tde_encryption=TransparentDataEncryption(status="Disabled"),
+        )
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION_ID: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    location="location",
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=[master_database],
+                    encryption_protector=EncryptionProtector(
+                        server_key_type="AzureKeyVault"
+                    ),
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.sqlserver.sqlserver_tde_encrypted_with_cmk.sqlserver_tde_encrypted_with_cmk.sqlserver_client",
+                new=sqlserver_client,
+            ),
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_tde_encrypted_with_cmk.sqlserver_tde_encrypted_with_cmk import (
+                sqlserver_tde_encrypted_with_cmk,
+            )
+
+            check = sqlserver_tde_encrypted_with_cmk()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_sql_servers_master_disabled_user_database_disabled(self):
+        # Filtering out "master" must not mask a genuinely failing user
+        # database: a disabled user DB still fails even with CMK.
+        sqlserver_client = mock.MagicMock
+        sqlserver_client.subscriptions = {
+            AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME
+        }
+        sql_server_name = "SQL Server Name"
+        sql_server_id = str(uuid4())
+        master_database = Database(
+            id="master_id",
+            name="master",
+            type="type",
+            location="location",
+            managed_by="managed_by",
+            tde_encryption=TransparentDataEncryption(status="Disabled"),
+        )
+        user_database = Database(
+            id="user_id",
+            name="DynamicBudgets_Intacct",
+            type="type",
+            location="location",
+            managed_by="managed_by",
+            tde_encryption=TransparentDataEncryption(status="Disabled"),
+        )
+        sqlserver_client.sql_servers = {
+            AZURE_SUBSCRIPTION_ID: [
+                Server(
+                    id=sql_server_id,
+                    name=sql_server_name,
+                    location="location",
+                    public_network_access="",
+                    minimal_tls_version="",
+                    administrators=None,
+                    auditing_policies=None,
+                    firewall_rules=None,
+                    databases=[master_database, user_database],
+                    encryption_protector=EncryptionProtector(
+                        server_key_type="AzureKeyVault"
+                    ),
+                )
+            ]
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.sqlserver.sqlserver_tde_encrypted_with_cmk.sqlserver_tde_encrypted_with_cmk.sqlserver_client",
+                new=sqlserver_client,
+            ),
+        ):
+            from prowler.providers.azure.services.sqlserver.sqlserver_tde_encrypted_with_cmk.sqlserver_tde_encrypted_with_cmk import (
+                sqlserver_tde_encrypted_with_cmk,
+            )
+
+            check = sqlserver_tde_encrypted_with_cmk()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"SQL Server {sql_server_name} from subscription {AZURE_SUBSCRIPTION_DISPLAY} has TDE disabled with CMK."
+            )
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+            assert result[0].resource_name == sql_server_name
+            assert result[0].resource_id == sql_server_id
+            assert result[0].location == "location"


### PR DESCRIPTION
### Description

The check iterated over every database returned by `databases.list_by_server`, including the system `master` database. In Azure SQL the `master` database always reports TDE `Disabled` and is not customer-controllable. Because the check fails on the first database whose TDE status is not `Enabled` and `master` is typically listed first, the server was marked FAIL regardless of the CMK protector and the user databases being correctly encrypted.

Fix: exclude the system `master` database (case-insensitive) before evaluating, mirroring the pre-existing pattern already used in the sibling check `sqlserver_tde_encryption_enabled` (`database.name.lower() == "master"`). The filtering is applied before the `len(databases) > 0` guard, so a server whose only database is `master` produces no finding. Consistent with the existing "no user databases -> no finding" semantics of this check.

The fix is intentionally at the check level (not the service layer) to stay consistent with the existing convention (services collect raw data; checks own the logic) and to avoid changing the data consumed by other `sqlserver` checks.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
