### PR TITLE
fix(api): chown src/backend and docker-entrypoint to prowler user

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -102,8 +102,8 @@ RUN uv sync --locked --no-install-project && \
 
 RUN .venv/bin/python .venv/lib/python3.12/site-packages/prowler/providers/m365/lib/powershell/m365_powershell.py
 
-COPY src/backend/ ./backend/
-COPY docker-entrypoint.sh ./docker-entrypoint.sh
+COPY --chown=prowler:prowler src/backend/ ./backend/
+COPY --chown=prowler:prowler docker-entrypoint.sh ./docker-entrypoint.sh
 
 WORKDIR /home/prowler/backend
 


### PR DESCRIPTION
### Context

PR #11243 (the uv.lock perms fix) added `--chown=prowler:prowler` to the `pyproject.toml uv.lock` COPY but missed the two remaining COPYs that run after `USER prowler`: `src/backend/` and `docker-entrypoint.sh`. These default to `root:root` even though the container runs as the `prowler` user. Any runtime flow that needs to create files or directories under `/home/prowler/backend/` will fail with `PermissionError`. The most visible failure path is Django's `collectstatic` writing to `STATIC_ROOT = /home/prowler/backend/staticfiles` — the user can't `mkdir` inside a root-owned parent.

### Description

Adds `--chown=prowler:prowler` to:

- `COPY src/backend/ ./backend/`
- `COPY docker-entrypoint.sh ./docker-entrypoint.sh`

With this change, the entire `/home/prowler/` tree in the final image is owned by the `prowler` user, so runtime operations that create files/directories inside the working tree (e.g. `collectstatic`, any future admin tooling, or local debugging) work without privilege escalation.

### Steps to review

- Diff is 2 lines.
- Build the image and confirm `ls -la /home/prowler/backend` shows `prowler:prowler` ownership.
- Confirm the existing `pyproject.toml uv.lock` chown is unchanged.

### Checklist

Tick the boxes that genuinely apply for an OSS Dockerfile permissions fix (no SDK/CLI/UI behavior change, no migration, no docs needed).

### License

By submitting this PR, the contributor confirms the contribution is licensed under the same terms as the project.