### PR TITLE
chore(ui): type process.env via ambient NodeJS.ProcessEnv

### DIFF
--- a/ui/__tests__/msw/handlers/attack-paths.ts
+++ b/ui/__tests__/msw/handlers/attack-paths.ts
@@ -10,7 +10,7 @@ import type {
   QueryResultAttributes,
 } from "@/types/attack-paths";
 
-const API = process.env.NEXT_PUBLIC_API_BASE_URL!;
+const API = process.env.NEXT_PUBLIC_API_BASE_URL;
 
 type JsonApiErrorBody = {
   errors: Array<{ detail: string; status: string }>;

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -1,0 +1,128 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      // Runtime (Node / Next.js)
+      NODE_ENV: "development" | "production" | "test";
+      NEXT_RUNTIME?: "nodejs" | "edge";
+
+      // Public client config
+      NEXT_PUBLIC_API_BASE_URL: string;
+      NEXT_PUBLIC_API_DOCS_URL?: string;
+      NEXT_PUBLIC_IS_CLOUD_ENV?: "true" | "false";
+      NEXT_PUBLIC_PROWLER_RELEASE_VERSION?: string;
+      NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID?: string;
+      NEXT_PUBLIC_SENTRY_DSN?: string;
+      NEXT_PUBLIC_SENTRY_ENVIRONMENT?: string;
+      NEXT_PUBLIC_POSTHOG_API_HOST?: string;
+      NEXT_PUBLIC_POSTHOG_UI_HOST?: string;
+      NEXT_PUBLIC_POSTHOG_KEY?: string;
+
+      // Auth (NextAuth)
+      AUTH_URL?: string;
+      AUTH_SECRET?: string;
+      AUTH_TRUST_HOST?: "true" | "false";
+      NEXTAUTH_URL?: string;
+
+      // Sentry (server / build)
+      SENTRY_DSN?: string;
+      SENTRY_ENVIRONMENT?: string;
+      SENTRY_RELEASE?: string;
+      SENTRY_ORG?: string;
+      SENTRY_PROJECT?: string;
+      SENTRY_AUTH_TOKEN?: string;
+
+      // Social OAuth
+      SOCIAL_GOOGLE_OAUTH_CLIENT_ID?: string;
+      SOCIAL_GOOGLE_OAUTH_CLIENT_SECRET?: string;
+      SOCIAL_GOOGLE_OAUTH_CALLBACK_URL?: string;
+      SOCIAL_GITHUB_OAUTH_CLIENT_ID?: string;
+      SOCIAL_GITHUB_OAUTH_CLIENT_SECRET?: string;
+      SOCIAL_GITHUB_OAUTH_CALLBACK_URL?: string;
+
+      // Feature integrations
+      PROWLER_MCP_SERVER_URL?: string;
+      // JSON-encoded array, parsed in actions/feeds
+      RSS_FEED_SOURCES?: string;
+
+      // Environment detection
+      CI?: string;
+      DOCKER?: string;
+      KUBERNETES_SERVICE_HOST?: string;
+
+      // E2E test credentials (Playwright only)
+      E2E_ADMIN_USER?: string;
+      E2E_ADMIN_PASSWORD?: string;
+      E2E_NEW_USER_PASSWORD?: string;
+      E2E_MANAGE_CLOUD_PROVIDERS_USER?: string;
+      E2E_MANAGE_CLOUD_PROVIDERS_PASSWORD?: string;
+      E2E_INVITE_AND_MANAGE_USERS_USER?: string;
+      E2E_INVITE_AND_MANAGE_USERS_PASSWORD?: string;
+      E2E_UNLIMITED_VISIBILITY_USER?: string;
+      E2E_UNLIMITED_VISIBILITY_PASSWORD?: string;
+      E2E_MANAGE_INTEGRATIONS_USER?: string;
+      E2E_MANAGE_INTEGRATIONS_PASSWORD?: string;
+      E2E_MANAGE_ACCOUNT_USER?: string;
+      E2E_MANAGE_ACCOUNT_PASSWORD?: string;
+      E2E_MANAGE_SCANS_USER?: string;
+      E2E_MANAGE_SCANS_PASSWORD?: string;
+      E2E_ORGANIZATION_ID?: string;
+
+      // E2E AWS
+      E2E_AWS_PROVIDER_ACCOUNT_ID?: string;
+      E2E_AWS_PROVIDER_ACCESS_KEY?: string;
+      E2E_AWS_PROVIDER_SECRET_KEY?: string;
+      E2E_AWS_PROVIDER_ROLE_ARN?: string;
+      E2E_AWS_ORGANIZATION_ID?: string;
+      E2E_AWS_ORGANIZATION_ROLE_ARN?: string;
+
+      // E2E Azure
+      E2E_AZURE_SUBSCRIPTION_ID?: string;
+      E2E_AZURE_CLIENT_ID?: string;
+      E2E_AZURE_SECRET_ID?: string;
+      E2E_AZURE_TENANT_ID?: string;
+
+      // E2E Microsoft 365
+      E2E_M365_DOMAIN_ID?: string;
+      E2E_M365_CLIENT_ID?: string;
+      E2E_M365_TENANT_ID?: string;
+      E2E_M365_SECRET_ID?: string;
+      E2E_M365_CERTIFICATE_CONTENT?: string;
+
+      // E2E GCP
+      E2E_GCP_PROJECT_ID?: string;
+      E2E_GCP_BASE64_SERVICE_ACCOUNT_KEY?: string;
+
+      // E2E Kubernetes
+      E2E_KUBERNETES_CONTEXT?: string;
+      E2E_KUBERNETES_KUBECONFIG_PATH?: string;
+
+      // E2E GitHub
+      E2E_GITHUB_USERNAME?: string;
+      E2E_GITHUB_PERSONAL_ACCESS_TOKEN?: string;
+      E2E_GITHUB_APP_ID?: string;
+      E2E_GITHUB_BASE64_APP_PRIVATE_KEY?: string;
+      E2E_GITHUB_ORGANIZATION?: string;
+      E2E_GITHUB_ORGANIZATION_ACCESS_TOKEN?: string;
+
+      // E2E Oracle Cloud
+      E2E_OCI_TENANCY_ID?: string;
+      E2E_OCI_USER_ID?: string;
+      E2E_OCI_FINGERPRINT?: string;
+      E2E_OCI_KEY_CONTENT?: string;
+      E2E_OCI_REGION?: string;
+
+      // E2E Alibaba Cloud
+      E2E_ALIBABACLOUD_ACCOUNT_ID?: string;
+      E2E_ALIBABACLOUD_ACCESS_KEY_ID?: string;
+      E2E_ALIBABACLOUD_ACCESS_KEY_SECRET?: string;
+      E2E_ALIBABACLOUD_ROLE_ARN?: string;
+
+      // E2E Google Workspace
+      E2E_GOOGLEWORKSPACE_CUSTOMER_ID?: string;
+      E2E_GOOGLEWORKSPACE_SERVICE_ACCOUNT_JSON?: string;
+      E2E_GOOGLEWORKSPACE_DELEGATED_USER?: string;
+    }
+  }
+}
+
+export {};

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -13,9 +13,6 @@ declare global {
       NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID?: string;
       NEXT_PUBLIC_SENTRY_DSN?: string;
       NEXT_PUBLIC_SENTRY_ENVIRONMENT?: string;
-      NEXT_PUBLIC_POSTHOG_API_HOST?: string;
-      NEXT_PUBLIC_POSTHOG_UI_HOST?: string;
-      NEXT_PUBLIC_POSTHOG_KEY?: string;
 
       // Auth (NextAuth)
       AUTH_URL?: string;

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -15,8 +15,8 @@ declare global {
       NEXT_PUBLIC_SENTRY_ENVIRONMENT?: string;
 
       // Auth (NextAuth)
-      AUTH_URL?: string;
-      AUTH_SECRET?: string;
+      AUTH_URL: string;
+      AUTH_SECRET: string;
       AUTH_TRUST_HOST?: "true" | "false";
       NEXTAUTH_URL?: string;
 


### PR DESCRIPTION
### Context

`process.env.*` reads in the UI workspace currently fall back to the default Node typing of `Record<string, string | undefined>`. That means no IntelliSense for which env vars exist, no narrowing of boolean-like or enum-like values, and no compile-time visibility of the deploy contract (which keys must be set, which are optional, which are test-only).

This PR adds a single ambient TypeScript declaration that augments `NodeJS.ProcessEnv` with every environment variable consumed by `ui/`, so reads pick up autocomplete and proper types while leaving runtime behavior untouched.

### Description

Adds `ui/types/env.d.ts` which lists every `process.env.*` key referenced in committed UI source (production code, server actions, Next config, Sentry init, Playwright tests, MSW handlers). Picked up automatically by `ui/tsconfig.json` via the existing `**/*.ts` glob.

**Required (typed as `string`):**

- `NODE_ENV` — Next.js guarantees a value at build and runtime.
- `NEXT_PUBLIC_API_BASE_URL` — the UI cannot talk to the API without it.
- `AUTH_URL`, `AUTH_SECRET` — NextAuth refuses to operate without either.

**Optional (typed as `?: string`):** every other key, including all `NEXT_PUBLIC_*` UI flags, `SENTRY_*`, social OAuth, MCP, RSS feed sources, environment detection (`CI`, `DOCKER`, `KUBERNETES_SERVICE_HOST`), and the full set of `E2E_*` Playwright credentials.

**String-literal unions** are used only for values that are already public:

- `NODE_ENV`: `"development" | "production" | "test"` (Node.js standard).
- `NEXT_RUNTIME`: `"nodejs" | "edge"` (Next.js public API).
- `NEXT_PUBLIC_IS_CLOUD_ENV`: `"true" | "false"` (boolean-like flag, compared with `=== "true"` in ~18 files).
- `AUTH_TRUST_HOST`: `"true" | "false"`.

Sentry environment names, cloud account IDs, infra hostnames, region codes, and similar internal taxonomy stay as plain `string` even when the code compares against specific values, so the typing file does not leak deploy-time information.

Additional cleanups bundled in this PR:

- Drops the now-redundant `!` non-null assertion on `process.env.NEXT_PUBLIC_API_BASE_URL` in `ui/__tests__/msw/handlers/attack-paths.ts` (the new typing makes the key non-nullable).
- Removes three `NEXT_PUBLIC_POSTHOG_*` keys that were only referenced in an untracked local `.env.local`; they have no committed source consumer, so typing them would have published unused key names without any corresponding code.

### Steps to review

1. Run `pnpm -C ui run typecheck` and `pnpm -C ui run lint:fix` — both must pass.
2. Open `ui/lib/helper.ts` in the IDE; hovering `process.env.NEXT_PUBLIC_API_BASE_URL` should show `string` (no longer `string | undefined`).
3. In any file that uses `NEXT_PUBLIC_IS_CLOUD_ENV === "true"`, hover the LHS — TS should report `"true" | "false" | undefined`.
4. Typing `process.env.NEXT_PUBLIC_` in any UI file should autocomplete the prefixed keys.

### Follow-up — Boot-time required-env assertion (proposed)

Marking required keys as `string` is honest only if the deploy actually sets them. If a deploy is misconfigured today, TypeScript still thinks the value is a `string`, the app starts, and the failure surfaces later as a cryptic runtime error inside NextAuth or a `fetch`.

Proposal for a follow-up PR (not in this one): add a small `ui/lib/env.ts` (~10 lines, no dependency) executed at module load that throws if any required key is missing. The required list is declared with `as const satisfies` so the keys are checked against `keyof NodeJS.ProcessEnv` at compile time — drift between the runtime guard and this typing file becomes a TS error rather than a silent gap:

```ts
const REQUIRED = [
  "NEXT_PUBLIC_API_BASE_URL",
  "AUTH_URL",
  "AUTH_SECRET",
] as const satisfies ReadonlyArray<keyof NodeJS.ProcessEnv>;

for (const key of REQUIRED) {
  if (!process.env[key]) {
    throw new Error(`Missing required env: ${key}`);
  }
}
```

Imported from `instrumentation.ts` (and possibly `next.config.js`), this turns the typing contract into a hard runtime check at boot rather than a latent bug.

Open to discuss: do we want this guard, or do we trust deploy configuration end-to-end?

### Follow-up — Existing runtime fallbacks worth reviewing

Some keys are read in code with `|| "default"` or `?? "default"`. With the new typing, several of those fallbacks are no longer needed to silence the compiler — they remain only if we want a real runtime default. Listing them so the team can decide whether to keep or drop each one.

**Production code — now contradictory with the new required types:**

- `ui/lib/helper.ts:16` — `process.env.AUTH_URL || "http://localhost:3000"`. `AUTH_URL` is now typed required; the `||` is dead for `undefined` (still catches empty string). Drop the fallback?

**Production code — keys remain optional; fallback is intentional default behavior:**

- `ui/app/api/health/route.ts:7` — `NEXT_PUBLIC_PROWLER_RELEASE_VERSION || "unknown"`.
- `ui/app/(auth)/layout.tsx:50` — `NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID || ""` (empty string means "GTM disabled").
- `ui/app/instrumentation.client.ts:34` — `NEXT_PUBLIC_SENTRY_ENVIRONMENT || "local"`.
- `ui/sentry/sentry.server.config.ts:22` and `ui/sentry/sentry.edge.config.ts:23` — `SENTRY_ENVIRONMENT || "local"`.

**Test scaffolding (recommended to leave as-is):**

- `ui/vitest.config.ts:9` — `NEXT_PUBLIC_API_BASE_URL ?? "http://localhost/api/v1"`.
- `ui/playwright.config.ts:150-156` — `NEXT_PUBLIC_API_BASE_URL`, `AUTH_SECRET`, `AUTH_TRUST_HOST`, `NEXTAUTH_URL`, `E2E_ADMIN_USER`, `E2E_ADMIN_PASSWORD` all with `||` test defaults.
- `ui/tests/helpers.ts:25,26,59` — admin user/password and `NEXTAUTH_URL` defaults.
- `ui/tests/providers/providers.spec.ts` — 40+ `E2E_* ?? ""` reads across AWS, Azure, M365, GCP, GitHub, OCI, Alibaba Cloud and Google Workspace spec blocks.

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. (N/A — no user-visible behavior change; `no-changelog` label applied.)

#### UI

- [x] All issue/task requirements work as expected on the UI (no runtime behavior change).
- [x] If this PR adds or updates npm dependencies, include package-health evidence. (N/A — no new dependencies.)
- [x] Screenshots/Video of the functionality flow (if applicable) — Mobile (N/A, type-level only).
- [x] Screenshots/Video of the functionality flow (if applicable) — Tablet (N/A, type-level only).
- [x] Screenshots/Video of the functionality flow (if applicable) — Desktop (N/A, type-level only).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. (N/A — `no-changelog` applied.)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
