### PR TITLE
feat(ui): list all onboarding flows in the product tour menu

### DIFF
--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/actions/attack-paths";
 import { adaptQueryResultToGraphData } from "@/actions/attack-paths/query-result.adapter";
 import { FindingDetailDrawer } from "@/components/findings/table";
+import { mapCloseToSequenceAction } from "@/components/onboarding/onboarding-trigger.logic";
 import { useFindingDetails } from "@/components/resources/table/use-finding-details";
 import { AutoRefresh } from "@/components/scans";
 import {
@@ -35,6 +36,7 @@ import { useToast } from "@/components/ui";
 import { attackPathsTour } from "@/lib/tours/attack-paths.tour";
 import { attackPathsEmptyTour } from "@/lib/tours/attack-paths-empty.tour";
 import { useDriverTour } from "@/lib/tours/use-driver-tour";
+import { useOnboardingSequenceStore } from "@/store/onboarding-sequence";
 import type {
   AttackPathQuery,
   AttackPathQueryError,
@@ -96,8 +98,32 @@ export default function AttackPathsPage() {
     enabled: !scansLoading && hasNoScans,
   });
 
+  // Follow-up (out of MVP scope): replaying attack-paths via
+  // `/attack-paths?onboarding=attack-paths` when a completion record ALREADY
+  // exists will not force the tour open — the page's normal auto-open only
+  // fires when no record is stored. Re-opening on an existing record would mean
+  // reading the `onboarding` param here and calling the tour result's `start()`.
+  // The avatar replay list still navigates here; the no-record case is covered.
+
   useDriverTour(attackPathsTour, {
     enabled: !scansLoading && hasReadyScan,
+    // Single-fire integration (Decision 4): the PAGE owns the only driver for
+    // attackPathsTour. When the guided sequence is on this flow, report the
+    // tour's outcome to the slice so completion advances (and, since
+    // attack-paths is the LAST ordered flow, advance() clears the slice) while
+    // any user-close stops it. Read live slice state at close time so the guard
+    // reflects the moment the tour ended, not the render that wired the option.
+    // Guarded by `active && currentFlowId === "attack-paths"`: a standalone
+    // visit (sequence inactive) leaves this inert, preserving today's behavior.
+    onClosed: (state) => {
+      const { active, currentFlowId } = useOnboardingSequenceStore.getState();
+      if (!active || currentFlowId !== "attack-paths") return;
+      if (mapCloseToSequenceAction(state) === "advance") {
+        useOnboardingSequenceStore.getState().advance();
+      } else {
+        useOnboardingSequenceStore.getState().stop();
+      }
+    },
     stepHandlers: {
       "scan-list": {
         onNext: async ({ waitForStep }) => {

--- a/ui/components/ui/user-nav/__tests__/user-nav.test.tsx
+++ b/ui/components/ui/user-nav/__tests__/user-nav.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getOrderedFlows } from "@/lib/onboarding";
+
 import { UserNav } from "../user-nav";
 
 const pushMock = vi.fn();
@@ -24,6 +26,22 @@ vi.mock("@/actions/auth", () => ({
   logOut: () => logOutMock(),
 }));
 
+// Opens the avatar menu and expands the "Product tour" submenu. Radix renders
+// sub-content items only once the sub-trigger is opened, and in jsdom the
+// reliable open path is keyboard navigation (focus the trigger, ArrowRight),
+// which also exercises the accessible keyboard interaction.
+const openProductTourSubmenu = async (
+  user: ReturnType<typeof userEvent.setup>,
+) => {
+  await user.click(screen.getByRole("button", { name: /account menu/i }));
+  const productTour = await screen.findByRole("menuitem", {
+    name: /product tour/i,
+  });
+  productTour.focus();
+  await user.keyboard("{ArrowRight}");
+  return productTour;
+};
+
 describe("UserNav", () => {
   beforeEach(() => {
     pushMock.mockClear();
@@ -35,7 +53,7 @@ describe("UserNav", () => {
   });
 
   describe("when the avatar menu is opened", () => {
-    it("renders a restart onboarding entry that is always present", async () => {
+    it("renders a product tour entry that is always present", async () => {
       // Given - an authenticated user
       const user = userEvent.setup();
       render(<UserNav />);
@@ -43,27 +61,65 @@ describe("UserNav", () => {
       // When - the user opens the avatar menu
       await user.click(screen.getByRole("button", { name: /account menu/i }));
 
-      // Then - the restart-onboarding entry is offered regardless of state
+      // Then - the product tour entry is offered regardless of state
       expect(
         await screen.findByRole("menuitem", { name: /product tour/i }),
       ).toBeInTheDocument();
     });
 
-    it("navigates to the first flow's route with the onboarding query param", async () => {
-      // Given - the avatar menu is open
+    it("lists every ordered onboarding flow inside the product tour submenu", async () => {
+      // Given - the registry exposes the ordered flows
+      const flows = getOrderedFlows();
       const user = userEvent.setup();
       render(<UserNav />);
-      await user.click(screen.getByRole("button", { name: /account menu/i }));
-      const productTour = await screen.findByRole("menuitem", {
-        name: /product tour/i,
-      });
 
-      // When - the user activates the restart entry
-      await user.click(productTour);
+      // When - the user opens the product tour submenu
+      await openProductTourSubmenu(user);
 
-      // Then - the app hands off to the first flow via the URL transport
+      // Then - one entry per ordered flow is offered, labelled by flow title
+      for (const flow of flows) {
+        expect(
+          await screen.findByRole("menuitem", { name: flow.title }),
+        ).toBeInTheDocument();
+      }
+    });
+
+    it("replays the selected single flow via the onboarding query param", async () => {
+      // Given - the product tour submenu is open
+      const flows = getOrderedFlows();
+      const targetIndex = 2; // a non-first flow proves the list is not hardcoded
+      const target = flows[targetIndex];
+      const user = userEvent.setup();
+      render(<UserNav />);
+      await openProductTourSubmenu(user);
+      await screen.findByRole("menuitem", { name: target.title });
+
+      // When - the user moves to that flow's entry and activates it
+      for (let step = 0; step < targetIndex; step += 1) {
+        await user.keyboard("{ArrowDown}");
+      }
+      await user.keyboard("{Enter}");
+
+      // Then - the app navigates to that single flow's replay URL only
       expect(pushMock).toHaveBeenCalledWith(
-        "/providers?onboarding=add-provider",
+        `${target.route}?onboarding=${target.id}`,
+      );
+    });
+
+    it("navigates to the first flow's replay URL when its entry is selected", async () => {
+      // Given - the product tour submenu is open
+      const [firstFlow] = getOrderedFlows();
+      const user = userEvent.setup();
+      render(<UserNav />);
+      await openProductTourSubmenu(user);
+      await screen.findByRole("menuitem", { name: firstFlow.title });
+
+      // When - the user activates the first (focused) flow entry
+      await user.keyboard("{Enter}");
+
+      // Then - the first flow replays through the URL transport
+      expect(pushMock).toHaveBeenCalledWith(
+        `${firstFlow.route}?onboarding=${firstFlow.id}`,
       );
     });
 

--- a/ui/components/ui/user-nav/user-nav.tsx
+++ b/ui/components/ui/user-nav/user-nav.tsx
@@ -12,6 +12,9 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/shadcn/dropdown/dropdown";
 import {
@@ -37,14 +40,14 @@ export const UserNav = () => {
         .join("")
     : name.charAt(0);
 
-  // Derive the restart destination from the registry so adding or reordering
-  // flows never requires editing this component. The trigger mounted on the
-  // target route consumes the `?onboarding=<id>` param and force-starts the tour.
-  const firstFlow = getOrderedFlows()[0];
+  // Derive the replay list entirely from the registry so adding or reordering
+  // flows never requires editing this component. Selecting an entry hands off
+  // to the target route's OnboardingTrigger via the `?onboarding=<id>` param,
+  // which force-starts that single flow only — no guided sequence is started.
+  const flows = getOrderedFlows();
 
-  const startProductTour = () => {
-    if (!firstFlow) return;
-    router.push(`${firstFlow.route}?onboarding=${firstFlow.id}`);
+  const replayFlow = (route: string, id: string) => {
+    router.push(`${route}?onboarding=${id}`);
   };
 
   return (
@@ -73,15 +76,23 @@ export const UserNav = () => {
             Account Settings
           </CustomLink>
         </DropdownMenuItem>
-        {firstFlow && (
-          <DropdownMenuItem
-            className="cursor-pointer"
-            onSelect={startProductTour}
-          >
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger className="cursor-pointer">
             <Compass />
             Product tour
-          </DropdownMenuItem>
-        )}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            {flows.map((flow) => (
+              <DropdownMenuItem
+                key={flow.id}
+                className="cursor-pointer"
+                onSelect={() => replayFlow(flow.route, flow.id)}
+              >
+                {flow.title}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           variant="destructive"

--- a/ui/lib/onboarding/__tests__/registry.test.ts
+++ b/ui/lib/onboarding/__tests__/registry.test.ts
@@ -37,6 +37,7 @@ const buildFlow = (
   route: overrides.route ?? "/route",
   tour: overrides.tour ?? buildTour(overrides.id ?? "flow"),
   isComplete: overrides.isComplete,
+  ownsAutoOpen: overrides.ownsAutoOpen,
 });
 
 const completedRecord = (
@@ -144,8 +145,31 @@ describe("onboardingFlows (production registry)", () => {
     expect(flow?.tour.id).toBe("view-compliance");
   });
 
-  it("orders the four sequence flows 1..4 by registry order", () => {
-    // Given / When - the production registry after Slices 4-6 registration
+  it("registers the attack-paths flow at order 5 on the attack-paths route", () => {
+    // Given / When - the integration flow added in Slice 7
+    const flow = getFlowById("attack-paths", onboardingFlows);
+
+    // Then - declared contract: order, route, and a matching tour id
+    expect(flow).toBeDefined();
+    expect(flow?.order).toBe(5);
+    expect(flow?.route).toBe("/attack-paths");
+    expect(flow?.tour.id).toBe("attack-paths");
+  });
+
+  it("flags attack-paths with ownsAutoOpen so the shared trigger never drives it", () => {
+    // Given / When - the attack-paths page owns its own driver (Decision 4)
+    const attackPaths = getFlowById("attack-paths", onboardingFlows);
+
+    // Then - only attack-paths carries the flag; every other flow is falsy
+    expect(attackPaths?.ownsAutoOpen).toBe(true);
+    for (const flow of onboardingFlows) {
+      if (flow.id === "attack-paths") continue;
+      expect(flow.ownsAutoOpen).toBeFalsy();
+    }
+  });
+
+  it("orders the five sequence flows 1..5 by registry order", () => {
+    // Given / When - the production registry after Slices 4-7 registration
     const ordered = getOrderedFlows(onboardingFlows);
 
     // Then - the guided sequence advances in declared order
@@ -154,6 +178,7 @@ describe("onboardingFlows (production registry)", () => {
       "view-first-scan",
       "explore-findings",
       "view-compliance",
+      "attack-paths",
     ]);
   });
 });

--- a/ui/lib/onboarding/registry.ts
+++ b/ui/lib/onboarding/registry.ts
@@ -1,4 +1,5 @@
 import { addProviderTour } from "@/lib/tours/add-provider.tour";
+import { attackPathsTour } from "@/lib/tours/attack-paths.tour";
 import { exploreFindingsTour } from "@/lib/tours/explore-findings.tour";
 import { localStorageAdapter } from "@/lib/tours/store/local-storage-adapter";
 import type { TourCompletionStore } from "@/lib/tours/store/tour-completion-store";
@@ -47,6 +48,18 @@ export const onboardingFlows: readonly OnboardingFlow[] = [
     description: "Map your findings to frameworks like CIS.",
     route: "/compliance",
     tour: viewComplianceTour,
+  },
+  {
+    id: "attack-paths",
+    order: 5,
+    title: "Visualize attack paths",
+    description: "See how a compromise could spread across your cloud.",
+    route: "/attack-paths",
+    tour: attackPathsTour,
+    // The attack-paths PAGE already drives this tour (its own auto-open +
+    // rich stepHandlers). The shared OnboardingTrigger must NOT mount a second
+    // runner; the page reports completion to the sequence slice instead.
+    ownsAutoOpen: true,
   },
 ];
 


### PR DESCRIPTION
### Context

Completes the sequence and exposes every flow for replay.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Adds the attack-paths flow (owns auto-open) and lists all sequence flows in the product-tour menu.

### Steps to review

Read the registry entry + menu list. Confirm attack-paths is last and owns auto-open.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 11 of 15 |
| Base | `chain/ob-10-tours` |
| Depends on | #11440 |
| Follow-up | #11442 |
| Review budget | 187 / 400 |
| Starts at | #11440 (sequence tours) |
| Ends with | the full flow set, replayable from the menu |


### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← 📍#11441 ← #11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** attack-paths flow + flow-list menu
- **Excludes:** none

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
