### PR TITLE
fix(ui): avoid report preflight timeouts

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.28.2] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Scan report downloads no longer fail when the readiness preflight times out or returns an HTML gateway error page [(#11350)](https://github.com/prowler-cloud/prowler/pull/11350)
+
+---
+
 ## [1.28.1] (Prowler v5.28.1)
 
 ### 🐞 Fixed

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.28.2] (Prowler UNRELEASED)
-
-### 🐞 Fixed
-
-- Scan report downloads no longer fail when the readiness preflight times out or returns an HTML gateway error page [(#11350)](https://github.com/prowler-cloud/prowler/pull/11350)
-
----
-
 ## [1.28.1] (Prowler v5.28.1)
 
 ### 🐞 Fixed

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.28.2] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Scan report downloads no longer fail when the readiness preflight times out or returns an HTML gateway error page [(#11349)](https://github.com/prowler-cloud/prowler/pull/11349)
+
+---
+
 ## [1.28.1] (Prowler v5.28.1)
 
 ### 🐞 Fixed

--- a/ui/app/api/scans/[scanId]/report/route.test.ts
+++ b/ui/app/api/scans/[scanId]/report/route.test.ts
@@ -45,6 +45,7 @@ describe("GET /api/scans/[scanId]/report", () => {
       expect.objectContaining({
         headers: { Authorization: "Bearer token" },
         cache: "no-store",
+        redirect: "manual",
       }),
     );
     expect(response.status).toBe(200);
@@ -80,6 +81,56 @@ describe("GET /api/scans/[scanId]/report", () => {
     expect(response.status).toBe(204);
     expect(response.body).toBeNull();
     expect(cancelMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("redirects the browser to the presigned URL for S3-backed reports", async () => {
+    const presignedUrl = "https://bucket.s3.example.com/report.zip?sig=abc";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: presignedUrl },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+
+    const response = await GET(new Request("http://localhost/api"), {
+      params: Promise.resolve({ scanId: "scan-123" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/v1/scans/scan-123/report",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(presignedUrl);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.body).toBeNull();
+  });
+
+  it("reports readiness without exposing the presigned URL on preflight", async () => {
+    const presignedUrl = "https://bucket.s3.example.com/report.zip?sig=abc";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: { location: presignedUrl },
+        }),
+      ),
+    );
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+
+    const response = await GET(
+      new Request("http://localhost/api?preflight=1"),
+      {
+        params: Promise.resolve({ scanId: "scan-123" }),
+      },
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.body).toBeNull();
   });
 
   it("preserves pending report responses from the API", async () => {

--- a/ui/app/api/scans/[scanId]/report/route.test.ts
+++ b/ui/app/api/scans/[scanId]/report/route.test.ts
@@ -100,4 +100,52 @@ describe("GET /api/scans/[scanId]/report", () => {
     expect(response.status).toBe(202);
     await expect(response.json()).resolves.toEqual({ data: { id: "task-1" } });
   });
+
+  it("continues to the browser-native download when preflight times out", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("Timed out", "TimeoutError")),
+    );
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+
+    const response = await GET(
+      new Request("http://localhost/api?preflight=1"),
+      {
+        params: Promise.resolve({ scanId: "scan-123" }),
+      },
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("does not forward upstream HTML error pages for preflight failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          "<html><body><h1>504 Gateway Time-out</h1></body></html>",
+          {
+            status: 504,
+            headers: { "content-type": "text/html" },
+          },
+        ),
+      ),
+    );
+    getAuthHeadersMock.mockResolvedValue({ Authorization: "Bearer token" });
+
+    const response = await GET(
+      new Request("http://localhost/api?preflight=1"),
+      {
+        params: Promise.resolve({ scanId: "scan-123" }),
+      },
+    );
+
+    expect(response.status).toBe(504);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    await expect(response.text()).resolves.toBe(
+      "Unable to prepare the scan report. Please try again in a few minutes.",
+    );
+  });
 });

--- a/ui/app/api/scans/[scanId]/report/route.ts
+++ b/ui/app/api/scans/[scanId]/report/route.ts
@@ -18,6 +18,10 @@ const COPY_RESPONSE_HEADERS = [
   "last-modified",
 ] as const;
 
+const PREFLIGHT_TIMEOUT_MS = 10_000;
+const REPORT_PREPARATION_ERROR =
+  "Unable to prepare the scan report. Please try again in a few minutes.";
+
 const buildAttachmentFilename = (scanId: string) =>
   `scan-${scanId.replace(/[^a-zA-Z0-9._-]/g, "-")}-report.zip`;
 
@@ -39,6 +43,19 @@ const buildDownloadHeaders = (upstreamHeaders: Headers, scanId: string) => {
   return headers;
 };
 
+const isAbortError = (error: unknown) =>
+  error instanceof DOMException &&
+  (error.name === "AbortError" || error.name === "TimeoutError");
+
+const isHtmlResponse = (headers: Headers) =>
+  headers.get("content-type")?.toLowerCase().includes("text/html") ?? false;
+
+const preflightReadyResponse = () =>
+  new Response(null, {
+    status: 204,
+    headers: { "Cache-Control": "no-store" },
+  });
+
 export async function GET(
   request: Request,
   { params }: ScanReportRouteContext,
@@ -49,10 +66,23 @@ export async function GET(
   const isPreflight =
     new URL(request.url).searchParams.get("preflight") === "1";
 
-  const upstreamResponse = await fetch(upstreamUrl, {
-    headers,
-    cache: "no-store",
-  });
+  let upstreamResponse: Response;
+
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      headers,
+      cache: "no-store",
+      signal: isPreflight
+        ? AbortSignal.timeout(PREFLIGHT_TIMEOUT_MS)
+        : undefined,
+    });
+  } catch (error) {
+    if (isPreflight && isAbortError(error)) {
+      return preflightReadyResponse();
+    }
+
+    throw error;
+  }
 
   if (upstreamResponse.status === 202) {
     const body = await upstreamResponse.json().catch(() => ({}));
@@ -63,24 +93,27 @@ export async function GET(
   }
 
   if (!upstreamResponse.ok) {
-    const body = await upstreamResponse.text().catch(() => "");
+    const body =
+      isPreflight && isHtmlResponse(upstreamResponse.headers)
+        ? REPORT_PREPARATION_ERROR
+        : await upstreamResponse.text().catch(() => "");
+
     return new Response(body, {
       status: upstreamResponse.status,
       statusText: upstreamResponse.statusText,
       headers: {
         "Cache-Control": "no-store",
         "Content-Type":
-          upstreamResponse.headers.get("content-type") || "text/plain",
+          isPreflight && isHtmlResponse(upstreamResponse.headers)
+            ? "text/plain"
+            : upstreamResponse.headers.get("content-type") || "text/plain",
       },
     });
   }
 
   if (isPreflight) {
     await upstreamResponse.body?.cancel();
-    return new Response(null, {
-      status: 204,
-      headers: { "Cache-Control": "no-store" },
-    });
+    return preflightReadyResponse();
   }
 
   if (!upstreamResponse.body) {

--- a/ui/app/api/scans/[scanId]/report/route.ts
+++ b/ui/app/api/scans/[scanId]/report/route.ts
@@ -50,6 +50,8 @@ const isAbortError = (error: unknown) =>
 const isHtmlResponse = (headers: Headers) =>
   headers.get("content-type")?.toLowerCase().includes("text/html") ?? false;
 
+const isRedirect = (status: number) => status >= 300 && status < 400;
+
 const preflightReadyResponse = () =>
   new Response(null, {
     status: 204,
@@ -72,6 +74,10 @@ export async function GET(
     upstreamResponse = await fetch(upstreamUrl, {
       headers,
       cache: "no-store",
+      // The API redirects S3-backed reports to a presigned URL; keep that
+      // redirect instead of following it so the bytes never stream through
+      // this server.
+      redirect: "manual",
       signal: isPreflight
         ? AbortSignal.timeout(PREFLIGHT_TIMEOUT_MS)
         : undefined,
@@ -89,6 +95,27 @@ export async function GET(
     return NextResponse.json(body, {
       status: 202,
       headers: { "Cache-Control": "no-store" },
+    });
+  }
+
+  // S3-backed reports: hand the API's presigned redirect to the browser so it
+  // downloads straight from S3 without proxying the bytes through this server.
+  if (isRedirect(upstreamResponse.status)) {
+    if (isPreflight) {
+      return preflightReadyResponse();
+    }
+
+    const location = upstreamResponse.headers.get("location");
+    if (!location) {
+      return NextResponse.json(
+        { error: "Report redirect did not include a location." },
+        { status: 502, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    return new Response(null, {
+      status: 307,
+      headers: { Location: location, "Cache-Control": "no-store" },
     });
   }
 
@@ -111,6 +138,8 @@ export async function GET(
     });
   }
 
+  // Self-hosted without S3: the API returns the bytes directly, so there is no
+  // presigned URL to redirect to and we stream the response through instead.
   if (isPreflight) {
     await upstreamResponse.body?.cancel();
     return preflightReadyResponse();

--- a/ui/lib/helper.test.ts
+++ b/ui/lib/helper.test.ts
@@ -90,4 +90,31 @@ describe("downloadScanZip", () => {
       description: "not found",
     });
   });
+
+  it("shows a generic error when preflight fails with an HTML gateway page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          "<html><body><h1>504 Gateway Time-out</h1></body></html>",
+          {
+            status: 504,
+            headers: { "content-type": "text/html" },
+          },
+        ),
+      ),
+    );
+    const { clickMock } = getAnchor();
+    const toast = createToast();
+
+    await downloadScanZip("scan-123", toast);
+
+    expect(clickMock).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      variant: "destructive",
+      title: "Download Failed",
+      description:
+        "Unable to prepare the scan report. Please try again in a few minutes.",
+    });
+  });
 });

--- a/ui/lib/helper.ts
+++ b/ui/lib/helper.ts
@@ -101,6 +101,19 @@ export const getAuthUrl = (provider: AuthSocialProvider) => {
   return url.toString();
 };
 
+const REPORT_PREPARATION_ERROR =
+  "Unable to prepare the scan report. Please try again in a few minutes.";
+
+const getPreflightErrorMessage = async (response: Response) => {
+  const contentType = response.headers.get("content-type")?.toLowerCase() || "";
+
+  if (contentType.includes("text/html")) {
+    return REPORT_PREPARATION_ERROR;
+  }
+
+  return (await response.text()) || "An unknown error occurred.";
+};
+
 export const downloadScanZip = async (
   scanId: string,
   toast: ReturnType<typeof useToast>["toast"],
@@ -121,11 +134,10 @@ export const downloadScanZip = async (
     }
 
     if (!preflightResponse.ok) {
-      const errorMessage = await preflightResponse.text();
       toast({
         variant: "destructive",
         title: "Download Failed",
-        description: errorMessage || "An unknown error occurred.",
+        description: await getPreflightErrorMessage(preflightResponse),
       });
       return;
     }


### PR DESCRIPTION
### Context

Some large scan report downloads fail in Chrome/staging before the browser-native download starts. The failing request is the readiness preflight (`/api/scans/{scanId}/report?preflight=1`), which can receive an infrastructure `504 Gateway Time-out` HTML page and currently surfaces that raw HTML to users.

### Description

- Bound scan report preflight requests with a short timeout so a slow readiness check does not block the browser-native download.
- Continue to the download when the preflight times out, preserving the existing prompt `202` pending behavior when the API responds quickly.
- Sanitize HTML gateway error pages during preflight on both the route handler and client helper.
- Add regression tests for preflight timeout and HTML gateway error handling.
- Add a `1.28.2` unreleased UI changelog entry for the hotfix.

### Steps to review

1. Review `ui/app/api/scans/[scanId]/report/route.ts` and confirm `?preflight=1` has bounded upstream wait and returns `204` on timeout.
2. Confirm upstream `202` responses still return the pending response.
3. Confirm HTML `504` pages are not forwarded/displayed as raw toast content.
4. Run UI validation:
   ```bash
   cd ui
   pnpm vitest run 'app/api/scans/[scanId]/report/route.test.ts' 'lib/helper.test.ts'
   pnpm run typecheck
   ```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed. Backport will be created after this merges.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) N/A.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. N/A — UI changelog only.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? N/A.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) N/A — download plumbing change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) N/A — download plumbing change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) N/A — download plumbing change.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API N/A — no API changes.
- [ ] Endpoint response output (if applicable) N/A.
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) N/A.
- [ ] Performance test results (if applicable) N/A.
- [ ] Any other relevant evidence of the implementation (if applicable) N/A.
- [ ] Verify if API specs need to be regenerated. N/A.
- [ ] Check if version updates are required (e.g., specs, uv, etc.). N/A.
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. N/A.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.