### PR TITLE
feat(ui): add add-provider onboarding tour and anchors

### DIFF
--- a/ui/components/providers/add-provider-button.tsx
+++ b/ui/components/providers/add-provider-button.tsx
@@ -23,7 +23,9 @@ export const AddProviderButton = ({ onOpenWizard }: AddProviderButtonProps) => {
 
   return (
     <>
-      <Button onClick={handleOpen}>Add Provider</Button>
+      <Button data-tour-id="add-provider-trigger" onClick={handleOpen}>
+        Add Provider
+      </Button>
       {!onOpenWizard && (
         <ProviderWizardModal open={open} onOpenChange={setOpen} />
       )}

--- a/ui/components/providers/workflow/forms/connect-account-form.tsx
+++ b/ui/components/providers/workflow/forms/connect-account-form.tsx
@@ -347,11 +347,13 @@ export const ConnectAccountForm = ({
       >
         {/* Step 1: Provider selection */}
         {prevStep === 1 && (
-          <RadioGroupProvider
-            control={form.control}
-            isInvalid={!!form.formState.errors.providerType}
-            errorMessage={form.formState.errors.providerType?.message}
-          />
+          <div data-tour-id="add-provider-provider-type">
+            <RadioGroupProvider
+              control={form.control}
+              isInvalid={!!form.formState.errors.providerType}
+              errorMessage={form.formState.errors.providerType?.message}
+            />
+          </div>
         )}
         {/* Step 2: AWS method selector (only for AWS, before choosing method) */}
         {prevStep === 2 && providerType === "aws" && awsMethod === null && (

--- a/ui/lib/onboarding/__tests__/registry.test.ts
+++ b/ui/lib/onboarding/__tests__/registry.test.ts
@@ -90,10 +90,25 @@ describe("OnboardingFlow / OnboardingContext types", () => {
   });
 });
 
-describe("onboardingFlows", () => {
-  it("starts empty (the add-provider entry is registered in Slice B)", () => {
-    // Given / When / Then - the production registry ships empty in Slice A
-    expect(onboardingFlows).toEqual([]);
+describe("onboardingFlows (production registry)", () => {
+  it("registers the add-provider flow as the first onboarding flow", () => {
+    // Given / When - the production registry after Slice B registration
+    const addProvider = getFlowById("add-provider", onboardingFlows);
+
+    // Then - the entry exists with its declared contract
+    expect(addProvider).toBeDefined();
+    expect(addProvider?.order).toBe(1);
+    expect(addProvider?.route).toBe("/providers");
+    expect(addProvider?.tour.id).toBe("add-provider");
+  });
+
+  it("treats add-provider as complete when the context reports providers", () => {
+    // Given - the production add-provider flow's completion predicate
+    const addProvider = getFlowById("add-provider", onboardingFlows);
+
+    // Then - isComplete delegates to the server-derived hasProviders signal
+    expect(addProvider?.isComplete?.({ hasProviders: true })).toBe(true);
+    expect(addProvider?.isComplete?.({ hasProviders: false })).toBe(false);
   });
 });
 

--- a/ui/lib/onboarding/registry.ts
+++ b/ui/lib/onboarding/registry.ts
@@ -1,12 +1,26 @@
+import { addProviderTour } from "@/lib/tours/add-provider.tour";
 import { localStorageAdapter } from "@/lib/tours/store/local-storage-adapter";
 import type { TourCompletionStore } from "@/lib/tours/store/tour-completion-store";
 
 import type { OnboardingContext, OnboardingFlow } from "./onboarding-types";
 
-// Single source of truth for onboarding flows. Starts empty in Slice A; the
-// `add-provider` entry is appended in Slice B. Adding a flow is one entry here
-// plus its `*.tour.ts` file — no gate, modal, or nav edits required.
-export const onboardingFlows: readonly OnboardingFlow[] = [];
+// Single source of truth for onboarding flows. Adding a flow is one entry here
+// plus its `*.tour.ts` file — no gate, modal, or nav edits required. `order`
+// is an explicit integer (gaps allowed) so reordering is a data edit.
+export const onboardingFlows: readonly OnboardingFlow[] = [
+  {
+    id: "add-provider",
+    order: 1,
+    title: "Add your first provider",
+    description:
+      "Connect a cloud account so Prowler has something to scan and assess.",
+    route: "/providers",
+    tour: addProviderTour,
+    // Server-derived authority: a user who already has providers is never
+    // gated into this flow, even with no local completion record.
+    isComplete: (ctx) => ctx.hasProviders,
+  },
+];
 
 // Returns flows sorted ascending by `order`. The sort is stable: entries that
 // share an `order` value keep their original relative position. The `flows`

--- a/ui/lib/tours/__tests__/add-provider.tour.test.ts
+++ b/ui/lib/tours/__tests__/add-provider.tour.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  addProviderTour,
+  type AddProviderTourTarget,
+} from "../add-provider.tour";
+
+// The set of anchored step targets the tour is allowed to reference. Only these
+// two carry a `data-tour-id` in the UI source; the welcome step has no target.
+const ALLOWED_TARGETS = ["trigger", "provider-type"] as const;
+
+const definedTargets = (): AddProviderTourTarget[] =>
+  addProviderTour.steps
+    .map((step) => step.target)
+    .filter((target): target is AddProviderTourTarget => target !== undefined);
+
+describe("addProviderTour shape", () => {
+  it("declares the add-provider id", () => {
+    // Given / When / Then - the tour id is the registry/anchor contract key
+    expect(addProviderTour.id).toBe("add-provider");
+  });
+
+  it("declares a positive integer version", () => {
+    // Given / When / Then - version drives the per-tour completion record key
+    expect(Number.isInteger(addProviderTour.version)).toBe(true);
+    expect(addProviderTour.version).toBeGreaterThan(0);
+  });
+
+  it("includes a trigger step and a provider-type step", () => {
+    // Given - the anchored step targets present in the tour
+    const targets = definedTargets();
+
+    // Then - both anchored stages exist
+    expect(targets).toContain("trigger");
+    expect(targets).toContain("provider-type");
+  });
+
+  it("never targets an element outside the allowed anchor set", () => {
+    // Given - every defined target across all steps
+    const targets = definedTargets();
+
+    // Then - no target escapes the two anchors guarded by tour:check
+    for (const target of targets) {
+      expect(ALLOWED_TARGETS).toContain(target);
+    }
+  });
+
+  it("includes a non-anchored welcome step (no target)", () => {
+    // Given - the modal welcome step carries no target
+    const welcomeSteps = addProviderTour.steps.filter(
+      (step) => step.target === undefined,
+    );
+
+    // Then - at least one targetless step exists for the welcome modal
+    expect(welcomeSteps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("covers the providers component tree for the tour:check gate", () => {
+    // Given / When / Then - coversFiles scopes the CI drift check to providers
+    expect(addProviderTour.coversFiles).toContain("ui/components/providers/**");
+  });
+});

--- a/ui/lib/tours/add-provider.tour.ts
+++ b/ui/lib/tours/add-provider.tour.ts
@@ -1,0 +1,63 @@
+import {
+  defineTour,
+  TOUR_STEP_ALIGNMENTS,
+  TOUR_STEP_SIDES,
+  type TourStepHandlers,
+} from "./tour-types";
+
+// The literal targets this tour anchors. `defineTour<...>` preserves the union
+// so `useDriverTour` can validate `stepHandlers` keys and `waitForStep`
+// arguments against exactly these two values.
+export type AddProviderTourTarget = "trigger" | "provider-type";
+
+export const addProviderTour = defineTour<AddProviderTourTarget>({
+  id: "add-provider",
+  version: 1,
+  // Scopes the `tour:check` / `prowler-tour` drift check to the providers tree
+  // where the `trigger` and `provider-type` anchors live.
+  coversFiles: ["ui/components/providers/**"],
+  steps: [
+    {
+      // Modal welcome step — no `target`, rendered as a centered popover.
+      title: "Connect your first provider",
+      description:
+        "Prowler scans the cloud accounts you connect. Let's walk through adding your first provider so scans have something to assess.",
+    },
+    {
+      target: "trigger",
+      side: TOUR_STEP_SIDES.BOTTOM,
+      align: TOUR_STEP_ALIGNMENTS.START,
+      title: "Open the Add Provider wizard",
+      description:
+        "Click Add Provider to launch the setup wizard. We'll point out the first thing to choose.",
+    },
+    {
+      target: "provider-type",
+      side: TOUR_STEP_SIDES.RIGHT,
+      align: TOUR_STEP_ALIGNMENTS.START,
+      title: "Pick a provider type",
+      description:
+        "Choose the cloud you want to connect (AWS, Azure, GCP, and more). From here the wizard guides you through the rest — go at your own pace.",
+    },
+  ],
+});
+
+// Step handlers are intentionally NOT part of the `TourDefinition` (which is the
+// CI-scanned, serializable shape). They are passed to `useDriverTour` at
+// consumption time. The factory takes the imperative wizard-open callback the
+// providers page owns (finalized in Slice C) so the tour file stays free of
+// page-level plumbing. The `trigger` step opens the wizard, then waits for the
+// `provider-type` anchor to mount before advancing; `provider-type` is the last
+// anchored step and releases control back to the user on completion.
+export function createAddProviderTourStepHandlers(openWizard: () => void): {
+  [K in AddProviderTourTarget]?: TourStepHandlers<AddProviderTourTarget>;
+} {
+  return {
+    trigger: {
+      onNext: async ({ waitForStep }) => {
+        openWizard();
+        await waitForStep("provider-type");
+      },
+    },
+  };
+}


### PR DESCRIPTION
### Context

First concrete flow registered on the core: the add-provider product tour.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

add-provider driver.js tour (welcome → trigger → provider-type) with `data-tour-id` anchors and step handlers that open the provider wizard.

### Steps to review

Read `ui/lib/tours/add-provider.tour.ts` and the new anchors. Run `node ui/scripts/check-tour-alignment.mjs`.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 2 of 15 |
| Base | `chain/ob-01-core` |
| Depends on | #11431 |
| Follow-up | #11433 |
| Review budget | 186 / 400 |
| Starts at | #11431 (onboarding core) |
| Ends with | a registered, anchored add-provider tour |


### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← 📍#11432 ← #11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** add-provider tour definition + page anchors
- **Excludes:** gate/modal/layout wiring (slice 03)

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
