### PR TITLE
feat(ui): add scan, findings and compliance onboarding tours

### DIFF
--- a/ui/components/compliance/compliance-overview-grid.tsx
+++ b/ui/components/compliance/compliance-overview-grid.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 
 import { ComplianceCard } from "@/components/compliance/compliance-card";
+import { OnboardingTrigger } from "@/components/onboarding";
 import { DataTableSearch } from "@/components/ui/table/data-table-search";
+import { getFlowById } from "@/lib/onboarding";
 import type { ComplianceOverviewData } from "@/types/compliance";
 import type { ScanEntity } from "@/types/scans";
+
+// Resolved once: the registry is static, so the flow this route owns never
+// changes at runtime.
+const viewComplianceFlow = getFlowById("view-compliance")!;
 
 interface ComplianceOverviewGridProps {
   frameworks: ComplianceOverviewData[];
@@ -35,17 +41,28 @@ export const ComplianceOverviewGrid = ({
 
   return (
     <>
+      {/* Renders null; reads the sequence slice + ?onboarding param and force-
+          starts the view-compliance tour. Suspense satisfies the App Router
+          requirement around `useSearchParams`. */}
+      <Suspense fallback={null}>
+        <OnboardingTrigger flow={viewComplianceFlow} />
+      </Suspense>
       <div className="flex items-center justify-between gap-4">
-        <DataTableSearch
-          controlledValue={searchTerm}
-          onSearchChange={setSearchTerm}
-          placeholder="Search frameworks..."
-        />
+        <div data-tour-id="view-compliance-search">
+          <DataTableSearch
+            controlledValue={searchTerm}
+            onSearchChange={setSearchTerm}
+            placeholder="Search frameworks..."
+          />
+        </div>
         <span className="text-text-neutral-secondary shrink-0 text-sm">
           {filteredFrameworks.length.toLocaleString()} Total Entries
         </span>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+      <div
+        data-tour-id="view-compliance-frameworks"
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4"
+      >
         {filteredFrameworks.map((compliance) => {
           const { attributes, id } = compliance;
           const {

--- a/ui/components/findings/findings-filters.tsx
+++ b/ui/components/findings/findings-filters.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronDown } from "lucide-react";
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 
 import { ApplyFiltersButton } from "@/components/filters/apply-filters-button";
 import { BatchFiltersLayout } from "@/components/filters/batch-filters-layout";
@@ -14,11 +14,13 @@ import {
   FilterSummaryStrip,
 } from "@/components/filters/filter-summary-strip";
 import { ProviderAccountSelectors } from "@/components/filters/provider-account-selectors";
+import { OnboardingTrigger } from "@/components/onboarding";
 import { Button } from "@/components/shadcn";
 import { ExpandableSection } from "@/components/ui/expandable-section";
 import { DataTableFilterCustom } from "@/components/ui/table/data-table-filter-custom";
 import { useFilterBatch } from "@/hooks/use-filter-batch";
 import { getCategoryLabel, getGroupLabel } from "@/lib/categories";
+import { getFlowById } from "@/lib/onboarding";
 import { FilterType, ScanEntity } from "@/types";
 import { DATA_TABLE_FILTER_MODE } from "@/types/filters";
 import { ProviderProps } from "@/types/providers";
@@ -27,6 +29,10 @@ import {
   buildFindingsFilterChips,
   getFindingsFilterDisplayValue,
 } from "./findings-filters.utils";
+
+// Resolved once: the registry is static, so the flow this route owns never
+// changes at runtime.
+const exploreFindingsFlow = getFlowById("explore-findings")!;
 
 interface FindingsFiltersProps {
   /** Provider data for provider/account filter controls. */
@@ -333,19 +339,27 @@ export const FindingsFilters = (props: FindingsFiltersProps) => {
   });
 
   return (
-    <FindingsFilterBatchControls
-      {...props}
-      appliedFilters={appliedFilters}
-      pendingFilters={pendingFilters}
-      changedFilters={changedFilters}
-      setPending={setPending}
-      applyAll={applyAll}
-      discardAll={discardAll}
-      clearAndApply={clearAndApply}
-      removeAppliedAndApply={removeAppliedAndApply}
-      hasChanges={hasChanges}
-      changeCount={changeCount}
-      getFilterValue={getFilterValue}
-    />
+    <div data-tour-id="explore-findings-filters">
+      {/* Renders null; reads the sequence slice + ?onboarding param and force-
+          starts the explore-findings tour. Suspense satisfies the App Router
+          requirement around `useSearchParams`. */}
+      <Suspense fallback={null}>
+        <OnboardingTrigger flow={exploreFindingsFlow} />
+      </Suspense>
+      <FindingsFilterBatchControls
+        {...props}
+        appliedFilters={appliedFilters}
+        pendingFilters={pendingFilters}
+        changedFilters={changedFilters}
+        setPending={setPending}
+        applyAll={applyAll}
+        discardAll={discardAll}
+        clearAndApply={clearAndApply}
+        removeAppliedAndApply={removeAppliedAndApply}
+        hasChanges={hasChanges}
+        changeCount={changeCount}
+        getFilterValue={getFilterValue}
+      />
+    </div>
   );
 };

--- a/ui/components/findings/table/findings-group-table.tsx
+++ b/ui/components/findings/table/findings-group-table.tsx
@@ -201,29 +201,32 @@ export function FindingsGroupTable({
         resolveMuteIds,
       }}
     >
-      <DataTable
-        columns={columns}
-        data={safeData}
-        metadata={metadata}
-        enableRowSelection
-        rowSelection={rowSelection}
-        onRowSelectionChange={setRowSelection}
-        getRowCanSelect={getRowCanSelect}
-        showSearch
-        searchPlaceholder={
-          expandedCheckId ? "Search resources..." : "Search by name"
-        }
-        controlledSearch={expandedCheckId ? resourceSearchInput : undefined}
-        onSearchChange={expandedCheckId ? setResourceSearchInput : undefined}
-        onSearchCommit={expandedCheckId ? setResourceSearch : undefined}
-        searchBadge={
-          expandedGroup
-            ? { label: expandedGroup.checkTitle, onDismiss: handleCollapse }
-            : undefined
-        }
-        toolbarRightContent={<CustomCheckboxMutedFindings />}
-        renderAfterRow={renderAfterRow}
-      />
+      {/* Anchor for the explore-findings onboarding tour `table` step. */}
+      <div data-tour-id="explore-findings-table">
+        <DataTable
+          columns={columns}
+          data={safeData}
+          metadata={metadata}
+          enableRowSelection
+          rowSelection={rowSelection}
+          onRowSelectionChange={setRowSelection}
+          getRowCanSelect={getRowCanSelect}
+          showSearch
+          searchPlaceholder={
+            expandedCheckId ? "Search resources..." : "Search by name"
+          }
+          controlledSearch={expandedCheckId ? resourceSearchInput : undefined}
+          onSearchChange={expandedCheckId ? setResourceSearchInput : undefined}
+          onSearchCommit={expandedCheckId ? setResourceSearch : undefined}
+          searchBadge={
+            expandedGroup
+              ? { label: expandedGroup.checkTitle, onDismiss: handleCollapse }
+              : undefined
+          }
+          toolbarRightContent={<CustomCheckboxMutedFindings />}
+          renderAfterRow={renderAfterRow}
+        />
+      </div>
 
       {(selectedCheckIds.length > 0 || hasResourceSelection) && (
         <FloatingMuteButton

--- a/ui/components/onboarding/__tests__/onboarding-gate.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-gate.test.tsx
@@ -78,6 +78,34 @@ describe("OnboardingGate", () => {
     });
   });
 
+  describe("when the gate flow is dismissed but later sequence flows are incomplete", () => {
+    it("does not show the Welcome modal for a later flow", async () => {
+      // Given - the gate flow (add-provider) is dismissed; the additional
+      // sequence flows (view-first-scan, explore-findings, view-compliance)
+      // have no record. The mandatory gate must ONLY ever force add-provider —
+      // the later flows are reached via the checkpoint/sequence, never the
+      // gate. So a dismissed add-provider record keeps the gate silent.
+      window.localStorage.setItem(
+        addProviderStorageKey,
+        JSON.stringify({
+          tourId: addProviderTour.id,
+          version: addProviderTour.version,
+          state: "dismissed",
+          completedAt: new Date().toISOString(),
+        }),
+      );
+
+      render(<OnboardingGate hasProviders={false} />);
+
+      // Then - the gate never surfaces a later flow's modal
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("button", { name: /get started/i }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe("when hasProviders is undefined (fail-open)", () => {
     it("does not show the Welcome modal", async () => {
       // Given - an ambiguous provider signal (transient / errored). The prop is

--- a/ui/components/onboarding/onboarding-gate.tsx
+++ b/ui/components/onboarding/onboarding-gate.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import {
-  getFirstIncompleteFlow,
+  getOrderedFlows,
   type OnboardingFlow,
   shouldStartOnboarding,
 } from "@/lib/onboarding";
@@ -31,22 +31,23 @@ export function OnboardingGate({ hasProviders }: OnboardingGateProps) {
   const [activeFlow, setActiveFlow] = useState<OnboardingFlow | null>(null);
 
   useEffect(() => {
-    // Select the first flow that is incomplete by account state and has no
-    // browser record. `OnboardingContext.hasProviders` is a strict boolean, so
-    // an unknown signal collapses to `false` here (`?? false`) for SELECTION
-    // ONLY — a flow is still picked. `getFirstIncompleteFlow` is NOT the final
-    // authority: `shouldStartOnboarding` below receives the RAW (possibly
-    // `undefined`) value and applies the strict `=== false` fail-open guard, so
-    // an ambiguous provider state never forces the modal.
-    const flow = getFirstIncompleteFlow(
-      { hasProviders: hasProviders ?? false },
-      localStorageAdapter,
-    );
+    // The mandatory gate ONLY ever forces the FIRST ordered flow (the new-user
+    // entry point, `add-provider`). The remaining sequence flows
+    // (view-first-scan, explore-findings, view-compliance, ...) are reached via
+    // the post-connect checkpoint and the avatar replay list — never the gate.
+    // Walking to the "first INCOMPLETE flow" would wrongly surface a later
+    // flow's modal once add-provider is dismissed but its successors have no
+    // record yet, so the gate is scoped to the first ordered flow alone.
+    const flow = getOrderedFlows()[0];
     if (!flow) {
       setActiveFlow(null);
       return;
     }
 
+    // `shouldStartOnboarding` receives the RAW (possibly `undefined`)
+    // `hasProviders` and applies the strict `=== false` fail-open guard, so an
+    // ambiguous provider state never forces the modal. A completion/dismissal
+    // record for the gate flow also keeps the gate silent.
     const completionRecord = localStorageAdapter.get(flow.tour);
     if (shouldStartOnboarding({ hasProviders, completionRecord })) {
       setActiveFlow(flow);

--- a/ui/components/scans/scans-page-shell.tsx
+++ b/ui/components/scans/scans-page-shell.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, Suspense, useState } from "react";
 
+import { OnboardingTrigger } from "@/components/onboarding";
 import { MutedFindingsConfigButton } from "@/components/providers/muted-findings-config-button";
 import {
   Button,
@@ -11,6 +12,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/shadcn";
+import { getFlowById } from "@/lib/onboarding";
 import {
   LAUNCH_SCAN_SEARCH_PARAM,
   LAUNCH_SCAN_SEARCH_VALUE,
@@ -18,6 +20,10 @@ import {
 import { useScansStore } from "@/store";
 import { SCAN_JOBS_TAB, SCAN_TAB_LABELS, type ScanJobsTab } from "@/types";
 import type { ProviderProps } from "@/types/providers";
+
+// Resolved once: the registry is static, so the flow this route owns never
+// changes at runtime.
+const viewFirstScanFlow = getFlowById("view-first-scan")!;
 
 import { CliImportBanner } from "./cli-import-banner";
 import { LaunchScanModal } from "./launch-scan-modal";
@@ -80,6 +86,12 @@ export function ScansPageShell({
 
   return (
     <div className="flex flex-col gap-[18px]">
+      {/* Renders null; reads the sequence slice + ?onboarding param and force-
+          starts the view-first-scan tour. Suspense satisfies the App Router
+          requirement around `useSearchParams`. */}
+      <Suspense fallback={null}>
+        <OnboardingTrigger flow={viewFirstScanFlow} />
+      </Suspense>
       <div
         role="group"
         aria-label="Scan filters and actions"
@@ -101,6 +113,7 @@ export function ScansPageShell({
           onClick={() => handleLaunchOpenChange(true)}
           disabled={launchDisabled}
           className="w-full md:w-auto"
+          data-tour-id="view-first-scan-launch"
         >
           Launch Scan
         </Button>
@@ -118,7 +131,10 @@ export function ScansPageShell({
           aria-label="Scan tabs"
           className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
         >
-          <TabsList className="overflow-x-auto">
+          <TabsList
+            className="overflow-x-auto"
+            data-tour-id="view-first-scan-tabs"
+          >
             {Object.values(SCAN_JOBS_TAB).map((tab) => (
               <TabsTrigger key={tab} value={tab}>
                 {getTabLabel(tab as ScanJobsTab)}

--- a/ui/lib/onboarding/__tests__/registry.test.ts
+++ b/ui/lib/onboarding/__tests__/registry.test.ts
@@ -110,6 +110,52 @@ describe("onboardingFlows (production registry)", () => {
     expect(addProvider?.isComplete?.({ hasProviders: true })).toBe(true);
     expect(addProvider?.isComplete?.({ hasProviders: false })).toBe(false);
   });
+
+  it("registers the view-first-scan flow at order 2 on the scans route", () => {
+    // Given / When - the sequence flow added in Slice 4
+    const flow = getFlowById("view-first-scan", onboardingFlows);
+
+    // Then - declared contract: order, route, and a matching tour id
+    expect(flow).toBeDefined();
+    expect(flow?.order).toBe(2);
+    expect(flow?.route).toBe("/scans");
+    expect(flow?.tour.id).toBe("view-first-scan");
+  });
+
+  it("registers the explore-findings flow at order 3 on the findings route", () => {
+    // Given / When - the sequence flow added in Slice 5
+    const flow = getFlowById("explore-findings", onboardingFlows);
+
+    // Then - declared contract: order, route, and a matching tour id
+    expect(flow).toBeDefined();
+    expect(flow?.order).toBe(3);
+    expect(flow?.route).toBe("/findings");
+    expect(flow?.tour.id).toBe("explore-findings");
+  });
+
+  it("registers the view-compliance flow at order 4 on the compliance route", () => {
+    // Given / When - the sequence flow added in Slice 6
+    const flow = getFlowById("view-compliance", onboardingFlows);
+
+    // Then - declared contract: order, route, and a matching tour id
+    expect(flow).toBeDefined();
+    expect(flow?.order).toBe(4);
+    expect(flow?.route).toBe("/compliance");
+    expect(flow?.tour.id).toBe("view-compliance");
+  });
+
+  it("orders the four sequence flows 1..4 by registry order", () => {
+    // Given / When - the production registry after Slices 4-6 registration
+    const ordered = getOrderedFlows(onboardingFlows);
+
+    // Then - the guided sequence advances in declared order
+    expect(ordered.map((flow) => flow.id)).toEqual([
+      "add-provider",
+      "view-first-scan",
+      "explore-findings",
+      "view-compliance",
+    ]);
+  });
 });
 
 describe("public api barrel", () => {

--- a/ui/lib/onboarding/registry.ts
+++ b/ui/lib/onboarding/registry.ts
@@ -1,6 +1,9 @@
 import { addProviderTour } from "@/lib/tours/add-provider.tour";
+import { exploreFindingsTour } from "@/lib/tours/explore-findings.tour";
 import { localStorageAdapter } from "@/lib/tours/store/local-storage-adapter";
 import type { TourCompletionStore } from "@/lib/tours/store/tour-completion-store";
+import { viewComplianceTour } from "@/lib/tours/view-compliance.tour";
+import { viewFirstScanTour } from "@/lib/tours/view-first-scan.tour";
 
 import type { OnboardingContext, OnboardingFlow } from "./onboarding-types";
 
@@ -19,6 +22,31 @@ export const onboardingFlows: readonly OnboardingFlow[] = [
     // Server-derived authority: a user who already has providers is never
     // gated into this flow, even with no local completion record.
     isComplete: (ctx) => ctx.hasProviders,
+  },
+  {
+    id: "view-first-scan",
+    order: 2,
+    title: "Run your first scan",
+    description:
+      "Launch a scan and watch Prowler assess your connected provider.",
+    route: "/scans",
+    tour: viewFirstScanTour,
+  },
+  {
+    id: "explore-findings",
+    order: 3,
+    title: "Explore your findings",
+    description: "See what Prowler detected and how to fix it.",
+    route: "/findings",
+    tour: exploreFindingsTour,
+  },
+  {
+    id: "view-compliance",
+    order: 4,
+    title: "Check compliance",
+    description: "Map your findings to frameworks like CIS.",
+    route: "/compliance",
+    tour: viewComplianceTour,
   },
 ];
 

--- a/ui/lib/tours/__tests__/explore-findings.tour.test.ts
+++ b/ui/lib/tours/__tests__/explore-findings.tour.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  exploreFindingsTour,
+  type ExploreFindingsTourTarget,
+} from "../explore-findings.tour";
+
+// The set of anchored step targets the tour is allowed to reference. Only these
+// two carry a `data-tour-id` in the UI source; the welcome step has no target.
+const ALLOWED_TARGETS = ["filters", "table"] as const;
+
+const definedTargets = (): ExploreFindingsTourTarget[] =>
+  exploreFindingsTour.steps
+    .map((step) => step.target)
+    .filter(
+      (target): target is ExploreFindingsTourTarget => target !== undefined,
+    );
+
+describe("exploreFindingsTour shape", () => {
+  it("declares the explore-findings id", () => {
+    // Given / When / Then - the tour id is the registry/anchor contract key
+    expect(exploreFindingsTour.id).toBe("explore-findings");
+  });
+
+  it("declares a positive integer version", () => {
+    // Given / When / Then - version drives the per-tour completion record key
+    expect(Number.isInteger(exploreFindingsTour.version)).toBe(true);
+    expect(exploreFindingsTour.version).toBeGreaterThan(0);
+  });
+
+  it("anchors filters before table, in that order", () => {
+    // Given - every defined anchored target in document order
+    const targets = definedTargets();
+
+    // Then - filters mounts immediately; table appears after Suspense, so the
+    // order matters and filters must precede table.
+    expect(targets).toEqual(["filters", "table"]);
+  });
+
+  it("never targets an element outside the allowed anchor set", () => {
+    // Given - every defined target across all steps
+    const targets = definedTargets();
+
+    // Then - no target escapes the two anchors guarded by tour:check
+    for (const target of targets) {
+      expect(ALLOWED_TARGETS).toContain(target);
+    }
+  });
+
+  it("includes a non-anchored welcome step (no target)", () => {
+    // Given - the modal welcome step carries no target
+    const welcomeSteps = exploreFindingsTour.steps.filter(
+      (step) => step.target === undefined,
+    );
+
+    // Then - at least one targetless step exists for the welcome modal
+    expect(welcomeSteps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("covers the findings route and component trees for the tour:check gate", () => {
+    // Given / When / Then - coversFiles scopes the CI drift check to findings
+    expect(exploreFindingsTour.coversFiles).toContain(
+      "ui/app/(prowler)/findings/**",
+    );
+    expect(exploreFindingsTour.coversFiles).toContain(
+      "ui/components/findings/**",
+    );
+  });
+});

--- a/ui/lib/tours/__tests__/view-compliance.tour.test.ts
+++ b/ui/lib/tours/__tests__/view-compliance.tour.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  viewComplianceTour,
+  type ViewComplianceTourTarget,
+} from "../view-compliance.tour";
+
+// The set of anchored step targets the tour is allowed to reference. Only these
+// two carry a `data-tour-id` in the UI source; the welcome step has no target.
+const ALLOWED_TARGETS = ["frameworks", "search"] as const;
+
+const definedTargets = (): ViewComplianceTourTarget[] =>
+  viewComplianceTour.steps
+    .map((step) => step.target)
+    .filter(
+      (target): target is ViewComplianceTourTarget => target !== undefined,
+    );
+
+describe("viewComplianceTour shape", () => {
+  it("declares the view-compliance id", () => {
+    // Given / When / Then - the tour id is the registry/anchor contract key
+    expect(viewComplianceTour.id).toBe("view-compliance");
+  });
+
+  it("declares a positive integer version", () => {
+    // Given / When / Then - version drives the per-tour completion record key
+    expect(Number.isInteger(viewComplianceTour.version)).toBe(true);
+    expect(viewComplianceTour.version).toBeGreaterThan(0);
+  });
+
+  it("anchors exactly the frameworks and search steps, in that order", () => {
+    // Given - every defined anchored target in document order
+    const targets = definedTargets();
+
+    // Then - shallow tour orients via frameworks then search only
+    expect(targets).toEqual(["frameworks", "search"]);
+  });
+
+  it("never targets an element outside the allowed anchor set", () => {
+    // Given - every defined target across all steps
+    const targets = definedTargets();
+
+    // Then - no target escapes the two anchors guarded by tour:check
+    for (const target of targets) {
+      expect(ALLOWED_TARGETS).toContain(target);
+    }
+  });
+
+  it("includes a non-anchored welcome step (no target)", () => {
+    // Given - the modal welcome step carries no target
+    const welcomeSteps = viewComplianceTour.steps.filter(
+      (step) => step.target === undefined,
+    );
+
+    // Then - at least one targetless step exists for the welcome modal
+    expect(welcomeSteps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("covers the compliance route and component trees for the tour:check gate", () => {
+    // Given / When / Then - coversFiles scopes the CI drift check to compliance
+    expect(viewComplianceTour.coversFiles).toContain(
+      "ui/app/(prowler)/compliance/**",
+    );
+    expect(viewComplianceTour.coversFiles).toContain(
+      "ui/components/compliance/**",
+    );
+  });
+});

--- a/ui/lib/tours/__tests__/view-first-scan.tour.test.ts
+++ b/ui/lib/tours/__tests__/view-first-scan.tour.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  viewFirstScanTour,
+  type ViewFirstScanTourTarget,
+} from "../view-first-scan.tour";
+
+// The set of anchored step targets the tour is allowed to reference. Only these
+// two carry a `data-tour-id` in the UI source; the welcome step has no target.
+const ALLOWED_TARGETS = ["launch", "tabs"] as const;
+
+const definedTargets = (): ViewFirstScanTourTarget[] =>
+  viewFirstScanTour.steps
+    .map((step) => step.target)
+    .filter(
+      (target): target is ViewFirstScanTourTarget => target !== undefined,
+    );
+
+describe("viewFirstScanTour shape", () => {
+  it("declares the view-first-scan id", () => {
+    // Given / When / Then - the tour id is the registry/anchor contract key
+    expect(viewFirstScanTour.id).toBe("view-first-scan");
+  });
+
+  it("declares a positive integer version", () => {
+    // Given / When / Then - version drives the per-tour completion record key
+    expect(Number.isInteger(viewFirstScanTour.version)).toBe(true);
+    expect(viewFirstScanTour.version).toBeGreaterThan(0);
+  });
+
+  it("anchors exactly the launch and tabs steps, in that order", () => {
+    // Given - every defined anchored target in document order
+    const targets = definedTargets();
+
+    // Then - shallow tour orients via launch then tabs only
+    expect(targets).toEqual(["launch", "tabs"]);
+  });
+
+  it("never targets an element outside the allowed anchor set", () => {
+    // Given - every defined target across all steps
+    const targets = definedTargets();
+
+    // Then - no target escapes the two anchors guarded by tour:check
+    for (const target of targets) {
+      expect(ALLOWED_TARGETS).toContain(target);
+    }
+  });
+
+  it("includes a non-anchored welcome step (no target)", () => {
+    // Given - the modal welcome step carries no target
+    const welcomeSteps = viewFirstScanTour.steps.filter(
+      (step) => step.target === undefined,
+    );
+
+    // Then - at least one targetless step exists for the welcome modal
+    expect(welcomeSteps.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("covers the scans route and component trees for the tour:check gate", () => {
+    // Given / When / Then - coversFiles scopes the CI drift check to scans
+    expect(viewFirstScanTour.coversFiles).toContain(
+      "ui/app/(prowler)/scans/**",
+    );
+    expect(viewFirstScanTour.coversFiles).toContain("ui/components/scans/**");
+  });
+});

--- a/ui/lib/tours/explore-findings.tour.ts
+++ b/ui/lib/tours/explore-findings.tour.ts
@@ -1,0 +1,45 @@
+import {
+  defineTour,
+  TOUR_STEP_ALIGNMENTS,
+  TOUR_STEP_SIDES,
+} from "./tour-types";
+
+// The literal targets this tour anchors. `defineTour<...>` preserves the union
+// so `useDriverTour` can validate `stepHandlers` keys and `waitForStep`
+// arguments against exactly these two values.
+export type ExploreFindingsTourTarget = "filters" | "table";
+
+export const exploreFindingsTour = defineTour<ExploreFindingsTourTarget>({
+  id: "explore-findings",
+  version: 1,
+  // Scopes the `tour:check` / `prowler-tour` drift check to the findings route
+  // and component trees where the `filters` and `table` anchors live.
+  coversFiles: ["ui/app/(prowler)/findings/**", "ui/components/findings/**"],
+  steps: [
+    {
+      // Modal welcome step — no `target`, rendered as a centered popover.
+      title: "Explore your findings",
+      description:
+        "Findings are the issues Prowler detected across your scans, grouped so you can act on what matters most.",
+    },
+    {
+      // `filters` is anchored before `table`: the filter controls render
+      // immediately, while the table mounts after its Suspense boundary
+      // resolves, so this ordering keeps both anchors resolvable in turn.
+      target: "filters",
+      side: TOUR_STEP_SIDES.BOTTOM,
+      align: TOUR_STEP_ALIGNMENTS.START,
+      title: "Focus on what matters",
+      description:
+        "Filter by provider, severity, service, and more to narrow down to the findings you care about.",
+    },
+    {
+      target: "table",
+      side: TOUR_STEP_SIDES.TOP,
+      align: TOUR_STEP_ALIGNMENTS.START,
+      title: "Open a finding group",
+      description:
+        "Each row groups related findings. Open one to see the affected resources and how to remediate them.",
+    },
+  ],
+});

--- a/ui/lib/tours/view-compliance.tour.ts
+++ b/ui/lib/tours/view-compliance.tour.ts
@@ -1,0 +1,45 @@
+import {
+  defineTour,
+  TOUR_STEP_ALIGNMENTS,
+  TOUR_STEP_SIDES,
+} from "./tour-types";
+
+// The literal targets this tour anchors. `defineTour<...>` preserves the union
+// so `useDriverTour` can validate `stepHandlers` keys and `waitForStep`
+// arguments against exactly these two values.
+export type ViewComplianceTourTarget = "frameworks" | "search";
+
+export const viewComplianceTour = defineTour<ViewComplianceTourTarget>({
+  id: "view-compliance",
+  version: 1,
+  // Scopes the `tour:check` / `prowler-tour` drift check to the compliance
+  // route and component trees where the `frameworks` and `search` anchors live.
+  coversFiles: [
+    "ui/app/(prowler)/compliance/**",
+    "ui/components/compliance/**",
+  ],
+  steps: [
+    {
+      // Modal welcome step — no `target`, rendered as a centered popover.
+      title: "Check your compliance",
+      description:
+        "Compliance maps your findings to frameworks like CIS so you can see where you stand against each standard.",
+    },
+    {
+      target: "frameworks",
+      side: TOUR_STEP_SIDES.TOP,
+      align: TOUR_STEP_ALIGNMENTS.START,
+      title: "Browse the frameworks",
+      description:
+        "Each card is a framework with your passed and total requirement counts. Open one to drill into its requirements.",
+    },
+    {
+      target: "search",
+      side: TOUR_STEP_SIDES.BOTTOM,
+      align: TOUR_STEP_ALIGNMENTS.START,
+      title: "Find a framework fast",
+      description:
+        "Search by name to jump straight to a specific framework instead of scrolling through every card.",
+    },
+  ],
+});

--- a/ui/lib/tours/view-first-scan.tour.ts
+++ b/ui/lib/tours/view-first-scan.tour.ts
@@ -1,0 +1,42 @@
+import {
+  defineTour,
+  TOUR_STEP_ALIGNMENTS,
+  TOUR_STEP_SIDES,
+} from "./tour-types";
+
+// The literal targets this tour anchors. `defineTour<...>` preserves the union
+// so `useDriverTour` can validate `stepHandlers` keys and `waitForStep`
+// arguments against exactly these two values.
+export type ViewFirstScanTourTarget = "launch" | "tabs";
+
+export const viewFirstScanTour = defineTour<ViewFirstScanTourTarget>({
+  id: "view-first-scan",
+  version: 1,
+  // Scopes the `tour:check` / `prowler-tour` drift check to the scans route and
+  // component trees where the `launch` and `tabs` anchors live.
+  coversFiles: ["ui/app/(prowler)/scans/**", "ui/components/scans/**"],
+  steps: [
+    {
+      // Modal welcome step — no `target`, rendered as a centered popover.
+      title: "This is Scan Jobs",
+      description:
+        "Scan Jobs is where you run and track scans against your connected providers.",
+    },
+    {
+      target: "launch",
+      side: TOUR_STEP_SIDES.BOTTOM,
+      align: TOUR_STEP_ALIGNMENTS.END,
+      title: "Launch a scan",
+      description:
+        "Click Launch Scan to start assessing a connected provider. You can pick which provider and what to scan.",
+    },
+    {
+      target: "tabs",
+      side: TOUR_STEP_SIDES.BOTTOM,
+      align: TOUR_STEP_ALIGNMENTS.START,
+      title: "Track your scan jobs",
+      description:
+        "Switch between these tabs to follow running, scheduled, and completed jobs as they progress.",
+    },
+  ],
+});


### PR DESCRIPTION
### Context

The actual guided-sequence steps across the product.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

scan, findings and compliance onboarding tours with their page anchors. Steps that need scan data carry a `dataRequirementHint`.

### Steps to review

Read the three tour files + anchors. Run `node ui/scripts/check-tour-alignment.mjs`.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 10 of 15 |
| Base | `chain/ob-09-checkpoint` |
| Depends on | #11439 |
| Follow-up | #11441 |
| Review budget | 606 / 400 ⚠️ |
| Starts at | #11439 (checkpoint) |
| Ends with | the three middle sequence steps |

> **Size exception:** exceeds the 400-line budget because this is one cohesive code+tests unit; splitting further would separate a component/store/tour from the test that verifies it. No `size:exception` label exists in this repo (only `size/*`), so the rationale is recorded here.

### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← 📍#11440 ← #11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** view-first-scan, explore-findings, view-compliance tours + anchors
- **Excludes:** attack-paths flow + menu (slice 11)

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
