### PR TITLE
fix(ui): resource tab scroll from container

### DIFF
--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
@@ -1087,6 +1087,7 @@ export function ResourceDetailDrawerContent({
               <ResourceMetadataPanel
                 metadata={f?.resourceMetadata}
                 details={f?.resourceDetails}
+                fill
               />
             )}
           </TabsContent>

--- a/ui/components/shared/resource-metadata-panel.tsx
+++ b/ui/components/shared/resource-metadata-panel.tsx
@@ -10,6 +10,13 @@ import { parseMetadata } from "@/lib/resource-metadata";
 interface ResourceMetadataPanelProps {
   metadata: Record<string, unknown> | string | null | undefined;
   details: string | null | undefined;
+  /**
+   * When true the metadata editor fills the available height and scrolls
+   * internally. Only enable this when the panel is rendered inside a bounded
+   * flex container; otherwise the editor collapses. Defaults to growing with
+   * its content.
+   */
+  fill?: boolean;
 }
 
 /**
@@ -24,6 +31,7 @@ interface ResourceMetadataPanelProps {
 export function ResourceMetadataPanel({
   metadata,
   details,
+  fill = false,
 }: ResourceMetadataPanelProps) {
   const parsedMetadata = parseMetadata(metadata);
   const hasMetadata =
@@ -58,7 +66,7 @@ export function ResourceMetadataPanel({
           copyValue={formattedMetadata}
           editable={false}
           minHeight={220}
-          fill
+          fill={fill}
           showCopyButton
           onChange={() => {}}
         />


### PR DESCRIPTION
### Description

improvements from https://github.com/prowler-cloud/prowler/pull/11320, 
This pull request enhances the `ResourceMetadataPanel` component by adding a new `fill` prop, allowing greater control over how the metadata editor fills its container. This makes the panel more flexible when used in different layouts, especially inside bounded flex containers.

Component flexibility improvements:

* Added a new optional `fill` prop to the `ResourceMetadataPanel` component, with documentation describing its usage and default behavior.
* Updated the `ResourceMetadataPanel` implementation to use the `fill` prop, defaulting to `false` if not provided, and passed its value to the underlying editor. [[1]](diffhunk://#diff-a3a1f32d2b7f2e452e3a8ea45d8e11830a765180a92c3b1a626ad80bdcfbb4faR34) [[2]](diffhunk://#diff-a3a1f32d2b7f2e452e3a8ea45d8e11830a765180a92c3b1a626ad80bdcfbb4faL61-R69)

Usage update:

* Updated the `ResourceDetailDrawerContent` to pass `fill` to `ResourceMetadataPanel`, ensuring the panel fills available space in the drawer context.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
