### PR TITLE
[CHAIN] docs(partner-portal): add billing documentation (PP-387)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -177,7 +177,8 @@
               "user-guide/tutorials/partner-portal-team",
               "user-guide/tutorials/partner-portal-organization",
               "user-guide/tutorials/partner-portal-branding",
-              "user-guide/tutorials/partner-portal-customer-onboarding"
+              "user-guide/tutorials/partner-portal-customer-onboarding",
+              "user-guide/tutorials/partner-portal-billing"
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -174,8 +174,8 @@
             "group": "Prowler Partner Portal",
             "pages": [
               "user-guide/tutorials/partner-portal-sign-up",
-              "user-guide/tutorials/partner-portal-organization",
               "user-guide/tutorials/partner-portal-team",
+              "user-guide/tutorials/partner-portal-organization",
               "user-guide/tutorials/partner-portal-branding",
               "user-guide/tutorials/partner-portal-customer-onboarding"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,12 @@
             ]
           },
           {
+            "group": "Prowler Partner Portal",
+            "pages": [
+              "getting-started/products/prowler-partner-portal"
+            ]
+          },
+          {
             "group": "Prowler MCP Server",
             "pages": [
               "getting-started/products/prowler-mcp",
@@ -162,6 +168,16 @@
                   "user-guide/tutorials/aws-organizations-bulk-provisioning"
                 ]
               }
