### PR TITLE
test(ui): find scheduled scan e2e row in In Progress tab

### DIFF
--- a/ui/tests/scans/scans-page.ts
+++ b/ui/tests/scans/scans-page.ts
@@ -171,9 +171,13 @@ export class ScansPage extends BasePage {
     // 1. The provider exists in the table (by account ID/UID)
     // 2. The scan name field contains "scheduled scan"
 
-    // Scheduled scans live in the Scheduled tab; /scans defaults to Completed,
-    // which would show an empty-state card (no table) in a fresh environment.
-    await this.gotoTab("scheduled");
+    // Adding a provider first creates a scheduled-trigger scan in the
+    // AVAILABLE state (the immediate first run), which the tabbed view lists
+    // under "In Progress" — not "Scheduled" (that tab only shows state=scheduled,
+    // a later run created asynchronously). /scans defaults to Completed, which
+    // would show an empty-state card (no table) in a fresh environment, so
+    // navigate to the active tab where this row actually appears.
+    await this.gotoTab("active");
     await this.verifyPageLoaded();
 
     // Find a row that contains the account ID (provider UID in Provider column)


### PR DESCRIPTION
### Context

The provider E2E tests (`PROVIDER-E2E-*`) fail in CI on the new tabbed Scan Jobs view. After adding a provider, `verifyScheduledScanStatus` navigated to the **Scheduled** tab to find the provider's scan row, but it never appears there.

The tabs filter scans by **state**, not trigger: `Scheduled` only shows `state=scheduled`. When a provider is created, the backend first creates a scheduled-trigger scan in the **`available`** state (the immediate first run), which the UI lists under **In Progress** (`available`/`executing`). The pure `state=scheduled` row (the next run) is created asynchronously and isn't present within the test window. The previous single-table view matched the row regardless of state; the tabbed view filters it out of Scheduled.

No Jira task associated.

### Description

- Point `verifyScheduledScanStatus` to the **In Progress** tab (`/scans?tab=active`) where the freshly created scheduled-trigger scan (`state=available`) actually appears.
- Keeps the existing reload + 15s fallback (the `reload()` preserves the `?tab=active` query param).
- Test-only change; no production code touched.

### Steps to review

1. `ui/tests/scans/scans-page.ts` → `verifyScheduledScanStatus`: confirm it now calls `gotoTab("active")` instead of `gotoTab("scheduled")`, with the comment explaining the AVAILABLE-state reasoning.
2. Confirm the CI `e2e-tests` job turns green for the `providers` project (previously failing at `scans-page.ts` row lookup).

### Checklist

- [x] Review if the code is being covered by tests.

#### UI
- [x] All issue/task requirements work as expected on the UI

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.