### PR TITLE
feat(claude-plugin): add Prowler plugin and marketplace for Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "prowler-plugins",
+  "description": "Prowler Cloud Security for Claude Code",
+  "owner": {
+    "name": "Prowler",
+    "email": "support@prowler.com"
+  },
+  "plugins": [
+    {
+      "name": "prowler",
+      "source": "./claude_plugins/prowler",
+      "description": "Prowler for Claude Code — cloud security and compliance skills powered by the Prowler MCP server. Bundles compliance triage and remediation; more skills coming.",
+      "category": "security",
+      "homepage": "https://prowler.com"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ htmlcov/
 **/mcp-config.json
 **/mcpServers.json
 .mcp/
-.mcp.json
 
 # AI Coding Assistants - Cursor
 .cursorignore

--- a/claude_plugins/prowler/.claude-plugin/plugin.json
+++ b/claude_plugins/prowler/.claude-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "prowler",
+  "version": "0.1.0",
+  "description": "Prowler for Claude Code — cloud security and compliance skills powered by the Prowler MCP server. Bundles compliance triage and remediation; more skills coming.",
+  "author": {
+    "name": "Prowler",
+    "email": "support@prowler.com",
+    "url": "https://prowler.com"
+  },
+  "homepage": "https://docs.prowler.com",
+  "repository": "https://github.com/prowler-cloud/prowler",
+  "license": "Apache-2.0",
+  "keywords": [
+    "prowler",
+    "security",
+    "compliance",
+    "cloud-security",
+    "mcp"
+  ],
+  "userConfig": {
+    "api_key": {
+      "type": "string",
+      "title": "Prowler API key",
+      "description": "API key token used to authenticate with Prowler Cloud / Prowler App via the Prowler MCP server. Create one at https://cloud.prowler.com.",
+      "sensitive": true,
+      "required": true
+    }
+  }
+}

--- a/claude_plugins/prowler/.mcp.json
+++ b/claude_plugins/prowler/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "prowler": {
+    "type": "http",
+    "url": "https://mcp.prowler.com/mcp",
+    "headers": {
+      "Authorization": "Bearer ${user_config.api_key}"
+    }
+  }
+}

--- a/claude_plugins/prowler/skills/framework-compliance-triage/SKILL.md
+++ b/claude_plugins/prowler/skills/framework-compliance-triage/SKILL.md
@@ -7,9 +7,29 @@ description: Make a cloud account compliant with a security or industry framewor
 
 Iterative, interactive flow that takes a cloud account through setup, reporting, and remediation until it complies with the chosen security or industry framework.
 
+## Checkpoints
+
+This skill uses **checkpoints** to mark moments where you must stop, post a clear question or summary to the user, and wait for the reply before continuing. Each checkpoint is rendered like this:
+
+> **Checkpoint — <name>**
+>
+> What to present, and what to wait for.
+
+Treat every checkpoint as a hard stop:
+
+- Do not skip a checkpoint because the user previously said "go ahead", "just do it", or similar. Confirmations are scoped to a single checkpoint and do not transfer to later ones.
+- Do not bundle two checkpoints into one message. Post one, wait for the reply, then continue.
+- Do not infer the user's answer from context or proceed on silence. Ask explicitly and wait.
+- If a checkpoint is conditional (e.g. only fires when multiple accounts exist), evaluate the condition first; if it does not apply, continue without prompting.
+- If the user's initial message already answers the question a checkpoint asks (e.g. "make my AWS subscription compliant with CIS using Terraform autonomously"), treat the checkpoint as satisfied for the parts they covered, and only ask for what is still missing.
+
 ## 1. Initial Prowler Cloud setup
 
-Ask the user which provider and framework to target, then confirm both are supported by the Prowler Hub MCP:
+> **Checkpoint — Provider and framework selection**
+>
+> If the user has not already specified both the provider and the framework, ask explicitly and wait for the answer. If they have specified them in their opening message, skip this checkpoint.
+
+Confirm both are supported by the Prowler Hub MCP:
 
 - Enumerate supported providers with `prowler_hub_list_providers`.
 - Enumerate frameworks for the chosen provider with `prowler_hub_list_compliances`, passing the provider `id` as the only element of the `provider` input list.
