### PR TITLE
feat(ui): wire onboarding gate into layout and providers re-trigger

### DIFF
--- a/ui/app/(prowler)/layout.tsx
+++ b/ui/app/(prowler)/layout.tsx
@@ -5,6 +5,7 @@ import { Metadata, Viewport } from "next";
 import { ReactNode } from "react";
 
 import { getProviders } from "@/actions/providers";
+import { OnboardingGate } from "@/components/onboarding";
 import MainLayout from "@/components/ui/main-layout/main-layout";
 import { NavigationProgress } from "@/components/ui/navigation-progress";
 import { Toaster } from "@/components/ui/toast";
@@ -57,6 +58,7 @@ export default async function RootLayout({
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
           <NavigationProgress />
           <StoreInitializer values={{ hasProviders }} />
+          <OnboardingGate hasProviders={hasProviders} />
           <MainLayout>{children}</MainLayout>
           <Toaster />
         </Providers>

--- a/ui/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { addProviderTour } from "@/lib/tours/add-provider.tour";
+import { buildStorageKey } from "@/lib/tours/store/local-storage-adapter";
+
+import { OnboardingGate } from "../onboarding-gate";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+const addProviderStorageKey = buildStorageKey({
+  id: addProviderTour.id,
+  version: addProviderTour.version,
+});
+
+describe("OnboardingGate", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    pushMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when the user has no providers and no completion record", () => {
+    it("shows the Welcome modal", async () => {
+      // Given - a fresh browser with no providers
+      render(<OnboardingGate hasProviders={false} />);
+
+      // Then - the gate surfaces the Welcome modal for the first flow
+      expect(
+        await screen.findByRole("button", { name: /get started/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("when the user already has providers", () => {
+    it("does not show the Welcome modal", async () => {
+      // Given - a user with providers
+      render(<OnboardingGate hasProviders={true} />);
+
+      // Then - the modal is never displayed
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /get started/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when a completion record already exists in this browser", () => {
+    it("does not show the Welcome modal", async () => {
+      // Given - a prior dismissal record for the first flow
+      window.localStorage.setItem(
+        addProviderStorageKey,
+        JSON.stringify({
+          tourId: addProviderTour.id,
+          version: addProviderTour.version,
+          state: "dismissed",
+          completedAt: new Date().toISOString(),
+        }),
+      );
+
+      render(<OnboardingGate hasProviders={false} />);
+
+      // Then - the gate respects the record and stays silent
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /get started/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when hasProviders is undefined (fail-open)", () => {
+    it("does not show the Welcome modal", async () => {
+      // Given - an ambiguous provider signal (transient / errored)
+      render(<OnboardingGate hasProviders={undefined as unknown as boolean} />);
+
+      // Then - the gate fails open and does not force onboarding
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /get started/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when the user accepts the Welcome modal", () => {
+    it("navigates to the flow route with the onboarding query param and writes no record", async () => {
+      // Given - the modal is shown for a zero-provider user
+      const user = userEvent.setup();
+      render(<OnboardingGate hasProviders={false} />);
+      const getStarted = await screen.findByRole("button", {
+        name: /get started/i,
+      });
+
+      // When - the user accepts
+      await user.click(getStarted);
+
+      // Then - the gate hands off via the URL and persists nothing yet
+      expect(pushMock).toHaveBeenCalledWith(
+        "/providers?onboarding=add-provider",
+      );
+      expect(window.localStorage.getItem(addProviderStorageKey)).toBeNull();
+    });
+  });
+
+  describe("when the user dismisses the Welcome modal", () => {
+    it("writes a dismissed record and stops showing the modal", async () => {
+      // Given - the modal is shown for a zero-provider user
+      const user = userEvent.setup();
+      render(<OnboardingGate hasProviders={false} />);
+      const skip = await screen.findByRole("button", {
+        name: /skip for now/i,
+      });
+
+      // When - the user skips
+      await user.click(skip);
+
+      // Then - a dismissal record is written and the modal closes
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /skip for now/i }),
+        ).not.toBeInTheDocument();
+      });
+      const raw = window.localStorage.getItem(addProviderStorageKey);
+      expect(raw).not.toBeNull();
+      expect(JSON.parse(raw as string).state).toBe("dismissed");
+    });
+  });
+});

--- a/ui/components/onboarding/__tests__/onboarding-welcome-modal.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-welcome-modal.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { OnboardingWelcomeModal } from "../onboarding-welcome-modal";
+
+describe("OnboardingWelcomeModal", () => {
+  describe("when open is true", () => {
+    it("renders the flow title and description", () => {
+      // Given - an open modal with a flow's copy
+      render(
+        <OnboardingWelcomeModal
+          open
+          flowTitle="Add your first provider"
+          flowDescription="Connect a cloud account so Prowler has something to scan."
+          onAccept={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+      );
+
+      // Then - the modal surfaces the flow copy
+      expect(screen.getByText("Add your first provider")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Connect a cloud account so Prowler has something to scan.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("calls onAccept when the primary action is clicked", async () => {
+      // Given - an open modal
+      const user = userEvent.setup();
+      const onAccept = vi.fn();
+      const onDismiss = vi.fn();
+      render(
+        <OnboardingWelcomeModal
+          open
+          flowTitle="Add your first provider"
+          onAccept={onAccept}
+          onDismiss={onDismiss}
+        />,
+      );
+
+      // When - the user clicks the primary CTA
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+
+      // Then - only onAccept fires
+      expect(onAccept).toHaveBeenCalledTimes(1);
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it("calls onDismiss when the skip action is clicked", async () => {
+      // Given - an open modal
+      const user = userEvent.setup();
+      const onAccept = vi.fn();
+      const onDismiss = vi.fn();
+      render(
+        <OnboardingWelcomeModal
+          open
+          flowTitle="Add your first provider"
+          onAccept={onAccept}
+          onDismiss={onDismiss}
+        />,
+      );
+
+      // When - the user clicks the secondary skip action
+      await user.click(screen.getByRole("button", { name: /skip for now/i }));
+
+      // Then - only onDismiss fires
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+      expect(onAccept).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when open is false", () => {
+    it("does not render the modal content", () => {
+      // Given - a closed modal
+      render(
+        <OnboardingWelcomeModal
+          open={false}
+          flowTitle="Add your first provider"
+          onAccept={vi.fn()}
+          onDismiss={vi.fn()}
+        />,
+      );
+
+      // Then - the primary CTA is not in the document
+      expect(
+        screen.queryByRole("button", { name: /get started/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/onboarding/__tests__/providers-onboarding-trigger.test.tsx
+++ b/ui/components/onboarding/__tests__/providers-onboarding-trigger.test.tsx
@@ -1,0 +1,78 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ProvidersOnboardingTrigger } from "../providers-onboarding-trigger";
+
+const startMock = vi.fn();
+const replaceMock = vi.fn();
+let searchParamsValue = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsValue,
+  usePathname: () => "/providers",
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+}));
+
+vi.mock("@/lib/tours/use-driver-tour", () => ({
+  useDriverTour: () => ({
+    start: startMock,
+    stop: vi.fn(),
+    hasCompleted: false,
+  }),
+}));
+
+describe("ProvidersOnboardingTrigger", () => {
+  beforeEach(() => {
+    startMock.mockClear();
+    replaceMock.mockClear();
+    searchParamsValue = new URLSearchParams();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when the onboarding param matches a known flow", () => {
+    it("force-starts the tour and clears the param", async () => {
+      // Given - the URL carries ?onboarding=add-provider
+      searchParamsValue = new URLSearchParams("onboarding=add-provider");
+
+      // When - the trigger mounts
+      render(<ProvidersOnboardingTrigger openWizard={vi.fn()} />);
+
+      // Then - it starts the tour and strips the param to avoid a reload loop
+      await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(replaceMock).toHaveBeenCalledWith("/providers"),
+      );
+    });
+  });
+
+  describe("when there is no onboarding param", () => {
+    it("does not start the tour", async () => {
+      // Given - a bare URL
+      searchParamsValue = new URLSearchParams();
+
+      // When - the trigger mounts
+      render(<ProvidersOnboardingTrigger openWizard={vi.fn()} />);
+
+      // Then - nothing is triggered
+      await waitFor(() => expect(startMock).not.toHaveBeenCalled());
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the onboarding param does not match a known flow", () => {
+    it("does not start the tour", async () => {
+      // Given - an unknown flow id in the URL
+      searchParamsValue = new URLSearchParams("onboarding=unknown-xyz");
+
+      // When - the trigger mounts
+      render(<ProvidersOnboardingTrigger openWizard={vi.fn()} />);
+
+      // Then - nothing is triggered
+      await waitFor(() => expect(startMock).not.toHaveBeenCalled());
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/components/onboarding/index.ts
+++ b/ui/components/onboarding/index.ts
@@ -3,3 +3,4 @@
 
 export { OnboardingGate } from "./onboarding-gate";
 export { OnboardingWelcomeModal } from "./onboarding-welcome-modal";
+export { ProvidersOnboardingTrigger } from "./providers-onboarding-trigger";

--- a/ui/components/onboarding/index.ts
+++ b/ui/components/onboarding/index.ts
@@ -1,0 +1,5 @@
+// Public surface for the onboarding UI components. Consumers import from
+// `@/components/onboarding` rather than reaching into individual files.
+
+export { OnboardingGate } from "./onboarding-gate";
+export { OnboardingWelcomeModal } from "./onboarding-welcome-modal";

--- a/ui/components/onboarding/onboarding-gate.tsx
+++ b/ui/components/onboarding/onboarding-gate.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import {
+  getFirstIncompleteFlow,
+  type OnboardingFlow,
+  shouldStartOnboarding,
+} from "@/lib/onboarding";
+import { localStorageAdapter } from "@/lib/tours/store/local-storage-adapter";
+import { TOUR_COMPLETION_STATES } from "@/lib/tours/tour-types";
+
+import { OnboardingWelcomeModal } from "./onboarding-welcome-modal";
+
+interface OnboardingGateProps {
+  hasProviders: boolean;
+}
+
+// Mandatory new-user gate. Mounted once in the (prowler) layout. Reads the
+// already-hydrated `hasProviders` signal plus the per-tour localStorage record
+// to decide whether to force a new user into the Welcome modal. All decision
+// logic runs inside `useEffect` (client-only) so the server renders nothing and
+// there is no hydration mismatch.
+export function OnboardingGate({ hasProviders }: OnboardingGateProps) {
+  const router = useRouter();
+  const [activeFlow, setActiveFlow] = useState<OnboardingFlow | null>(null);
+
+  useEffect(() => {
+    // Select the first flow that is incomplete by account state and has no
+    // browser record. `getFirstIncompleteFlow` uses `isComplete(ctx)` which
+    // false-positives when `hasProviders` is undefined, so it is NOT the final
+    // authority — `shouldStartOnboarding` below applies the strict `=== false`
+    // fail-open guard.
+    const flow = getFirstIncompleteFlow({ hasProviders }, localStorageAdapter);
+    if (!flow) {
+      setActiveFlow(null);
+      return;
+    }
+
+    const completionRecord = localStorageAdapter.get(flow.tour);
+    if (shouldStartOnboarding({ hasProviders, completionRecord })) {
+      setActiveFlow(flow);
+    } else {
+      setActiveFlow(null);
+    }
+  }, [hasProviders]);
+
+  if (!activeFlow) return null;
+
+  const handleAccept = () => {
+    // Hand off via the URL; the providers page's trigger starts the tour. No
+    // record is written here — completion is persisted only when the tour
+    // finishes or is skipped.
+    setActiveFlow(null);
+    router.push(`${activeFlow.route}?onboarding=${activeFlow.id}`);
+  };
+
+  const handleDismiss = () => {
+    // Persist a dismissal so the gate stops re-prompting in this browser.
+    localStorageAdapter.set(
+      { id: activeFlow.tour.id, version: activeFlow.tour.version },
+      {
+        tourId: activeFlow.tour.id,
+        version: activeFlow.tour.version,
+        state: TOUR_COMPLETION_STATES.DISMISSED,
+        completedAt: new Date().toISOString(),
+      },
+    );
+    setActiveFlow(null);
+  };
+
+  return (
+    <OnboardingWelcomeModal
+      open
+      flowTitle={activeFlow.title}
+      flowDescription={activeFlow.description}
+      onAccept={handleAccept}
+      onDismiss={handleDismiss}
+    />
+  );
+}

--- a/ui/components/onboarding/onboarding-welcome-modal.tsx
+++ b/ui/components/onboarding/onboarding-welcome-modal.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@/components/shadcn";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/shadcn/dialog";
+
+interface OnboardingWelcomeModalProps {
+  open: boolean;
+  flowTitle?: string;
+  flowDescription?: string;
+  onAccept: () => void;
+  onDismiss: () => void;
+}
+
+// Presentational entry point for the mandatory onboarding gate. It owns no
+// navigation or persistence: accepting and dismissing are delegated to the
+// caller (the gate) so this component stays reusable across any flow.
+export function OnboardingWelcomeModal({
+  open,
+  flowTitle,
+  flowDescription,
+  onAccept,
+  onDismiss,
+}: OnboardingWelcomeModalProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Closing via the overlay, Escape, or the X is treated as a dismiss so
+        // the gate can persist the dismissal record exactly once.
+        if (!next) onDismiss();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{flowTitle}</DialogTitle>
+          {/* Always render a description region: Radix associates the dialog
+              with it via aria-describedby, and flows supply copy here. */}
+          <DialogDescription>{flowDescription}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onDismiss}>
+            Skip for now
+          </Button>
+          <Button onClick={onAccept}>Get started</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/components/onboarding/providers-onboarding-trigger.tsx
+++ b/ui/components/onboarding/providers-onboarding-trigger.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import { getFlowById, type OnboardingFlow } from "@/lib/onboarding";
+import { createAddProviderTourStepHandlers } from "@/lib/tours/add-provider.tour";
+import { useDriverTour } from "@/lib/tours/use-driver-tour";
+
+interface ProvidersOnboardingTriggerProps {
+  // Imperative wizard open owned by the providers view; the tour's `trigger`
+  // step calls this to launch the Add Provider wizard.
+  openWizard: () => void;
+}
+
+const ONBOARDING_PARAM = "onboarding";
+
+// Reads `?onboarding=<flowId>` and, when it matches a known flow, force-starts
+// that flow's tour over the real page surface, then strips the param so a
+// refresh does not re-trigger. Renders nothing.
+export function ProvidersOnboardingTrigger({
+  openWizard,
+}: ProvidersOnboardingTriggerProps) {
+  const searchParams = useSearchParams();
+  // `useSearchParams` can return null outside a router/Suspense context.
+  const flowId = searchParams?.get(ONBOARDING_PARAM) ?? null;
+  const flow = flowId ? getFlowById(flowId) : undefined;
+
+  if (!flow) return null;
+
+  // Delegated to an inner component so the `useDriverTour` hook is always
+  // called unconditionally for the resolved flow (Rules of Hooks): this whole
+  // tree only mounts when a valid flow is present.
+  return <OnboardingTourRunner flow={flow} openWizard={openWizard} />;
+}
+
+interface OnboardingTourRunnerProps {
+  flow: OnboardingFlow;
+  openWizard: () => void;
+}
+
+function OnboardingTourRunner({ flow, openWizard }: OnboardingTourRunnerProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const hasStartedRef = useRef(false);
+
+  const { start } = useDriverTour(flow.tour, {
+    autoOpen: false,
+    stepHandlers: createAddProviderTourStepHandlers(openWizard),
+  });
+
+  useEffect(() => {
+    // Force-start once: bypasses the `hasCompleted` short-circuit so the
+    // re-trigger works even with an existing completion record.
+    if (hasStartedRef.current) return;
+    hasStartedRef.current = true;
+
+    start();
+    // Strip the param so a hard reload does not re-launch the tour.
+    router.replace(pathname);
+  }, [start, router, pathname]);
+
+  return null;
+}

--- a/ui/components/providers/providers-accounts-view.tsx
+++ b/ui/components/providers/providers-accounts-view.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 
+import { ProvidersOnboardingTrigger } from "@/components/onboarding";
 import { AddProviderButton } from "@/components/providers/add-provider-button";
 import { MutedFindingsConfigButton } from "@/components/providers/muted-findings-config-button";
 import { ProvidersAccountsTable } from "@/components/providers/providers-accounts-table";
@@ -60,6 +61,12 @@ export function ProvidersAccountsView({
 
   return (
     <>
+      {/* Renders null; reads ?onboarding and force-starts the tour, wiring the
+          tour's wizard-open step to this view's imperative open. Suspense
+          satisfies the App Router requirement around `useSearchParams`. */}
+      <Suspense fallback={null}>
+        <ProvidersOnboardingTrigger openWizard={() => openProviderWizard()} />
+      </Suspense>
       <div className="flex flex-col gap-6">
         <ProvidersFilters
           filters={filters}


### PR DESCRIPTION
### Context

Makes onboarding mandatory for zero-provider users and re-triggerable later.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Wires the onboarding gate, welcome modal and trigger into the app layout, plus the providers-page re-trigger. Tri-state `hasProviders` so the gate fails open during an API outage.

### Steps to review

Read `components/onboarding/*` and `app/(prowler)/layout.tsx`. Verify the gate only fires for zero-provider users and fails open on `undefined`.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 3 of 15 |
| Base | `chain/ob-02-tour` |
| Depends on | #11432 |
| Follow-up | #11434 |
| Review budget | 528 / 400 ⚠️ |
| Starts at | #11432 (add-provider tour) |
| Ends with | a mandatory, re-triggerable add-provider onboarding |

> **Size exception:** exceeds the 400-line budget because this is one cohesive code+tests unit; splitting further would separate a component/store/tour from the test that verifies it. No `size:exception` label exists in this repo (only `size/*`), so the rationale is recorded here.

### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← 📍#11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** gate, welcome modal, trigger, layout + providers mounts
- **Excludes:** StrictMode/timing hardening (slice 06), user-nav (slice 04)

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
