### PR TITLE
feat(ui): add onboarding flow registry and gate-decision core

### DIFF
--- a/ui/lib/onboarding/__tests__/gate-decision.test.ts
+++ b/ui/lib/onboarding/__tests__/gate-decision.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import type { TourCompletionRecord } from "@/lib/tours/tour-types";
+import { TOUR_COMPLETION_STATES } from "@/lib/tours/tour-types";
+
+import { shouldStartOnboarding } from "../gate-decision";
+
+const recordWithState = (
+  state: TourCompletionRecord["state"],
+): TourCompletionRecord => ({
+  tourId: "add-provider",
+  version: 1,
+  state,
+  completedAt: "2026-01-15T12:00:00.000Z",
+});
+
+describe("shouldStartOnboarding", () => {
+  it("returns true for a zero-provider user with no completion record", () => {
+    // Given - no providers, nothing recorded yet
+    // When
+    const result = shouldStartOnboarding({
+      hasProviders: false,
+      completionRecord: null,
+    });
+
+    // Then - the mandatory gate fires
+    expect(result).toBe(true);
+  });
+
+  it("returns false when the user already has providers", () => {
+    // Given - providers exist, no record
+    // When
+    const result = shouldStartOnboarding({
+      hasProviders: true,
+      completionRecord: null,
+    });
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("returns false when a dismissed record exists", () => {
+    // Given - user previously dismissed the modal
+    // When
+    const result = shouldStartOnboarding({
+      hasProviders: false,
+      completionRecord: recordWithState(TOUR_COMPLETION_STATES.DISMISSED),
+    });
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("returns false when a completed record exists", () => {
+    // Given - user already completed the tour in this browser
+    // When
+    const result = shouldStartOnboarding({
+      hasProviders: false,
+      completionRecord: recordWithState(TOUR_COMPLETION_STATES.COMPLETED),
+    });
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("returns false when a skipped record exists", () => {
+    // Given - user skipped the tour mid-flow
+    // When
+    const result = shouldStartOnboarding({
+      hasProviders: false,
+      completionRecord: recordWithState(TOUR_COMPLETION_STATES.SKIPPED),
+    });
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("fails open when hasProviders is undefined", () => {
+    // Given - ambiguous provider signal (undefined)
+    // When - strict === false check rejects non-false values
+    const result = shouldStartOnboarding({
+      hasProviders: undefined as unknown as boolean,
+      completionRecord: null,
+    });
+
+    // Then - do not force onboarding on an unknown state
+    expect(result).toBe(false);
+  });
+
+  it("fails open when hasProviders is null", () => {
+    // Given - ambiguous provider signal (null)
+    // When
+    const result = shouldStartOnboarding({
+      hasProviders: null as unknown as boolean,
+      completionRecord: null,
+    });
+
+    // Then
+    expect(result).toBe(false);
+  });
+});

--- a/ui/lib/onboarding/__tests__/registry.test.ts
+++ b/ui/lib/onboarding/__tests__/registry.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+
+import type { TourCompletionStore } from "@/lib/tours/store/tour-completion-store";
+import type {
+  TourCompletionRecord,
+  TourDefinition,
+  TourId,
+} from "@/lib/tours/tour-types";
+import { TOUR_COMPLETION_STATES } from "@/lib/tours/tour-types";
+
+import * as onboardingPublicApi from "../index";
+import type { OnboardingContext, OnboardingFlow } from "../onboarding-types";
+import {
+  getFirstIncompleteFlow,
+  getFlowById,
+  getOrderedFlows,
+  onboardingFlows,
+} from "../registry";
+
+// Minimal valid TourDefinition stub used to build OnboardingFlow fixtures.
+// The registry never reads tour internals beyond { id, version } (TourId), so
+// a flat definition is sufficient for these pure-logic tests.
+const buildTour = (id: string, version = 1): TourDefinition => ({
+  id,
+  version,
+  coversFiles: [],
+  steps: [],
+});
+
+const buildFlow = (
+  overrides: Partial<OnboardingFlow> = {},
+): OnboardingFlow => ({
+  id: overrides.id ?? "flow",
+  order: overrides.order ?? 1,
+  title: overrides.title ?? "Title",
+  description: overrides.description ?? "Description",
+  route: overrides.route ?? "/route",
+  tour: overrides.tour ?? buildTour(overrides.id ?? "flow"),
+  isComplete: overrides.isComplete,
+});
+
+const completedRecord = (
+  tourId: string,
+  version = 1,
+): TourCompletionRecord => ({
+  tourId,
+  version,
+  state: TOUR_COMPLETION_STATES.COMPLETED,
+  completedAt: "2026-01-15T12:00:00.000Z",
+});
+
+// In-memory store implementing the TourCompletionStore contract. Injecting it
+// keeps getFirstIncompleteFlow unit-testable with no localStorage mocking.
+const fakeStore = (
+  seed: Record<string, TourCompletionRecord> = {},
+): TourCompletionStore => {
+  const data = new Map<string, TourCompletionRecord>(Object.entries(seed));
+  const key = (id: TourId) => `${id.id}.v${id.version}`;
+  return {
+    get: (id) => data.get(key(id)) ?? null,
+    set: (id, record) => {
+      data.set(key(id), record);
+    },
+    clear: (id) => {
+      data.delete(key(id));
+    },
+  };
+};
+
+describe("OnboardingFlow / OnboardingContext types", () => {
+  it("compiles a fully-populated OnboardingFlow against the declared contract", () => {
+    // Given - a flow object that exercises every field of the contract
+    const ctx: OnboardingContext = { hasProviders: false };
+    const flow: OnboardingFlow = {
+      id: "add-provider",
+      order: 1,
+      title: "Add your first provider",
+      description: "Connect a cloud account to start scanning.",
+      route: "/providers",
+      tour: buildTour("add-provider"),
+      isComplete: (c: OnboardingContext) => c.hasProviders,
+    };
+
+    // When / Then - the contract resolves at runtime
+    expect(flow.id).toBe("add-provider");
+    expect(flow.order).toBe(1);
+    expect(flow.route).toBe("/providers");
+    expect(flow.isComplete?.(ctx)).toBe(false);
+    expect(flow.isComplete?.({ hasProviders: true })).toBe(true);
+  });
+});
+
+describe("onboardingFlows", () => {
+  it("starts empty (the add-provider entry is registered in Slice B)", () => {
+    // Given / When / Then - the production registry ships empty in Slice A
+    expect(onboardingFlows).toEqual([]);
+  });
+});
+
+describe("public api barrel", () => {
+  it("re-exports the registry and gate-decision surface", () => {
+    // Given / When / Then - the index forwards the same callable references
+    expect(onboardingPublicApi.getOrderedFlows).toBe(getOrderedFlows);
+    expect(onboardingPublicApi.getFlowById).toBe(getFlowById);
+    expect(onboardingPublicApi.getFirstIncompleteFlow).toBe(
+      getFirstIncompleteFlow,
+    );
+    expect(onboardingPublicApi.onboardingFlows).toBe(onboardingFlows);
+    expect(typeof onboardingPublicApi.shouldStartOnboarding).toBe("function");
+  });
+});
+
+describe("getOrderedFlows", () => {
+  it("returns an empty array when the registry has no flows", () => {
+    // Given - the empty production registry
+    // When
+    const result = getOrderedFlows([]);
+
+    // Then
+    expect(result).toEqual([]);
+  });
+
+  it("sorts ascending by order, stably preserving array position on ties", () => {
+    // Given - entries declared out of order, plus a tie on order 2
+    const second = buildFlow({ id: "second", order: 2 });
+    const first = buildFlow({ id: "first", order: 1 });
+    const secondTie = buildFlow({ id: "second-tie", order: 2 });
+    const flows = [second, first, secondTie];
+
+    // When
+    const result = getOrderedFlows(flows);
+
+    // Then - order 1 first, then the two order-2 entries in original sequence
+    expect(result.map((f) => f.id)).toEqual(["first", "second", "second-tie"]);
+  });
+});
+
+describe("getFlowById", () => {
+  it("returns the matching flow when the id exists", () => {
+    // Given
+    const addProvider = buildFlow({ id: "add-provider", order: 1 });
+    const flows = [addProvider, buildFlow({ id: "other", order: 2 })];
+
+    // When
+    const result = getFlowById("add-provider", flows);
+
+    // Then
+    expect(result).toBe(addProvider);
+  });
+
+  it("returns undefined when the id is unknown", () => {
+    // Given
+    const flows = [buildFlow({ id: "add-provider", order: 1 })];
+
+    // When
+    const result = getFlowById("unknown-xyz", flows);
+
+    // Then
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("getFirstIncompleteFlow", () => {
+  const ctx: OnboardingContext = { hasProviders: false };
+
+  it("returns undefined when the registry is empty", () => {
+    // Given - no flows
+    // When
+    const result = getFirstIncompleteFlow(ctx, fakeStore(), []);
+
+    // Then
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when every flow is complete via isComplete(ctx)", () => {
+    // Given - both flows report complete through their predicate
+    const flows = [
+      buildFlow({ id: "a", order: 1, isComplete: () => true }),
+      buildFlow({ id: "b", order: 2, isComplete: () => true }),
+    ];
+
+    // When
+    const result = getFirstIncompleteFlow(ctx, fakeStore(), flows);
+
+    // Then
+    expect(result).toBeUndefined();
+  });
+
+  it("returns the second flow when the first is complete via store record", () => {
+    // Given - first flow has a persisted completion record, second does not
+    const first = buildFlow({
+      id: "first",
+      order: 1,
+      tour: buildTour("first"),
+    });
+    const second = buildFlow({
+      id: "second",
+      order: 2,
+      tour: buildTour("second"),
+    });
+    const store = fakeStore({ "first.v1": completedRecord("first") });
+
+    // When
+    const result = getFirstIncompleteFlow(ctx, store, [second, first]);
+
+    // Then - ordered evaluation skips the recorded flow, returns the next
+    expect(result).toBe(second);
+  });
+
+  it("passes the provided context object through to isComplete", () => {
+    // Given - a predicate that captures the context it receives
+    let received: OnboardingContext | undefined;
+    const flow = buildFlow({
+      id: "captures",
+      order: 1,
+      isComplete: (c) => {
+        received = c;
+        return c.hasProviders;
+      },
+    });
+    const providedCtx: OnboardingContext = { hasProviders: true };
+
+    // When
+    const result = getFirstIncompleteFlow(providedCtx, fakeStore(), [flow]);
+
+    // Then - the exact context object was forwarded, flow counted complete
+    expect(received).toBe(providedCtx);
+    expect(result).toBeUndefined();
+  });
+
+  it("treats isComplete(ctx) === true as complete even when a store record is absent", () => {
+    // Given - no store record at all, but predicate says complete
+    const flow = buildFlow({
+      id: "predicate-wins",
+      order: 1,
+      tour: buildTour("predicate-wins"),
+      isComplete: () => true,
+    });
+
+    // When
+    const result = getFirstIncompleteFlow(ctx, fakeStore(), [flow]);
+
+    // Then
+    expect(result).toBeUndefined();
+  });
+
+  it("returns the first incomplete flow when neither predicate nor record marks it complete", () => {
+    // Given - first flow incomplete (no record, no predicate), second complete
+    const first = buildFlow({
+      id: "first",
+      order: 1,
+      tour: buildTour("first"),
+    });
+    const second = buildFlow({
+      id: "second",
+      order: 2,
+      tour: buildTour("second"),
+      isComplete: () => true,
+    });
+
+    // When
+    const result = getFirstIncompleteFlow(ctx, fakeStore(), [first, second]);
+
+    // Then
+    expect(result).toBe(first);
+  });
+});

--- a/ui/lib/onboarding/gate-decision.ts
+++ b/ui/lib/onboarding/gate-decision.ts
@@ -1,0 +1,21 @@
+import type { TourCompletionRecord } from "@/lib/tours/tour-types";
+
+export interface GateDecisionInput {
+  hasProviders: boolean;
+  completionRecord: TourCompletionRecord | null;
+}
+
+// Pure decision for the mandatory new-user gate. Returns `true` only when the
+// user provably has no providers AND no prior tour record exists in this
+// browser. The strict `=== false` check fails open: any ambiguous provider
+// signal (`undefined`, `null`, error state) is treated as "do not force".
+// The explicit null/undefined check covers both an absent record and an
+// unexpected `undefined` passed from a defensive caller.
+export function shouldStartOnboarding({
+  hasProviders,
+  completionRecord,
+}: GateDecisionInput): boolean {
+  const hasNoRecord =
+    completionRecord === null || completionRecord === undefined;
+  return hasProviders === false && hasNoRecord;
+}

--- a/ui/lib/onboarding/index.ts
+++ b/ui/lib/onboarding/index.ts
@@ -1,0 +1,12 @@
+// Public surface for the onboarding system. Consumers import from
+// `@/lib/onboarding` rather than reaching into individual modules.
+
+export type { GateDecisionInput } from "./gate-decision";
+export { shouldStartOnboarding } from "./gate-decision";
+export type { OnboardingContext, OnboardingFlow } from "./onboarding-types";
+export {
+  getFirstIncompleteFlow,
+  getFlowById,
+  getOrderedFlows,
+  onboardingFlows,
+} from "./registry";

--- a/ui/lib/onboarding/onboarding-types.ts
+++ b/ui/lib/onboarding/onboarding-types.ts
@@ -1,0 +1,22 @@
+import type { TourDefinition } from "@/lib/tours/tour-types";
+
+// Server-derived signals the gate and flow-completion checks consult.
+// Kept intentionally minimal: only `hasProviders` is needed today, and the
+// shape is the single argument passed to every `isComplete(ctx)` predicate.
+export interface OnboardingContext {
+  hasProviders: boolean;
+}
+
+// A single onboarding flow. The flow *is* its tour: completion persistence
+// reuses the tour's own `TourCompletionRecord` (via the tour's id/version),
+// so there is no second source of truth. `order` is an explicit integer
+// (gaps allowed) so reordering is a data edit, never a code move.
+export interface OnboardingFlow {
+  id: string;
+  order: number;
+  title: string;
+  description: string;
+  route: string;
+  tour: TourDefinition;
+  isComplete?: (ctx: OnboardingContext) => boolean;
+}

--- a/ui/lib/onboarding/registry.ts
+++ b/ui/lib/onboarding/registry.ts
@@ -1,0 +1,54 @@
+import { localStorageAdapter } from "@/lib/tours/store/local-storage-adapter";
+import type { TourCompletionStore } from "@/lib/tours/store/tour-completion-store";
+
+import type { OnboardingContext, OnboardingFlow } from "./onboarding-types";
+
+// Single source of truth for onboarding flows. Starts empty in Slice A; the
+// `add-provider` entry is appended in Slice B. Adding a flow is one entry here
+// plus its `*.tour.ts` file — no gate, modal, or nav edits required.
+export const onboardingFlows: readonly OnboardingFlow[] = [];
+
+// Returns flows sorted ascending by `order`. The sort is stable: entries that
+// share an `order` value keep their original relative position. The `flows`
+// argument defaults to the production registry; tests inject fixtures.
+export function getOrderedFlows(
+  flows: readonly OnboardingFlow[] = onboardingFlows,
+): OnboardingFlow[] {
+  return flows
+    .map((flow, index) => ({ flow, index }))
+    .sort((a, b) => a.flow.order - b.flow.order || a.index - b.index)
+    .map(({ flow }) => flow);
+}
+
+// Resolves a flow by its stable `id`, or `undefined` when none matches.
+export function getFlowById(
+  id: string,
+  flows: readonly OnboardingFlow[] = onboardingFlows,
+): OnboardingFlow | undefined {
+  return flows.find((flow) => flow.id === id);
+}
+
+// A flow is complete when its server-derived predicate says so OR a tour
+// completion record already exists in the store for its tour.
+function isFlowComplete(
+  flow: OnboardingFlow,
+  ctx: OnboardingContext,
+  store: TourCompletionStore,
+): boolean {
+  if (flow.isComplete?.(ctx) === true) return true;
+  return store.get(flow.tour) !== null;
+}
+
+// Returns the first flow (by `order`) that is NOT complete, or `undefined`
+// when every flow is complete. The store is injected with a production default
+// (`localStorageAdapter`) so the function stays pure and unit-testable: tests
+// pass an in-memory store instead of mocking localStorage.
+export function getFirstIncompleteFlow(
+  ctx: OnboardingContext,
+  store: TourCompletionStore = localStorageAdapter,
+  flows: readonly OnboardingFlow[] = onboardingFlows,
+): OnboardingFlow | undefined {
+  return getOrderedFlows(flows).find(
+    (flow) => !isFlowComplete(flow, ctx, store),
+  );
+}


### PR DESCRIPTION
### Context

Foundation of the onboarding system — the data layer every later slice builds on.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Typed `OnboardingFlow` contract, the flow registry, and the pure `shouldStartOnboarding` gate-decision (fails open on an unknown provider signal). No UI yet: registering a flow is a single registry entry, no edits to gate/modal/user-nav.

### Steps to review

Read `ui/lib/onboarding/{onboarding-types,registry,gate-decision}.ts`. Confirm the gate-decision is pure and fail-open. Run `pnpm exec vitest run --project unit`.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 1 of 15 |
| Base | `feat/onboarding-system` |
| Depends on | #11430 (tracker) |
| Follow-up | #11432 |
| Review budget | 477 / 400 ⚠️ |
| Starts at | the PoC integration branch `feat/onboarding-system` |
| Ends with | a typed, tested onboarding-core module |

> **Size exception:** exceeds the 400-line budget because this is one cohesive code+tests unit; splitting further would separate a component/store/tour from the test that verifies it. No `size:exception` label exists in this repo (only `size/*`), so the rationale is recorded here.

### Chain Overview

```text
master ← #11430 tracker(draft) ← 📍#11431 ← #11432 ← #11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** flow types, registry, gate-decision + unit tests
- **Excludes:** all React/UI, tours and the guided sequence (later slices)

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
