### PR TITLE
feat(ui): add onboarding checkpoint after first provider connects

### DIFF
--- a/ui/app/(prowler)/layout.tsx
+++ b/ui/app/(prowler)/layout.tsx
@@ -5,7 +5,10 @@ import { Metadata, Viewport } from "next";
 import { ReactNode } from "react";
 
 import { getProviders } from "@/actions/providers";
-import { OnboardingGate } from "@/components/onboarding";
+import {
+  OnboardingCheckpointWatcher,
+  OnboardingGate,
+} from "@/components/onboarding";
 import MainLayout from "@/components/ui/main-layout/main-layout";
 import { NavigationProgress } from "@/components/ui/navigation-progress";
 import { Toaster } from "@/components/ui/toast";
@@ -73,6 +76,11 @@ export default async function RootLayout({
               fail open on an unknown provider signal. */}
           <StoreInitializer values={{ hasProviders: hasProviders ?? false }} />
           <OnboardingGate hasProviders={hasProviders} />
+          {/* Layout-level watcher: reads `hasProviders` from the UI store
+              (synced by StoreInitializer) and fires the checkpoint dialog once
+              on the first `false -> true` provider flip. One mount point so it
+              survives the post-connect navigation. */}
+          <OnboardingCheckpointWatcher />
           <MainLayout>{children}</MainLayout>
           <Toaster />
         </Providers>

--- a/ui/components/onboarding/__tests__/onboarding-checkpoint-dialog.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-checkpoint-dialog.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingCheckpointDialog } from "../onboarding-checkpoint-dialog";
+
+describe("OnboardingCheckpointDialog", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when open", () => {
+    it("shows the checkpoint title and both choices", () => {
+      // Given - the checkpoint dialog is open
+      render(
+        <OnboardingCheckpointDialog
+          open
+          onContinue={vi.fn()}
+          onFinish={vi.fn()}
+        />,
+      );
+
+      // Then - the user sees the prompt and both actions
+      expect(
+        screen.getByText("Provider connected — keep exploring?"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /continue the tour/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /finish here/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls onContinue when the primary button is clicked", async () => {
+      // Given - an open dialog with distinct callbacks
+      const user = userEvent.setup();
+      const onContinue = vi.fn();
+      const onFinish = vi.fn();
+      render(
+        <OnboardingCheckpointDialog
+          open
+          onContinue={onContinue}
+          onFinish={onFinish}
+        />,
+      );
+
+      // When - the user chooses to continue the tour
+      await user.click(
+        screen.getByRole("button", { name: /continue the tour/i }),
+      );
+
+      // Then - only onContinue fires
+      expect(onContinue).toHaveBeenCalledTimes(1);
+      expect(onFinish).not.toHaveBeenCalled();
+    });
+
+    it("calls onFinish when the ghost button is clicked", async () => {
+      // Given - an open dialog with distinct callbacks
+      const user = userEvent.setup();
+      const onContinue = vi.fn();
+      const onFinish = vi.fn();
+      render(
+        <OnboardingCheckpointDialog
+          open
+          onContinue={onContinue}
+          onFinish={onFinish}
+        />,
+      );
+
+      // When - the user chooses to finish here
+      await user.click(screen.getByRole("button", { name: /finish here/i }));
+
+      // Then - only onFinish fires
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(onContinue).not.toHaveBeenCalled();
+    });
+
+    it("treats Escape (overlay/X dismiss) as finish", async () => {
+      // Given - an open dialog
+      const user = userEvent.setup();
+      const onContinue = vi.fn();
+      const onFinish = vi.fn();
+      render(
+        <OnboardingCheckpointDialog
+          open
+          onContinue={onContinue}
+          onFinish={onFinish}
+        />,
+      );
+
+      // When - the user dismisses via Escape (same path as overlay/X)
+      await user.keyboard("{Escape}");
+
+      // Then - dismissal is treated as finishing, never continuing
+      await waitFor(() => expect(onFinish).toHaveBeenCalledTimes(1));
+      expect(onContinue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when closed", () => {
+    it("renders nothing", () => {
+      // Given/When - the dialog is closed
+      render(
+        <OnboardingCheckpointDialog
+          open={false}
+          onContinue={vi.fn()}
+          onFinish={vi.fn()}
+        />,
+      );
+
+      // Then - the prompt is not in the document
+      expect(
+        screen.queryByText("Provider connected — keep exploring?"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/onboarding/__tests__/onboarding-checkpoint-watcher.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-checkpoint-watcher.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getFlowById } from "@/lib/onboarding";
+
+import { OnboardingCheckpointWatcher } from "../onboarding-checkpoint-watcher";
+
+const pushMock = vi.fn();
+const startSequenceMock = vi.fn();
+
+// The current `hasProviders` value the mocked UI-store selector returns. Tests
+// mutate this then re-render to drive a `false -> true` flip.
+let hasProvidersValue = false;
+
+const CHECKPOINT_MARKER = "prowler.onboarding.checkpoint";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/store/ui/store", () => ({
+  useUIStore: (selector: (state: { hasProviders: boolean }) => unknown) =>
+    selector({ hasProviders: hasProvidersValue }),
+}));
+
+vi.mock("@/store/onboarding-sequence", () => ({
+  useOnboardingSequenceStore: {
+    getState: () => ({ startSequence: startSequenceMock }),
+  },
+}));
+
+describe("OnboardingCheckpointWatcher", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    startSequenceMock.mockClear();
+    hasProvidersValue = false;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("firing rules", () => {
+    it("opens the dialog on a concrete false -> true flip", async () => {
+      // Given - the watcher first observes a no-provider state
+      hasProvidersValue = false;
+      const { rerender } = render(<OnboardingCheckpointWatcher />);
+      expect(
+        screen.queryByText("Provider connected — keep exploring?"),
+      ).not.toBeInTheDocument();
+
+      // When - the post-connect re-fetch flips hasProviders to true
+      hasProvidersValue = true;
+      rerender(<OnboardingCheckpointWatcher />);
+
+      // Then - the checkpoint dialog appears
+      expect(
+        await screen.findByText("Provider connected — keep exploring?"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not fire on a true -> true steady state", () => {
+      // Given - the user already had providers on the first observed render
+      hasProvidersValue = true;
+      const { rerender } = render(<OnboardingCheckpointWatcher />);
+
+      // When - providers stay present
+      rerender(<OnboardingCheckpointWatcher />);
+
+      // Then - no checkpoint (no false -> true flip)
+      expect(
+        screen.queryByText("Provider connected — keep exploring?"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not fire on the undefined -> true initial read", () => {
+      // Given/When - the very first observed value is already true (no prior
+      // false was seen, so prev is undefined, not false)
+      hasProvidersValue = true;
+      render(<OnboardingCheckpointWatcher />);
+
+      // Then - the checkpoint must NOT fire on the initial read
+      expect(
+        screen.queryByText("Provider connected — keep exploring?"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not fire when the checkpoint was already handled", () => {
+      // Given - the marker is already set from a previous session
+      window.localStorage.setItem(CHECKPOINT_MARKER, "true");
+      hasProvidersValue = false;
+      const { rerender } = render(<OnboardingCheckpointWatcher />);
+
+      // When - a false -> true flip happens
+      hasProvidersValue = true;
+      rerender(<OnboardingCheckpointWatcher />);
+
+      // Then - the marker suppresses the dialog
+      expect(
+        screen.queryByText("Provider connected — keep exploring?"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when the user continues the tour", () => {
+    it("marks handled, starts the sequence at the next flow, and navigates", async () => {
+      // Given - the dialog is open after a first-connect flip
+      const user = userEvent.setup();
+      hasProvidersValue = false;
+      const { rerender } = render(<OnboardingCheckpointWatcher />);
+      hasProvidersValue = true;
+      rerender(<OnboardingCheckpointWatcher />);
+      await screen.findByText("Provider connected — keep exploring?");
+
+      // When - the user continues
+      await user.click(
+        screen.getByRole("button", { name: /continue the tour/i }),
+      );
+
+      // Then - the marker is set, the sequence starts at the flow AFTER
+      // add-provider, and the watcher navigates to that flow's route.
+      const nextFlow = getFlowById("view-first-scan");
+      expect(window.localStorage.getItem(CHECKPOINT_MARKER)).not.toBeNull();
+      if (nextFlow) {
+        expect(startSequenceMock).toHaveBeenCalledWith(nextFlow.id);
+        expect(pushMock).toHaveBeenCalledWith(nextFlow.route);
+      } else {
+        // Registry still add-provider-only (Slices 4-6 not landed): guard
+        // gracefully — no crash, no sequence start, no navigation.
+        expect(startSequenceMock).not.toHaveBeenCalled();
+        expect(pushMock).not.toHaveBeenCalled();
+      }
+
+      // And - the dialog closes either way.
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Provider connected — keep exploring?"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("when the user finishes here", () => {
+    it("marks handled and does not start a sequence or navigate", async () => {
+      // Given - the dialog is open after a first-connect flip
+      const user = userEvent.setup();
+      hasProvidersValue = false;
+      const { rerender } = render(<OnboardingCheckpointWatcher />);
+      hasProvidersValue = true;
+      rerender(<OnboardingCheckpointWatcher />);
+      await screen.findByText("Provider connected — keep exploring?");
+
+      // When - the user finishes here
+      await user.click(screen.getByRole("button", { name: /finish here/i }));
+
+      // Then - the marker is set, no sequence starts, no navigation happens
+      expect(window.localStorage.getItem(CHECKPOINT_MARKER)).not.toBeNull();
+      expect(startSequenceMock).not.toHaveBeenCalled();
+      expect(pushMock).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Provider connected — keep exploring?"),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it("stays handled so the dialog never re-appears on a later flip", async () => {
+      // Given - the user finished once, setting the marker
+      const user = userEvent.setup();
+      hasProvidersValue = false;
+      const { rerender } = render(<OnboardingCheckpointWatcher />);
+      hasProvidersValue = true;
+      rerender(<OnboardingCheckpointWatcher />);
+      await screen.findByText("Provider connected — keep exploring?");
+      await user.click(screen.getByRole("button", { name: /finish here/i }));
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Provider connected — keep exploring?"),
+        ).not.toBeInTheDocument(),
+      );
+
+      // When - a fresh false -> true flip occurs later
+      hasProvidersValue = false;
+      rerender(<OnboardingCheckpointWatcher />);
+      hasProvidersValue = true;
+      rerender(<OnboardingCheckpointWatcher />);
+
+      // Then - the marker keeps the dialog suppressed
+      expect(
+        screen.queryByText("Provider connected — keep exploring?"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/onboarding/index.ts
+++ b/ui/components/onboarding/index.ts
@@ -1,6 +1,7 @@
 // Public surface for the onboarding UI components. Consumers import from
 // `@/components/onboarding` rather than reaching into individual files.
 
+export { OnboardingCheckpointWatcher } from "./onboarding-checkpoint-watcher";
 export { OnboardingGate } from "./onboarding-gate";
 export { OnboardingTrigger } from "./onboarding-trigger";
 export { OnboardingWelcomeModal } from "./onboarding-welcome-modal";

--- a/ui/components/onboarding/onboarding-checkpoint-dialog.tsx
+++ b/ui/components/onboarding/onboarding-checkpoint-dialog.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@/components/shadcn";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/shadcn/dialog";
+
+interface OnboardingCheckpointDialogProps {
+  open: boolean;
+  // Start the guided sequence and continue into the next flow.
+  onContinue: () => void;
+  // End onboarding here. Closing via the overlay, Escape, or the X maps to this
+  // same action (mirrors the welcome modal's dismiss convention).
+  onFinish: () => void;
+}
+
+// Presentational checkpoint shown after the first provider connects. It owns no
+// navigation, persistence, or sequence state: the watcher decides what to do on
+// each choice so this component stays a pure render of the prompt.
+export function OnboardingCheckpointDialog({
+  open,
+  onContinue,
+  onFinish,
+}: OnboardingCheckpointDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Closing via the overlay, Escape, or the X is treated as "Finish here"
+        // so the watcher persists the handled marker exactly once.
+        if (!next) onFinish();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Provider connected — keep exploring?</DialogTitle>
+          <DialogDescription>
+            Your first provider is connected. Want a quick guided tour of scans,
+            findings, compliance, and attack paths? You can stop anytime.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onFinish}>
+            Finish here
+          </Button>
+          <Button onClick={onContinue}>Continue the tour</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/components/onboarding/onboarding-checkpoint-watcher.tsx
+++ b/ui/components/onboarding/onboarding-checkpoint-watcher.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+import { getOrderedFlows } from "@/lib/onboarding";
+import { useOnboardingSequenceStore } from "@/store/onboarding-sequence";
+import { useUIStore } from "@/store/ui/store";
+
+import { shouldFireCheckpoint } from "./checkpoint.logic";
+import { OnboardingCheckpointDialog } from "./onboarding-checkpoint-dialog";
+
+// localStorage flag set once the user has either continued or finished the
+// checkpoint. It keeps the dialog from re-appearing on any later provider flip
+// in this browser. Distinct from per-tour `prowler.tour.*` completion records.
+const CHECKPOINT_MARKER = "prowler.onboarding.checkpoint";
+
+// The first ordered flow is `add-provider` (the gate). The checkpoint begins
+// the sequence at the flow AFTER it, so any flow id but `add-provider` qualifies
+// as the next one to start.
+const FIRST_FLOW_ID = "add-provider";
+
+function isCheckpointHandled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(CHECKPOINT_MARKER) !== null;
+  } catch {
+    // Fail open: an unreadable storage should not block the checkpoint.
+    return false;
+  }
+}
+
+function markCheckpointHandled(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(CHECKPOINT_MARKER, "true");
+  } catch {
+    // Non-fatal: a re-shown checkpoint beats a thrown render.
+  }
+}
+
+// Layout-level watcher (sibling to OnboardingGate). It observes `hasProviders`
+// from the UI store — which `StoreInitializer` re-syncs on every layout render,
+// including the post-connect re-fetch — and opens the checkpoint dialog exactly
+// once on a concrete `false -> true` flip that has not been handled. Renders the
+// dialog only; all decision logic runs in a client effect so the server renders
+// nothing and there is no hydration mismatch.
+export function OnboardingCheckpointWatcher() {
+  const router = useRouter();
+  const hasProviders = useUIStore((state) => state.hasProviders);
+
+  // The previous observed `hasProviders`. `undefined` means "first read, no
+  // transition seen yet" — that case must NOT fire the checkpoint.
+  const previous = useRef<boolean | undefined>(undefined);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const was = previous.current;
+    previous.current = hasProviders;
+    if (
+      shouldFireCheckpoint({
+        prev: was,
+        next: hasProviders,
+        handled: isCheckpointHandled(),
+      })
+    ) {
+      setOpen(true);
+    }
+  }, [hasProviders]);
+
+  const handleContinue = () => {
+    // Mark handled first so a re-render mid-navigation never re-opens it.
+    markCheckpointHandled();
+    setOpen(false);
+
+    // Start at the first ordered flow that is NOT add-provider (i.e. the next
+    // flow). Guard gracefully when none exists yet (registry may still be
+    // add-provider-only until later slices add flows): close without crashing.
+    const nextFlow = getOrderedFlows().find(
+      (flow) => flow.id !== FIRST_FLOW_ID,
+    );
+    if (!nextFlow) return;
+
+    useOnboardingSequenceStore.getState().startSequence(nextFlow.id);
+    router.push(nextFlow.route);
+  };
+
+  const handleFinish = () => {
+    // Onboarding ends here: mark handled, start no sequence. Remaining flows
+    // stay reachable via the avatar replay list.
+    markCheckpointHandled();
+    setOpen(false);
+  };
+
+  return (
+    <OnboardingCheckpointDialog
+      open={open}
+      onContinue={handleContinue}
+      onFinish={handleFinish}
+    />
+  );
+}


### PR DESCRIPTION
### Context

Asks the user to keep exploring right after the first provider connects.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Layout-level checkpoint watcher + dialog that fires once when the provider wizard closes having connected a provider — never mid-wizard, never for an established user.

### Steps to review

Read `onboarding-checkpoint-*`. Confirm it fires only on wizard close with a connected provider.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 9 of 15 |
| Base | `chain/ob-08-seq-trigger` |
| Depends on | #11438 |
| Follow-up | #11440 |
| Review budget | 483 / 400 ⚠️ |
| Starts at | #11438 (generalized trigger) |
| Ends with | a post-connect checkpoint entry to the sequence |

> **Size exception:** exceeds the 400-line budget because this is one cohesive code+tests unit; splitting further would separate a component/store/tour from the test that verifies it. No `size:exception` label exists in this repo (only `size/*`), so the rationale is recorded here.

### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← 📍#11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** checkpoint watcher + dialog + store arming
- **Excludes:** sequence tours (10), timing fixes (13)

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
