### PR TITLE
feat(ui): add restart onboarding entry to user nav

### DIFF
--- a/ui/components/ui/user-nav/__tests__/user-nav.test.tsx
+++ b/ui/components/ui/user-nav/__tests__/user-nav.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UserNav } from "../user-nav";
+
+const pushMock = vi.fn();
+const logOutMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { name: "Ada Lovelace" } } }),
+}));
+
+vi.mock("@/auth.config", () => ({
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("@/actions/auth", () => ({
+  logOut: () => logOutMock(),
+}));
+
+describe("UserNav", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    logOutMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when the avatar menu is opened", () => {
+    it("renders a restart onboarding entry that is always present", async () => {
+      // Given - an authenticated user
+      const user = userEvent.setup();
+      render(<UserNav />);
+
+      // When - the user opens the avatar menu
+      await user.click(screen.getByRole("button", { name: /account menu/i }));
+
+      // Then - the restart-onboarding entry is offered regardless of state
+      expect(
+        await screen.findByRole("menuitem", { name: /product tour/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("navigates to the first flow's route with the onboarding query param", async () => {
+      // Given - the avatar menu is open
+      const user = userEvent.setup();
+      render(<UserNav />);
+      await user.click(screen.getByRole("button", { name: /account menu/i }));
+      const productTour = await screen.findByRole("menuitem", {
+        name: /product tour/i,
+      });
+
+      // When - the user activates the restart entry
+      await user.click(productTour);
+
+      // Then - the app hands off to the first flow via the URL transport
+      expect(pushMock).toHaveBeenCalledWith(
+        "/providers?onboarding=add-provider",
+      );
+    });
+
+    it("preserves the existing account settings and sign out entries", async () => {
+      // Given - the avatar menu is open
+      const user = userEvent.setup();
+      render(<UserNav />);
+      await user.click(screen.getByRole("button", { name: /account menu/i }));
+
+      // Then - the account settings link keeps its destination
+      const accountSettings = await screen.findByRole("menuitem", {
+        name: /account settings/i,
+      });
+      expect(accountSettings).toHaveAttribute("href", "/profile");
+
+      // When - the user signs out
+      await user.click(
+        await screen.findByRole("menuitem", { name: /sign out/i }),
+      );
+
+      // Then - the existing sign-out action still fires
+      await waitFor(() => expect(logOutMock).toHaveBeenCalledTimes(1));
+    });
+  });
+});

--- a/ui/components/ui/user-nav/user-nav.tsx
+++ b/ui/components/ui/user-nav/user-nav.tsx
@@ -1,24 +1,30 @@
 "use client";
 
-import { LogOut } from "lucide-react";
+import { Compass, LogOut, Settings } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 
 import { logOut } from "@/actions/auth";
 import { Button } from "@/components/shadcn/button/button";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/shadcn/tooltip";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/shadcn/dropdown/dropdown";
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@/components/ui/avatar/avatar";
 import { CustomLink } from "@/components/ui/custom/custom-link";
+import { getOrderedFlows } from "@/lib/onboarding";
 
 export const UserNav = () => {
   const { data: session } = useSession();
+  const router = useRouter();
 
   if (!session?.user) return null;
 
@@ -31,43 +37,61 @@ export const UserNav = () => {
         .join("")
     : name.charAt(0);
 
-  return (
-    <div className="flex items-center gap-2">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="outline"
-            size="icon-sm"
-            className="border-border-input-primary-fill rounded-full"
-            asChild
-          >
-            <CustomLink href="/profile" target="_self" aria-label="Account">
-              <Avatar className="h-8 w-8">
-                <AvatarImage src="#" alt="Avatar" />
-                <AvatarFallback className="bg-transparent text-xs font-bold">
-                  {initials}
-                </AvatarFallback>
-              </Avatar>
-            </CustomLink>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Account Settings</TooltipContent>
-      </Tooltip>
+  // Derive the restart destination from the registry so adding or reordering
+  // flows never requires editing this component. The trigger mounted on the
+  // target route consumes the `?onboarding=<id>` param and force-starts the tour.
+  const firstFlow = getOrderedFlows()[0];
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="border-border-input-primary-fill rounded-full"
-            onClick={() => logOut()}
-            aria-label="Sign out"
+  const startProductTour = () => {
+    if (!firstFlow) return;
+    router.push(`${firstFlow.route}?onboarding=${firstFlow.id}`);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon-sm"
+          className="border-border-input-primary-fill rounded-full"
+          aria-label="Account menu"
+        >
+          <Avatar className="h-8 w-8">
+            <AvatarImage src="#" alt="Avatar" />
+            <AvatarFallback className="bg-transparent text-xs font-bold">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>{name}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild className="cursor-pointer">
+          <CustomLink href="/profile" target="_self">
+            <Settings />
+            Account Settings
+          </CustomLink>
+        </DropdownMenuItem>
+        {firstFlow && (
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onSelect={startProductTour}
           >
-            <LogOut />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>Sign Out</TooltipContent>
-      </Tooltip>
-    </div>
+            <Compass />
+            Product tour
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          variant="destructive"
+          className="cursor-pointer"
+          onSelect={() => logOut()}
+        >
+          <LogOut />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };


### PR DESCRIPTION
### Context

Lets users replay onboarding from anywhere.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Adds a 'Product tour' submenu to the avatar/user nav listing every registered flow, with URLs derived from the registry.

### Steps to review

Read `components/ui/user-nav/user-nav.tsx`. Confirm the list is registry-driven (adding a flow needs no edit here).

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 4 of 15 |
| Base | `chain/ob-03-gate` |
| Depends on | #11433 |
| Follow-up | #11435 |
| Review budget | 197 / 400 |
| Starts at | #11433 (gate wiring) |
| Ends with | a replay entry point in the avatar menu |


### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← 📍#11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** user-nav restart submenu
- **Excludes:** the guided-sequence flows (change 2)

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
