### PR TITLE
docs(skills): strengthen UI review rules

### DIFF
--- a/skills/prowler-ui/SKILL.md
+++ b/skills/prowler-ui/SKILL.md
@@ -79,8 +79,10 @@ Recharts/library?      → CHART_COLORS constant + var()
 
 ### Scope Rule (ABSOLUTE)
 
-- Used 2+ places → `lib/` or `types/` or `hooks/` (components go in `components/{domain}/`)
+- Used by unrelated features → `lib/` or `types/` or `hooks/` (components go in `components/{domain}/`)
+- Used by 2+ files in the same feature/domain → keep it inside that feature/domain, e.g. `_lib/`, `_hooks/`, or local `types.ts`
 - Used 1 place → keep local in feature directory
+- **Feature/domain ownership beats raw usage count**: sharing between sibling files does not automatically make a helper global
 - **This determines ALL folder structure decisions**
 
 ## Project Structure
@@ -241,6 +243,27 @@ import { severityLabel } from "@/types/findings";
 ```
 
 If a helper doesn't exist and will be used in 2+ places, add it to `ui/lib/` or `ui/types/` and reuse it. Keep local only if used in exactly one place.
+
+## Error State Replacement Checklist (REQUIRED)
+
+When replacing UI error-state logic, remove legacy state fields and branches that the new contract can no longer produce.
+
+Before finishing the change, check:
+
+- [ ] Are there flags, union members, buttons, or handlers that are now unreachable?
+- [ ] Does the UI still render an action for an error case the new API contract cannot emit?
+- [ ] Does retry appear only for errors where repeating the same action can help?
+- [ ] Are error mappers matching specific status/code/detail or field pointers rather than broad payload-level pointers?
+- [ ] Are negative tests present for over-broad mapper/type-guard matches?
+
+```typescript
+// ❌ BAD: old branch kept after new mapper never returns needsSignOut
+if (state.needsSignOut) return <SignInWithDifferentAccount />;
+
+// ✅ GOOD: remove unreachable state and render only reachable actions
+{state.canRetry && <Button onClick={retry}>Retry</Button>}
+<Button asChild><Link href="/sign-in">Go to Sign In</Link></Button>
+```
 
 ## Derived State Rule (REQUIRED)
 

--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -102,6 +102,38 @@ function isUser(value: unknown): value is User {
 }
 ```
 
+### Type Guard Tests (REQUIRED)
+
+When adding or changing a type guard or mapper predicate, test both accepted and rejected shapes. A positive test alone often hides over-broad matching.
+
+```typescript
+const ERROR_POINTER = {
+  INVITATION_TOKEN: "/data/attributes/invitation_token",
+} as const;
+
+function isInvitationTokenError(error: ApiError): boolean {
+  return error.source?.pointer === ERROR_POINTER.INVITATION_TOKEN;
+}
+
+it("should identify invitation token errors", () => {
+  expect(
+    isInvitationTokenError({
+      detail: "Invalid invitation code.",
+      source: { pointer: ERROR_POINTER.INVITATION_TOKEN },
+    }),
+  ).toBe(true);
+});
+
+it("should not identify payload-level errors as invitation token errors", () => {
+  expect(
+    isInvitationTokenError({
+      detail: "Invalid request data.",
+      source: { pointer: "/data" },
+    }),
+  ).toBe(false);
+});
+```
+
 ## Coupled Optional Props (REQUIRED)
 
 Do not model semantically coupled props as independent optionals — this allows invalid half-states that compile but break at runtime. Use discriminated unions with `never` to make invalid combinations impossible.


### PR DESCRIPTION
### Context

Follow-up from the review on #11376 / [PROWLER-1770](https://prowlerpro.atlassian.net/browse/PROWLER-1770).

That review surfaced three reusable process gaps in the UI skills: feature-local helper placement, stale UI error branches after contract changes, and missing negative tests for mapper/type-guard predicates.

### Description

This PR strengthens the AI-agent skill guidance so future UI changes catch those issues earlier.

- Clarifies that feature/domain ownership beats raw usage count for helper placement
- Adds a required UI error-state replacement checklist
- Adds TypeScript guidance requiring negative tests for type guards and mapper predicates

### Steps to review

1. Review `skills/prowler-ui/SKILL.md` for the feature-local helper and error-state checklist additions.
2. Review `skills/typescript/SKILL.md` for type guard negative-test guidance.
3. Confirm no generated AGENTS metadata changes are needed because skill metadata was not changed.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This follow-up comes from PR review feedback in #11376 / PROWLER-1770
- [x] Is it assigned to me, if not, request it via the issue/feature in Jira or Prowler Community Slack

</details>


- [x] Review if the code is being covered by tests. Not applicable; documentation-only skill guidance.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings. Not applicable.
- [x] Review if backport is needed. Not needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md). Not needed.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. Not applicable; skill documentation only.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Not applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI. Not applicable; no UI runtime changes.
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. Not applicable; no dependency changes.
- [x] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px). Not applicable.
- [x] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px). Not applicable.
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px). Not applicable.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. Not applicable; skill documentation only.

#### API
- [x] All issue/task requirements work as expected on the API. Not applicable.
- [x] Endpoint response output (if applicable). Not applicable.
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable). Not applicable.
- [x] Performance test results (if applicable). Not applicable.
- [x] Any other relevant evidence of the implementation (if applicable). Not applicable.
- [x] Verify if API specs need to be regenerated. Not applicable.
- [x] Check if version updates are required (e.g., specs, uv, etc.). Not applicable.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


[PROWLER-1770]: https://prowlerpro.atlassian.net/browse/PROWLER-1770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