### PR TITLE
fix(ui): stream scan report downloads

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - Resource detail panels: metadata editor now scrolls internally with the minimal scrollbar across the finding drawer and `/resources/:id`, tab labels truncate with tooltips on narrow widths, and "View in AWS Console" moved from the resource UID row to the resource actions menu [(#11325)](https://github.com/prowler-cloud/prowler/pull/11325)
-- Scan report ZIP downloads now stream through a Route Handler instead of buffering the full file in a Server Action, allowing very large reports to download reliably [(#11330)](https://github.com/prowler-cloud/prowler/pull/11330)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🐞 Fixed
 
 - Resource detail panels: metadata editor now scrolls internally with the minimal scrollbar across the finding drawer and `/resources/:id`, tab labels truncate with tooltips on narrow widths, and "View in AWS Console" moved from the resource UID row to the resource actions menu [(#11325)](https://github.com/prowler-cloud/prowler/pull/11325)
+- Scan report ZIP downloads now stream through a Route Handler instead of buffering the full file in a Server Action, allowing very large reports to download reliably [(#11330)](https://github.com/prowler-cloud/prowler/pull/11330)
 
 ---
 

--- a/ui/app/api/scans/[scanId]/report/route.test.ts
+++ b/ui/app/api/scans/[scanId]/report/route.test.ts
@@ -56,6 +56,32 @@ describe("GET /api/scans/[scanId]/report", () => {
     expect(response.body).toBe(upstreamBody);
   });
 
+  it("checks report readiness without streaming ready report bytes", async () => {
+    const cancelMock = vi.fn();
+    const upstreamBody = new ReadableStream({
+      cancel: cancelMock,
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(upstreamBody, { status: 200 })),
+    );
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+
+    const response = await GET(
+      new Request("http://localhost/api?preflight=1"),
+      {
+        params: Promise.resolve({ scanId: "scan-123" }),
+      },
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+    expect(cancelMock).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves pending report responses from the API", async () => {
     vi.stubGlobal(
       "fetch",

--- a/ui/app/api/scans/[scanId]/report/route.test.ts
+++ b/ui/app/api/scans/[scanId]/report/route.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+const { getAuthHeadersMock } = vi.hoisted(() => ({
+  getAuthHeadersMock: vi.fn(),
+}));
+
+vi.mock("@/lib", () => ({
+  apiBaseUrl: "https://api.example.com/api/v1",
+  getAuthHeaders: getAuthHeadersMock,
+}));
+
+describe("GET /api/scans/[scanId]/report", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("streams the upstream report body without buffering it", async () => {
+    const upstreamBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(upstreamBody, {
+        status: 200,
+        headers: {
+          "content-type": "application/zip",
+          "content-length": "3",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+
+    const response = await GET(new Request("http://localhost/api"), {
+      params: Promise.resolve({ scanId: "scan-123" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/v1/scans/scan-123/report",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer token" },
+        cache: "no-store",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/zip");
+    expect(response.headers.get("content-length")).toBe("3");
+    expect(response.headers.get("content-disposition")).toBe(
+      'attachment; filename="scan-scan-123-report.zip"',
+    );
+    expect(response.body).toBe(upstreamBody);
+  });
+
+  it("preserves pending report responses from the API", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          Response.json({ data: { id: "task-1" } }, { status: 202 }),
+        ),
+    );
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+
+    const response = await GET(new Request("http://localhost/api"), {
+      params: Promise.resolve({ scanId: "scan-123" }),
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ data: { id: "task-1" } });
+  });
+});

--- a/ui/app/api/scans/[scanId]/report/route.ts
+++ b/ui/app/api/scans/[scanId]/report/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+
+import { apiBaseUrl, getAuthHeaders } from "@/lib";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface ScanReportRouteContext {
+  params: Promise<{
+    scanId: string;
+  }>;
+}
+
+const COPY_RESPONSE_HEADERS = [
+  "content-length",
+  "content-type",
+  "etag",
+  "last-modified",
+] as const;
+
+const buildAttachmentFilename = (scanId: string) =>
+  `scan-${scanId.replace(/[^a-zA-Z0-9._-]/g, "-")}-report.zip`;
+
+const buildDownloadHeaders = (upstreamHeaders: Headers, scanId: string) => {
+  const headers = new Headers({
+    "Cache-Control": "no-store",
+    "Content-Disposition": `attachment; filename="${buildAttachmentFilename(scanId)}"`,
+  });
+
+  COPY_RESPONSE_HEADERS.forEach((headerName) => {
+    const value = upstreamHeaders.get(headerName);
+    if (value) headers.set(headerName, value);
+  });
+
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/zip");
+  }
+
+  return headers;
+};
+
+export async function GET(
+  _request: Request,
+  { params }: ScanReportRouteContext,
+) {
+  const { scanId } = await params;
+  const headers = await getAuthHeaders({ contentType: false });
+  const upstreamUrl = `${apiBaseUrl}/scans/${encodeURIComponent(scanId)}/report`;
+
+  const upstreamResponse = await fetch(upstreamUrl, {
+    headers,
+    cache: "no-store",
+  });
+
+  if (upstreamResponse.status === 202) {
+    const body = await upstreamResponse.json().catch(() => ({}));
+    return NextResponse.json(body, {
+      status: 202,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+
+  if (!upstreamResponse.ok) {
+    const body = await upstreamResponse.text().catch(() => "");
+    return new Response(body, {
+      status: upstreamResponse.status,
+      statusText: upstreamResponse.statusText,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type":
+          upstreamResponse.headers.get("content-type") || "text/plain",
+      },
+    });
+  }
+
+  if (!upstreamResponse.body) {
+    return NextResponse.json(
+      { error: "Report response did not include a readable body." },
+      { status: 502, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: buildDownloadHeaders(upstreamResponse.headers, scanId),
+  });
+}

--- a/ui/app/api/scans/[scanId]/report/route.ts
+++ b/ui/app/api/scans/[scanId]/report/route.ts
@@ -40,12 +40,14 @@ const buildDownloadHeaders = (upstreamHeaders: Headers, scanId: string) => {
 };
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: ScanReportRouteContext,
 ) {
   const { scanId } = await params;
   const headers = await getAuthHeaders({ contentType: false });
   const upstreamUrl = `${apiBaseUrl}/scans/${encodeURIComponent(scanId)}/report`;
+  const isPreflight =
+    new URL(request.url).searchParams.get("preflight") === "1";
 
   const upstreamResponse = await fetch(upstreamUrl, {
     headers,
@@ -70,6 +72,14 @@ export async function GET(
         "Content-Type":
           upstreamResponse.headers.get("content-type") || "text/plain",
       },
+    });
+  }
+
+  if (isPreflight) {
+    await upstreamResponse.body?.cancel();
+    return new Response(null, {
+      status: 204,
+      headers: { "Cache-Control": "no-store" },
     });
   }
 

--- a/ui/components/resources/table/resource-detail-content.test.ts
+++ b/ui/components/resources/table/resource-detail-content.test.ts
@@ -30,7 +30,9 @@ describe("resource detail content", () => {
   it("renders the external resource link below the resource title row", () => {
     expect(source).toContain(`</div>
           <ExternalResourceLink`);
-    expect(source).toContain('className="self-start justify-start"');
+    expect(source).toMatch(
+      /className="(?:self-start justify-start|justify-start self-start)"/,
+    );
   });
 
   it("keeps resource date fields together on the third details row", () => {

--- a/ui/lib/helper.test.ts
+++ b/ui/lib/helper.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { downloadScanZip } from "./helper";
+
+vi.mock("@/actions/scans", () => ({
+  getComplianceCsv: vi.fn(),
+  getCompliancePdfReport: vi.fn(),
+}));
+
+vi.mock("@/actions/task", () => ({
+  getTask: vi.fn(),
+}));
+
+vi.mock("@/auth.config", () => ({
+  auth: vi.fn(),
+}));
+
+const createToast = () => vi.fn();
+
+const getAnchor = () => {
+  const anchor = document.createElement("a");
+  const clickMock = vi.spyOn(anchor, "click").mockImplementation(() => {});
+  vi.spyOn(document, "createElement").mockReturnValue(anchor);
+  return { anchor, clickMock };
+};
+
+describe("downloadScanZip", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.replaceChildren();
+  });
+
+  it("preflights the report and starts a browser-native download when ready", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+    );
+    const { anchor, clickMock } = getAnchor();
+    const toast = createToast();
+
+    await downloadScanZip("scan-123", toast);
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/scans/scan-123/report?preflight=1",
+      {
+        cache: "no-store",
+      },
+    );
+    expect(anchor.href).toContain("/api/scans/scan-123/report");
+    expect(anchor.download).toBe("scan-scan-123-report.zip");
+    expect(clickMock).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith({
+      title: "Download Started",
+      description: "Your browser is downloading the scan report.",
+    });
+  });
+
+  it("shows the pending report message without starting a download", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("{}", { status: 202 })),
+    );
+    const { clickMock } = getAnchor();
+    const toast = createToast();
+
+    await downloadScanZip("scan-123", toast);
+
+    expect(clickMock).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: "The report is still being generated",
+      description: "Please try again in a few minutes.",
+    });
+  });
+
+  it("shows an error without starting a download when preflight fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("not found", { status: 404 })),
+    );
+    const { clickMock } = getAnchor();
+    const toast = createToast();
+
+    await downloadScanZip("scan-123", toast);
+
+    expect(clickMock).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "Download Failed",
+      description: "not found",
+    });
+  });
+});

--- a/ui/lib/helper.ts
+++ b/ui/lib/helper.ts
@@ -1,7 +1,6 @@
 import {
   getComplianceCsv,
   getCompliancePdfReport,
-  getExportsZip,
   type ScanBinaryResult,
 } from "@/actions/scans";
 import { getTask } from "@/actions/task";
@@ -106,44 +105,17 @@ export const downloadScanZip = async (
   scanId: string,
   toast: ReturnType<typeof useToast>["toast"],
 ) => {
-  const result = await getExportsZip(scanId);
+  const a = document.createElement("a");
+  a.href = `/api/scans/${encodeURIComponent(scanId)}/report`;
+  a.download = `scan-${scanId}-report.zip`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
 
-  if (result?.pending) {
-    toast({
-      title: "The report is still being generated",
-      description: "Please try again in a few minutes.",
-    });
-    return;
-  }
-
-  if (result?.success && result.data) {
-    const binaryString = window.atob(result.data);
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
-
-    const blob = new Blob([bytes], { type: "application/zip" });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = result.filename;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    window.URL.revokeObjectURL(url);
-
-    toast({
-      title: "Download Complete",
-      description: "Your scan report has been downloaded successfully.",
-    });
-  } else {
-    toast({
-      variant: "destructive",
-      title: "Download Failed",
-      description: result?.error || "An unknown error occurred.",
-    });
-  }
+  toast({
+    title: "Download Started",
+    description: "Your browser is downloading the scan report.",
+  });
 };
 
 /**

--- a/ui/lib/helper.ts
+++ b/ui/lib/helper.ts
@@ -105,8 +105,41 @@ export const downloadScanZip = async (
   scanId: string,
   toast: ReturnType<typeof useToast>["toast"],
 ) => {
+  const reportUrl = `/api/scans/${encodeURIComponent(scanId)}/report`;
+
+  try {
+    const preflightResponse = await fetch(`${reportUrl}?preflight=1`, {
+      cache: "no-store",
+    });
+
+    if (preflightResponse.status === 202) {
+      toast({
+        title: "The report is still being generated",
+        description: "Please try again in a few minutes.",
+      });
+      return;
+    }
+
+    if (!preflightResponse.ok) {
+      const errorMessage = await preflightResponse.text();
+      toast({
+        variant: "destructive",
+        title: "Download Failed",
+        description: errorMessage || "An unknown error occurred.",
+      });
+      return;
+    }
+  } catch (_error) {
+    toast({
+      variant: "destructive",
+      title: "Download Failed",
+      description: "Unable to start the report download. Please try again.",
+    });
+    return;
+  }
+
   const a = document.createElement("a");
-  a.href = `/api/scans/${encodeURIComponent(scanId)}/report`;
+  a.href = reportUrl;
   a.download = `scan-${scanId}-report.zip`;
   document.body.appendChild(a);
   a.click();


### PR DESCRIPTION
### Context

Large scan report ZIPs can exceed browser and Server Action memory limits. The previous UI path fetched the report through a Server Action, buffered the entire response with `arrayBuffer()`, serialized it as base64, decoded it in the browser, and created a `Blob` before downloading. Reports can be several GB, so that flow is not viable.

### Description

- Add a Next.js Route Handler at `/api/scans/[scanId]/report` that proxies the authenticated API report endpoint and streams the upstream response body directly to the browser.
- Update scan ZIP downloads to use browser-native navigation to the streaming route instead of buffering report bytes in a Server Action.
- Add unit coverage for streaming successful responses and preserving pending `202` report-generation responses.

### Steps to review

1. Review `ui/app/api/scans/[scanId]/report/route.ts` and confirm the successful response returns `new Response(upstreamResponse.body, ...)` without `arrayBuffer()`, `blob()`, or base64 conversion.
2. Review `ui/lib/helper.ts` and confirm `downloadScanZip()` points the browser at `/api/scans/${scanId}/report`.
3. Run UI validation:
   ```bash
   cd ui
   pnpm vitest run 'app/api/scans/[scanId]/report/route.test.ts'
   pnpm run typecheck
   ```
4. From the Scans table, download a completed scan report and confirm the browser starts a ZIP download.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. **N/A — `no-changelog` label applies.**

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? N/A.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. N/A — no new dependencies.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) N/A — download plumbing change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) N/A.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) N/A.
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. **N/A — `no-changelog` label applies.**

#### API
- [ ] All issue/task requirements work as expected on the API N/A — no API changes.
- [ ] Endpoint response output (if applicable) N/A.
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) N/A.
- [ ] Performance test results (if applicable) N/A.
- [ ] Any other relevant evidence of the implementation (if applicable) N/A.
- [ ] Verify if API specs need to be regenerated. N/A.
- [ ] Check if version updates are required (e.g., specs, uv, etc.). N/A.
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. N/A.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

