### PR TITLE
ci(api): simplify SDK release pin to a single uv lock --upgrade-package

### DIFF
--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -145,25 +145,16 @@ jobs:
           pip install --no-cache-dir "uv==0.11.14"
           (cd api && uv lock)
 
-      - name: Pin prowler SDK to latest release branch (v5.Y) commit and refresh lockfile
+      - name: Refresh prowler SDK pin to latest release branch (v5.Y) commit
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         run: |
-          set -e
-          # RELEASE_TAG looks like "5.14.0"; the SDK release branch is "v5.14".
-          VERSION="${RELEASE_TAG#v}"
-          VERSION_BRANCH="v$(echo "${VERSION}" | cut -d. -f1,2)"
-          LATEST_SHA=$(git ls-remote https://github.com/prowler-cloud/prowler.git "refs/heads/${VERSION_BRANCH}" | cut -f1)
-          if [ -z "${LATEST_SHA}" ]; then
-            echo "ERROR: release branch ${VERSION_BRANCH} not found in prowler-cloud/prowler"
-            exit 1
-          fi
-          echo "Pinning SDK to ${VERSION_BRANCH}@${LATEST_SHA}"
-          sed -i "s|prowler-cloud/prowler.git@master|prowler-cloud/prowler.git@${LATEST_SHA}|" api/pyproject.toml
-          # Refresh api/uv.lock so it matches the pinned SHA above; the API
-          # Dockerfile runs `uv sync --locked`, which aborts on any drift
-          # between pyproject.toml and uv.lock.
+          # pyproject.toml is already pinned to `@v5.X` by prepare-release.yml; force uv
+          # to re-resolve so uv.lock captures the current branch tip at deploy time.
+          # The SDK release on prowler-cloud/prowler is published AFTER this release
+          # event, so the matching SDK tag doesn't exist yet here — the v5.X branch
+          # tip is the commit that will become that SDK release.
           pip install --no-cache-dir "uv==0.11.14"
-          (cd api && uv lock)
+          (cd api && uv lock --upgrade-package prowler)
 
       - name: Login to DockerHub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -133,23 +133,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Refresh prowler SDK pin to latest master commit
-        if: github.event_name == 'push'
+      - name: Refresh prowler SDK pin to current branch tip
         run: |
-          # pyproject.toml stays at `@master`; force uv to re-resolve so uv.lock
-          # captures the current master tip at build time. Dockerfile runs
+          # api/pyproject.toml has `@master` on master and `@v5.X` on release
+          # branches (set by prepare-release.yml). uv lock --upgrade-package
+          # re-resolves whichever ref is present against the current branch tip
+          # and writes the SHA into api/uv.lock. The Dockerfile runs
           # `uv sync --locked`, which is what actually drives the install.
-          pip install --no-cache-dir "uv==0.11.14"
-          (cd api && uv lock --upgrade-package prowler)
-
-      - name: Refresh prowler SDK pin to latest release branch (v5.Y) commit
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-        run: |
-          # pyproject.toml is already pinned to `@v5.X` by prepare-release.yml; force uv
-          # to re-resolve so uv.lock captures the current branch tip at deploy time.
-          # The SDK release on prowler-cloud/prowler is published AFTER this release
-          # event, so the matching SDK tag doesn't exist yet here — the v5.X branch
-          # tip is the commit that will become that SDK release.
           pip install --no-cache-dir "uv==0.11.14"
           (cd api && uv lock --upgrade-package prowler)
 

--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -133,17 +133,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Pin prowler SDK to latest master commit and refresh lockfile
+      - name: Refresh prowler SDK pin to latest master commit
         if: github.event_name == 'push'
         run: |
-          set -e
-          LATEST_SHA=$(git ls-remote https://github.com/prowler-cloud/prowler.git refs/heads/master | cut -f1)
-          sed -i "s|prowler-cloud/prowler.git@master|prowler-cloud/prowler.git@${LATEST_SHA}|" api/pyproject.toml
-          # Refresh api/uv.lock so it matches the pinned SHA above; the API
-          # Dockerfile runs `uv sync --locked`, which aborts on any drift
-          # between pyproject.toml and uv.lock.
+          # pyproject.toml stays at `@master`; force uv to re-resolve so uv.lock
+          # captures the current master tip at build time. Dockerfile runs
+          # `uv sync --locked`, which is what actually drives the install.
           pip install --no-cache-dir "uv==0.11.14"
-          (cd api && uv lock)
+          (cd api && uv lock --upgrade-package prowler)
 
       - name: Refresh prowler SDK pin to latest release branch (v5.Y) commit
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
### Context

The release-branch SDK pin step in `.github/workflows/api-container-build-push.yml` had a quietly-broken `sed`:

```bash
sed -i "s|prowler-cloud/prowler.git@master|prowler-cloud/prowler.git@${LATEST_SHA}|" api/pyproject.toml
```

On the release branch, `prepare-release.yml` has already rewritten `api/pyproject.toml` from `@master` to `@v5.X` by the time this workflow runs, so the `sed` never matches and the `Pinning SDK to v5.14@<SHA>` log line is a lie. The deploy still ended up pinned correctly because the trailing `uv lock` re-resolved `@v5.X` against the current branch tip — uv was silently doing the work the `sed` was supposed to do.

### Description

Replace the broken `sed` + misleading log with a two-line step that defers everything to uv:

```yaml
- name: Refresh prowler SDK pin to latest release branch (v5.Y) commit
  if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
  run: |
    pip install --no-cache-dir "uv==0.11.14"
    (cd api && uv lock --upgrade-package prowler)
```

`uv lock --upgrade-package prowler` forces uv to re-resolve the `@v5.X` ref against the current branch tip and write the resulting SHA into `api/uv.lock`. The Dockerfile runs `uv sync --locked`, so the lock is the authoritative input — no behavior change for the deployed image; the step is now honest about what it does.

Note: SDK releases on `prowler-cloud/prowler` are published *after* this cloud release event fires, so the matching SDK tag doesn't exist yet — pinning to the branch tip (the commit that will become that SDK release) is the only thing that works.

Companion PR in prowler-cloud with the same simplification for the cloud-deployment workflow: https://github.com/prowler-cloud/prowler-cloud/pull/4316.

### Steps to review

- Confirm the new step's `if:` keeps `release || workflow_dispatch` (the workflow-level `RELEASE_TAG` env covers both triggers).
- Confirm the master-pin step at lines ~136-146 (the non-release path) is untouched.
- Verify `uv lock --upgrade-package prowler` is the right invocation to force re-resolution of the `@v5.X` Git ref in `api/uv.lock`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.