### PR TITLE
fix(mcp_server): preserve authorization header in HTTP mode

### DIFF
--- a/mcp_server/CHANGELOG.md
+++ b/mcp_server/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler MCP Server** are documented in this file.
 
+## [0.7.2] (Prowler v5.28.1)
+
+### 🐞 Fixed
+
+- Preserve authorization header in HTTP mode [(#11366)](https://github.com/prowler-cloud/prowler/pull/11366)
+
+---
+
 ## [0.7.1] (Prowler v5.28.0)
 
 ### 🔐 Security
@@ -43,6 +51,8 @@ All notable changes to the **Prowler MCP Server** are documented in this file.
 ### 🚀 Added
 
 - Attack Path tool to get Neo4j DB schema [(#10321)](https://github.com/prowler-cloud/prowler/pull/10321)
+
+---
 
 ## [0.4.0] (Prowler v5.19.0)
 

--- a/mcp_server/prowler_mcp_server/prowler_app/utils/auth.py
+++ b/mcp_server/prowler_mcp_server/prowler_app/utils/auth.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Dict, Optional
 
 from fastmcp.server.dependencies import get_http_headers
+
 from prowler_mcp_server import __version__
 from prowler_mcp_server.lib.logger import logger
 
@@ -68,7 +69,7 @@ class ProwlerAppAuth:
     async def authenticate(self) -> str:
         """Authenticate and return token (API key for STDIO, API key or JWT for HTTP)."""
         if self.mode == "http":
-            headers = get_http_headers()
+            headers = get_http_headers(include={"authorization"})
             authorization_header = headers.get("authorization", None)
 
             if not authorization_header:


### PR DESCRIPTION
### Context

After bumping `fastmcp` from 2.14.0 to 3.2.4 in #4317, every authenticated call to the MCP server in HTTP mode started failing with `ValueError: No authorization header provided`. FastMCP 3.2.4 added `authorization` to the default exclusion set of `get_http_headers()` (see `fastmcp/server/dependencies.py:442`), so the bearer token sent by the lighthouse agent (and any other HTTP client) was being filtered out before reaching the auth flow.

### Description

Pass `include={"authorization"}` to `get_http_headers()` so the authorization header survives the default exclusion and reaches `ProwlerAppAuth.authenticate()`.

### Steps to review

1. Read the change in `mcp_server/prowler_mcp_server/prowler_app/utils/auth.py`.
2. Run the MCP server in HTTP mode and call any authenticated tool (e.g. `prowler_app_get_mutelist`) with a valid `Authorization: Bearer <token>` header — it should now succeed instead of raising `No authorization header provided`.
3. Confirm STDIO mode is unaffected (the `mode == "http"` branch is the only change).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.