### PR TITLE
perf(api): use literal scan_ids in finding-groups /latest aggregation

### DIFF
--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -7483,18 +7483,10 @@ class FindingGroupViewSet(BaseRLSViewSet):
         return finding_params, computed_params
 
     def _get_latest_findings_per_provider(self, filtered_queryset):
-        """Keep only findings from each provider's most recent completed scan.
-
-        The scan ids are resolved into a concrete list rather than left as a
-        subquery: as an inline ``scan_id IN (SELECT DISTINCT ON ...)`` the
-        planner cannot estimate the match count and badly underestimates it,
-        which on a large latest scan picks a serial nested loop into
-        ``resource_finding_mappings`` for ``COUNT(DISTINCT resource_id)``. A
-        literal id list gives an accurate estimate, so the planner switches to a
-        parallel hash join (measured ~3.6x faster when the latest scan holds most
-        findings). Same scan ids, same rows, so this is behaviour-preserving; it
-        costs one extra small indexed lookup of a handful of ids.
-        """
+        """Keep only findings from each provider's most recent completed scan."""
+      # Materialize to a literal IN list. Left as a subquery, Postgres can't
+      # estimate the match count and picks a serial nested loop on
+      # resource_finding_mappings when one scan dominates findings
         latest_scan_ids = list(
             Scan.objects.filter(
                 tenant_id=self.request.tenant_id,

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -7484,9 +7484,9 @@ class FindingGroupViewSet(BaseRLSViewSet):
 
     def _get_latest_findings_per_provider(self, filtered_queryset):
         """Keep only findings from each provider's most recent completed scan."""
-      # Materialize to a literal IN list. Left as a subquery, Postgres can't
-      # estimate the match count and picks a serial nested loop on
-      # resource_finding_mappings when one scan dominates findings
+        # Materialize to a literal IN list. Left as a subquery, Postgres can't
+        # estimate the match count and picks a serial nested loop on
+        # resource_finding_mappings when one scan dominates findings
         latest_scan_ids = list(
             Scan.objects.filter(
                 tenant_id=self.request.tenant_id,

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -7483,15 +7483,26 @@ class FindingGroupViewSet(BaseRLSViewSet):
         return finding_params, computed_params
 
     def _get_latest_findings_per_provider(self, filtered_queryset):
-        """Keep only findings from each provider's most recent completed scan."""
-        latest_scan_ids = (
+        """Keep only findings from each provider's most recent completed scan.
+
+        The scan ids are resolved into a concrete list rather than left as a
+        subquery: as an inline ``scan_id IN (SELECT DISTINCT ON ...)`` the
+        planner cannot estimate the match count and badly underestimates it,
+        which on a large latest scan picks a serial nested loop into
+        ``resource_finding_mappings`` for ``COUNT(DISTINCT resource_id)``. A
+        literal id list gives an accurate estimate, so the planner switches to a
+        parallel hash join (measured ~3.6x faster when the latest scan holds most
+        findings). Same scan ids, same rows, so this is behaviour-preserving; it
+        costs one extra small indexed lookup of a handful of ids.
+        """
+        latest_scan_ids = list(
             Scan.objects.filter(
                 tenant_id=self.request.tenant_id,
                 state=StateChoices.COMPLETED,
             )
             .order_by("provider_id", "-completed_at", "-inserted_at")
             .distinct("provider_id")
-            .values("id")
+            .values_list("id", flat=True)
         )
         return filtered_queryset.filter(scan_id__in=latest_scan_ids)
 


### PR DESCRIPTION
### Context

`GET /api/v1/finding-groups/latest?filter[region__in]=...` was multi-second on tenants where a single latest completed scan held a large share of findings. The finding-level aggregation (`FindingGroupViewSet._aggregate_findings`) restricts to each provider's most recent completed scan via:

```sql
scan_id IN (SELECT DISTINCT ON (provider_id) id FROM scans
            WHERE state='completed' AND tenant_id=...
            ORDER BY provider_id, completed_at DESC, inserted_at DESC)
```

When `latest_scan_ids` was left as a Django QuerySet, this rendered as an inline subquery. Postgres cannot push selectivity statistics through that shape and underestimated the match count badly (estimated ~11k rows vs actual 70k-700k depending on how concentrated the latest scan is). Under that estimate the planner chose a serial Nested Loop into `resource_finding_mappings` for the two `COUNT(DISTINCT resource_id)` and a single ~62 MB external-merge sort on `(check_id, resource_id)`, making the endpoint multi-second whenever a single latest scan held a large share of findings.

### Description

`_get_latest_findings_per_provider` now resolves the scan ids into a concrete Python list before filtering (`list(... .values_list("id", flat=True))`). The main query then emits a literal `scan_id IN (uuid, uuid, ...)`. With an accurate row estimate the planner switches to a Parallel Hash Join and per-worker sorts.

The change is behaviour-preserving: same scan ids, byte-identical 300-group output (verified by md5-equal raw SQL output and the full `TestFindingGroupViewSet` pytest suite, 160/160 passing). The added cost is one extra small indexed lookup of one scan id per provider before the main query runs. Scope is surgical: only the finding-level branch of `/finding-groups/latest`. The pre-aggregated `FindingGroupDailySummary` path and the date-filtered `/finding-groups` list path are untouched.

### Steps to review

1. Read the diff (one method, +14/-3 in `api/src/backend/api/v1/views.py`: `_get_latest_findings_per_provider`).
2. Confirm the new code resolves the scan ids into a Python list before filtering and that the rest of the method semantics are identical (same `Scan.objects.filter(...)` chain, same `scan_id__in` filter).
3. (Optional) Run the test suite locally: `pytest api/tests/test_views.py::TestFindingGroupViewSet`.

### API evidence

EXPLAIN ANALYZE on the original pasted query, worst shape (2M findings, ~1.8M under the latest scans, ~629k matching `us-east-1`; Postgres 16, `work_mem=4MB`, `jit=on`, warm):

**Before (`scan_id IN (subquery)`):**
```
Execution Time:  32609 ms
Planning Time:     195 ms
Plan: Nested Loop Left Join (serial) into resource_finding_mappings
Sort Method:     external merge  Disk: 952 MB
JIT functions:   155
Workers Launched: 0
```

**After (`scan_id IN (literal list)`):**
```
Execution Time:   8878 ms
Planning Time:     20 ms
Plan: Parallel Hash Join + Parallel Append into resource_finding_mappings
Sort Method:     external merge  Disk: 322 MB (per worker ~315 MB)
JIT functions:   275
Workers Launched: 2
```

Performance results, ORM end-to-end on the same 2M-finding seeded tenant (warm):

| Shape | Old (subquery) | New (literal list) | Speedup |
|---|---|---|---|
| Normal (~10% findings under latest scan, ~70k matching) | ~1.4 s | ~0.86 s | ~1.7x |
| Single huge latest scan (~700k matching) | ~11.3 s warm SQL / ~17.8 s ORM cold | ~3.1 s | ~3.6x / ~5.7x |
| Fan-out (3 distinct resources per finding, ~2.1 M join rows) | ~13.5 s | ~5.3 s | ~2.6x |

### Checklist

- [x] Behaviour preserved: identical 300-group output (md5-equal raw SQL and 160/160 `TestFindingGroupViewSet` tests passing).
- [x] EXPLAIN ANALYZE and performance results included above.
- [x] No API spec changes.
- [x] No version updates required.
- [x] No CHANGELOG entry (`no-changelog`).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
