### PR TITLE
feat(ui): add onboarding sequence state and tour completion callback

### DIFF
--- a/ui/components/onboarding/__tests__/checkpoint.test.ts
+++ b/ui/components/onboarding/__tests__/checkpoint.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldFireCheckpoint } from "../checkpoint.logic";
+
+describe("shouldFireCheckpoint", () => {
+  it("fires on a concrete false -> true flip that has not been handled", () => {
+    // Given - the user just connected their first provider, unhandled
+    // When/Then - the checkpoint fires
+    expect(
+      shouldFireCheckpoint({ prev: false, next: true, handled: false }),
+    ).toBe(true);
+  });
+
+  it("does not fire on an undefined -> true initial read", () => {
+    // Given - the user already had providers (no transition observed)
+    // When/Then - the checkpoint must NOT fire on the first read
+    expect(
+      shouldFireCheckpoint({ prev: undefined, next: true, handled: false }),
+    ).toBe(false);
+  });
+
+  it("does not fire on a true -> true steady state", () => {
+    // Given - providers were already present and stay present
+    // When/Then - no flip, no checkpoint
+    expect(
+      shouldFireCheckpoint({ prev: true, next: true, handled: false }),
+    ).toBe(false);
+  });
+
+  it("does not fire on a false -> true flip that was already handled", () => {
+    // Given - the flip happened but the user already chose continue/finish
+    // When/Then - the marker suppresses re-appearance
+    expect(
+      shouldFireCheckpoint({ prev: false, next: true, handled: true }),
+    ).toBe(false);
+  });
+
+  it("does not fire on a false -> false steady state", () => {
+    // Given - still no providers
+    // When/Then - nothing to celebrate yet
+    expect(
+      shouldFireCheckpoint({ prev: false, next: false, handled: false }),
+    ).toBe(false);
+  });
+
+  it("does not fire on a true -> false regression", () => {
+    // Given - providers disappeared (e.g. deleted)
+    // When/Then - the checkpoint is only about gaining the first provider
+    expect(
+      shouldFireCheckpoint({ prev: true, next: false, handled: false }),
+    ).toBe(false);
+  });
+});

