### PR TITLE
fix(docker): chown copied files to prowler pin uv sync --locked

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -139,6 +139,17 @@ jobs:
           sed -i "s|version = \"${CURRENT_API_VERSION}\"|version = \"${NEXT_API_VERSION}\"|" api/pyproject.toml
           sed -i "s|  version: ${CURRENT_API_VERSION}|  version: ${NEXT_API_VERSION}|" api/src/backend/api/specs/v1.yaml
 
+      - name: Regenerate lockfiles after version bump
+        run: |
+          set -e
+          # The bumps above edit pyproject.toml / api/pyproject.toml but leave
+          # uv.lock / api/uv.lock stale, which makes `uv sync --locked` fail in
+          # the container builds. Refresh both with the uv version the images
+          # pin (plain `uv lock`, no --upgrade: only the version line changes).
+          pip install --no-cache-dir "uv==0.11.14"
+          uv lock
+          (cd api && uv lock)
+
       - name: Bump UI version (.env)
         run: |
           set -e
@@ -240,6 +251,17 @@ jobs:
           sed -i "s|version = \"${CURRENT_API_VERSION}\"|version = \"${FIRST_API_PATCH_VERSION}\"|" api/pyproject.toml
           sed -i "s|  version: ${CURRENT_API_VERSION}|  version: ${FIRST_API_PATCH_VERSION}|" api/src/backend/api/specs/v1.yaml
 
+      - name: Regenerate lockfiles after version bump
+        run: |
+          set -e
+          # The bumps above edit pyproject.toml / api/pyproject.toml but leave
+          # uv.lock / api/uv.lock stale, which makes `uv sync --locked` fail in
+          # the container builds. Refresh both with the uv version the images
+          # pin (plain `uv lock`, no --upgrade: only the version line changes).
+          pip install --no-cache-dir "uv==0.11.14"
+          uv lock
+          (cd api && uv lock)
+
       - name: Bump UI version (.env)
         run: |
           set -e
@@ -340,6 +362,17 @@ jobs:
           set -e
           sed -i "s|version = \"${CURRENT_API_VERSION}\"|version = \"${NEXT_API_PATCH_VERSION}\"|" api/pyproject.toml
           sed -i "s|  version: ${CURRENT_API_VERSION}|  version: ${NEXT_API_PATCH_VERSION}|" api/src/backend/api/specs/v1.yaml
+
+      - name: Regenerate lockfiles after version bump
+        run: |
+          set -e
+          # The bumps above edit pyproject.toml / api/pyproject.toml but leave
+          # uv.lock / api/uv.lock stale, which makes `uv sync --locked` fail in
+          # the container builds. Refresh both with the uv version the images
+          # pin (plain `uv lock`, no --upgrade: only the version line changes).
+          pip install --no-cache-dir "uv==0.11.14"
+          uv lock
+          (cd api && uv lock)
 
       - name: Bump UI version (.env)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,11 +76,11 @@ USER prowler
 WORKDIR /home/prowler
 
 # Copy necessary files
-COPY prowler/  /home/prowler/prowler/
-COPY dashboard/ /home/prowler/dashboard/
-COPY pyproject.toml uv.lock /home/prowler/
-COPY README.md /home/prowler/
-COPY prowler/providers/m365/lib/powershell/m365_powershell.py /home/prowler/prowler/providers/m365/lib/powershell/m365_powershell.py
+COPY --chown=prowler:prowler prowler/  /home/prowler/prowler/
+COPY --chown=prowler:prowler dashboard/ /home/prowler/dashboard/
+COPY --chown=prowler:prowler pyproject.toml uv.lock /home/prowler/
+COPY --chown=prowler:prowler README.md /home/prowler/
+COPY --chown=prowler:prowler prowler/providers/m365/lib/powershell/m365_powershell.py /home/prowler/prowler/providers/m365/lib/powershell/m365_powershell.py
 
 # Install Python dependencies
 ENV HOME='/home/prowler'
@@ -89,7 +89,7 @@ ENV PATH="${HOME}/.local/bin:${PATH}"
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir uv==0.11.14
 
-RUN uv sync --compile-bytecode && \
+RUN uv sync --locked --compile-bytecode && \
     rm -rf ~/.cache/uv
 
 # Install PowerShell modules

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "prowler-api"
-version = "1.28.0"
+version = "1.29.0"
 source = { virtual = "." }
 dependencies = [
     { name = "cartography" },

--- a/uv.lock
+++ b/uv.lock
@@ -3241,7 +3241,7 @@ wheels = [
 
 [[package]]
 name = "prowler"
-version = "5.27.0"
+version = "5.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "alibabacloud-actiontrail20200706" },


### PR DESCRIPTION
### Description

- `Dockerfile`: add `--chown=prowler:prowler` to all `COPY` instructions so the build context is owned by the `prowler` user (required anyway — `uv sync` creates `.venv/` and compiles bytecode under `/home/prowler`).
- `Dockerfile`: change `uv sync` to `uv sync --locked` so the image build is reproducible, never mutates `uv.lock`, and fails fast and explicitly in CI if the lockfile drifts again instead of failing deferred and unrelated.
- `uv.lock`: regenerated so the `prowler` package version matches `pyproject.toml` (`5.27.0` → `5.28.0`). 
 
Regenerated with the Docker-pinned `uv 0.11.14` (via `uvx uv@0.11.14 lock`) to preserve the lockfile format (`revision = 3`); the only change is the single version line.

### Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
