### PR TITLE
fix(ui): start onboarding tour reliably under React StrictMode

### DIFF
--- a/ui/app/(prowler)/layout.tsx
+++ b/ui/app/(prowler)/layout.tsx
@@ -43,7 +43,18 @@ export default async function RootLayout({
   children: ReactNode;
 }) {
   const providersData = await getProviders({ page: 1, pageSize: 1 });
-  const hasProviders = !!(providersData?.data && providersData.data.length > 0);
+  // Tri-state on purpose: a SUCCESSFUL fetch carries `data` (an array, possibly
+  // empty); a FAILED/ambiguous fetch yields `undefined` (network error) or an
+  // error envelope without `data`. Collapsing the failure to `false` would
+  // force the mandatory onboarding gate onto an existing user during an API
+  // outage, so we keep `undefined` distinct and let the gate fail open.
+  //   - success with providers -> true
+  //   - success, zero providers -> false
+  //   - failed/ambiguous fetch  -> undefined
+  const hasProviders =
+    providersData?.data === undefined
+      ? undefined
+      : providersData.data.length > 0;
 
   return (
     <html suppressHydrationWarning lang="en">
@@ -57,7 +68,10 @@ export default async function RootLayout({
       >
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
           <NavigationProgress />
-          <StoreInitializer values={{ hasProviders }} />
+          {/* Store keeps a plain boolean: existing sidebar/empty-state
+              behavior is unchanged. Only the gate gets the tri-state so it can
+              fail open on an unknown provider signal. */}
+          <StoreInitializer values={{ hasProviders: hasProviders ?? false }} />
           <OnboardingGate hasProviders={hasProviders} />
           <MainLayout>{children}</MainLayout>
           <Toaster />

--- a/ui/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -80,10 +80,25 @@ describe("OnboardingGate", () => {
 
   describe("when hasProviders is undefined (fail-open)", () => {
     it("does not show the Welcome modal", async () => {
-      // Given - an ambiguous provider signal (transient / errored)
-      render(<OnboardingGate hasProviders={undefined as unknown as boolean} />);
+      // Given - an ambiguous provider signal (transient / errored). The prop is
+      // optional (`boolean | undefined`) so `undefined` is passed type-cleanly,
+      // mirroring the tri-state the layout forwards on a failed provider fetch.
+      render(<OnboardingGate hasProviders={undefined} />);
 
       // Then - the gate fails open and does not force onboarding
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /get started/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("can be mounted with the prop omitted entirely (fail-open)", async () => {
+      // Given - the layout forwards `undefined` (omitted) when the provider
+      // fetch failed; the gate must still fail open rather than force the modal.
+      render(<OnboardingGate />);
+
+      // Then - no modal
       await waitFor(() => {
         expect(
           screen.queryByRole("button", { name: /get started/i }),

--- a/ui/components/onboarding/__tests__/providers-onboarding-trigger.test.tsx
+++ b/ui/components/onboarding/__tests__/providers-onboarding-trigger.test.tsx
@@ -5,6 +5,10 @@ import { ProvidersOnboardingTrigger } from "../providers-onboarding-trigger";
 
 const startMock = vi.fn();
 const replaceMock = vi.fn();
+// Counts every `useDriverTour` invocation. A mounted runner re-invokes the
+// hook on each render; an unmounted runner never invokes it again. This is the
+// signal the unmount-regression test reads.
+const useDriverTourMock = vi.fn();
 let searchParamsValue = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
@@ -14,17 +18,21 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/lib/tours/use-driver-tour", () => ({
-  useDriverTour: () => ({
-    start: startMock,
-    stop: vi.fn(),
-    hasCompleted: false,
-  }),
+  useDriverTour: () => {
+    useDriverTourMock();
+    return {
+      start: startMock,
+      stop: vi.fn(),
+      hasCompleted: false,
+    };
+  },
 }));
 
 describe("ProvidersOnboardingTrigger", () => {
   beforeEach(() => {
     startMock.mockClear();
     replaceMock.mockClear();
+    useDriverTourMock.mockClear();
     searchParamsValue = new URLSearchParams();
   });
 
@@ -36,14 +44,20 @@ describe("ProvidersOnboardingTrigger", () => {
     it("force-starts the tour and clears the param", async () => {
       // Given - the URL carries ?onboarding=add-provider
       searchParamsValue = new URLSearchParams("onboarding=add-provider");
+      const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
       // When - the trigger mounts
       render(<ProvidersOnboardingTrigger openWizard={vi.fn()} />);
 
-      // Then - it starts the tour and strips the param to avoid a reload loop
+      // Then - it starts the tour and strips the param (preserving the current
+      // pathname) to avoid a reload loop, without a router round-trip.
       await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
       await waitFor(() =>
-        expect(replaceMock).toHaveBeenCalledWith("/providers"),
+        expect(replaceStateSpy).toHaveBeenCalledWith(
+          null,
+          "",
+          window.location.pathname,
+        ),
       );
     });
   });
@@ -52,13 +66,14 @@ describe("ProvidersOnboardingTrigger", () => {
     it("does not start the tour", async () => {
       // Given - a bare URL
       searchParamsValue = new URLSearchParams();
+      const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
       // When - the trigger mounts
       render(<ProvidersOnboardingTrigger openWizard={vi.fn()} />);
 
       // Then - nothing is triggered
       await waitFor(() => expect(startMock).not.toHaveBeenCalled());
-      expect(replaceMock).not.toHaveBeenCalled();
+      expect(replaceStateSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -66,13 +81,45 @@ describe("ProvidersOnboardingTrigger", () => {
     it("does not start the tour", async () => {
       // Given - an unknown flow id in the URL
       searchParamsValue = new URLSearchParams("onboarding=unknown-xyz");
+      const replaceStateSpy = vi.spyOn(window.history, "replaceState");
 
       // When - the trigger mounts
       render(<ProvidersOnboardingTrigger openWizard={vi.fn()} />);
 
       // Then - nothing is triggered
       await waitFor(() => expect(startMock).not.toHaveBeenCalled());
-      expect(replaceMock).not.toHaveBeenCalled();
+      expect(replaceStateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the param is cleared after the tour starts", () => {
+    it("keeps the tour runner mounted and does not restart the tour", async () => {
+      // Given - the URL carries ?onboarding=add-provider and the tour starts
+      searchParamsValue = new URLSearchParams("onboarding=add-provider");
+      const { rerender } = render(
+        <ProvidersOnboardingTrigger openWizard={vi.fn()} />,
+      );
+      await waitFor(() => expect(startMock).toHaveBeenCalledTimes(1));
+
+      const callsBeforeClear = useDriverTourMock.mock.calls.length;
+
+      // When - the onboarding param is stripped from the URL (as happens after
+      // the trigger clears it) and the component re-renders
+      searchParamsValue = new URLSearchParams();
+      rerender(<ProvidersOnboardingTrigger openWizard={vi.fn()} />);
+
+      // Then - the runner stays mounted (the latched flow is not torn down) and
+      // the tour is not started a second time. This is the regression guard:
+      // the old code derived `flow` from the live param and UNMOUNTED the
+      // runner here (destroying the just-started tour). A mounted runner
+      // re-invokes `useDriverTour` on the re-render; an unmounted one never
+      // would.
+      await waitFor(() =>
+        expect(useDriverTourMock.mock.calls.length).toBeGreaterThan(
+          callsBeforeClear,
+        ),
+      );
+      expect(startMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ui/components/onboarding/onboarding-gate.tsx
+++ b/ui/components/onboarding/onboarding-gate.tsx
@@ -14,7 +14,11 @@ import { TOUR_COMPLETION_STATES } from "@/lib/tours/tour-types";
 import { OnboardingWelcomeModal } from "./onboarding-welcome-modal";
 
 interface OnboardingGateProps {
-  hasProviders: boolean;
+  // Tri-state: `true`/`false` from a successful provider fetch, `undefined`
+  // when the layout could not determine provider state (failed/ambiguous
+  // fetch). `undefined` must fail open — never force the modal on an unknown
+  // state.
+  hasProviders?: boolean;
 }
 
 // Mandatory new-user gate. Mounted once in the (prowler) layout. Reads the
@@ -28,11 +32,16 @@ export function OnboardingGate({ hasProviders }: OnboardingGateProps) {
 
   useEffect(() => {
     // Select the first flow that is incomplete by account state and has no
-    // browser record. `getFirstIncompleteFlow` uses `isComplete(ctx)` which
-    // false-positives when `hasProviders` is undefined, so it is NOT the final
-    // authority — `shouldStartOnboarding` below applies the strict `=== false`
-    // fail-open guard.
-    const flow = getFirstIncompleteFlow({ hasProviders }, localStorageAdapter);
+    // browser record. `OnboardingContext.hasProviders` is a strict boolean, so
+    // an unknown signal collapses to `false` here (`?? false`) for SELECTION
+    // ONLY — a flow is still picked. `getFirstIncompleteFlow` is NOT the final
+    // authority: `shouldStartOnboarding` below receives the RAW (possibly
+    // `undefined`) value and applies the strict `=== false` fail-open guard, so
+    // an ambiguous provider state never forces the modal.
+    const flow = getFirstIncompleteFlow(
+      { hasProviders: hasProviders ?? false },
+      localStorageAdapter,
+    );
     if (!flow) {
       setActiveFlow(null);
       return;

--- a/ui/components/onboarding/providers-onboarding-trigger.tsx
+++ b/ui/components/onboarding/providers-onboarding-trigger.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 
 import { getFlowById, type OnboardingFlow } from "@/lib/onboarding";
 import { createAddProviderTourStepHandlers } from "@/lib/tours/add-provider.tour";
@@ -15,6 +15,13 @@ interface ProvidersOnboardingTriggerProps {
 
 const ONBOARDING_PARAM = "onboarding";
 
+// A single, latched trigger request. `key` lets us mount a FRESH runner per
+// re-trigger so the tour can be restarted repeatedly.
+interface OnboardingRequest {
+  flow: OnboardingFlow;
+  key: number;
+}
+
 // Reads `?onboarding=<flowId>` and, when it matches a known flow, force-starts
 // that flow's tour over the real page surface, then strips the param so a
 // refresh does not re-trigger. Renders nothing.
@@ -24,14 +31,41 @@ export function ProvidersOnboardingTrigger({
   const searchParams = useSearchParams();
   // `useSearchParams` can return null outside a router/Suspense context.
   const flowId = searchParams?.get(ONBOARDING_PARAM) ?? null;
-  const flow = flowId ? getFlowById(flowId) : undefined;
 
-  if (!flow) return null;
+  // The flow is LATCHED into state rather than derived from the live params on
+  // every render. Once latched, stripping the param does NOT unmount the
+  // runner — which previously destroyed the just-started tour.
+  const [request, setRequest] = useState<OnboardingRequest | null>(null);
+  const keyRef = useRef(0);
 
-  // Delegated to an inner component so the `useDriverTour` hook is always
-  // called unconditionally for the resolved flow (Rules of Hooks): this whole
-  // tree only mounts when a valid flow is present.
-  return <OnboardingTourRunner flow={flow} openWizard={openWizard} />;
+  useEffect(() => {
+    if (!flowId) return;
+    const flow = getFlowById(flowId);
+    if (!flow) return;
+
+    keyRef.current += 1;
+    setRequest({ flow, key: keyRef.current });
+
+    // Strip the param via history so a hard reload does not re-launch the tour.
+    // We use `window.history.replaceState` instead of `router.replace` so that
+    // clearing the param does NOT re-trigger `useSearchParams` reactivity or a
+    // server route round-trip. The latched runner therefore stays mounted.
+    window.history.replaceState(null, "", window.location.pathname);
+  }, [flowId]);
+
+  if (!request) return null;
+
+  // Keyed so each re-trigger mounts a FRESH runner (fresh `hasStartedRef`),
+  // preserving "restart works repeatedly". The runner calls `useDriverTour`
+  // unconditionally, so Rules of Hooks hold even though this parent can return
+  // null above.
+  return (
+    <OnboardingTourRunner
+      key={request.key}
+      flow={request.flow}
+      openWizard={openWizard}
+    />
+  );
 }
 
 interface OnboardingTourRunnerProps {
@@ -40,8 +74,6 @@ interface OnboardingTourRunnerProps {
 }
 
 function OnboardingTourRunner({ flow, openWizard }: OnboardingTourRunnerProps) {
-  const router = useRouter();
-  const pathname = usePathname();
   const hasStartedRef = useRef(false);
 
   const { start } = useDriverTour(flow.tour, {
@@ -56,9 +88,7 @@ function OnboardingTourRunner({ flow, openWizard }: OnboardingTourRunnerProps) {
     hasStartedRef.current = true;
 
     start();
-    // Strip the param so a hard reload does not re-launch the tour.
-    router.replace(pathname);
-  }, [start, router, pathname]);
+  }, [start]);
 
   return null;
 }

--- a/ui/components/onboarding/providers-onboarding-trigger.tsx
+++ b/ui/components/onboarding/providers-onboarding-trigger.tsx
@@ -74,21 +74,26 @@ interface OnboardingTourRunnerProps {
 }
 
 function OnboardingTourRunner({ flow, openWizard }: OnboardingTourRunnerProps) {
-  const hasStartedRef = useRef(false);
-
   const { start } = useDriverTour(flow.tour, {
     autoOpen: false,
     stepHandlers: createAddProviderTourStepHandlers(openWizard),
   });
 
+  // Force-start once per mount. This bypasses the `hasCompleted` short-circuit
+  // so re-trigger works even with an existing completion record.
+  //
+  // The empty dependency array is intentional (NOT `[start]`): `start` gets a
+  // new identity every render and always reads the latest `driverRef.current`,
+  // so a single call on mount is correct. A `hasStartedRef` guard must NOT be
+  // used here: under React StrictMode (dev) the effect runs setup → cleanup →
+  // setup; the first setup starts the tour, the cleanup destroys it, and a ref
+  // guard would then skip the re-start on the second setup, leaving no visible
+  // tour. Mounting a fresh runner per re-trigger (via the parent `key`) already
+  // guarantees one start per intentional trigger.
   useEffect(() => {
-    // Force-start once: bypasses the `hasCompleted` short-circuit so the
-    // re-trigger works even with an existing completion record.
-    if (hasStartedRef.current) return;
-    hasStartedRef.current = true;
-
     start();
-  }, [start]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return null;
 }

--- a/ui/lib/onboarding/__tests__/gate-decision.test.ts
+++ b/ui/lib/onboarding/__tests__/gate-decision.test.ts
@@ -76,10 +76,11 @@ describe("shouldStartOnboarding", () => {
   });
 
   it("fails open when hasProviders is undefined", () => {
-    // Given - ambiguous provider signal (undefined)
+    // Given - ambiguous provider signal (undefined), passed type-cleanly
+    // because the input type accepts `boolean | undefined`
     // When - strict === false check rejects non-false values
     const result = shouldStartOnboarding({
-      hasProviders: undefined as unknown as boolean,
+      hasProviders: undefined,
       completionRecord: null,
     });
 

--- a/ui/lib/onboarding/gate-decision.ts
+++ b/ui/lib/onboarding/gate-decision.ts
@@ -1,7 +1,10 @@
 import type { TourCompletionRecord } from "@/lib/tours/tour-types";
 
 export interface GateDecisionInput {
-  hasProviders: boolean;
+  // Accepts `undefined` so callers can forward an ambiguous/failed provider
+  // signal without casting. The strict `=== false` check below fails open on
+  // anything that is not provably `false`.
+  hasProviders: boolean | undefined;
   completionRecord: TourCompletionRecord | null;
 }
 


### PR DESCRIPTION
### Context

Fixes two reliability issues found while testing change 1.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Starts the tour reliably under React StrictMode (drops the ref guard for a keyed runner) and keeps the gate fail-open on an undefined provider signal.

### Steps to review

Diff the trigger + gate. Confirm the tour starts exactly once in dev (StrictMode double-invoke).

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 6 of 15 |
| Base | `chain/ob-05-e2e` |
| Depends on | #11435 |
| Follow-up | #11437 |
| Review budget | 208 / 400 |
| Starts at | #11435 (change-1 e2e) |
| Ends with | a robust change-1 baseline (closes change 1) |


### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← #11435 ← 📍#11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** StrictMode tour-start fix + fail-open hardening
- **Excludes:** none

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
