### PR TITLE
test(ui): add onboarding e2e tests and changelog

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🚀 Added
 
 - In-product tour for the Attack Paths workflow [(#11383)](https://github.com/prowler-cloud/prowler/pull/11383)
+- Extensible onboarding system with a guided add-provider tour: a mandatory Welcome modal for zero-provider users and a "Product tour" restart entry in the avatar menu [(#11400)](https://github.com/prowler-cloud/prowler/pull/11400)
 
 ---
 

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -138,6 +138,12 @@ export default defineConfig({
       testMatch: "invitations.spec.ts",
       dependencies: ["admin.auth.setup"],
     },
+    // This project runs the onboarding test suite
+    {
+      name: "onboarding",
+      testMatch: "onboarding.spec.ts",
+      dependencies: ["admin.auth.setup"],
+    },
   ],
 
   webServer: {

--- a/ui/tests/onboarding/onboarding-page.ts
+++ b/ui/tests/onboarding/onboarding-page.ts
@@ -1,0 +1,118 @@
+import { Locator, Page, expect } from "@playwright/test";
+
+import { BasePage } from "../base-page";
+
+// localStorage key prefix used by the tour completion store
+// (`prowler.tour.<tourId>.v<version>`). Kept here so the cleanup helper never
+// hand-builds keys elsewhere in the suite.
+const TOUR_KEY_PREFIX = "prowler.tour";
+const ADD_PROVIDER_TOUR_KEY = `${TOUR_KEY_PREFIX}.add-provider.v1`;
+
+// Page Object for the onboarding flows. URL assertions live here (per the
+// prowler-test-ui convention) so the spec only orchestrates user actions.
+export class OnboardingPage extends BasePage {
+  // Welcome modal (mandatory gate entry point) and its actions.
+  readonly welcomeModal: Locator;
+  readonly getStartedButton: Locator;
+  readonly skipButton: Locator;
+
+  // Tour anchors mounted on the providers surface.
+  readonly addProviderTriggerAnchor: Locator;
+  readonly providerTypeAnchor: Locator;
+
+  // User-nav restart entry point.
+  readonly accountMenuTrigger: Locator;
+  readonly productTourNavEntry: Locator;
+
+  constructor(page: Page) {
+    super(page);
+
+    this.welcomeModal = page.getByRole("dialog").filter({
+      has: page.getByRole("heading", { name: /Add your first provider/i }),
+    });
+    this.getStartedButton = page.getByRole("button", { name: "Get started" });
+    this.skipButton = page.getByRole("button", { name: "Skip for now" });
+
+    this.addProviderTriggerAnchor = page.locator(
+      '[data-tour-id="add-provider-trigger"]',
+    );
+    this.providerTypeAnchor = page.locator(
+      '[data-tour-id="add-provider-provider-type"]',
+    );
+
+    this.accountMenuTrigger = page.getByRole("button", {
+      name: "Account menu",
+    });
+    this.productTourNavEntry = page.getByRole("menuitem", {
+      name: "Product tour",
+    });
+  }
+
+  // Clear every `prowler.tour.*` key so the gate evaluates as a fresh browser.
+  async clearOnboardingState(): Promise<void> {
+    await this.page.evaluate((prefix) => {
+      const keys: string[] = [];
+      for (let i = 0; i < window.localStorage.length; i++) {
+        const key = window.localStorage.key(i);
+        if (key && key.startsWith(prefix)) keys.push(key);
+      }
+      keys.forEach((key) => window.localStorage.removeItem(key));
+    }, TOUR_KEY_PREFIX);
+  }
+
+  // Seed a `completed` record so the restart path proves the tour starts despite
+  // an existing completion record.
+  async seedCompletedAddProviderRecord(): Promise<void> {
+    await this.page.evaluate((key) => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({
+          tourId: "add-provider",
+          version: 1,
+          state: "completed",
+          completedAt: new Date().toISOString(),
+        }),
+      );
+    }, ADD_PROVIDER_TOUR_KEY);
+  }
+
+  async openAccountMenu(): Promise<void> {
+    await this.accountMenuTrigger.click();
+  }
+
+  async startProductTourFromNav(): Promise<void> {
+    await this.openAccountMenu();
+    await expect(this.productTourNavEntry).toBeVisible();
+    await this.productTourNavEntry.click();
+  }
+
+  async clickGetStarted(): Promise<void> {
+    await this.getStartedButton.click();
+  }
+
+  async verifyWelcomeModalVisible(): Promise<void> {
+    await expect(this.welcomeModal).toBeVisible();
+  }
+
+  async verifyWelcomeModalNotVisible(): Promise<void> {
+    await expect(this.welcomeModal).not.toBeVisible();
+  }
+
+  async verifyTriggerAnchorPresent(): Promise<void> {
+    await expect(this.addProviderTriggerAnchor).toBeVisible();
+  }
+
+  async verifyAnchorsPresent(): Promise<void> {
+    await expect(this.addProviderTriggerAnchor).toBeVisible();
+    await expect(this.providerTypeAnchor).toBeVisible();
+  }
+
+  // URL assertions encapsulated in the POM (prowler-test-ui convention).
+  async verifyOnProvidersPage(): Promise<void> {
+    await this.page.waitForURL(/\/providers(\?|$)/);
+  }
+
+  async verifyOnProvidersPageWithOnboardingParam(): Promise<void> {
+    await this.page.waitForURL(/\/providers\?onboarding=add-provider/);
+  }
+}

--- a/ui/tests/onboarding/onboarding.md
+++ b/ui/tests/onboarding/onboarding.md
@@ -1,0 +1,105 @@
+### E2E Tests: Onboarding System
+
+**Suite ID:** `OB-E2E`
+**Feature:** Extensible UI onboarding system with the guided add-provider tour.
+
+> Behavioral assertions only: Welcome modal visibility, navigation to the flow
+> route, and presence of the `data-tour-id` anchors in the DOM. Driver.js overlay
+> animation is never asserted. Waits use `expect(...).toBeVisible()` and
+> `page.waitForURL()` — never `networkidle`.
+
+---
+
+## Test Case: `OB-E2E-001` - Mandatory new-user onboarding path
+
+**Priority:** `critical`
+
+**Tags:**
+
+- type → @e2e
+- feature → @onboarding
+
+**Description/Objective:** A zero-provider authenticated user is forced into the
+Welcome modal on first load; accepting it navigates to the add-provider flow and
+exposes the tour trigger anchor.
+
+**Preconditions:**
+
+- Admin user authentication required (`admin.auth.setup`, reused `storageState`)
+- All `prowler.tour.*` localStorage keys cleared before the test
+- The account has zero providers (existing providers removed via `deleteProviderIfExists`)
+
+### Flow Steps
+
+1. Navigate to a page inside `app/(prowler)/`
+2. Assert the Welcome modal is visible
+3. Click "Get started"
+4. Assert navigation to `/providers` (the `?onboarding=add-provider` param is consumed)
+5. Assert the `data-tour-id="add-provider-trigger"` anchor is present in the DOM
+
+### Expected Result
+
+- Welcome modal is displayed for the zero-provider user
+- Accepting navigates to the providers route
+- The add-provider trigger anchor is mounted on the providers page
+
+### Key verification points
+
+- Welcome modal visible on first authenticated load (gate forced it)
+- After accept, the URL is `/providers`
+- `[data-tour-id="add-provider-trigger"]` exists in the DOM
+
+### Notes
+
+- Maps to spec: "Zero-provider user on first authenticated load", "User accepts
+  the Welcome modal", "Every tour step target has a matching data-tour-id anchor"
+- Full execution requires the Prowler stack (API + DB + auth env). The trigger
+  anchor proves the tour surface is reachable without asserting overlay animation
+
+---
+
+## Test Case: `OB-E2E-002` - Restart onboarding from the avatar menu
+
+**Priority:** `high`
+
+**Tags:**
+
+- type → @e2e
+- feature → @onboarding
+
+**Description/Objective:** A user who already completed the tour can restart it
+from the avatar menu; the tour starts again despite the existing completion
+record.
+
+**Preconditions:**
+
+- Admin user authentication required (`admin.auth.setup`, reused `storageState`)
+- A `completed` record exists in localStorage for `add-provider`
+  (`prowler.tour.add-provider.v1`)
+
+### Flow Steps
+
+1. Navigate to a page with the user nav visible
+2. Open the avatar account menu
+3. Click "Product tour"
+4. Assert navigation to `/providers?onboarding=add-provider`
+5. Assert the `data-tour-id="add-provider-trigger"` anchor is present in the DOM
+
+### Expected Result
+
+- The restart entry navigates to the add-provider flow route with the onboarding param
+- The tour starts despite the existing completion record (no Welcome modal)
+- The add-provider trigger anchor is mounted on the providers page
+
+### Key verification points
+
+- "Product tour" entry is present in the avatar menu
+- After selecting it, the URL is `/providers?onboarding=add-provider`
+- `[data-tour-id="add-provider-trigger"]` exists in the DOM (re-trigger bypassed the completion record)
+
+### Notes
+
+- Maps to spec: "User activates the restart entry point from the avatar menu",
+  "Re-trigger works after a full page reload", "Re-trigger does not depend on
+  prior browser state"
+- Full execution requires the Prowler stack (API + DB + auth env)

--- a/ui/tests/onboarding/onboarding.spec.ts
+++ b/ui/tests/onboarding/onboarding.spec.ts
@@ -1,0 +1,89 @@
+import { test } from "@playwright/test";
+
+import { deleteProviderIfExists } from "../helpers";
+import { ProvidersPage } from "../providers/providers-page";
+import { OnboardingPage } from "./onboarding-page";
+
+test.describe("Onboarding", () => {
+  // Reuse admin authentication; provider management requires it and the gate
+  // reads the already-hydrated `hasProviders` signal from this session.
+  test.use({ storageState: "playwright/.auth/admin_user.json" });
+
+  test.describe("Mandatory new-user path", () => {
+    // The gate only fires for a zero-provider account, so the existing E2E AWS
+    // provider (when configured) is removed and the tour state is cleared.
+    const accountId = process.env.E2E_AWS_PROVIDER_ACCOUNT_ID ?? "";
+
+    test.beforeEach(async ({ page }) => {
+      const providersPage = new ProvidersPage(page);
+      if (accountId) {
+        await deleteProviderIfExists(providersPage, accountId);
+      }
+
+      // Clear any tour records so the gate evaluates as a fresh browser.
+      await providersPage.goto();
+      const onboardingPage = new OnboardingPage(page);
+      await onboardingPage.clearOnboardingState();
+    });
+
+    test(
+      "forces the Welcome modal and hands off to the add-provider tour",
+      {
+        tag: ["@critical", "@e2e", "@onboarding", "@OB-E2E-001"],
+      },
+      async ({ page }) => {
+        test.skip(
+          !accountId,
+          "E2E_AWS_PROVIDER_ACCOUNT_ID is not set; cannot guarantee a zero-provider account",
+        );
+
+        const onboardingPage = new OnboardingPage(page);
+
+        // Reload so the gate re-evaluates with a cleared tour state.
+        await onboardingPage.goto("/providers");
+
+        // The zero-provider account is forced into the Welcome modal.
+        await onboardingPage.verifyWelcomeModalVisible();
+
+        // Accepting hands off to the providers route (param consumed).
+        await onboardingPage.clickGetStarted();
+        await onboardingPage.verifyOnProvidersPage();
+
+        // The tour trigger anchor is mounted on the providers surface.
+        await onboardingPage.verifyTriggerAnchorPresent();
+      },
+    );
+  });
+
+  test.describe("Restart path", () => {
+    test.beforeEach(async ({ page }) => {
+      // Land on a page with the user nav, then seed a completed record so the
+      // restart entry proves the tour starts despite an existing record.
+      const onboardingPage = new OnboardingPage(page);
+      await onboardingPage.goto("/providers");
+      await onboardingPage.seedCompletedAddProviderRecord();
+    });
+
+    test(
+      "restarts the tour from the avatar menu despite a completion record",
+      {
+        tag: ["@high", "@e2e", "@onboarding", "@OB-E2E-002"],
+      },
+      async ({ page }) => {
+        const onboardingPage = new OnboardingPage(page);
+
+        // Reload so the seeded record is in effect for the gate.
+        await onboardingPage.goto("/providers");
+
+        // Open the avatar menu and select "Product tour".
+        await onboardingPage.startProductTourFromNav();
+
+        // Navigation carries the onboarding param to the flow route.
+        await onboardingPage.verifyOnProvidersPageWithOnboardingParam();
+
+        // The tour started despite the existing completion record.
+        await onboardingPage.verifyTriggerAnchorPresent();
+      },
+    );
+  });
+});


### PR DESCRIPTION
### Context

Locks the change-1 behaviour with end-to-end coverage.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Playwright e2e for the mandatory gate + add-provider tour, plus the UI CHANGELOG entry.

### Steps to review

Read `ui/tests/onboarding/*`. Run the onboarding e2e locally if desired.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [x] New entry added to UI `CHANGELOG.md`
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 5 of 15 |
| Base | `chain/ob-04-usernav` |
| Depends on | #11434 |
| Follow-up | #11436 |
| Review budget | 319 / 400 |
| Starts at | #11434 (user-nav) |
| Ends with | a covered, documented add-ui-onboarding-system change |


### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← 📍#11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** change-1 e2e specs + CHANGELOG entry
- **Excludes:** none

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