+            ]
+          },
+          {
+            "group": "Prowler Partner Portal",
+            "pages": [
+              "user-guide/tutorials/partner-portal-sign-up",
+              "user-guide/tutorials/partner-portal-organization",
+              "user-guide/tutorials/partner-portal-team",
+              "user-guide/tutorials/partner-portal-branding",
+              "user-guide/tutorials/partner-portal-customer-onboarding"
             ]
           },
           {

--- a/docs/getting-started/products/prowler-partner-portal.mdx
+++ b/docs/getting-started/products/prowler-partner-portal.mdx
@@ -6,7 +6,9 @@ title: 'Overview'
 
 It gives every partner organization its own sign-in surface, a partner-scoped team and role model, branding controls, and a managed flow to provision and access customer Prowler Cloud tenants. Every action against a customer tenant is auditable as the partner user acting on behalf of the customer.
 
-<Card title="Sign up for Prowler Partner Portal" href="https://partners.prowler.com/sign-up" />
+<Card title="Sign up for Prowler Partner Portal" icon="rocket" href="https://partners.prowler.com/sign-up" />
+
+{/* TODO: Add architecture diagram */}
 
 Prowler Partner Portal provides:
 
@@ -25,7 +27,7 @@ The Partner Portal stack mirrors Prowler Cloud:
 - **Partner Portal API** at `api.partners.prowler.com` — Django REST Framework backend (JSON:API, JWT RS256).
 - **Prowler Cloud integration** — server-to-server signed tokens carry an `on_behalf_of` claim so Prowler Cloud attributes partner-driven actions to the customer tenant they target.
 
-## How it relates to Prowler Cloud
+## How It Relates to Prowler Cloud
 
 | Capability | Prowler Cloud | Prowler Partner Portal |
 |---|---|---|
@@ -35,6 +37,23 @@ The Partner Portal stack mirrors Prowler Cloud:
 | Tenancy | Customer-owned | Partner-owned, with managed access to customer tenants |
 | Branding | Prowler-branded | Partner-branded sign-in and console |
 
-## Getting access
+## Getting Access
 
-Prowler Partner Portal is invitation-driven. Sign up at `partners.prowler.com/sign-up`; a new partner organization stays in **Pending Approval** until the Prowler team reviews and approves the application. Once active, the partner administrator can invite team members and start onboarding customer organizations.
+Prowler Partner Portal is invitation-driven. Sign up at [partners.prowler.com/sign-up](https://partners.prowler.com/sign-up); a new partner organization stays in **Pending Approval** until the Prowler team reviews and approves the application. Once active, the partner administrator can invite team members and start onboarding customer organizations.
+
+## Next Steps
+
+<Columns cols={2}>
+  <Card title="Sign Up and Sign In" icon="user-plus" href="/user-guide/tutorials/partner-portal-sign-up">
+    Self-service sign-up, sign-in, password reset and session handling.
+  </Card>
+  <Card title="Managing Your Partner Portal Team" icon="users" href="/user-guide/tutorials/partner-portal-team">
+    Invite team members, assign roles, and manage memberships.
+  </Card>
+  <Card title="Onboarding Customers" icon="building" href="/user-guide/tutorials/partner-portal-customer-onboarding">
+    Provision customer Prowler Cloud tenants and operate on their behalf.
+  </Card>
+  <Card title="Your Partner Organization" icon="briefcase" href="/user-guide/tutorials/partner-portal-organization">
+    Lifecycle, settings, Partner Code and closing your organization.
+  </Card>
+</Columns>

--- a/docs/getting-started/products/prowler-partner-portal.mdx
+++ b/docs/getting-started/products/prowler-partner-portal.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Overview'
+---
+
+[Prowler Partner Portal](https://partners.prowler.com) is a dedicated console for Prowler partners — resellers, MSPs and consultants — to onboard customers, manage their teams, and operate Prowler Cloud tenants on their customers' behalf.
+
+It gives every partner organization its own sign-in surface, a partner-scoped team and role model, branding controls, and a managed flow to provision and access customer Prowler Cloud tenants. Every action against a customer tenant is auditable as the partner user acting on behalf of the customer.
+
+<Card title="Sign up for Prowler Partner Portal" href="https://partners.prowler.com/sign-up" />
+
+Prowler Partner Portal provides:
+
+<ul>
+    <li> Self-service sign-up that flows through email verification and Prowler approval before activating a partner organization. </li>
+    <li> A partner-scoped role model with granular permissions for managing members, settings, billing, customer organizations, and tenant access. </li>
+    <li> Managed customer-tenant provisioning into Prowler Cloud. </li>
+    <li> Branding controls — partner logo on the sign-in screen, invitation emails, and the console header. </li>
+</ul>
+
+## Components
+
+The Partner Portal stack mirrors Prowler Cloud:
+
+- **Partner Portal UI** at `partners.prowler.com` — Next.js console for partner administrators and operators.
+- **Partner Portal API** at `api.partners.prowler.com` — Django REST Framework backend (JSON:API, JWT RS256).
+- **Prowler Cloud integration** — server-to-server signed tokens carry an `on_behalf_of` claim so Prowler Cloud attributes partner-driven actions to the customer tenant they target.
+
+## How it relates to Prowler Cloud
+
+| Capability | Prowler Cloud | Prowler Partner Portal |
+|---|---|---|
+| Audience | End customers | Resellers, MSPs, consultants |
+| Console | `cloud.prowler.com` | `partners.prowler.com` |
+| API | `api.prowler.com` | `api.partners.prowler.com` |
+| Tenancy | Customer-owned | Partner-owned, with managed access to customer tenants |
+| Branding | Prowler-branded | Partner-branded sign-in and console |
+
+## Getting access
+
+Prowler Partner Portal is invitation-driven. Sign up at `partners.prowler.com/sign-up`; a new partner organization stays in **Pending Approval** until the Prowler team reviews and approves the application. Once active, the partner administrator can invite team members and start onboarding customer organizations.

--- a/docs/getting-started/products/prowler-partner-portal.mdx
+++ b/docs/getting-started/products/prowler-partner-portal.mdx
@@ -2,9 +2,9 @@
 title: 'Overview'
 ---
 
-[Prowler Partner Portal](https://partners.prowler.com) is a dedicated console for Prowler partners — resellers, MSPs and consultants — to onboard customers, manage their teams, and operate Prowler Cloud tenants on their customers' behalf.
+[Prowler Partner Portal](https://partners.prowler.com) is a dedicated console for Prowler partners — resellers, MSPs and consultants — to onboard customers, manage their teams, and operate customer workspaces in Prowler Cloud on their customers' behalf.
 
-It gives every partner organization its own sign-in surface, a partner-scoped team and role model, branding controls, and a managed flow to provision and access customer Prowler Cloud tenants. Every action against a customer tenant is auditable as the partner user acting on behalf of the customer.
+It gives every partner organization its own sign-in surface, a partner-scoped team and role model, branding controls, and a managed flow to provision and access customer workspaces in Prowler Cloud. Every action against a customer workspace is auditable as the partner user acting on behalf of the customer.
 
 <Card title="Sign up for Prowler Partner Portal" icon="rocket" href="https://partners.prowler.com/sign-up" />
 
@@ -14,8 +14,8 @@ Prowler Partner Portal provides:
 
 <ul>
     <li> Self-service sign-up that flows through email verification and Prowler approval before activating a partner organization. </li>
-    <li> A partner-scoped role model with granular permissions for managing members, settings, billing, customer organizations, and tenant access. </li>
-    <li> Managed customer-tenant provisioning into Prowler Cloud. </li>
+    <li> A partner-scoped role model with granular permissions for managing members, settings, billing, customer organizations, and customer workspace access. </li>
+    <li> Managed customer workspace provisioning into Prowler Cloud. </li>
     <li> Branding controls — partner logo on the sign-in screen, invitation emails, and the console header. </li>
 </ul>
 
@@ -25,7 +25,7 @@ The Partner Portal stack mirrors Prowler Cloud:
 
 - **Partner Portal UI** at `partners.prowler.com` — Next.js console for partner administrators and operators.
 - **Partner Portal API** at `api.partners.prowler.com` — Django REST Framework backend (JSON:API, JWT RS256).
-- **Prowler Cloud integration** — server-to-server signed tokens carry an `on_behalf_of` claim so Prowler Cloud attributes partner-driven actions to the customer tenant they target.
+- **Prowler Cloud integration** — server-to-server signed tokens carry an `on_behalf_of` claim so Prowler Cloud attributes partner-driven actions to the customer workspace they target.
 
 ## How It Relates to Prowler Cloud
 
@@ -34,7 +34,7 @@ The Partner Portal stack mirrors Prowler Cloud:
 | Audience | End customers | Resellers, MSPs, consultants |
 | Console | `cloud.prowler.com` | `partners.prowler.com` |
 | API | `api.prowler.com` | `api.partners.prowler.com` |
-| Tenancy | Customer-owned | Partner-owned, with managed access to customer tenants |
+| Tenancy | Customer-owned | Partner-owned, with managed access to customer workspaces |
 | Branding | Prowler-branded | Partner-branded sign-in and console |
 
 ## Getting Access
@@ -51,7 +51,7 @@ Prowler Partner Portal is invitation-driven. Sign up at [partners.prowler.com/si
     Invite team members, assign roles, and manage memberships.
   </Card>
   <Card title="Onboarding Customers" icon="building" href="/user-guide/tutorials/partner-portal-customer-onboarding">
-    Provision customer Prowler Cloud tenants and operate on their behalf.
+    Provision customer workspaces in Prowler Cloud and operate on their behalf.
   </Card>
   <Card title="Your Partner Organization" icon="briefcase" href="/user-guide/tutorials/partner-portal-organization">
     Lifecycle, settings, Partner Code and closing your organization.

--- a/docs/user-guide/tutorials/partner-portal-billing.mdx
+++ b/docs/user-guide/tutorials/partner-portal-billing.mdx
@@ -1,0 +1,107 @@
+---
+title: 'Managing Billing and Customer Plans'
+---
+
+Prowler Partner Portal billing has two sides: the partner's own billing posture (payment method and partner plan) lives on the dedicated **Billing** page, while customer-level plans and subscriptions are managed from the **Customers** view. This page walks through both.
+
+## Permissions
+
+The `manage_billing` permission controls every billing surface that mutates state. It is granted today to both built-in roles — **Superadmin** and **Organization Admin** — so any active team member with a seed role can manage billing. See [Managing Your Partner Portal Team](/user-guide/tutorials/partner-portal-team) for the full permission matrix.
+
+## Partner Billing Settings
+
+The **Billing** entry in the sidebar opens the partner's own billing settings at `/billing`. The page is gated behind the `NEXT_PUBLIC_BILLING_ENABLED` feature flag and only ships when Prowler enables it for your partner organization — if you do not see the sidebar entry, billing has not been enabled yet for your account.
+
+The page is organized in three tabs:
+
+- **Billing & Wallet** — Your Partner Plan and Payment Method, side by side.
+- **Invoice History** — invoice listing (coming soon).
+- **Customer Billing** — per-customer billing detail (coming soon).
+
+### Your Partner Plan
+
+The **Your Partner Plan** card on the Billing & Wallet tab shows the agreement Prowler has negotiated with your partner organization. It surfaces:
+
+- **Partner Discount** — the discount applied to every customer invoice.
+- **Scan Credit Price** — the rate at which scan credits are billed.
+- **Resource Overage Rate** — the per-resource rate for usage above plan limits.
+
+Use **View My Partner Agreement** to download the full agreement.
+
+### Payment Method
+
+The **Payment Method** card holds the single card that funds every customer subscription for the partner account. From here you can:
+
+<Steps>
+  <Step title="Add or replace the card">
+    Click **Add Payment Method** (or **Replace Payment Method** if a card already exists) to open the Stripe-backed dialog. The card brand (Visa, Mastercard, Amex) and the last four digits are displayed once saved.
+  </Step>
+
+  <Step title="Watch for expiry">
+    Cards close to expiry show an **Expiring soon** badge. Expired cards switch to a red **Expired** label and block new subscriptions until replaced.
+  </Step>
+</Steps>
+
+Some partners are configured for **invoice billing** instead of card billing. In that case the Payment Method card is provisioned automatically the first time a customer plan change requires it; no card entry is needed.
+
+## Adding a Customer with a Billing Plan
+
+The **+ Add Customer** wizard on `/customers` includes a billing-plan step. The wizard runs in three stages:
+
+<Steps>
+  <Step title="Create the customer profile">
+    Enter the customer's organization name and primary contact email.
+  </Step>
+
+  <Step title="Set the billing plan">
+    Pick a plan from the available list:
+
+    | Plan | Price | Notes |
+    |---|---|---|
+    | **Trial** | $0 | Single-scan trial, upgrade anytime. |
+    | **Prowler Cloud Pro (Annual)** | $79 / month | 20 provider accounts, 250 provider scans, billed annually. |
+    | **Prowler Cloud Pro (Monthly)** | $99 / month | 20 provider accounts, 240 provider scans, monthly billing cycle. |
+
+    The Trial plan is selectable here but **not** offered later in the Change Plan drawer — it is a one-time onboarding option.
+  </Step>
+
+  <Step title="Launch the customer workspace">
+    Navigate into the customer's workspace to connect cloud providers and set up scan schedules. See [Onboarding Customers](/user-guide/tutorials/partner-portal-customer-onboarding).
+  </Step>
+</Steps>
+
+## Changing a Customer's Plan
+
+To move an existing customer between paid plans, open the customer row on `/customers` and choose **Change plan**. A drawer slides in with the available paid plans pre-selected at the customer's current plan. Pick a new plan and click **Apply plan change**; a toast confirms the transition and the customer row refreshes.
+
+If the customer is still on **Trial**, the drawer title changes to **Complete subscription** — applying a plan there is the customer's first paid subscription, not a change.
+
+When the partner is on invoice billing and no payment method exists yet, the drawer provisions an invoice payment method automatically before applying the change. If provisioning fails, the toast surfaces the error and the plan change is not applied.
+
+## Per-Customer Billing Visibility
+
+The **Customers** view exposes the customer-level billing posture in two places:
+
+- **Billing stats cards** at the top of the page summarize:
+  - **Billing active** — count of customers with an active subscription.
+  - **Total MTD** per currency — month-to-date revenue with a comparison to last month and a trend indicator.
+- **Customer table columns** — each row shows the customer's plan, billing status and current period totals alongside the cloud-account and findings counts.
+
+The billing stats cards are hidden when no customer has billing activity yet.
+
+## Notes
+
+- Card payments are processed by **Stripe**. Plan changes and recurring billing are coordinated through **Metronome**; partner billing identifiers are persisted on the partner record on the first plan change.
+- The legacy `scan_based` plan has been retired. Existing customers on `scan_based` are migrated to one of the Prowler Cloud Pro plans during onboarding.
+- Backend identifiers such as `tenant_id` remain unchanged in API payloads and audit logs, even though the partner-facing UI consistently uses **customer** or **customer workspace**.
+
+## Next Steps
+
+<Columns cols={2}>
+  <Card title="Onboarding Customers" icon="building" href="/user-guide/tutorials/partner-portal-customer-onboarding">
+    Provision customer workspaces in Prowler Cloud and operate on their behalf.
+  </Card>
+  <Card title="Your Partner Organization" icon="briefcase" href="/user-guide/tutorials/partner-portal-organization">
+    Lifecycle, settings, Partner Code and closing your organization.
+  </Card>
+</Columns>

--- a/docs/user-guide/tutorials/partner-portal-branding.mdx
+++ b/docs/user-guide/tutorials/partner-portal-branding.mdx
@@ -1,22 +1,33 @@
 ---
-title: 'Customise Partner Portal branding'
+title: 'Customizing Partner Portal Branding'
 ---
 
-Partner administrators with the **Manage settings** permission can upload a logo and customise visual identity for their partner organization. Branding is shown to the partner team across the Partner Portal console and on outbound communications such as invitation emails.
+Partner administrators with the **Manage settings** permission can upload a logo and customize visual identity for their partner organization. Branding is shown to the partner team across the Partner Portal console and on outbound communications such as invitation emails.
 
-## What you can change
+## What You Can Change
 
 | Element | Where it appears |
 |---|---|
 | **Logo** | Sign-in screen, top-left of the console, invitation emails |
 | **Company name** | Browser tab title, sign-in screen, invitation emails |
 
-## Upload a logo
+## Uploading a Logo
 
 The logo is a single image file uploaded by a partner administrator from **Settings → Branding**. PNG, JPEG and SVG formats are supported; SVG renders best at small sizes. The maximum file size is **1 MB**; transparent backgrounds work best, and wide horizontal logos render cleanest in the sidebar.
 
 Once uploaded, the logo is shown immediately to the team in the console and on subsequent sign-ins. Replacing or removing the logo is also a one-click operation from the same tab; removing reverts the console to the default Prowler branding.
 
-## Note on customer-facing surfaces
+## Note on Customer-Facing Surfaces
 
-Branding applies to Prowler Partner Portal only. Customers signing in to https://cloud.prowler.com see the standard Prowler-branded UI. **White-labelling of `cloud.prowler.com` for partners is not supported today.**
+Branding applies to Prowler Partner Portal only. Customers signing in to [cloud.prowler.com](https://cloud.prowler.com) see the standard Prowler-branded UI. **White-labeling of `cloud.prowler.com` for partners is not supported today.**
+
+## Next Steps
+
+<Columns cols={2}>
+  <Card title="Your Partner Organization" icon="briefcase" href="/user-guide/tutorials/partner-portal-organization">
+    Lifecycle, settings, Partner Code and closing your organization.
+  </Card>
+  <Card title="Managing Your Partner Portal Team" icon="users" href="/user-guide/tutorials/partner-portal-team">
+    Invite team members, assign roles, and manage memberships.
+  </Card>
+</Columns>

--- a/docs/user-guide/tutorials/partner-portal-branding.mdx
+++ b/docs/user-guide/tutorials/partner-portal-branding.mdx
@@ -1,0 +1,22 @@
+---
+title: 'Customise Partner Portal branding'
+---
+
+Partner administrators with the **Manage settings** permission can upload a logo and customise visual identity for their partner organization. Branding is shown to the partner team across the Partner Portal console and on outbound communications such as invitation emails.
+
+## What you can change
+
+| Element | Where it appears |
+|---|---|
+| **Logo** | Sign-in screen, top-left of the console, invitation emails |
+| **Company name** | Browser tab title, sign-in screen, invitation emails |
+
+## Upload a logo
+
+The logo is a single image file uploaded by a partner administrator from **Settings → Branding**. PNG, JPEG and SVG formats are supported; SVG renders best at small sizes. The maximum file size is **1 MB**; transparent backgrounds work best, and wide horizontal logos render cleanest in the sidebar.
+
+Once uploaded, the logo is shown immediately to the team in the console and on subsequent sign-ins. Replacing or removing the logo is also a one-click operation from the same tab; removing reverts the console to the default Prowler branding.
+
+## Note on customer-facing surfaces
+
+Branding applies to Prowler Partner Portal only. Customers signing in to https://cloud.prowler.com see the standard Prowler-branded UI. **White-labelling of `cloud.prowler.com` for partners is not supported today.**

--- a/docs/user-guide/tutorials/partner-portal-customer-onboarding.mdx
+++ b/docs/user-guide/tutorials/partner-portal-customer-onboarding.mdx
@@ -1,14 +1,14 @@
 ---
-title: 'Onboard a customer and access their tenant'
+title: 'Onboarding Customers and Accessing Their Tenants'
 ---
 
 Prowler Partner Portal lets partners provision Prowler Cloud tenants for customer organizations and operate inside those tenants on the customer's behalf. Every partner action is recorded in Prowler Cloud's audit log with both the partner identity and an `on_behalf_of` claim that pinpoints the customer.
 
-## Provision a customer
+## Provisioning a Customer
 
 <Steps>
   <Step title="Open Customers">
-    From the sidebar, choose **Customers**. The page is only visible to all signed-in partner users; the **+ Add Customer** button on the toolbar requires the `manage_organizations` permission.
+    From the sidebar, choose **Customers**. The page is visible to all signed-in partner users; the **+ Add Customer** button on the toolbar requires the `manage_organizations` permission.
   </Step>
 
   <Step title="Start the wizard">
@@ -22,34 +22,45 @@ Prowler Partner Portal lets partners provision Prowler Cloud tenants for custome
 
 The customer is now visible to your team in the Customers table and ready for partner-side operations.
 
-## The Customers view
+## The Customers View
 
 The Customers table lists the customer organizations linked to your partner. Each row carries:
 
 - **Customer** — the cloud organization name.
 - **Cloud accounts** — count of cloud-provider accounts attached to the customer.
-- **Providers** — icons for each cloud provider in use (AWS, Azure, GCP, Kubernetes, Microsoft 365, GitHub, IAC, Vercel, MongoDB Atlas, Cloudflare, Google Workspace, Alibaba Cloud, Oracle Cloud, image scanning, OpenStack — plus any new providers Prowler adds).
+- **Providers** — icons for each cloud provider in use. See [supported providers](/getting-started/products/prowler-app#components).
 - **Findings** — Critical / High / Medium counts from the latest scan.
 - **Last scan** — timestamp of the last successful scan.
 
-## Customer self-pairing with a Partner Code
+## Customer Self-Pairing with a Partner Code
 
 Each approved partner has a **Partner Code** — a unique, Prowler-issued value shown on **Settings → Profile** with the helper text *"Share this code with customers to link their accounts"*. Sharing the code lets a customer paste it into their Prowler Cloud account and request the partner relationship; once confirmed, the customer is listed in your Customers view alongside any partner-provisioned tenants.
 
 The customer-side flow that consumes the Partner Code is rolled out progressively in Prowler Cloud. Verify availability with your Prowler contact before sharing the code.
 
-## Access a customer tenant on behalf of
+## Accessing a Customer Tenant on Behalf of the Customer
 
-From **Customers**, open the customer's row and choose **Open in Prowler Cloud**. You're redirected to https://cloud.prowler.com signed in as a partner user **on behalf of** the customer. While operating in the tenant:
+From **Customers**, open the customer's row and choose **Open in Prowler Cloud**. You're redirected to [cloud.prowler.com](https://cloud.prowler.com) signed in as a partner user **on behalf of** the customer. While operating in the tenant:
 
 - You see the same Prowler Cloud UI a customer administrator would see.
 - Every action is recorded in Prowler Cloud's audit log with both your identity (the partner user) and an `on_behalf_of` claim identifying the customer tenant.
 - Returning to Prowler Partner Portal — close the tab or use the *Back to Partner Portal* link.
 
-## Customer self-access
+## Customer Self-Access
 
-Customers continue to sign into https://cloud.prowler.com directly with their own users. Partner-side access is **additive** — it does not replace customer-side users.
+Customers continue to sign into [cloud.prowler.com](https://cloud.prowler.com) directly with their own users. Partner-side access is **additive** — it does not replace customer-side users.
 
-## Removing a customer
+## Removing a Customer
 
 Removing a customer in Prowler Partner Portal detaches the tenant from your partner organization but does **not** delete the underlying Prowler Cloud tenant. Coordinate tenant disposal with the customer through Prowler Cloud directly.
+
+## Next Steps
+
+<Columns cols={2}>
+  <Card title="Your Partner Organization" icon="briefcase" href="/user-guide/tutorials/partner-portal-organization">
+    Lifecycle, settings, Partner Code and closing your organization.
+  </Card>
+  <Card title="Managing Your Partner Portal Team" icon="users" href="/user-guide/tutorials/partner-portal-team">
+    Invite team members, assign roles, and manage memberships.
+  </Card>
+</Columns>

--- a/docs/user-guide/tutorials/partner-portal-customer-onboarding.mdx
+++ b/docs/user-guide/tutorials/partner-portal-customer-onboarding.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Onboarding Customers and Accessing Their Tenants'
+title: 'Onboarding Customers and Accessing Their Workspaces'
 ---
 
-Prowler Partner Portal lets partners provision Prowler Cloud tenants for customer organizations and operate inside those tenants on the customer's behalf. Every partner action is recorded in Prowler Cloud's audit log with both the partner identity and an `on_behalf_of` claim that pinpoints the customer.
+Prowler Partner Portal lets partners provision customer workspaces in Prowler Cloud for customer organizations and operate inside those workspaces on the customer's behalf. Every partner action is recorded in Prowler Cloud's audit log with both the partner identity and an `on_behalf_of` claim that pinpoints the customer.
 
 ## Provisioning a Customer
 
@@ -16,7 +16,7 @@ Prowler Partner Portal lets partners provision Prowler Cloud tenants for custome
   </Step>
 
   <Step title="Wait for provisioning">
-    Prowler Partner Portal calls Prowler Cloud to create the tenant. Provisioning is asynchronous; the customer row updates from **Pending** to **Active** when the tenant is ready (usually under a minute).
+    Prowler Partner Portal calls Prowler Cloud to create the customer workspace. Provisioning is asynchronous; the customer row updates from **Pending** to **Active** when the workspace is ready (usually under a minute).
   </Step>
 </Steps>
 
@@ -34,16 +34,16 @@ The Customers table lists the customer organizations linked to your partner. Eac
 
 ## Customer Self-Pairing with a Partner Code
 
-Each approved partner has a **Partner Code** — a unique, Prowler-issued value shown on **Settings → Profile** with the helper text *"Share this code with customers to link their accounts"*. Sharing the code lets a customer paste it into their Prowler Cloud account and request the partner relationship; once confirmed, the customer is listed in your Customers view alongside any partner-provisioned tenants.
+Each approved partner has a **Partner Code** — a unique, Prowler-issued value shown on **Settings → Profile** with the helper text *"Share this code with customers to link their accounts"*. Sharing the code lets a customer paste it into their Prowler Cloud account and request the partner relationship; once confirmed, the customer is listed in your Customers view alongside any partner-provisioned customer workspaces.
 
 The customer-side flow that consumes the Partner Code is rolled out progressively in Prowler Cloud. Verify availability with your Prowler contact before sharing the code.
 
-## Accessing a Customer Tenant on Behalf of the Customer
+## Accessing a Customer Workspace on Behalf of the Customer
 
-From **Customers**, open the customer's row and choose **Open in Prowler Cloud**. You're redirected to [cloud.prowler.com](https://cloud.prowler.com) signed in as a partner user **on behalf of** the customer. While operating in the tenant:
+From **Customers**, open the customer's row and choose **Open in Prowler Cloud**. You're redirected to [cloud.prowler.com](https://cloud.prowler.com) signed in as a partner user **on behalf of** the customer. While operating in the customer workspace:
 
 - You see the same Prowler Cloud UI a customer administrator would see.
-- Every action is recorded in Prowler Cloud's audit log with both your identity (the partner user) and an `on_behalf_of` claim identifying the customer tenant.
+- Every action is recorded in Prowler Cloud's audit log with both your identity (the partner user) and an `on_behalf_of` claim identifying the customer.
 - Returning to Prowler Partner Portal — close the tab or use the *Back to Partner Portal* link.
 
 ## Customer Self-Access
@@ -52,7 +52,7 @@ Customers continue to sign into [cloud.prowler.com](https://cloud.prowler.com) d
 
 ## Removing a Customer
 
-Removing a customer in Prowler Partner Portal detaches the tenant from your partner organization but does **not** delete the underlying Prowler Cloud tenant. Coordinate tenant disposal with the customer through Prowler Cloud directly.
+Removing a customer in Prowler Partner Portal detaches the customer workspace from your partner organization but does **not** delete the underlying customer data in Prowler Cloud. Coordinate workspace disposal with the customer through Prowler Cloud directly.
 
 ## Next Steps
 

--- a/docs/user-guide/tutorials/partner-portal-customer-onboarding.mdx
+++ b/docs/user-guide/tutorials/partner-portal-customer-onboarding.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Onboard a customer and access their tenant'
+---
+
+Prowler Partner Portal lets partners provision Prowler Cloud tenants for customer organizations and operate inside those tenants on the customer's behalf. Every partner action is recorded in Prowler Cloud's audit log with both the partner identity and an `on_behalf_of` claim that pinpoints the customer.
+
+## Provision a customer
+
+<Steps>
+  <Step title="Open Customers">
+    From the sidebar, choose **Customers**. The page is only visible to all signed-in partner users; the **+ Add Customer** button on the toolbar requires the `manage_organizations` permission.
+  </Step>
+
+  <Step title="Start the wizard">
+    Click **+ Add Customer**. Fill in the customer's organization name and primary contact email. Organization name uniqueness is validated per partner; trying to add a duplicate returns an inline error.
+  </Step>
+
+  <Step title="Wait for provisioning">
+    Prowler Partner Portal calls Prowler Cloud to create the tenant. Provisioning is asynchronous; the customer row updates from **Pending** to **Active** when the tenant is ready (usually under a minute).
+  </Step>
+</Steps>
+
+The customer is now visible to your team in the Customers table and ready for partner-side operations.
+
+## The Customers view
+
+The Customers table lists the customer organizations linked to your partner. Each row carries:
+
+- **Customer** — the cloud organization name.
+- **Cloud accounts** — count of cloud-provider accounts attached to the customer.
+- **Providers** — icons for each cloud provider in use (AWS, Azure, GCP, Kubernetes, Microsoft 365, GitHub, IAC, Vercel, MongoDB Atlas, Cloudflare, Google Workspace, Alibaba Cloud, Oracle Cloud, image scanning, OpenStack — plus any new providers Prowler adds).
+- **Findings** — Critical / High / Medium counts from the latest scan.
+- **Last scan** — timestamp of the last successful scan.
+
+## Customer self-pairing with a Partner Code
+
+Each approved partner has a **Partner Code** — a unique, Prowler-issued value shown on **Settings → Profile** with the helper text *"Share this code with customers to link their accounts"*. Sharing the code lets a customer paste it into their Prowler Cloud account and request the partner relationship; once confirmed, the customer is listed in your Customers view alongside any partner-provisioned tenants.
+
+The customer-side flow that consumes the Partner Code is rolled out progressively in Prowler Cloud. Verify availability with your Prowler contact before sharing the code.
+
+## Access a customer tenant on behalf of
+
+From **Customers**, open the customer's row and choose **Open in Prowler Cloud**. You're redirected to https://cloud.prowler.com signed in as a partner user **on behalf of** the customer. While operating in the tenant:
+
+- You see the same Prowler Cloud UI a customer administrator would see.
+- Every action is recorded in Prowler Cloud's audit log with both your identity (the partner user) and an `on_behalf_of` claim identifying the customer tenant.
+- Returning to Prowler Partner Portal — close the tab or use the *Back to Partner Portal* link.
+
+## Customer self-access
+
+Customers continue to sign into https://cloud.prowler.com directly with their own users. Partner-side access is **additive** — it does not replace customer-side users.
+
+## Removing a customer
+
+Removing a customer in Prowler Partner Portal detaches the tenant from your partner organization but does **not** delete the underlying Prowler Cloud tenant. Coordinate tenant disposal with the customer through Prowler Cloud directly.

--- a/docs/user-guide/tutorials/partner-portal-organization.mdx
+++ b/docs/user-guide/tutorials/partner-portal-organization.mdx
@@ -1,0 +1,40 @@
+---
+title: 'Your partner organization'
+---
+
+Your **partner organization** in Prowler Partner Portal is the top-level container for your team, your branding, your role catalogue and the customers you operate Prowler Cloud tenants for.
+
+## Lifecycle
+
+A partner organization moves through these states:
+
+| State | Meaning |
+|---|---|
+| **Pending email verification** | The first administrator has signed up but has not yet clicked the email verification link. |
+| **Pending approval** | Email verified; Prowler is reviewing the application. |
+| **Active** | Approved by Prowler. The partner organization can sign in, invite team members and onboard customers. |
+| **Rejected** | Prowler reviewed and declined the application. The account cannot sign in; the decision email contains the reason. |
+| **Suspended** | A previously active partner has been suspended. Sign-in is blocked; resolve manually with Prowler support. |
+
+If an application is rejected, you receive an email with the reason. Common rejection categories include incomplete documentation, ineligibility and duplicate registrations.
+
+## Settings
+
+Partner administrators with the **Manage settings** permission can edit the partner organization's profile from **Settings**:
+
+- **Company name** — the display name shown in the console, invitations and emails.
+- **Branding** — logo and visual identity. See [Customise Partner Portal branding](/user-guide/tutorials/partner-portal-branding).
+- **Partner Code** — a Prowler-issued, read-only value shown on the Profile tab. Customers paste this code in Prowler Cloud to link their tenant to your partner.
+- **Security** — password change for any signed-in user, plus a Danger zone for partner administrators to **request partner deletion**.
+
+## Customer capacity
+
+Each partner organization has a maximum number of concurrent customer organizations (default: **50**). To raise the limit, contact Prowler.
+
+## Closing your organization
+
+To close a partner organization, an administrator submits a deletion request from **Settings → Security → Danger zone**. Typing `DELETE` in the confirmation field and (optionally) providing a short reason files the request; the partner moves into the **deletion requested** state.
+
+While the request is pending, you and your team can still sign in and use the Partner Portal. Once Prowler processes the request, the partner organization, its team memberships and its branding assets are removed and all sessions are invalidated.
+
+Customer Prowler Cloud tenants are **not** automatically deleted — coordinate tenant disposal with each customer through Prowler Cloud directly.

--- a/docs/user-guide/tutorials/partner-portal-organization.mdx
+++ b/docs/user-guide/tutorials/partner-portal-organization.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Your partner organization'
+title: 'Your Partner Organization'
 ---
 
-Your **partner organization** in Prowler Partner Portal is the top-level container for your team, your branding, your role catalogue and the customers you operate Prowler Cloud tenants for.
+Your **partner organization** in Prowler Partner Portal is the top-level container for your team, your branding, your role catalog and the customers you operate Prowler Cloud tenants for.
 
 ## Lifecycle
 
@@ -23,18 +23,32 @@ If an application is rejected, you receive an email with the reason. Common reje
 Partner administrators with the **Manage settings** permission can edit the partner organization's profile from **Settings**:
 
 - **Company name** — the display name shown in the console, invitations and emails.
-- **Branding** — logo and visual identity. See [Customise Partner Portal branding](/user-guide/tutorials/partner-portal-branding).
+- **Branding** — logo and visual identity. See [Customizing Partner Portal Branding](/user-guide/tutorials/partner-portal-branding).
 - **Partner Code** — a Prowler-issued, read-only value shown on the Profile tab. Customers paste this code in Prowler Cloud to link their tenant to your partner.
 - **Security** — password change for any signed-in user, plus a Danger zone for partner administrators to **request partner deletion**.
 
-## Customer capacity
+## Customer Capacity
 
 Each partner organization has a maximum number of concurrent customer organizations (default: **50**). To raise the limit, contact Prowler.
 
-## Closing your organization
+## Closing Your Organization
 
 To close a partner organization, an administrator submits a deletion request from **Settings → Security → Danger zone**. Typing `DELETE` in the confirmation field and (optionally) providing a short reason files the request; the partner moves into the **deletion requested** state.
 
 While the request is pending, you and your team can still sign in and use the Partner Portal. Once Prowler processes the request, the partner organization, its team memberships and its branding assets are removed and all sessions are invalidated.
 
 Customer Prowler Cloud tenants are **not** automatically deleted — coordinate tenant disposal with each customer through Prowler Cloud directly.
+
+## Next Steps
+
+<Columns cols={2}>
+  <Card title="Managing Your Partner Portal Team" icon="users" href="/user-guide/tutorials/partner-portal-team">
+    Invite team members, assign roles, and manage memberships.
+  </Card>
+  <Card title="Customizing Partner Portal Branding" icon="palette" href="/user-guide/tutorials/partner-portal-branding">
+    Upload your logo and customize visual identity.
+  </Card>
+  <Card title="Onboarding Customers" icon="building" href="/user-guide/tutorials/partner-portal-customer-onboarding">
+    Provision customer Prowler Cloud tenants and operate on their behalf.
+  </Card>
+</Columns>

--- a/docs/user-guide/tutorials/partner-portal-organization.mdx
+++ b/docs/user-guide/tutorials/partner-portal-organization.mdx
@@ -2,7 +2,7 @@
 title: 'Your Partner Organization'
 ---
 
-Your **partner organization** in Prowler Partner Portal is the top-level container for your team, your branding, your role catalog and the customers you operate Prowler Cloud tenants for.
+Your **partner organization** in Prowler Partner Portal is the top-level container for your team, your branding, your role catalog and the customers whose Prowler Cloud workspaces you operate.
 
 ## Lifecycle
 
@@ -24,7 +24,7 @@ Partner administrators with the **Manage settings** permission can edit the part
 
 - **Company name** — the display name shown in the console, invitations and emails.
 - **Branding** — logo and visual identity. See [Customizing Partner Portal Branding](/user-guide/tutorials/partner-portal-branding).
-- **Partner Code** — a Prowler-issued, read-only value shown on the Profile tab. Customers paste this code in Prowler Cloud to link their tenant to your partner.
+- **Partner Code** — a Prowler-issued, read-only value shown on the Profile tab. Customers paste this code in Prowler Cloud to link their workspace to your partner.
 - **Security** — password change for any signed-in user, plus a Danger zone for partner administrators to **request partner deletion**.
 
 ## Customer Capacity
@@ -37,7 +37,7 @@ To close a partner organization, an administrator submits a deletion request fro
 
 While the request is pending, you and your team can still sign in and use the Partner Portal. Once Prowler processes the request, the partner organization, its team memberships and its branding assets are removed and all sessions are invalidated.
 
-Customer Prowler Cloud tenants are **not** automatically deleted — coordinate tenant disposal with each customer through Prowler Cloud directly.
+Customer workspaces in Prowler Cloud are **not** automatically deleted — coordinate workspace disposal with each customer through Prowler Cloud directly.
 
 ## Next Steps
 
@@ -49,6 +49,6 @@ Customer Prowler Cloud tenants are **not** automatically deleted — coordinate 
     Upload your logo and customize visual identity.
   </Card>
   <Card title="Onboarding Customers" icon="building" href="/user-guide/tutorials/partner-portal-customer-onboarding">
-    Provision customer Prowler Cloud tenants and operate on their behalf.
+    Provision customer workspaces in Prowler Cloud and operate on their behalf.
   </Card>
 </Columns>

--- a/docs/user-guide/tutorials/partner-portal-sign-up.mdx
+++ b/docs/user-guide/tutorials/partner-portal-sign-up.mdx
@@ -1,0 +1,50 @@
+---
+title: 'Sign up and sign in to Prowler Partner Portal'
+---
+
+Prowler Partner Portal sign-up and sign-in run on Prowler-managed accounts. The first administrator of a partner organization signs up self-service; subsequent team members are added by invitation.
+
+## Self-service sign-up
+
+<Steps>
+  <Step title="Open the sign-up page">
+    Go to https://partners.prowler.com/sign-up and provide your work email, your name, and the company name to register as a partner. Pick a password of at least 12 characters; a strength helper validates it as you type.
+  </Step>
+
+  <Step title="Verify your email">
+    Prowler sends a verification email with a one-time link, valid for **24 hours**. After verification, your partner organization moves to **Pending Approval**. If the link expires, request a new one at https://partners.prowler.com/resend-verification — issuing a fresh link invalidates any previous unused link for the same account.
+  </Step>
+
+  <Step title="Wait for Prowler approval">
+    Prowler reviews each new partner application. You receive an email when the organization is approved (status moves to **Active**) or, in rare cases, rejected with a reason.
+  </Step>
+
+  <Step title="Sign in">
+    Once approved, sign in at https://partners.prowler.com with the email and password you set during sign-up. You land on your partner organization's dashboard.
+  </Step>
+</Steps>
+
+## Sign-in
+
+Existing users sign in at https://partners.prowler.com with email and password. On success you land on `/dashboard`.
+
+Common sign-in errors:
+
+- `Invalid email or password` — credentials do not match an account.
+- `Please verify your email before signing in` — verification has not been completed; open the verification email or request a fresh link from `/resend-verification`.
+- `Your partner application is still under review` — sign-in is blocked until Prowler approves the application.
+- `Your partner application was not approved` — the application was rejected; the account cannot sign in.
+
+## Forgot password
+
+Click **Forgot password?** on the sign-in screen and enter your email at `/forgot-password`. Prowler sends a password reset email; the reset link is valid for a fixed window. The reset page asks for a new password (minimum 12 characters) and a confirmation; on success you are redirected back to sign-in.
+
+For security, the confirmation banner on the Forgot-password screen is shown whether or not the email matches an account — a fresh request invalidates any previous unused reset link.
+
+## Sessions
+
+Prowler Partner Portal uses short-lived JWTs (RS256) refreshed automatically while you remain active. Refresh tokens rotate on every refresh; previous refresh tokens are revoked. If a refresh fails — for example, after a long inactivity, a server restart, or a revoked token — you are returned to `/sign-in?error=RefreshAccessTokenError`. Sign in again to continue.
+
+## Sign out
+
+Open the user avatar in the top-right of any page and pick **Sign out**. The session is cleared and you are returned to the sign-in form.

--- a/docs/user-guide/tutorials/partner-portal-sign-up.mdx
+++ b/docs/user-guide/tutorials/partner-portal-sign-up.mdx
@@ -1,18 +1,18 @@
 ---
-title: 'Sign up and sign in to Prowler Partner Portal'
+title: 'Sign Up and Sign In to Prowler Partner Portal'
 ---
 
 Prowler Partner Portal sign-up and sign-in run on Prowler-managed accounts. The first administrator of a partner organization signs up self-service; subsequent team members are added by invitation.
 
-## Self-service sign-up
+## Self-Service Sign-Up
 
 <Steps>
   <Step title="Open the sign-up page">
-    Go to https://partners.prowler.com/sign-up and provide your work email, your name, and the company name to register as a partner. Pick a password of at least 12 characters; a strength helper validates it as you type.
+    Go to [partners.prowler.com/sign-up](https://partners.prowler.com/sign-up) and provide your work email, your name, and the company name to register as a partner. Pick a password of at least 12 characters; a strength helper validates it as you type.
   </Step>
 
   <Step title="Verify your email">
-    Prowler sends a verification email with a one-time link, valid for **24 hours**. After verification, your partner organization moves to **Pending Approval**. If the link expires, request a new one at https://partners.prowler.com/resend-verification — issuing a fresh link invalidates any previous unused link for the same account.
+    Prowler sends a verification email with a one-time link, valid for **24 hours**. After verification, your partner organization moves to **Pending Approval**. If the link expires, request a new one at [partners.prowler.com/resend-verification](https://partners.prowler.com/resend-verification) — issuing a fresh link invalidates any previous unused link for the same account.
   </Step>
 
   <Step title="Wait for Prowler approval">
@@ -20,13 +20,13 @@ Prowler Partner Portal sign-up and sign-in run on Prowler-managed accounts. The 
   </Step>
 
   <Step title="Sign in">
-    Once approved, sign in at https://partners.prowler.com with the email and password you set during sign-up. You land on your partner organization's dashboard.
+    Once approved, sign in at [partners.prowler.com](https://partners.prowler.com) with the email and password you set during sign-up. You land on your partner organization's dashboard.
   </Step>
 </Steps>
 
-## Sign-in
+## Sign-In
 
-Existing users sign in at https://partners.prowler.com with email and password. On success you land on `/dashboard`.
+Existing users sign in at [partners.prowler.com](https://partners.prowler.com) with email and password. On success you land on `/dashboard`.
 
 Common sign-in errors:
 
@@ -35,7 +35,7 @@ Common sign-in errors:
 - `Your partner application is still under review` — sign-in is blocked until Prowler approves the application.
 - `Your partner application was not approved` — the application was rejected; the account cannot sign in.
 
-## Forgot password
+## Forgot Password
 
 Click **Forgot password?** on the sign-in screen and enter your email at `/forgot-password`. Prowler sends a password reset email; the reset link is valid for a fixed window. The reset page asks for a new password (minimum 12 characters) and a confirmation; on success you are redirected back to sign-in.
 
@@ -45,6 +45,17 @@ For security, the confirmation banner on the Forgot-password screen is shown whe
 
 Prowler Partner Portal uses short-lived JWTs (RS256) refreshed automatically while you remain active. Refresh tokens rotate on every refresh; previous refresh tokens are revoked. If a refresh fails — for example, after a long inactivity, a server restart, or a revoked token — you are returned to `/sign-in?error=RefreshAccessTokenError`. Sign in again to continue.
 
-## Sign out
+## Sign Out
 
 Open the user avatar in the top-right of any page and pick **Sign out**. The session is cleared and you are returned to the sign-in form.
+
+## Next Steps
+
+<Columns cols={2}>
+  <Card title="Managing Your Partner Portal Team" icon="users" href="/user-guide/tutorials/partner-portal-team">
+    Invite team members, assign roles, and manage memberships.
+  </Card>
+  <Card title="Your Partner Organization" icon="briefcase" href="/user-guide/tutorials/partner-portal-organization">
+    Lifecycle, settings, Partner Code and closing your organization.
+  </Card>
+</Columns>

--- a/docs/user-guide/tutorials/partner-portal-team.mdx
+++ b/docs/user-guide/tutorials/partner-portal-team.mdx
@@ -8,22 +8,22 @@ Each partner organization in Prowler Partner Portal has its own team and its own
 
 Today every partner organization ships with two built-in roles:
 
-- **Admin** — full management of the partner organization (team, customers, settings, branding, billing, partner deletion). Admins are mapped to **Cloud Manager** on the customer tenants the partner manages on Prowler Cloud.
-- **Member** — read-only inside the Partner Portal. Members can change their own password and operate on customer tenants as **Cloud Operator** on Prowler Cloud.
-
-The role assigned at invitation time decides both Partner Portal and Cloud-side permissions; there is no separate Cloud role to assign.
+- **Superadmin** — full partner account management. Invites members, manages customer organizations, edits branding, and accesses customer workspaces.
+- **Organization Admin** — manages customer organizations and billing, and accesses customer workspaces. Cannot invite members or change partner settings.
 
 Each role bundles a set of permissions:
 
-| Permission | Description |
-|---|---|
-| Manage members | Invite, re-invite, revoke and remove team members. |
-| Manage settings | Edit the partner organization's profile and configuration. |
-| Manage billing | Manage billing details and subscriptions. |
-| Manage organizations | Add and remove customer organizations and provision their Prowler Cloud tenants. |
-| Access tenants | Open a customer tenant in Prowler Cloud on behalf of the customer. |
+| Permission | Description | Superadmin | Organization Admin |
+|---|---|:---:|:---:|
+| Manage members | Invite, re-invite, revoke and remove team members. | ✓ | |
+| Manage settings | Edit the partner organization's profile and configuration. | ✓ | |
+| Manage billing | Manage billing details and subscriptions. | ✓ | ✓ |
+| Manage organizations | Add and remove customer organizations and provision their customer workspaces. | ✓ | ✓ |
+| Access tenants | Open a customer workspace in Prowler Cloud on behalf of the customer. | ✓ | ✓ |
 
 Permissions surface on the session as boolean flags (`manage_members`, `manage_settings`, `manage_billing`, `manage_organizations`, `access_tenants`) that the UI consults to gate the corresponding sidebar entries and actions.
+
+The Cloud-side permission level (Manager or Operator) used when a partner user opens a customer workspace in Prowler Cloud is provisioned automatically and managed in Prowler Cloud — there is no separate Cloud role to assign at invitation time.
 
 ## Inviting a Team Member
 
@@ -65,7 +65,7 @@ Disabled members can be **Enabled** to restore access, or **Re-invited** to send
 
 <Columns cols={2}>
   <Card title="Onboarding Customers" icon="building" href="/user-guide/tutorials/partner-portal-customer-onboarding">
-    Provision customer Prowler Cloud tenants and operate on their behalf.
+    Provision customer workspaces in Prowler Cloud and operate on their behalf.
   </Card>
   <Card title="Customizing Partner Portal Branding" icon="palette" href="/user-guide/tutorials/partner-portal-branding">
     Upload your logo and customize visual identity.

--- a/docs/user-guide/tutorials/partner-portal-team.mdx
+++ b/docs/user-guide/tutorials/partner-portal-team.mdx
@@ -1,8 +1,8 @@
 ---
-title: 'Manage your Partner Portal team'
+title: 'Managing Your Partner Portal Team'
 ---
 
-Each partner organization in Prowler Partner Portal has its own team and its own role catalogue. Partner administrators invite team members by email and assign each member a role from the catalogue.
+Each partner organization in Prowler Partner Portal has its own team and its own role catalog. Partner administrators invite team members by email and assign each member a role from the catalog.
 
 ## Roles
 
@@ -15,15 +15,17 @@ The role assigned at invitation time decides both Partner Portal and Cloud-side 
 
 Each role bundles a set of permissions:
 
-- **Manage members** — invite, re-invite, revoke and remove team members.
-- **Manage settings** — edit the partner organization's profile and configuration.
-- **Manage billing** — manage billing details and subscriptions.
-- **Manage organizations** — add and remove customer organizations and provision their Prowler Cloud tenants.
-- **Access tenants** — open a customer tenant in Prowler Cloud on behalf of the customer.
+| Permission | Description |
+|---|---|
+| Manage members | Invite, re-invite, revoke and remove team members. |
+| Manage settings | Edit the partner organization's profile and configuration. |
+| Manage billing | Manage billing details and subscriptions. |
+| Manage organizations | Add and remove customer organizations and provision their Prowler Cloud tenants. |
+| Access tenants | Open a customer tenant in Prowler Cloud on behalf of the customer. |
 
 Permissions surface on the session as boolean flags (`manage_members`, `manage_settings`, `manage_billing`, `manage_organizations`, `access_tenants`) that the UI consults to gate the corresponding sidebar entries and actions.
 
-## Invite a team member
+## Inviting a Team Member
 
 <Steps>
   <Step title="Open Team">
@@ -41,13 +43,13 @@ Permissions surface on the session as boolean flags (`manage_members`, `manage_s
 
 When the invitee opens the link, they fill in their full name and a password (minimum 12 characters), accept, and are redirected to the sign-in page with a confirmation banner.
 
-## Re-invite or revoke
+## Re-Inviting or Revoking
 
 For invitations in **Pending** or **Expired** state, the row's **Re-invite** action emails a fresh link, bumps the invitation's expiry, and updates the **Invite Sent** column. **Revoke** invalidates the invitation immediately; the invitee can no longer accept it.
 
 An email address can have only one **Pending** invitation at a time. To re-issue, revoke the existing invitation first or use **Re-invite**.
 
-## Disable, enable, or remove a member
+## Disabling, Enabling, or Removing a Member
 
 Active members expose a **Disable** action on their row. Disabling soft-deletes the member: their access is revoked immediately, but the row stays in the table flagged as **Disabled** for audit trail.
 
@@ -58,3 +60,14 @@ Disabled members can be **Enabled** to restore access, or **Re-invited** to send
 - The first administrator of a new partner organization is created during sign-up.
 - An email address can have only one active membership in a given partner organization.
 - Permissions are scoped to a partner organization — a session for partner A does not carry permissions on partner B.
+
+## Next Steps
+
+<Columns cols={2}>
+  <Card title="Onboarding Customers" icon="building" href="/user-guide/tutorials/partner-portal-customer-onboarding">
+    Provision customer Prowler Cloud tenants and operate on their behalf.
+  </Card>
+  <Card title="Customizing Partner Portal Branding" icon="palette" href="/user-guide/tutorials/partner-portal-branding">
+    Upload your logo and customize visual identity.
+  </Card>
+</Columns>

--- a/docs/user-guide/tutorials/partner-portal-team.mdx
+++ b/docs/user-guide/tutorials/partner-portal-team.mdx
@@ -1,0 +1,60 @@
+---
+title: 'Manage your Partner Portal team'
+---
+
+Each partner organization in Prowler Partner Portal has its own team and its own role catalogue. Partner administrators invite team members by email and assign each member a role from the catalogue.
+
+## Roles
+
+Today every partner organization ships with two built-in roles:
+
+- **Admin** — full management of the partner organization (team, customers, settings, branding, billing, partner deletion). Admins are mapped to **Cloud Manager** on the customer tenants the partner manages on Prowler Cloud.
+- **Member** — read-only inside the Partner Portal. Members can change their own password and operate on customer tenants as **Cloud Operator** on Prowler Cloud.
+
+The role assigned at invitation time decides both Partner Portal and Cloud-side permissions; there is no separate Cloud role to assign.
+
+Each role bundles a set of permissions:
+
+- **Manage members** — invite, re-invite, revoke and remove team members.
+- **Manage settings** — edit the partner organization's profile and configuration.
+- **Manage billing** — manage billing details and subscriptions.
+- **Manage organizations** — add and remove customer organizations and provision their Prowler Cloud tenants.
+- **Access tenants** — open a customer tenant in Prowler Cloud on behalf of the customer.
+
+Permissions surface on the session as boolean flags (`manage_members`, `manage_settings`, `manage_billing`, `manage_organizations`, `access_tenants`) that the UI consults to gate the corresponding sidebar entries and actions.
+
+## Invite a team member
+
+<Steps>
+  <Step title="Open Team">
+    From the sidebar, choose **Team**. The page is only visible to users whose role grants `manage_members`.
+  </Step>
+
+  <Step title="Send the invitation">
+    Click **Invite user**, enter the work email, choose a role, and send. Inviting an email that is already a team member is rejected. The invitee receives an email with a one-time link that opens the public `/invitations/accept` page.
+  </Step>
+
+  <Step title="Track status">
+    The Team table lists each invitation's state: **Pending**, **Accepted**, **Expired** or **Revoked**.
+  </Step>
+</Steps>
+
+When the invitee opens the link, they fill in their full name and a password (minimum 12 characters), accept, and are redirected to the sign-in page with a confirmation banner.
+
+## Re-invite or revoke
+
+For invitations in **Pending** or **Expired** state, the row's **Re-invite** action emails a fresh link, bumps the invitation's expiry, and updates the **Invite Sent** column. **Revoke** invalidates the invitation immediately; the invitee can no longer accept it.
+
+An email address can have only one **Pending** invitation at a time. To re-issue, revoke the existing invitation first or use **Re-invite**.
+
+## Disable, enable, or remove a member
+
+Active members expose a **Disable** action on their row. Disabling soft-deletes the member: their access is revoked immediately, but the row stays in the table flagged as **Disabled** for audit trail.
+
+Disabled members can be **Enabled** to restore access, or **Re-invited** to send a fresh invitation that brings them back as a fresh active member.
+
+## Notes
+
+- The first administrator of a new partner organization is created during sign-up.
+- An email address can have only one active membership in a given partner organization.
+- Permissions are scoped to a partner organization — a session for partner A does not carry permissions on partner B.


### PR DESCRIPTION
### Context

Adds a new MDX page covering Prowler Partner Portal billing on `docs.prowler.com`. Child task of epic [PP-323](https://prowlerpro.atlassian.net/browse/PP-323), tracked under [PP-387](https://prowlerpro.atlassian.net/browse/PP-387).

> [!IMPORTANT]
> **Chained PR** — blocked by #10999.
> This branch sits on top of `docs/pp-323-partner-portal-docs`. Until #10999 merges to `master`, the GitHub diff here will include the PP-323 commits. Once #10999 merges, this diff collapses to just the billing changes.

### Description

One new page and one `docs.json` update:

| Task | Path |
| --- | --- |
| PP-387 — Billing | `docs/user-guide/tutorials/partner-portal-billing.mdx` |

`docs/docs.json` adds `partner-portal-billing` to the **Guides → Prowler Partner Portal** group, after `partner-portal-customer-onboarding`. Final lifecycle ordering: Sign-up → Team → Organization → Branding → Customer onboarding → **Billing**.

The page covers:

- **Partner billing settings** at `/billing` (Billing & Wallet tab with the Your Partner Plan and Payment Method cards, plus the Invoice History and Customer Billing placeholders). Calls out the `NEXT_PUBLIC_BILLING_ENABLED` feature flag explicitly.
- **Adding a customer with a billing plan** — the plan-selector step in the Add Customer wizard, with the three plans surfaced today (Trial, Pro Annual, Pro Monthly).
- **Changing a customer's plan** — the Change Plan drawer from a customer row, including the *Complete subscription* variant for Trial customers and the auto-provisioned invoice payment method path.
- **Per-customer billing visibility** — Billing Stats cards (Billing active, Total MTD per currency, trend) and the per-customer billing columns.
- **Permissions** — `manage_billing` flag, set on both Superadmin and Organization Admin seed roles.

### Steps to review

1. Wait until #10999 merges to `master`; then this PR's diff resolves to just the billing changes.
2. Check out the branch and run `cd docs && npm install -g mint && mint dev`.
3. Open `http://localhost:3000/user-guide/tutorials/partner-portal-billing` — page should render.
4. Verify the left nav under **Guides → Prowler Partner Portal** shows **Managing Billing and Customer Plans** as the last entry in the group.
5. Optionally check the Mintlify preview deploy posted on this PR by the Mintlify GitHub App.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No** — docs-only PR.
    - If so, do we need to update permissions for the provider? Please review this carefully.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


[PP-387]: https://prowlerpro.atlassian.net/browse/PP-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PP-323]: https://prowlerpro.atlassian.net/browse/PP-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