@@ -27,7 +47,11 @@ Call `prowler_app_search_providers` to check whether the target provider (AWS ac
 
 - **Provider not present.** Guide the user through adding and configuring it. Retrieve the relevant connection, credential, and permission instructions with `prowler_docs_search`.
 - **Provider present but misconfigured** (missing credentials, insufficient permissions, etc.). Walk the user through fixing the configuration, pulling the relevant guidance with `prowler_docs_search`.
-- **Provider present and configured.** If multiple accounts are configured for the same provider, list them with helpful detail (account name, ID, last scan date) and ask which to use. If only one is configured, use it without prompting.
+- **Provider present and configured.** Continue.
+
+> **Checkpoint — Account selection** *(conditional: more than one account of the chosen provider is configured)*
+>
+> List the accounts with helpful detail (account name, uid, last scan date) and ask which one to use. Wait for the answer. If only one account exists, skip this checkpoint and use it.
 
 ### 1.3 Review compliance report for the provider account
 
@@ -35,24 +59,28 @@ The flow needs at least one completed scan with a compliance report available.
 
 Look for a completed scan first: call `prowler_app_list_scans` with the selected `provider_id` and `state: ["completed"]`, then call `prowler_app_get_compliance_overview` with each `scan_id` to find one whose compliance report is available. If one is found, continue to the next section.
 
-If no completed scan has a report, call `prowler_app_list_scans` again with `state: ["available", "executing"]` to detect a scan in progress. If one exists, tell the user and ask whether to wait or start a new one.
+If no completed scan has a report, call `prowler_app_list_scans` again with `state: ["available", "executing"]` to detect a scan in progress.
 
-Otherwise, trigger a new scan with `prowler_app_trigger_scan` and the `provider_id`. Warn the user it may take time. When the scan completes, restart this section to re-check the results.
+> **Checkpoint — Scan-in-progress decision** *(conditional: an in-progress scan was detected)*
+>
+> Tell the user a scan is already running and ask whether to wait for it to complete or start a fresh one. Wait for the answer.
 
-If the scan is in progress or just started, stop the flow and ask the user to return when it's completed. Optionally, provide a link to the Prowler Cloud console where they can monitor the scan's progress. The link looks like `https://cloud.prowler.com/scans?filter%5Bprovider_uid__in%5D={provider_id}`.
+If no scan is running (or the user chose to start a fresh one), trigger a new scan with `prowler_app_trigger_scan` and the `provider_id`. The link `https://cloud.prowler.com/scans?filter%5Bprovider_uid__in%5D={provider_id}` lets the user monitor progress.
+
+When a scan is in progress (either pre-existing and elected to wait, or just triggered), stop the flow and ask the user to return when it's completed — restart this section to re-check the results.
 
 ## 2. Compliance report
 
 Every iteration of the remediation loop reads and writes a single markdown file per provider account and framework, stored at `${CLAUDE_PROJECT_DIR}/.prowler/compliance-<compliance_id>-<provider_uid>.md`. Sanitize `<provider_uid>` to `[a-zA-Z0-9_-]` by replacing anything else with `-`. Create `.prowler/` if missing.
 
-Across iterations, edit only: status tags on failed requirements and their findings, the per-requirement `Fix plan` / `Fix applied` sub-bullets added during sections 3.2–3.3, the **Global remediation approach** block, and the **Activity log** (append-only, newest on top). Requirement descriptions, finding IDs, and the entire **Manual review requirements** section are read-only after first render.
+Across iterations, edit only: status tags on failed requirements and their findings, the per-requirement `Fix plan` / `Fix applied` sub-bullets added during sections 3.3–3.4, the **Global remediation approach** block, and the **Activity log** (append-only, newest on top). Requirement descriptions, finding IDs, and the entire **Manual review requirements** section are read-only after first render.
 
 Status taxonomy for failed requirements and their findings:
 
 - `[FAIL]` — failing in the latest scan.
-- `[IN PROGRESS]` — picked up by section 3.2.
+- `[IN PROGRESS]` — picked up by section 3.3.
 - `[FIXED-UNVERIFIED]` — remediation applied; not yet confirmed.
-- `[PASS]` — passing in the latest scan (set when a rescan in section 3.4 confirms the fix).
+- `[PASS]` — passing in the latest scan (set when a rescan in section 3.5 confirms the fix).
 - `[SKIPPED]` — user explicitly deferred.
 
 ### Report template
@@ -94,7 +122,13 @@ Resolve the report path for the current `compliance_id` and provider account.
 
 If the file does not exist, call `prowler_app_get_compliance_framework_state_details` for the target scan, render the template above, and write the file with one initialization entry in the activity log.
 
-If the file exists, read it and compare its `Scan ID` to the target scan from section 1.3. When the scan matches, reuse the file and summarize remaining `[FAIL]` and `[IN PROGRESS]` items in chat. When the scan differs, ask the user whether to refresh — on confirmation, regenerate the failed-requirements section from the new tool response, carry forward the **Global remediation approach** block and the full activity log, and append an activity-log entry noting the scan change.
+If the file exists, read it and compare its `Scan ID` to the target scan from section 1.3. When the scan matches, reuse the file and summarize remaining `[FAIL]` and `[IN PROGRESS]` items in chat.
+
+> **Checkpoint — Report refresh** *(conditional: the file's `Scan ID` differs from the current target scan)*
+>
+> Tell the user the report on disk was generated from a different scan and ask whether to refresh it from the new scan. Wait for the answer.
+
+On confirmation, regenerate the failed-requirements section from the new `prowler_app_get_compliance_framework_state_details` response, carry forward the **Global remediation approach** block and the full activity log, and append an activity-log entry noting the scan change.
 
 Once the file is current, surface the top failing requirements in chat: sort by finding count descending, show the top 5 with their codes and counts, and point to the file path for the full list.
 
@@ -102,18 +136,64 @@ Once the file is current, surface the top failing requirements in chat: sort by 
 
 ### 3.1 Define the global remediation approach
 
-Ask the user which tool to use for fixes (Terraform, Azure CLI, AWS CLI, web console, mixed...) and whether Claude should remediate autonomously or step by step alongside them. Write the answers into the **Global remediation approach** block of the report file. If the block is already populated from a previous session, confirm with the user before overwriting.
+Two modes are available:
 
-### 3.2 Pick the first FAIL requirement and inspect its findings
+- **Claude-assisted** (default when the user has not specified): per-requirement confirmation. For each requirement Claude shows the target resource, exact commands, side effects, and reversibility, then waits for explicit go-ahead before applying.
+- **Claude autonomous**: no per-requirement gate, but Claude still presents one batch-level fix plan up front (§3.2) and waits for a single confirmation, and pauses if a finding looks not applicable, requires a paid feature, or has wide blast radius (breaks dev workflow, forces collaborator changes, is hard to reverse).
+
+If the user phrases their request as "just do it" or similar, treat that as autonomous **with** the batch-plan confirmation still required — the confirmation is a property of the skill, not the user's verbosity preference.
+
+> **Checkpoint — Global remediation approach**
+>
+> Ask the user which tool to use for fixes (Terraform, gh / az / aws CLI, web console, mixed...) and which mode to operate in. Wait for the answer before continuing. This checkpoint is non-negotiable: never assume a default tool, and never assume autonomous mode.
+
+Once answered, write the values into the **Global remediation approach** block of the report file.
+
+> **Checkpoint — Overwriting an existing approach** *(conditional: the block is already populated from a previous session)*
+>
+> Show the previous values and the new ones, and ask the user to confirm before overwriting. Wait for the answer.
+
+### 3.2 Present the batch fix plan *(autonomous mode only)*
+
+In **assisted** mode, skip this section — the per-requirement gate in §3.3 confirms each fix as it comes up. Only run §3.2 in **autonomous** mode, where the loop will otherwise apply fixes without further input.
+
+Before touching anything, post a single chat summary covering every `[FAIL]` requirement:
+
+- Group findings that share a fix (e.g. ten branch-protection requirements satisfied by one PUT call → present as one group).
+- For each group: target resource, exact tool calls, side effects, reversibility.
+- Call out findings that look **not applicable** to this target (e.g. an Organization-only check evaluated against a User account, a feature gated by a paid plan, a resource type the user doesn't have) and propose `[SKIPPED]` with the reason.
+- Call out findings that require manual user action Claude cannot perform.
+
+> **Checkpoint — Batch fix plan approval** *(conditional: autonomous mode)*
+>
+> Post the grouped plan and wait for explicit confirmation. Do not start any fix before the user replies.
+
+Once approved, the loop proceeds through the batch without further prompts unless something deviates from the approved plan.
+
+### 3.3 Pick the first FAIL requirement and inspect its findings
 
 Pick the first `[FAIL]` requirement at the top of the failed-requirements section. Move its status and every finding under it to `[IN PROGRESS]`, and add a `**Fix plan**:` sub-bullet describing what will be done.
 
 Call `prowler_app_get_finding_details` for each `finding_id` to retrieve the failing resource and the Prowler Hub's remediation guidance for that check using the tool `prowler_hub_get_check_details` with the `check_id` from the finding details. Summarize the guidance in chat, and append it to the `**Fix plan**` note for each finding.
 
-### 3.3 Diagnose and fix
+If a finding does not apply to the target resource (Organization-only check on a User account, paid-tier feature, missing resource type, etc.), set the requirement status to `[SKIPPED]` with the reason, log it in the activity log, and move on without attempting the fix — even if it was missed during §3.2.
 
-Read the remediation guidance returned in 3.2, identify the root cause, and apply the fix using the tool defined in the `**Global remediation approach**` section. Append a `**Fix applied**: <tool, summary, refs>` sub-bullet to the requirement, move each fixed finding to `[FIXED-UNVERIFIED]`, and add one activity-log entry describing the change.
+> **Checkpoint — Per-requirement approval** *(conditional: assisted mode)*
+>
+> Post the per-requirement plan in chat — resource, command, side effects, reversibility — and wait for confirmation before moving to §3.4. In **autonomous** mode, post the plan for transparency but proceed unless it deviates from the batch plan agreed in §3.2.
 
-### 3.4 Loop
+### 3.4 Diagnose, fix, verify
 
-Move to the next `[FAIL]` requirement and repeat from section 3.2. When no `[FAIL]` requirements remain (all are `[FIXED-UNVERIFIED]` or `[SKIPPED]`), trigger a fresh scan with `prowler_app_trigger_scan` to verify the fixes end-to-end. When the new scan completes, restart section 2.1 with the carry-forward path — requirements no longer in the new FAIL list move to `[PASS]`, anything still failing reverts to `[FAIL]` with the previous fix attempt visible in the activity log.
+Read the remediation guidance returned in §3.3, identify the root cause, and apply the fix using the tool defined in the **Global remediation approach** block. After applying, verify via the same tool that applied the fix or via a provider API call when applicable. If the re-read shows the change did not land, leave the status at `[IN PROGRESS]`, surface the error to the user, and stop the loop for this requirement.
+
+When the change is in place, append a `**Fix applied**: <tool, summary, refs>` sub-bullet to the requirement, move each fixed finding to `[FIXED-UNVERIFIED]`, and add one activity-log entry describing the change. If no programmatic verification was possible (e.g. web console action), note in the activity log that confirmation depends on the rescan in §3.5.
+
+### 3.5 Loop
+
+Move to the next `[FAIL]` requirement and repeat from section 3.3.
+
+> **Checkpoint — Rescan trigger** *(conditional: no `[FAIL]` requirements remain; all are `[FIXED-UNVERIFIED]` or `[SKIPPED]`)*
+>
+> Summarize what was applied, list any `[SKIPPED]` items with reasons, and ask whether to trigger a fresh scan with `prowler_app_trigger_scan` to verify the fixes end-to-end. Wait for the answer.
+
+On confirmation, trigger the rescan. When it completes, restart section 2.1 with the carry-forward path — requirements no longer in the new FAIL list move to `[PASS]`, anything still failing reverts to `[FAIL]` with the previous fix attempt visible in the activity log.

--- a/claude_plugins/prowler/skills/framework-compliance-triage/SKILL.md
+++ b/claude_plugins/prowler/skills/framework-compliance-triage/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: framework-compliance-triage
+description: Make a cloud account compliant with a security or industry framework using Prowler Cloud.
+---
+
+# Framework compliance
+
+Iterative, interactive flow that takes a cloud account through setup, reporting, and remediation until it complies with the chosen security or industry framework.
+
+## 1. Initial Prowler Cloud setup
+
+Ask the user which provider and framework to target, then confirm both are supported by the Prowler Hub MCP:
+
+- Enumerate supported providers with `prowler_hub_list_providers`.
+- Enumerate frameworks for the chosen provider with `prowler_hub_list_compliances`, passing the provider `id` as the only element of the `provider` input list.
+
+If the framework is not supported, tell the user, suggest they request it or contribute it themselves, and end the flow. Otherwise continue.
+
+### 1.1 Connect to Prowler Cloud
+
+Verify the Prowler MCP connection by calling `prowler_app_search_providers` — a successful response returns the list of providers. If the call fails, walk the user through troubleshooting: internet connectivity, Prowler Cloud credentials, and permissions on the Prowler Cloud account.
+For getting accurate information about configurations use `prowler_docs_search` to pull relevant instructions from the Prowler documentation.
+
+### 1.2 Verify the provider is configured (or configure it)
+
+Call `prowler_app_search_providers` to check whether the target provider (AWS account, Azure Subscription, GitHub Account...) exists in the user's Prowler Cloud account. Handle the result based on what's found:
+
+- **Provider not present.** Guide the user through adding and configuring it. Retrieve the relevant connection, credential, and permission instructions with `prowler_docs_search`.
+- **Provider present but misconfigured** (missing credentials, insufficient permissions, etc.). Walk the user through fixing the configuration, pulling the relevant guidance with `prowler_docs_search`.
+- **Provider present and configured.** If multiple accounts are configured for the same provider, list them with helpful detail (account name, ID, last scan date) and ask which to use. If only one is configured, use it without prompting.
+
+### 1.3 Review compliance report for the provider account
+
+The flow needs at least one completed scan with a compliance report available.
+
+Look for a completed scan first: call `prowler_app_list_scans` with the selected `provider_id` and `state: ["completed"]`, then call `prowler_app_get_compliance_overview` with each `scan_id` to find one whose compliance report is available. If one is found, continue to the next section.
+
+If no completed scan has a report, call `prowler_app_list_scans` again with `state: ["available", "executing"]` to detect a scan in progress. If one exists, tell the user and ask whether to wait or start a new one.
+
+Otherwise, trigger a new scan with `prowler_app_trigger_scan` and the `provider_id`. Warn the user it may take time. When the scan completes, restart this section to re-check the results.
+
+If the scan is in progress or just started, stop the flow and ask the user to return when it's completed. Optionally, provide a link to the Prowler Cloud console where they can monitor the scan's progress. The link looks like `https://cloud.prowler.com/scans?filter%5Bprovider_uid__in%5D={provider_id}`.
+
+## 2. Compliance report
+
+Every iteration of the remediation loop reads and writes a single markdown file per provider account and framework, stored at `${CLAUDE_PROJECT_DIR}/.prowler/compliance-<compliance_id>-<provider_uid>.md`. Sanitize `<provider_uid>` to `[a-zA-Z0-9_-]` by replacing anything else with `-`. Create `.prowler/` if missing.
+
+Across iterations, edit only: status tags on failed requirements and their findings, the per-requirement `Fix plan` / `Fix applied` sub-bullets added during sections 3.2–3.3, the **Global remediation approach** block, and the **Activity log** (append-only, newest on top). Requirement descriptions, finding IDs, and the entire **Manual review requirements** section are read-only after first render.
+
+Status taxonomy for failed requirements and their findings:
+
+- `[FAIL]` — failing in the latest scan.
+- `[IN PROGRESS]` — picked up by section 3.2.
+- `[FIXED-UNVERIFIED]` — remediation applied; not yet confirmed.
+- `[PASS]` — passing in the latest scan (set when a rescan in section 3.4 confirms the fix).
+- `[SKIPPED]` — user explicitly deferred.
+
+### Report template
+
+A fresh report is rendered like this (substituting values from the `prowler_app_get_compliance_framework_state_details` Prowler MCP tool response):
+
+````markdown
+# Compliance report: <compliance_id>
+
+**Provider account**: <display name + uid>
+**Scan ID**: <scan_id>
+**Generated**: <ISO timestamp>
+**Last update**: <ISO timestamp>
+**Status**: <passed>/<total> passing (<pct>%) · <failed> failing · <manual_review> manual review
+
+## Global remediation approach
+<!-- Filled by section 3.1. -->
+- **Primary tool**: _Terraform | Azure CLI | AWS CLI | web console | mixed_
+- **Mode**: _Claude autonomous | Claude-assisted_
+- **Notes**:
+
+## Activity log
+- <ISO timestamp> — Report initialized from scan `<scan_id>`.
+
+## Failed requirements
+
+### <code> — [FAIL]
+**Description**: <text>
+**Findings** (<n>):
+- [FAIL] `<finding_id>`
+
+## Manual review requirements
+- **<code>** — [PENDING]: <description>
+````
+
+### 2.1 Generate or refresh the report
+
+Resolve the report path for the current `compliance_id` and provider account.
+
+If the file does not exist, call `prowler_app_get_compliance_framework_state_details` for the target scan, render the template above, and write the file with one initialization entry in the activity log.
+
+If the file exists, read it and compare its `Scan ID` to the target scan from section 1.3. When the scan matches, reuse the file and summarize remaining `[FAIL]` and `[IN PROGRESS]` items in chat. When the scan differs, ask the user whether to refresh — on confirmation, regenerate the failed-requirements section from the new tool response, carry forward the **Global remediation approach** block and the full activity log, and append an activity-log entry noting the scan change.
+
+Once the file is current, surface the top failing requirements in chat: sort by finding count descending, show the top 5 with their codes and counts, and point to the file path for the full list.
+
+## 3. Remediation loop
+
+### 3.1 Define the global remediation approach
+
+Ask the user which tool to use for fixes (Terraform, Azure CLI, AWS CLI, web console, mixed...) and whether Claude should remediate autonomously or step by step alongside them. Write the answers into the **Global remediation approach** block of the report file. If the block is already populated from a previous session, confirm with the user before overwriting.
+
+### 3.2 Pick the first FAIL requirement and inspect its findings
+
+Pick the first `[FAIL]` requirement at the top of the failed-requirements section. Move its status and every finding under it to `[IN PROGRESS]`, and add a `**Fix plan**:` sub-bullet describing what will be done.
+
+Call `prowler_app_get_finding_details` for each `finding_id` to retrieve the failing resource and the Prowler Hub's remediation guidance for that check using the tool `prowler_hub_get_check_details` with the `check_id` from the finding details. Summarize the guidance in chat, and append it to the `**Fix plan**` note for each finding.
+
+### 3.3 Diagnose and fix
+
+Read the remediation guidance returned in 3.2, identify the root cause, and apply the fix using the tool defined in the `**Global remediation approach**` section. Append a `**Fix applied**: <tool, summary, refs>` sub-bullet to the requirement, move each fixed finding to `[FIXED-UNVERIFIED]`, and add one activity-log entry describing the change.
+
+### 3.4 Loop
+
+Move to the next `[FAIL]` requirement and repeat from section 3.2. When no `[FAIL]` requirements remain (all are `[FIXED-UNVERIFIED]` or `[SKIPPED]`), trigger a fresh scan with `prowler_app_trigger_scan` to verify the fixes end-to-end. When the new scan completes, restart section 2.1 with the carry-forward path — requirements no longer in the new FAIL list move to `[PASS]`, anything still failing reverts to `[FAIL]` with the previous fix attempt visible in the activity log.


### PR DESCRIPTION
### Context

First version of the Prowler [Claude Code](https://www.claude.com/product/claude-code) plugin.

Claude Code's plugin system lets vendors ship a bundle of MCP servers, skills, agents, and hooks that users install via `/plugin`. This PR stands up the marketplace and the first plugin so Prowler users can run an end-to-end compliance assessment and remediation workflow against Prowler Cloud directly inside Claude Code.

### Description

Adds a single-plugin marketplace and a `prowler` plugin under `claude_plugins/`:

- **MCP server config** (`claude_plugins/prowler/.mcp.json`) connects directly to `https://mcp.prowler.com/mcp` over HTTP using a Bearer token sourced from a sensitive `api_key` declared in `userConfig` — no `mcp-remote` / `npx` proxy required.
- **`framework-compliance-triage` skill** walks the user through provider setup, scan selection, gap report generation, and an iterative remediation loop. It writes a per-account compliance report to `\${CLAUDE_PROJECT_DIR}/.prowler/compliance-<compliance_id>-<provider_uid>.md` and updates it in place across loop iterations, so multiple cloud accounts on the same framework are tracked side-by-side.
- **Marketplace manifest** (`.claude-plugin/marketplace.json`).

Removes `.mcp.json` from `.gitignore` so the plugin-bundled MCP config can be committed.

### Steps to review

1. Confirm the file layout:
   ```
   .claude-plugin/marketplace.json
   claude_plugins/prowler/
   ├── .claude-plugin/plugin.json
   ├── .mcp.json
   └── skills/framework-compliance-triage/SKILL.md
   ```
2. (Optional) Validate the plugin schema locally:
   ```bash
   claude plugin validate claude_plugins/prowler
   ```
3. Install from the local marketplace and verify the MCP server connects:
   ```
   /plugin marketplace add <path-to-this-repo>
   /plugin install prowler@prowler-plugins
   # paste your Prowler API key when prompted
   /reload-plugins   # load the public in the current session
   /mcp        # → \"prowler\" listed and connected
   /plugin     # → \"prowler\" enabled, skill discoverable as prowler:framework-compliance-triage
   ```
4. Trigger the skill (e.g. *\"Make my AWS account compliant with CIS\"*) and confirm Claude follows the flow defined in `SKILL.md`: setup → scan check → report generation under `.prowler/` → remediation loop.

### Checklist

<details>
<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the roadmap (PROWLER-1756)
- [x] Assigned to me

</details>

- [ ] Review if the code is being covered by tests. *(N/A — plugin is declarative JSON + Markdown; no executable code paths.)*
- [ ] Review if code is being documented following the Google style guide. *(N/A — no Python added.)*
- [ ] Review if backport is needed. *(N/A — net-new plugin distribution.)*
- [ ] Review if is needed to change the README.md. *(Recommend a follow-up to add a \"Use Prowler in Claude Code\" pointer.)*
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable. *(N/A — this is plugin distribution, not SDK behavior.)*

#### SDK/CLI
- Are there new checks included in this PR? **No.**

#### UI / API
N/A — no UI or API changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.