### PR TITLE
chore(ci): disable Renovate patch, minor and major version bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,10 +31,32 @@
   "rangeStrategy": "pin",
   "packageRules": [
     {
-      "description": "Disable minor and major version bumps (patch + security only)",
+      "description": "Patches: 1st of every month, Madrid overnight window (22:00-06:00)",
       "matchUpdateTypes": [
-        "minor",
+        "patch"
+      ],
+      "schedule": [
+        "* 22-23,0-5 1 * *"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Minors: 8th of every 3 months, Madrid overnight window (22:00-06:00)",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "schedule": [
+        "* 22-23,0-5 8 */3 *"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Majors: 15th of every 3 months, Madrid overnight window",
+      "matchUpdateTypes": [
         "major"
+      ],
+      "schedule": [
+        "* 22-23,0-5 15 */3 *"
       ],
       "enabled": false
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,22 +31,12 @@
   "rangeStrategy": "pin",
   "packageRules": [
     {
-      "description": "Minors: 8th of every 3 months, Madrid overnight window (22:00-06:00)",
+      "description": "Disable minor and major version bumps (patch + security only)",
       "matchUpdateTypes": [
-        "minor"
-      ],
-      "schedule": [
-        "* 22-23,0-5 8 */3 *"
-      ]
-    },
-    {
-      "description": "Majors: 15th of every 3 months, Madrid overnight window",
-      "matchUpdateTypes": [
+        "minor",
         "major"
       ],
-      "schedule": [
-        "* 22-23,0-5 15 */3 *"
-      ]
+      "enabled": false
     },
     {
       "description": "GitHub Actions - single grouped PR, no changelog, scope=ci",


### PR DESCRIPTION
### Context

We want Renovate to stop opening PRs for patch, minor and major version bumps. Security/vulnerability alerts must remain active so urgent fixes still land automatically.

### Description

Keep the three original `packageRules` for patches, minors and majors in `.github/renovate.json` — preserving their descriptions and Madrid overnight schedules for the historical record — and mark each one with `"enabled": false`. Renovate will skip all routine version bumps, while `vulnerabilityAlerts` (which overrides `prHourlyLimit`/`prConcurrentLimit` to allow security PRs) continues working as before.

### Steps to review

1. Open `.github/renovate.json` and confirm the three rules (patch / minor / major) are still present with their original schedules.
2. Confirm each of the three rules has `"enabled": false`.
3. Confirm the `vulnerabilityAlerts` block, grouped manager rules (github-actions, docker, pre-commit), scope rules (ui, api, mcp, sdk) and global settings (`minimumReleaseAge`, `rangeStrategy`) are unchanged.
4. The pre-commit `renovate-config-validator` hook ran locally and passed.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests. (N/A — Renovate config; validated by `renovate-config-validator` pre-commit hook)
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings (N/A)
- [x] Review if backport is needed. (No)
- [x] Review if is needed to change the Readme.md (No)
- [x] Ensure new entries are added to CHANGELOG.md, if applicable. (N/A — CI configuration change)

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI (if applicable)
N/A

#### API (if applicable)
N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.