### PR TITLE
fix(gcp): match enable-oslogin metadata case-insensitively

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
+## [5.28.1] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- `compute_project_os_login_enabled` and `compute_project_os_login_2fa_enabled` checks for GCP provider no longer false-FAIL on projects where the `enable-oslogin` / `enable-oslogin-2fa` metadata is not set explicitly but is inherited automatically from the `constraints/compute.requireOsLogin` org policy. The policy controller writes the inherited value in lowercase (`"true"`), but the service-layer parser compared it to the uppercase string literal `"TRUE"`. Comparison is now case-insensitive [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
+
+---
+
 ## [5.28.0] (Prowler v5.28.0)
 
 ### 🚀 Added

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### 🐞 Fixed
 
-- `compute_project_os_login_enabled` and `compute_project_os_login_2fa_enabled` checks for GCP provider no longer false-FAIL on projects where the `enable-oslogin` / `enable-oslogin-2fa` metadata is not set explicitly but is inherited automatically from the `constraints/compute.requireOsLogin` org policy. The policy controller writes the inherited value in lowercase (`"true"`), but the service-layer parser compared it to the uppercase string literal `"TRUE"`. Comparison is now case-insensitive [(#XXXX)](https://github.com/prowler-cloud/prowler/pull/XXXX)
+- `compute_project_os_login_enabled` and `compute_project_os_login_2fa_enabled` checks for GCP provider no longer false-FAIL on projects where the `enable-oslogin` / `enable-oslogin-2fa` metadata is not set explicitly but is inherited automatically from the `constraints/compute.requireOsLogin` org policy. The policy controller writes the inherited value in lowercase (`"true"`), but the service-layer parser compared it to the uppercase string literal `"TRUE"`. Comparison is now case-insensitive [(#11341)](https://github.com/prowler-cloud/prowler/pull/11341)
 
 ---
 

--- a/prowler/providers/gcp/services/compute/compute_service.py
+++ b/prowler/providers/gcp/services/compute/compute_service.py
@@ -87,9 +87,15 @@ class Compute(GCPService):
                     .execute(num_retries=DEFAULT_RETRY_ATTEMPTS)
                 )
                 for item in response["commonInstanceMetadata"].get("items", []):
-                    if item["key"] == "enable-oslogin" and item["value"] == "TRUE":
+                    if (
+                        item["key"] == "enable-oslogin"
+                        and item["value"].lower() == "true"
+                    ):
                         enable_oslogin = True
-                    if item["key"] == "enable-oslogin-2fa" and item["value"] == "TRUE":
+                    if (
+                        item["key"] == "enable-oslogin-2fa"
+                        and item["value"].lower() == "true"
+                    ):
                         enable_oslogin_2fa = True
                 self.compute_projects.append(
                     Project(

--- a/tests/providers/gcp/gcp_fixtures.py
+++ b/tests/providers/gcp/gcp_fixtures.py
@@ -126,7 +126,11 @@ def mock_api_projects_calls(client: MagicMock):
         "etag": "BwWWja0YfJA=",
         "version": 3,
     }
-    # Used by compute client and cloudresourcemanager
+    # Used by compute client and cloudresourcemanager.
+    # `enable-oslogin` covers the documented uppercase form (TRUE);
+    # `enable-oslogin-2fa` covers the lowercase form (true) that GCP's
+    # `constraints/compute.requireOsLogin` org-policy controller writes
+    # in production. The service-layer parser must handle both casings.
     client.projects().get().execute.return_value = {
         "projectNumber": "123456789012",
         "commonInstanceMetadata": {
@@ -138,6 +142,10 @@ def mock_api_projects_calls(client: MagicMock):
                 {
                     "key": "enable-oslogin",
                     "value": "FALSE",
+                },
+                {
+                    "key": "enable-oslogin-2fa",
+                    "value": "true",
                 },
                 {
                     "key": "testing-key",

--- a/tests/providers/gcp/services/compute/compute_service_test.py
+++ b/tests/providers/gcp/services/compute/compute_service_test.py
@@ -34,6 +34,7 @@ class TestComputeService:
             assert len(compute_client.compute_projects) == 1
             assert compute_client.compute_projects[0].id == GCP_PROJECT_ID
             assert compute_client.compute_projects[0].enable_oslogin
+            assert compute_client.compute_projects[0].enable_oslogin_2fa
 
             assert len(compute_client.instances) == 2
             assert compute_client.instances[0].name == "instance1"


### PR DESCRIPTION
### Context

Fixes #11340.

The `compute_project_os_login_enabled` and `compute_project_os_login_2fa_enabled` GCP checks false-FAIL for every project under an organization that enforces `constraints/compute.requireOsLogin` — which is the documented CIS-aligned posture and the pattern the official [`terraform-example-foundation`](https://github.com/terraform-google-modules/terraform-example-foundation/blob/master/1-org/envs/shared/org_policy.tf) blueprint applies. Investigation in #11340 isolated the mechanism: when the org policy is enforced, GCP's org-policy controller auto-populates the `enable-oslogin` (and `enable-oslogin-2fa`) project metadata with the lowercase canonical value `"true"`. Prowler's service-layer parser compared it to the uppercase string literal `"TRUE"`, so the comparison never matched.

### Description

`prowler/providers/gcp/services/compute/compute_service.py` — switch both metadata-value comparisons to `item["value"].lower() == "true"`. This matches:

- The lowercase form the policy controller writes (dominant production case under CIS-aligned posture).
- The documented uppercase form `TRUE` from the GCP OS Login docs.
- Any mixed-case value third-party tooling might emit.

The check-level tests already pass because they construct `Project(enable_oslogin=True)` directly, bypassing the buggy service-layer parser. Regression coverage is added at the service layer:

- `tests/providers/gcp/gcp_fixtures.py` — the shared `mock_api_projects_calls` fixture now includes an `enable-oslogin-2fa` metadata item with the lowercase value `"true"`, mirroring what GCP actually returns under the org policy.
- `tests/providers/gcp/services/compute/compute_service_test.py` — adds an assertion that `Project.enable_oslogin_2fa` is `True` under the lowercase fixture. Without the fix, this assertion fails.

The fixture's existing `enable-oslogin: "TRUE"` entry is preserved so the documented uppercase form stays covered alongside the lowercase regression case.

### Steps to review

1. Re-read the comparison in `compute_service.py` (now lines 89-100) against the empirical determination in #11340 — the lowercase value is the policy controller's canonical form, not generic API normalization (case is preserved for any other metadata write).
2. Confirm the test fixture's new `enable-oslogin-2fa: "true"` entry matches the lowercase form documented in the issue.
3. Run the touched tests locally:

   ```
   uv run pytest \
     tests/providers/gcp/services/compute/compute_service_test.py \
     tests/providers/gcp/services/compute/compute_project_os_login_enabled/ \
     tests/providers/gcp/services/compute/compute_project_os_login_2fa_enabled/ \
     -v
   ```

   All 12 tests pass.

4. Full GCP suite stays green (546 tests).

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI

- Are there new checks included in this PR? No.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
