### PR TITLE
fix(ui): resource tab scroll from container

### DIFF
--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
@@ -1079,7 +1079,7 @@ export function ResourceDetailDrawerContent({
           {/* Metadata */}
           <TabsContent
             value="metadata"
-            className="minimal-scrollbar flex flex-col gap-4 overflow-y-auto"
+            className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden"
           >
             {isNavigating ? (
               <MetadataNavigationSkeleton />

--- a/ui/components/shared/query-code-editor.tsx
+++ b/ui/components/shared/query-code-editor.tsx
@@ -1103,9 +1103,11 @@ const DARK_SELECTION_BG = "rgba(121, 192, 255, 0.18)";
 function createEditorTheme({
   isDarkMode,
   minHeight,
+  fill,
 }: {
   isDarkMode: boolean;
   minHeight: number;
+  fill?: boolean;
 }) {
   return EditorView.theme(
     {
@@ -1114,12 +1116,17 @@ function createEditorTheme({
         color: "var(--text-neutral-primary)",
         fontFamily: MONO_FONT,
         fontSize: "12px",
+        // When filling, the editor takes the full height of its (bounded)
+        // wrapper so the scroller below can scroll instead of growing.
+        ...(fill && { height: "100%" }),
       },
       "&.cm-focused": {
         outline: "none",
       },
       ".cm-scroller": {
-        minHeight: `${minHeight}px`,
+        // A fixed min-height would force the editor to overflow a smaller
+        // container; when filling we let flexbox size it instead.
+        ...(fill ? {} : { minHeight: `${minHeight}px` }),
         overflow: "auto",
         fontFamily: MONO_FONT,
         lineHeight: "1.5rem",
@@ -1174,6 +1181,12 @@ interface QueryCodeEditorProps
   requirementBadge?: string;
   editable?: boolean;
   minHeight?: number;
+  /**
+   * When true the editor fills the height of its parent (which must be a
+   * bounded flex container) and scrolls internally instead of growing with
+   * its content.
+   */
+  fill?: boolean;
   showCopyButton?: boolean;
   showLineNumbers?: boolean;
   onChange: (value: string) => void;
@@ -1193,6 +1206,7 @@ export const QueryCodeEditor = ({
   requirementBadge,
   editable = true,
   minHeight = 320,
+  fill = false,
   showCopyButton = false,
   showLineNumbers = true,
   onChange,
@@ -1202,7 +1216,7 @@ export const QueryCodeEditor = ({
   const { resolvedTheme } = useTheme();
   const [copied, setCopied] = useState(false);
   const isDarkMode = resolvedTheme === "dark";
-  const editorTheme = createEditorTheme({ isDarkMode, minHeight });
+  const editorTheme = createEditorTheme({ isDarkMode, minHeight, fill });
   const editorHighlightStyle = isDarkMode
     ? darkHighlightStyle
     : lightHighlightStyle;
@@ -1261,12 +1275,13 @@ export const QueryCodeEditor = ({
       data-show-line-numbers={String(showLineNumbers)}
       className={cn(
         "border-border-neutral-secondary bg-bg-neutral-primary overflow-hidden rounded-xl border",
+        fill && "flex min-h-0 flex-1 flex-col",
         invalid && "border-border-error-primary",
         className,
       )}
       {...props}
     >
-      <div className="border-border-neutral-secondary bg-bg-neutral-secondary flex items-center justify-between border-b px-4 py-2">
+      <div className="border-border-neutral-secondary bg-bg-neutral-secondary flex shrink-0 items-center justify-between border-b px-4 py-2">
         {visibleLabel ? (
           <span className="text-text-neutral-secondary text-xs font-medium">
             {visibleLabel}
@@ -1303,6 +1318,7 @@ export const QueryCodeEditor = ({
       <CodeMirror
         value={value}
         theme={editorTheme}
+        className={cn(fill && "min-h-0 flex-1")}
         basicSetup={{
           foldGutter: false,
           highlightActiveLine: false,

--- a/ui/components/shared/resource-metadata-panel.tsx
+++ b/ui/components/shared/resource-metadata-panel.tsx
@@ -58,6 +58,7 @@ export function ResourceMetadataPanel({
           copyValue={formattedMetadata}
           editable={false}
           minHeight={220}
+          fill
           showCopyButton
           onChange={() => {}}
         />


### PR DESCRIPTION
### Description

This pull request improves the layout flexibility of the `QueryCodeEditor` component and its usage in resource detail views. The main change is the addition of a new `fill` prop that allows the editor to fill the height of its parent container and properly handle scrolling within flex layouts. This enables better integration in complex UI layouts, especially when embedding the editor in panels that need to scroll or resize dynamically.

**Enhancements to `QueryCodeEditor` layout and API:**

* Added a new optional `fill` prop to `QueryCodeEditor`, allowing the editor to expand to fill its parent container and adjust its internal scrolling and sizing accordingly. [[1]](diffhunk://#diff-eb038c8d104acb1d67149d28d9f61232cc4289a2fffefb7579fe51c125fba9feR1184-R1189) [[2]](diffhunk://#diff-eb038c8d104acb1d67149d28d9f61232cc4289a2fffefb7579fe51c125fba9feR1209)
* Updated the `createEditorTheme` function and related style logic to support the `fill` prop, ensuring the editor's height and min-height are set appropriately based on the prop. [[1]](diffhunk://#diff-eb038c8d104acb1d67149d28d9f61232cc4289a2fffefb7579fe51c125fba9feR1106-R1110) [[2]](diffhunk://#diff-eb038c8d104acb1d67149d28d9f61232cc4289a2fffefb7579fe51c125fba9feR1119-R1129) [[3]](diffhunk://#diff-eb038c8d104acb1d67149d28d9f61232cc4289a2fffefb7579fe51c125fba9feL1205-R1219) [[4]](diffhunk://#diff-eb038c8d104acb1d67149d28d9f61232cc4289a2fffefb7579fe51c125fba9feR1321)
* Modified the main editor container and toolbar to support flex layouts when `fill` is enabled, preventing overflow and ensuring proper sizing.

**Integration in resource detail panels:**

* Enabled the `fill` prop for the `QueryCodeEditor` used in `ResourceMetadataPanel`, so the editor fills available space and scrolls as intended within the resource detail drawer.
* Adjusted the `TabsContent` container in `ResourceDetailDrawerContent` to use `flex` and `overflow-hidden`, allowing its children (including the editor) to fill and scroll correctly.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
