### PR TITLE
docs(claude-plugin): add Prowler for Claude Code page and plugin README

### DIFF
--- a/claude_plugins/prowler/README.md
+++ b/claude_plugins/prowler/README.md
@@ -1,0 +1,80 @@
+# Prowler for Claude Code
+
+End-to-end cloud security and compliance from inside [Claude Code](https://www.claude.com/product/claude-code), powered by the [Prowler MCP server](https://docs.prowler.com/projects/prowler-mcp/). The plugin lets Claude walk a Prowler Cloud-connected account through a compliance assessment and remediate findings until the chosen security or industry framework is compliant.
+
+> **Preview**: this plugin is under active development. Report issues at <https://github.com/prowler-cloud/prowler/issues> or join the [Slack community](https://goto.prowler.com/slack).
+
+## Requirements
+
+- [Claude Code](https://www.claude.com/product/claude-code) installed and signed in.
+- A [Prowler Cloud](https://cloud.prowler.com) account (the free tier is enough to start).
+- A Prowler API key — create one at <https://cloud.prowler.com/profile>.
+
+## Installation
+
+Inside a Claude Code session:
+
+```text
+/plugin marketplace add prowler-cloud/prowler
+/plugin install prowler@prowler-plugins
+```
+
+Or, if you already have the repo checked out locally:
+
+```text
+/plugin marketplace add /absolute/path/to/prowler
+/plugin install prowler@prowler-plugins
+```
+
+## Configuration
+
+On first install, Claude Code prompts for your **Prowler API key**. It is stored securely (macOS keychain or `~/.claude/.credentials.json`) and used to authenticate against Prowler Cloud.
+
+To rotate the key, uninstall and reinstall the plugin — Claude Code will prompt again.
+
+## Verify the install
+
+In a Claude Code session:
+
+```text
+/mcp          → "prowler" appears as a connected server
+/plugin       → "prowler" enabled, skill listed as prowler:framework-compliance-triage
+```
+
+If `/mcp` reports the `prowler` server as failed, the most common cause is a rejected API key — re-issue one in Prowler Cloud and reinstall the plugin so it re-prompts.
+
+## Usage
+
+Open a conversation that mentions the framework you want to comply with. Examples:
+
+- *"Make my AWS production account compliant with CIS 4.0."*
+- *"Make my current Terraform project compliant with the Prowler ThreatScore Compliance Framework based on the latest scan results."*
+- *"Help me get to 100% on PCI-DSS for this GCP project."*
+
+You pick a **primary tool** (Terraform, gh / az / aws CLI, web console, or mixed) and a **mode**:
+
+- **Claude-assisted** (default). Claude shows each fix — target resource, exact commands, side effects, reversibility — and waits for your go-ahead before applying.
+- **Claude autonomous**. Claude presents a single up-front plan grouped by shared fixes, waits for one confirmation, then proceeds. It pauses mid-loop if a fix has wide blast radius or a finding is not applicable.
+
+Claude tracks progress in a markdown report under `.prowler/` at your project root — one file per framework × account. Open it any time to see exactly where the flow is. When all findings are addressed, Claude proposes a fresh Prowler scan to verify everything end-to-end.
+
+## Uninstalling
+
+```text
+/plugin uninstall prowler@prowler-plugins
+/plugin marketplace remove prowler-plugins
+```
+
+The stored API key is removed automatically.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `/mcp` shows `prowler` as failed | Rejected API key | Generate a new one in Prowler Cloud and reinstall the plugin to re-prompt. |
+| Skill not invoked when expected | The skill description didn't match the prompt | Mention the framework name plus "compliance" or "compliant" in your prompt. |
+| "Framework not supported" | Prowler Hub does not list the framework for that provider | Open an issue or PR at <https://github.com/prowler-cloud/prowler>. |
+
+## License
+
+Apache 2.0 — see [LICENSE](../../LICENSE).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,12 @@
             ]
           },
           {
+            "group": "Prowler for Claude Code",
+            "pages": [
+              "getting-started/products/prowler-claude-code-plugin"
+            ]
+          },
+          {
             "group": "Prowler MCP Server",
             "pages": [
               "getting-started/products/prowler-mcp",

--- a/docs/getting-started/products/prowler-claude-code-plugin.mdx
+++ b/docs/getting-started/products/prowler-claude-code-plugin.mdx
@@ -1,0 +1,101 @@
+---
+title: 'Prowler for Claude Code'
+---
+
+End-to-end cloud security and compliance from inside [Claude Code](https://www.claude.com/product/claude-code), powered by the [Prowler MCP server](/getting-started/products/prowler-mcp). The plugin lets Claude walk a Prowler Cloud-connected account through a compliance assessment and remediate findings until the chosen security or industry framework is compliant.
+
+<Warning>
+**Preview**: this plugin is under active development. Please report issues on [GitHub](https://github.com/prowler-cloud/prowler/issues) or join the [Slack community](https://goto.prowler.com/slack) for feedback.
+</Warning>
+
+## Requirements
+
+<CardGroup cols={3}>
+  <Card title="Claude Code" icon="terminal">
+    Installed and signed in. See the [official install guide](https://www.claude.com/product/claude-code).
+  </Card>
+  <Card title="Prowler Cloud account" icon="cloud">
+    The free tier is enough to start. Sign up at [cloud.prowler.com](https://cloud.prowler.com).
+  </Card>
+  <Card title="Prowler API key" icon="key">
+    Create one at [cloud.prowler.com/profile](https://cloud.prowler.com/profile).
+  </Card>
+</CardGroup>
+
+## Installation
+
+<Tabs>
+  <Tab title="From GitHub (recommended)">
+    Inside a Claude Code session:
+
+    ```text
+    /plugin marketplace add prowler-cloud/prowler
+    /plugin install prowler@prowler-plugins
+    ```
+  </Tab>
+  <Tab title="From a local clone">
+    If you already have the repository checked out:
+
+    ```text
+    /plugin marketplace add /absolute/path/to/prowler
+    /plugin install prowler@prowler-plugins
+    ```
+  </Tab>
+</Tabs>
+
+## Configuration
+
+On first install, Claude Code prompts for your **Prowler API key**. The value is stored securely (macOS keychain or `~/.claude/.credentials.json`) and used to authenticate against Prowler Cloud.
+
+<Note>
+To rotate the key, uninstall and reinstall the plugin — Claude Code will prompt again.
+</Note>
+
+## Verify the installation
+
+In a Claude Code session:
+
+```text
+/mcp          → "prowler" appears as a connected server
+/plugin       → "prowler" enabled, skill listed as prowler:framework-compliance-triage
+```
+
+If `/mcp` reports the `prowler` server as failed, the most common cause is a rejected API key — re-issue one in Prowler Cloud and reinstall the plugin so it re-prompts.
+
+## Usage
+
+Open a conversation that mentions the framework you want to comply with. Examples:
+
+- *"Make my AWS production account compliant with CIS 4.0."*
+- *"Make my current Terraform project compliant with Prowler ThreatScore Compliance Framework based on the latest scan results."*
+- *"Help me get to 100% on PCI-DSS for this GCP project."*
+
+You pick a **primary tool** (Terraform, gh / az / aws CLI, web console, or mixed) and a **mode**:
+
+<CardGroup cols={2}>
+  <Card title="Claude-assisted (default)" icon="hand">
+    Claude shows each fix — target resource, exact commands, side effects, reversibility — and waits for your go-ahead before applying.
+  </Card>
+  <Card title="Claude autonomous" icon="robot">
+    Claude presents a single up-front plan grouped by shared fixes, waits for one confirmation, then proceeds. It pauses mid-loop if a fix has wide blast radius or a finding is not applicable.
+  </Card>
+</CardGroup>
+
+Claude tracks progress in a markdown report under `.prowler/` at your project root — one file per framework × account. Open it any time to see exactly where the flow is. When all findings are addressed, Claude proposes a fresh Prowler scan to verify everything end-to-end.
+
+## Uninstalling
+
+```text
+/plugin uninstall prowler@prowler-plugins
+/plugin marketplace remove prowler-plugins
+```
+
+The stored API key is removed automatically.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `/mcp` shows `prowler` as failed | Rejected API key | Generate a new one in Prowler Cloud and reinstall the plugin to re-prompt. |
+| Skill not invoked when expected | The skill description didn't match the prompt | Mention the framework name plus "compliance" or "compliant" in your prompt. |
+| "Framework not supported" | Prowler Hub does not list the framework for that provider | Open an issue or PR at [github.com/prowler-cloud/prowler](https://github.com/prowler-cloud/prowler). |


### PR DESCRIPTION
### Context

Follow-up to #11248 (the Prowler Claude Code plugin), which shipped the plugin and marketplace but no end-user documentation. This PR fills that gap so users can discover, install, configure, and use the plugin without reading the source.

### Description

Adds user-facing documentation in two places:

- **`claude_plugins/prowler/README.md`** — plugin-local README. This is the file Claude Code surfaces via `/plugin info` and the one users land on when browsing the plugin source on GitHub.
- **`docs/getting-started/products/prowler-claude-code-plugin.mdx`** — new Mintlify page registered under a new \"Prowler for Claude Code\" group in `docs/docs.json`, placed between \"Prowler Lighthouse AI\" and \"Prowler MCP Server\" so all AI-adjacent integrations sit together.

Both pages cover:

- Requirements (Claude Code, Prowler Cloud account, API key).
- Installation from GitHub or a local clone.
- API key configuration and rotation.
- Install verification via `/mcp` and `/plugin`.
- Usage with example prompts and the assisted vs autonomous mode choice.
- Uninstalling.
- A short troubleshooting table.

Internal mechanics (the full checkpoint catalogue, exact status-tag lifecycle, report filename pattern with placeholders) are intentionally omitted — they belong in the skill source for Claude to consume, not in user-facing docs.

### Steps to review

1. Render the Mintlify page locally and confirm the nav update lands correctly:
   ```bash
   cd docs && mint dev
   ```
   Open the dev URL (default <http://localhost:3000>) and navigate to **Get Started → Prowler for Claude Code**. Confirm the page renders, the \`<CardGroup>\`, \`<Tabs>\`, \`<Warning>\`, and \`<Note>\` components display correctly, and all links resolve.
2. Read `claude_plugins/prowler/README.md` directly on GitHub to confirm the markdown renders cleanly.
3. Sanity-check that install commands in both files match what was shipped in #11248 (`/plugin marketplace add prowler-cloud/prowler` and `/plugin install prowler@prowler-plugins`).

### Checklist

<details>
<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed (PROWLER-1756 follow-up to #11248)
- [x] Assigned to me

</details>

- [ ] Review if the code is being covered by tests. *(N/A — docs only; no executable code.)*
- [ ] Review if code is being documented following the Google style guide. *(N/A — no Python.)*
- [ ] Review if backport is needed. *(N/A — net-new docs.)*
- [ ] Review if is needed to change the README.md. *(N/A — this PR is the README change.)*
- [ ] Ensure new entries are added to CHANGELOG.md. *(N/A — docs-only change.)*

#### SDK/CLI
- Are there new checks included in this PR? **No.**

#### UI / API
N/A — no UI or API changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.