### PR TITLE
fix(compliance/ens): remap resilience VPC checks out of mp.com.4

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### 🐞 Fixed
 
-- ENS RD 311/2022 (AWS) compliance mapping: `vpc_different_regions` and `vpc_subnet_different_az` were mapped under the `mp.com.4` family (Network segregation), but their `Categories` is `resilience` and they measure multi-region/multi-AZ availability, not network segmentation. Both checks are now mapped to a new `op.cont.2.aws.vpc.1` requirement under the Continuity of Service control [(#PRNUM)](https://github.com/prowler-cloud/prowler/pull/PRNUM)
+- ENS RD 311/2022 (AWS) compliance mapping: `vpc_different_regions` and `vpc_subnet_different_az` were mapped under the `mp.com.4` family (Network segregation), but their `Categories` is `resilience` and they measure multi-region/multi-AZ availability, not network segmentation. Both checks are now mapped to a new `op.cont.2.aws.vpc.1` requirement under the Continuity of Service control [(#11372)](https://github.com/prowler-cloud/prowler/pull/11372)
 
 ---
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - AWS AI Security Framework compliance for AWS provider [(#11353)](https://github.com/prowler-cloud/prowler/pull/11353)
 - `storage_account_public_network_access_disabled` check for Azure provider and remapped the Azure CIS "Public Network Access is Disabled" requirements to it [(#11334)](https://github.com/prowler-cloud/prowler/pull/11334)
 
+### 🐞 Fixed
+
+- ENS RD 311/2022 (AWS) compliance mapping: `vpc_different_regions` and `vpc_subnet_different_az` were mapped under the `mp.com.4` family (Network segregation), but their `Categories` is `resilience` and they measure multi-region/multi-AZ availability, not network segmentation. Both checks are now mapped to a new `op.cont.2.aws.vpc.1` requirement under the Continuity of Service control [(#PRNUM)](https://github.com/prowler-cloud/prowler/pull/PRNUM)
+
 ---
 
 ## [5.28.1] (Prowler 5.28.1)

--- a/prowler/compliance/aws/ens_rd2022_aws.json
+++ b/prowler/compliance/aws/ens_rd2022_aws.json
@@ -2539,8 +2539,7 @@
         }
       ],
       "Checks": [
-        "vpc_subnet_separate_private_public",
-        "vpc_different_regions"
+        "vpc_subnet_separate_private_public"
       ]
     },
     {
@@ -2592,10 +2591,7 @@
           ]
         }
       ],
-      "Checks": [
-        "vpc_subnet_different_az",
-        "vpc_different_regions"
-      ]
+      "Checks": []
     },
     {
       "Id": "mp.si.2.aws.kms.1",
@@ -4261,6 +4257,29 @@
         }
       ],
       "Checks": []
+    },
+    {
+      "Id": "op.cont.2.aws.vpc.1",
+      "Description": "Plan de continuidad",
+      "Attributes": [
+        {
+          "IdGrupoControl": "op.cont.2",
+          "Marco": "operacional",
+          "Categoria": "continuidad del servicio",
+          "DescripcionControl": "Distribución de las VPCs entre múltiples regiones y zonas de disponibilidad de AWS para garantizar la continuidad del servicio ante fallos regionales o zonales.",
+          "Nivel": "alto",
+          "Tipo": "requisito",
+          "Dimensiones": [
+            "disponibilidad"
+          ],
+          "ModoEjecucion": "automático",
+          "Dependencias": []
+        }
+      ],
+      "Checks": [
+        "vpc_different_regions",
+        "vpc_subnet_different_az"
+      ]
     },
     {
       "Id": "op.cont.3.aws.drs.1",


### PR DESCRIPTION
### Context

The ENS RD 311/2022 (AWS) compliance framework shipped in `prowler/compliance/aws/ens_rd2022_aws.json` maps two resilience checks (`vpc_different_regions` and `vpc_subnet_different_az`) under the `mp.com.4` family (Network segregation, Anexo II of RD 311/2022), but those checks measure multi-region/multi-AZ availability, not network segmentation. This causes ENS reports to incorrectly grade the **MP.COM.4 — "Segregación de redes"** control based on geographic distribution of VPCs rather than on actual traffic/trust-zone segmentation.

Fix #11371

### Description

This PR corrects the mismapping by:

1. **Removing** `vpc_different_regions` from `mp.com.4.r1.aws.vpc.1` (Segmentación lógica avanzada). The remaining check, `vpc_subnet_separate_private_public` (`Categories: ["trust-boundaries"]`), is correctly aligned with the control and is preserved.
2. **Removing** `vpc_different_regions` and `vpc_subnet_different_az` from `mp.com.4.r3.aws.vpc.1` (Segmentación física). The requirement is left with `Checks: []`, matching the existing pattern in the file for refinements that do not yet have an automated check (see e.g. `op.cont.2.aws.az.1`, `op.mon.1.aws.gd.4`, `mp.com.2.aws.vpn.1`).
3. **Adding** a new requirement `op.cont.2.aws.vpc.1` (Plan de continuidad, `ModoEjecucion: automático`, `Dimensiones: ["disponibilidad"]`, `Checks: ["vpc_different_regions", "vpc_subnet_different_az"]`). It coexists with the pre-existing `op.cont.2.aws.az.1` under the same `IdGrupoControl: op.cont.2`, following the same `<ENS_id>.aws.<service>.<seq>` pattern used elsewhere in this file (e.g. `op.acc.1.aws.iam.2`). The existing `op.cont.2.aws.az.1` requirement is left untouched.

The new requirement's `DescripcionControl` is: *"Distribución de las VPCs entre múltiples regiones y zonas de disponibilidad de AWS para garantizar la continuidad del servicio ante fallos regionales o zonales."*

#### Why this is the right mapping

- Check metadata (`prowler/providers/aws/services/vpc/vpc_different_regions/vpc_different_regions.metadata.json`):
  - `"Categories": ["resilience"]`
  - `"CheckType"` includes `"Effects/Denial of Service"`
  - `Risk` field reads: *"Single-region VPC deployment weakens **availability** and **resilience** [...] hinder recovery, and increase the **blast radius** of incidents impacting business continuity."*
- Same shape for `vpc_subnet_different_az` (`Categories: ["resilience"]`, multi-AZ HA).
- Anexo II of RD 311/2022 defines **MP.COM.4** as the control for *network segregation* by criticality and function (DMZ, trust zones, management traffic isolation). Its reinforcements (R1 logical, R2 logical+VPN, R3 physical) are about isolating traffic, not about geographic redundancy.
- Anexo II of RD 311/2022 defines **OP.CONT** as the control family for *continuity of service*. The existing `op.cont.2.aws.az.1` requirement already states its control description verbatim: *"Deberá implementarse correctamente la distribución de servicios según regiones y zonas de disponibilidad para limitar al máximo los riesgos asociados a una única ubicación."*

#### References

- Real Decreto 311/2022 (BOE-A-2022-7191), Anexo II: <https://www.boe.es/buscar/act.php?id=BOE-A-2022-7191>
- Prowler Hub:
  - <https://hub.prowler.com/check/vpc_different_regions>
  - <https://hub.prowler.com/check/vpc_subnet_different_az>

### Steps to review

1. Inspect the diff in `prowler/compliance/aws/ens_rd2022_aws.json`. Three localized blocks change: `mp.com.4.r1.aws.vpc.1`, `mp.com.4.r3.aws.vpc.1`, and the newly inserted `op.cont.2.aws.vpc.1` (placed after `op.cont.2.aws.az.1`).
2. Confirm the new requirement's attributes are consistent with `op.cont.2.aws.az.1`: same `IdGrupoControl`, `Marco`, `Categoria`, `Nivel`, `Dimensiones`. `ModoEjecucion` is `automático` here because the new requirement does carry automated checks.
3. Confirm `mp.com.4.r1.aws.vpc.1` still contains `vpc_subnet_separate_private_public` (the correctly-mapped trust-boundary check) and only that one.
4. Confirm `mp.com.4.r3.aws.vpc.1` is left with `Checks: []`, mirroring the empty-checks pattern used by other manual or yet-uncovered requirements.
5. Optionally, validate the file loads cleanly via Prowler's compliance loader (parsed against `prowler/lib/check/compliance_models.py`); the change preserves the schema.
6. Verify the `prowler/CHANGELOG.md` entry under `[5.29.0] (Prowler UNRELEASED) → 🐞 Fixed`. **Reminder:** before merge, replace the placeholder `#PRNUM` with the actual PR number once GitHub assigns one.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com  *(issue [#11371](https://github.com/prowler-cloud/prowler/issues/11371))*
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)  *(N/A — small, self-contained compliance mapping fix; will request assignment from maintainers if they prefer the issue-first flow)*

</details>


- [ ] Review if the code is being covered by tests.  *(N/A — this PR only modifies compliance JSON data and the SDK CHANGELOG. There is no executable code change. The existing compliance-loading machinery (`prowler/lib/check/compliance_models.py`) already validates the schema at load time.)*
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings  *(N/A — no Python code added or modified.)*
- [ ] Review if backport is needed.  *(Discretion of the maintainers. The mismapping has been present in `master` for several minor releases and is also present on the active LTS branches that ship `ens_rd2022_aws.json`. A backport to the current supported `v5.x` branches would benefit ENS-compliant customers; deferring the decision to the release owner.)*
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)  *(N/A — `README.md` does not list individual mappings inside compliance frameworks.)*
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.  *(Added under `[5.29.0] (Prowler UNRELEASED) → 🐞 Fixed`. Contains a `#PRNUM` placeholder that must be replaced with the PR number after opening.)*

#### SDK/CLI
- Are there new checks included in this PR? **No.**
    - If so, do we need to update permissions for the provider? Please review this carefully.  *(N/A — no new checks; no provider permissions are touched.)*

#### UI
- [ ] All issue/task requirements work as expected on the UI  *(N/A — no UI changes.)*
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.  *(N/A — no npm dependencies touched.)*
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)  *(N/A — no UI changes.)*
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)  *(N/A — no UI changes.)*
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)  *(N/A — no UI changes.)*
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.  *(N/A — UI is not affected.)*

#### API
- [ ] All issue/task requirements work as expected on the API  *(N/A — no API changes.)*
- [ ] Endpoint response output (if applicable)  *(N/A — no API endpoints touched.)*
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)  *(N/A — no SQL or DB queries touched.)*
- [ ] Performance test results (if applicable)  *(N/A — no performance-sensitive changes.)*
- [ ] Any other relevant evidence of the implementation (if applicable)  *(N/A.)*
- [ ] Verify if API specs need to be regenerated.  *(N/A — no API specs affected.)*
- [ ] Check if version updates are required (e.g., specs, uv, etc.).  *(N/A — no version bumps or dependency changes.)*
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.  *(N/A — API is not affected.)*

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