--- a/ui/components/onboarding/__tests__/onboarding-trigger.decision.test.ts
+++ b/ui/components/onboarding/__tests__/onboarding-trigger.decision.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mapCloseToSequenceAction,
+  resolveTriggerRequest,
+} from "../onboarding-trigger.logic";
+
+describe("resolveTriggerRequest", () => {
+  describe("replay (param) path", () => {
+    it("requests a replay start when the param matches this flow", () => {
+      // Given - the URL carries `?onboarding=<flowId>` for THIS route's flow
+      // When - the trigger resolves the request
+      const result = resolveTriggerRequest({
+        param: "add-provider",
+        sliceActive: false,
+        currentFlowId: null,
+        flowId: "add-provider",
+      });
+
+      // Then - it starts in replay mode (single-flow, no sequence)
+      expect(result).toEqual({ start: true, mode: "replay" });
+    });
+
+    it("takes precedence over the sequence when the param matches", () => {
+      // Given - both the param and the active slice name THIS flow
+      // When - the trigger resolves the request
+      const result = resolveTriggerRequest({
+        param: "add-provider",
+        sliceActive: true,
+        currentFlowId: "add-provider",
+        flowId: "add-provider",
+      });
+
+      // Then - the documented precedence picks replay deterministically
+      expect(result).toEqual({ start: true, mode: "replay" });
+    });
+  });
+
+  describe("sequence (slice) path", () => {
+    it("requests a sequence start when the active slice names this flow", () => {
+      // Given - no param, but the active sequence points at THIS flow
+      // When - the trigger resolves the request
+      const result = resolveTriggerRequest({
+        param: null,
+        sliceActive: true,
+        currentFlowId: "add-provider",
+        flowId: "add-provider",
+      });
+
+      // Then - it starts in sequence mode
+      expect(result).toEqual({ start: true, mode: "sequence" });
+    });
+
+    it("does not start when the active slice names a different flow", () => {
+      // Given - the active sequence points at ANOTHER flow
+      // When - the trigger resolves the request
+      const result = resolveTriggerRequest({
+        param: null,
+        sliceActive: true,
+        currentFlowId: "view-first-scan",
+        flowId: "add-provider",
+      });
+
+      // Then - no start is requested for this route's flow
+      expect(result).toBeNull();
+    });
+
+    it("does not start when the slice is inactive even if the id matches", () => {
+      // Given - the slice names this flow but is inactive
+      // When - the trigger resolves the request
+      const result = resolveTriggerRequest({
+        param: null,
+        sliceActive: false,
+        currentFlowId: "add-provider",
+        flowId: "add-provider",
+      });
+
+      // Then - no start (an inactive slice never drives a start)
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("no-match path", () => {
+    it("returns null when the param targets a different flow and the slice is inactive", () => {
+      // Given - a param for ANOTHER flow and an inactive slice
+      // When - the trigger resolves the request
+      const result = resolveTriggerRequest({
+        param: "view-first-scan",
+        sliceActive: false,
+        currentFlowId: null,
+        flowId: "add-provider",
+      });
+
+      // Then - this route's flow has nothing to start
+      expect(result).toBeNull();
+    });
+
+    it("returns null when neither the param nor the slice match", () => {
+      // Given - no param and no active slice
+      // When - the trigger resolves the request
+      const result = resolveTriggerRequest({
+        param: null,
+        sliceActive: false,
+        currentFlowId: null,
+        flowId: "add-provider",
+      });
+
+      // Then - null
+      expect(result).toBeNull();
+    });
+  });
+});
+
+describe("mapCloseToSequenceAction", () => {
+  it("advances the sequence when the tour completes", () => {
+    // Given/When/Then - last-step completion drives the sequence forward
+    expect(mapCloseToSequenceAction("completed")).toBe("advance");
+  });
+
+  it("stops the sequence when the tour is skipped", () => {
+    // Given/When/Then - a mid-tour skip ends the sequence
+    expect(mapCloseToSequenceAction("skipped")).toBe("stop");
+  });
+
+  it("stops the sequence when the tour is dismissed", () => {
+    // Given/When/Then - an unmount/dismiss ends the sequence
+    expect(mapCloseToSequenceAction("dismissed")).toBe("stop");
+  });
+});

--- a/ui/components/onboarding/checkpoint.logic.ts
+++ b/ui/components/onboarding/checkpoint.logic.ts
@@ -1,0 +1,23 @@
+// Inputs the checkpoint watcher reads to decide whether to open the dialog.
+// Framework-free so the firing rule is unit-testable without React effects.
+export interface CheckpointInput {
+  // The previous `hasProviders` value. `undefined` means "first read, no
+  // transition observed yet".
+  prev: boolean | undefined;
+  // The current `hasProviders` value.
+  next: boolean;
+  // Whether the checkpoint was already handled (continue/finish chosen) in this
+  // browser, per the localStorage marker.
+  handled: boolean;
+}
+
+// Fires the checkpoint EXACTLY on a concrete `false -> true` flip that has not
+// been handled. The `undefined -> true` case (user already had providers) must
+// NOT fire — only a real first-connect transition counts.
+export function shouldFireCheckpoint({
+  prev,
+  next,
+  handled,
+}: CheckpointInput): boolean {
+  return prev === false && next === true && !handled;
+}

--- a/ui/components/onboarding/onboarding-trigger.logic.ts
+++ b/ui/components/onboarding/onboarding-trigger.logic.ts
@@ -1,0 +1,51 @@
+import type { TourCompletionRecord } from "@/lib/tours/tour-types";
+import type { OnboardingSequenceMode } from "@/store/onboarding-sequence";
+
+// Inputs the generalized `OnboardingTrigger` reads to decide whether THIS
+// route's flow should force-start. Flat args keep the decision framework-free
+// and unit-testable in isolation from the React component.
+export interface TriggerRequestInput {
+  // The `?onboarding=<id>` query param value, or null when absent.
+  param: string | null;
+  // Whether the sequence slice is currently active.
+  sliceActive: boolean;
+  // The flow id the active sequence points at, or null.
+  currentFlowId: string | null;
+  // The id of the flow THIS route owns.
+  flowId: string;
+}
+
+// The resolved start request, or null when this route's flow should not start.
+export interface TriggerRequest {
+  start: true;
+  mode: OnboardingSequenceMode;
+}
+
+// Decides whether (and how) to force-start this route's flow. Replay (the
+// param) takes documented precedence over the sequence so a manual list replay
+// never gets hijacked by an in-flight sequence. Returns null when neither
+// source names this flow.
+export function resolveTriggerRequest({
+  param,
+  sliceActive,
+  currentFlowId,
+  flowId,
+}: TriggerRequestInput): TriggerRequest | null {
+  if (param === flowId) {
+    return { start: true, mode: "replay" };
+  }
+  if (sliceActive && currentFlowId === flowId) {
+    return { start: true, mode: "sequence" };
+  }
+  return null;
+}
+
+// The action a sequence-driven trigger takes once its tour closes. Last-step
+// completion advances the sequence; any user-close (skip/dismiss) ends it.
+export type SequenceCloseAction = "advance" | "stop";
+
+export function mapCloseToSequenceAction(
+  state: TourCompletionRecord["state"],
+): SequenceCloseAction {
+  return state === "completed" ? "advance" : "stop";
+}

--- a/ui/lib/onboarding/onboarding-types.ts
+++ b/ui/lib/onboarding/onboarding-types.ts
@@ -19,4 +19,9 @@ export interface OnboardingFlow {
   route: string;
   tour: TourDefinition;
   isComplete?: (ctx: OnboardingContext) => boolean;
+  // When true, the route's PAGE already drives this flow's tour (e.g.
+  // attack-paths). The shared OnboardingTrigger must NOT mount a runner for it;
+  // the page owns auto-open and reports completion to the sequence slice.
+  // Additive, optional, defaults to undefined/false.
+  ownsAutoOpen?: boolean;
 }

--- a/ui/lib/tours/__tests__/use-driver-tour.test.tsx
+++ b/ui/lib/tours/__tests__/use-driver-tour.test.tsx
@@ -1,0 +1,58 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { addProviderTour } from "../add-provider.tour";
+import type { TourCompletionRecord } from "../tour-types";
+import { useDriverTour } from "../use-driver-tour";
+
+// The hook short-circuits its driver.js effect when `NODE_ENV === "test"`, so
+// these tests assert the PUBLIC contract: the additive `onClosed` option is
+// accepted and does NOT change the returned result shape. Driver.js close
+// behavior is covered by E2E (slice 9).
+
+function HookProbe({
+  onClosed,
+  onResult,
+}: {
+  onClosed?: (state: TourCompletionRecord["state"]) => void;
+  onResult: (result: ReturnType<typeof useDriverTour>) => void;
+}) {
+  const result = useDriverTour(addProviderTour, { autoOpen: false, onClosed });
+  onResult(result);
+  return null;
+}
+
+describe("useDriverTour onClosed option", () => {
+  it("accepts the onClosed option and returns the existing result surface", () => {
+    // Given - a consumer that passes the additive onClosed callback
+    const onClosed = vi.fn();
+    const results: ReturnType<typeof useDriverTour>[] = [];
+
+    // When - the hook renders with onClosed
+    render(<HookProbe onClosed={onClosed} onResult={(r) => results.push(r)} />);
+
+    // Then - the public result is unchanged (start, stop, hasCompleted)
+    const result = results.at(-1);
+    expect(result).toBeDefined();
+    expect(typeof result?.start).toBe("function");
+    expect(typeof result?.stop).toBe("function");
+    expect(typeof result?.hasCompleted).toBe("boolean");
+    // And the result surface exposes no onClosed (it is input-only)
+    expect(result && "onClosed" in result).toBe(false);
+  });
+
+  it("keeps the same result surface when onClosed is omitted (backward-compatible)", () => {
+    // Given - an existing caller that omits onClosed
+    const results: ReturnType<typeof useDriverTour>[] = [];
+
+    // When - the hook renders without onClosed
+    render(<HookProbe onResult={(r) => results.push(r)} />);
+
+    // Then - the result is identical in shape
+    const result = results.at(-1);
+    expect(result).toBeDefined();
+    expect(typeof result?.start).toBe("function");
+    expect(typeof result?.stop).toBe("function");
+    expect(typeof result?.hasCompleted).toBe("boolean");
+  });
+});

--- a/ui/lib/tours/use-driver-tour.ts
+++ b/ui/lib/tours/use-driver-tour.ts
@@ -32,6 +32,13 @@ export interface UseDriverTourOptions<TTarget extends string = string> {
   configOverrides?: Partial<Config>;
   /** Indexed by step `target`; overrides driver.js's default Next/Back for that step. */
   stepHandlers?: { [K in TTarget]?: TourStepHandlers<TTarget> };
+  /**
+   * Fired once when the tour is destroyed (completed OR user-dismissed), with
+   * the final persisted state. Additive: existing callers omit it and keep the
+   * current behavior. Invoked from inside `onDestroyed`, AFTER persist, via a
+   * ref so a changing callback identity never recreates the driver.
+   */
+  onClosed?: (state: TourCompletionRecord["state"]) => void;
 }
 
 export interface UseDriverTourResult {
@@ -147,6 +154,7 @@ export function useDriverTour<TTarget extends string>(
     store = localStorageAdapter,
     configOverrides,
     stepHandlers,
+    onClosed,
   } = options;
 
   const { resolvedTheme } = useTheme();
@@ -166,6 +174,13 @@ export function useDriverTour<TTarget extends string>(
   stepHandlersRef.current = stepHandlers as
     | Record<string, TourStepHandlers<TTarget> | undefined>
     | undefined;
+
+  // Ref so a changing `onClosed` identity never recreates the driver (mirrors
+  // `stepHandlersRef`). NOT added to the effect dependency array.
+  const onClosedRef = useRef<
+    ((state: TourCompletionRecord["state"]) => void) | undefined
+  >(onClosed);
+  onClosedRef.current = onClosed;
 
   const tourId = tour.id;
   const tourVersion = tour.version;
@@ -255,6 +270,7 @@ export function useDriverTour<TTarget extends string>(
       },
       onDestroyed: () => {
         persist(finalStateRef.current);
+        onClosedRef.current?.(finalStateRef.current);
       },
     });
 

--- a/ui/store/__tests__/onboarding-sequence.test.ts
+++ b/ui/store/__tests__/onboarding-sequence.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getOrderedFlows } from "@/lib/onboarding";
+
+import { useOnboardingSequenceStore } from "../onboarding-sequence";
+
+// Resets the ephemeral slice to its initial state before every test. The slice
+// is plain (no persist), so a `setState` is enough to isolate cases.
+function resetStore(): void {
+  useOnboardingSequenceStore.setState({
+    active: false,
+    currentFlowId: null,
+    mode: null,
+  });
+}
+
+describe("useOnboardingSequenceStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  describe("startSequence", () => {
+    it("starts at the first ordered flow when called with no argument", () => {
+      // Given - an inactive sequence
+      // When - the sequence starts with no explicit flow
+      useOnboardingSequenceStore.getState().startSequence();
+
+      // Then - it activates at the first ordered flow in sequence mode
+      const state = useOnboardingSequenceStore.getState();
+      expect(state.active).toBe(true);
+      expect(state.currentFlowId).toBe(getOrderedFlows()[0].id);
+      expect(state.mode).toBe("sequence");
+    });
+
+    it("starts at the requested flow when given an explicit id", () => {
+      // Given - a flow id that exists in the registry
+      const targetId = getOrderedFlows()[0].id;
+
+      // When - the sequence starts at that flow
+      useOnboardingSequenceStore.getState().startSequence(targetId);
+
+      // Then - it activates at the requested flow
+      const state = useOnboardingSequenceStore.getState();
+      expect(state.active).toBe(true);
+      expect(state.currentFlowId).toBe(targetId);
+      expect(state.mode).toBe("sequence");
+    });
+  });
+
+  describe("advance", () => {
+    it("moves to the next ordered flow when the current one is not last", () => {
+      // Given - a sequence that needs at least two ordered flows
+      const ordered = getOrderedFlows();
+      if (ordered.length < 2) {
+        // The registry currently grows in later slices; skip the multi-flow
+        // assertion until a second flow exists rather than asserting on a
+        // single-flow registry.
+        return;
+      }
+      useOnboardingSequenceStore.setState({
+        active: true,
+        currentFlowId: ordered[0].id,
+        mode: "sequence",
+      });
+
+      // When - the sequence advances
+      useOnboardingSequenceStore.getState().advance();
+
+      // Then - it points at the next ordered flow and stays active
+      const state = useOnboardingSequenceStore.getState();
+      expect(state.active).toBe(true);
+      expect(state.currentFlowId).toBe(ordered[1].id);
+      expect(state.mode).toBe("sequence");
+    });
+
+    it("resets to inactive when advancing past the last ordered flow", () => {
+      // Given - a sequence positioned on the LAST ordered flow
+      const ordered = getOrderedFlows();
+      const lastFlow = ordered[ordered.length - 1];
+      useOnboardingSequenceStore.setState({
+        active: true,
+        currentFlowId: lastFlow.id,
+        mode: "sequence",
+      });
+
+      // When - the sequence advances past the end
+      useOnboardingSequenceStore.getState().advance();
+
+      // Then - it clears all three fields (sequence finished)
+      const state = useOnboardingSequenceStore.getState();
+      expect(state.active).toBe(false);
+      expect(state.currentFlowId).toBeNull();
+      expect(state.mode).toBeNull();
+    });
+  });
+
+  describe("stop", () => {
+    it("resets every field to its inactive value", () => {
+      // Given - an active sequence in progress
+      useOnboardingSequenceStore.setState({
+        active: true,
+        currentFlowId: getOrderedFlows()[0].id,
+        mode: "sequence",
+      });
+
+      // When - the sequence stops
+      useOnboardingSequenceStore.getState().stop();
+
+      // Then - all three fields are reset
+      const state = useOnboardingSequenceStore.getState();
+      expect(state.active).toBe(false);
+      expect(state.currentFlowId).toBeNull();
+      expect(state.mode).toBeNull();
+    });
+  });
+});

