### PR TITLE
fix(openstack): move exception codes off the Alibaba Cloud range

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 - ENS RD 311/2022 (AWS) compliance mapping: `vpc_different_regions` was uncorrectly mapped under the `mp.com.4` family (Network segregation). That check is now mapped to a new `op.cont.2.aws.vpc.1` requirement under the Continuity of Service control [(#11372)](https://github.com/prowler-cloud/prowler/pull/11372)
 - Compliance CSV row count now matches the UI per requirement by sourcing rows from the framework JSON's `requirement.Checks` instead of the stale `finding.compliance` snapshot [(#11370)](https://github.com/prowler-cloud/prowler/pull/11370)
+- OpenStack provider exception codes moved from the `10000-10999` range, shared with the AlibabaCloud provider, to the free `17000-17999` range to keep error codes unambiguous [(#11382)](https://github.com/prowler-cloud/prowler/pull/11382)
 
 ---
 

--- a/prowler/providers/openstack/exceptions/exceptions.py
+++ b/prowler/providers/openstack/exceptions/exceptions.py
@@ -1,56 +1,56 @@
 from prowler.exceptions.exceptions import ProwlerException
 
 
-# Exceptions codes from 10000 to 10999 are reserved for OpenStack exceptions
+# Exceptions codes from 17000 to 17999 are reserved for OpenStack exceptions
 class OpenStackBaseException(ProwlerException):
     """Base class for OpenStack Errors."""
 
     OPENSTACK_ERROR_CODES = {
-        (10000, "OpenStackCredentialsError"): {
+        (17000, "OpenStackCredentialsError"): {
             "message": "OpenStack credentials not found or invalid",
             "remediation": "Check the OpenStack API credentials and ensure they are properly set.",
         },
-        (10001, "OpenStackAuthenticationError"): {
+        (17001, "OpenStackAuthenticationError"): {
             "message": "OpenStack authentication failed",
             "remediation": "Check the OpenStack API credentials and ensure they are valid.",
         },
-        (10002, "OpenStackSessionError"): {
+        (17002, "OpenStackSessionError"): {
             "message": "OpenStack session setup failed",
             "remediation": "Check the session setup and ensure it is properly configured.",
         },
-        (10003, "OpenStackIdentityError"): {
+        (17003, "OpenStackIdentityError"): {
             "message": "OpenStack identity setup failed",
             "remediation": "Check credentials and ensure they are properly set up for OpenStack.",
         },
-        (10004, "OpenStackAPIError"): {
+        (17004, "OpenStackAPIError"): {
             "message": "OpenStack API call failed",
             "remediation": "Check the API request and ensure it is properly formatted.",
         },
-        (10005, "OpenStackRateLimitError"): {
+        (17005, "OpenStackRateLimitError"): {
             "message": "OpenStack API rate limit exceeded",
             "remediation": "Reduce the number of API requests or wait before making more requests.",
         },
-        (10006, "OpenStackConfigFileNotFoundError"): {
+        (17006, "OpenStackConfigFileNotFoundError"): {
             "message": "OpenStack clouds.yaml configuration file not found",
             "remediation": "Check that the clouds.yaml file exists at the specified path or in standard locations (~/.config/openstack/clouds.yaml, /etc/openstack/clouds.yaml, ./clouds.yaml).",
         },
-        (10007, "OpenStackCloudNotFoundError"): {
+        (17007, "OpenStackCloudNotFoundError"): {
             "message": "Specified cloud not found in clouds.yaml configuration",
             "remediation": "Check that the cloud name exists in your clouds.yaml file and is properly configured.",
         },
-        (10008, "OpenStackInvalidConfigError"): {
+        (17008, "OpenStackInvalidConfigError"): {
             "message": "Invalid or malformed clouds.yaml configuration file",
             "remediation": "Check that the clouds.yaml file is valid YAML and follows the OpenStack configuration format.",
         },
-        (10009, "OpenStackInvalidProviderIdError"): {
+        (17009, "OpenStackInvalidProviderIdError"): {
             "message": "Provider ID does not match the project_id in clouds.yaml",
             "remediation": "Ensure the provider_id matches the project_id configured in your clouds.yaml file.",
         },
-        (10010, "OpenStackNoRegionError"): {
+        (17010, "OpenStackNoRegionError"): {
             "message": "No region configuration found in clouds.yaml",
             "remediation": "Add either 'region_name' (single region) or 'regions' (list of regions) to your cloud configuration in clouds.yaml.",
         },
-        (10011, "OpenStackAmbiguousRegionError"): {
+        (17011, "OpenStackAmbiguousRegionError"): {
             "message": "Ambiguous region configuration in clouds.yaml",
             "remediation": "Use either 'region_name' or 'regions' in your cloud configuration, not both.",
         },
@@ -75,7 +75,7 @@ class OpenStackCredentialsError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10000,
+            code=17000,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -87,7 +87,7 @@ class OpenStackAuthenticationError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10001,
+            code=17001,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -99,7 +99,7 @@ class OpenStackSessionError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10002,
+            code=17002,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -111,7 +111,7 @@ class OpenStackIdentityError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10003,
+            code=17003,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -123,7 +123,7 @@ class OpenStackAPIError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10004,
+            code=17004,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -135,7 +135,7 @@ class OpenStackRateLimitError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10005,
+            code=17005,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -147,7 +147,7 @@ class OpenStackConfigFileNotFoundError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10006,
+            code=17006,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -159,7 +159,7 @@ class OpenStackCloudNotFoundError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10007,
+            code=17007,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -171,7 +171,7 @@ class OpenStackInvalidConfigError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10008,
+            code=17008,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -183,7 +183,7 @@ class OpenStackInvalidProviderIdError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10009,
+            code=17009,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -195,7 +195,7 @@ class OpenStackNoRegionError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10010,
+            code=17010,
             file=file,
             original_exception=original_exception,
             message=message,
@@ -207,7 +207,7 @@ class OpenStackAmbiguousRegionError(OpenStackBaseException):
 
     def __init__(self, file=None, original_exception=None, message=None):
         super().__init__(
-            code=10011,
+            code=17011,
             file=file,
             original_exception=original_exception,
             message=message,


### PR DESCRIPTION
### Context

The OpenStack provider reserved exception codes `10000-10999`, the exact range already reserved by the AlibabaCloud provider (`prowler/providers/alibabacloud/exceptions/exceptions.py`). Two providers sharing the same code range breaks the one-range-per-provider convention used across the SDK and makes error codes ambiguous.

### Description

Move the OpenStack exception codes from `10000-10999` to the free `17000-17999` range.

Range allocation context (highest reserved ranges): Scaleway `15000-15999`, and the StackIT provider claims `16000-16999` in the in-flight PR #9237. To avoid colliding with that StackIT range, OpenStack takes the next free range, `17000-17999`.

- Updates the reserved-range header comment.
- Renumbers the 12 codes in `OPENSTACK_ERROR_CODES` (`10000-10011` → `17000-17011`) and the matching `code=` values in every `OpenStack*Error` subclass.
- No public behavior change: the codes are internal identifiers and are not referenced by tests or by any literal outside the exceptions module.

### Steps to review

- `prowler/providers/openstack/exceptions/exceptions.py`: confirm the comment now reads `17000 to 17999` and every code is in the `1700x`/`1701x` range.
- Confirm no other provider uses `17000-17999` (StackIT PR #9237 uses `16000-16999`, no overlap).
- Run the OpenStack test suite:

\`\`\`bash
poetry run pytest tests/providers/openstack -q
\`\`\`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.