--- a/ui/store/onboarding-sequence.ts
+++ b/ui/store/onboarding-sequence.ts
@@ -1,0 +1,59 @@
+import { create } from "zustand";
+
+import { getFlowById, getOrderedFlows } from "@/lib/onboarding";
+
+// Distinguishes a slice-driven start ("sequence") from a param-driven replay
+// ("replay"). The trigger sets "replay" when it processes a `?onboarding=` param
+// so a single flow is replayed without touching the sequence.
+export type OnboardingSequenceMode = "sequence" | "replay";
+
+interface OnboardingSequenceState {
+  active: boolean;
+  currentFlowId: string | null;
+  mode: OnboardingSequenceMode | null;
+
+  // Begin a guided sequence at `startFlowId` (defaults to the first ordered
+  // flow). Falls back to the first ordered flow when the id is unknown.
+  startSequence: (startFlowId?: string) => void;
+  // Move to the next ordered flow after the current one. Clears state when the
+  // current flow is the last (sequence finished).
+  advance: () => void;
+  // End the sequence immediately (user closed a tour, or finished). Resets all.
+  stop: () => void;
+}
+
+// Ephemeral, NOT persisted: persisting `active`/`currentFlowId` would resurrect
+// a sequence after a hard refresh, violating "refresh mid-sequence must not
+// re-fire". The slice is the transient hand-off carrier across `router.push`
+// navigations within a single SPA session; durable "already saw this" memory
+// stays in the per-tour localStorage `TourCompletionRecord` (untouched here).
+export const useOnboardingSequenceStore = create<OnboardingSequenceState>(
+  (set, get) => ({
+    active: false,
+    currentFlowId: null,
+    mode: null,
+
+    startSequence: (startFlowId) => {
+      const ordered = getOrderedFlows();
+      const start = startFlowId
+        ? (getFlowById(startFlowId) ?? ordered[0])
+        : ordered[0];
+      if (!start) return;
+      set({ active: true, currentFlowId: start.id, mode: "sequence" });
+    },
+
+    advance: () => {
+      const { currentFlowId } = get();
+      const ordered = getOrderedFlows();
+      const idx = ordered.findIndex((flow) => flow.id === currentFlowId);
+      const next = idx >= 0 ? ordered[idx + 1] : undefined;
+      if (!next) {
+        set({ active: false, currentFlowId: null, mode: null });
+        return;
+      }
+      set({ currentFlowId: next.id });
+    },
+
+    stop: () => set({ active: false, currentFlowId: null, mode: null }),
+  }),
+);


### PR DESCRIPTION
### Context

Starts SDD change 2: chaining flows into a guided sequence after the first provider connects.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Ephemeral guided-sequence Zustand store (no persist) and the additive `onClosed` tour-completion callback used to chain flows. The banner owns advance; `onClosed` is inert.

### Steps to review

Read `store/onboarding-sequence.ts` and the `use-driver-tour.ts` `onClosed` wiring.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 7 of 15 |
| Base | `chain/ob-06-hardening1` |
| Depends on | #11436 |
| Follow-up | #11438 |
| Review budget | 510 / 400 ⚠️ |
| Starts at | #11436 (change-1 hardening) |
| Ends with | the state backbone for the guided sequence |

> **Size exception:** exceeds the 400-line budget because this is one cohesive code+tests unit; splitting further would separate a component/store/tour from the test that verifies it. No `size:exception` label exists in this repo (only `size/*`), so the rationale is recorded here.

### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← #11435 ← #11436 ← 📍#11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** sequence state + onClosed callback
- **Excludes:** trigger generalization (08), checkpoint (09)

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
