### PR TITLE
test(ui): add guided onboarding sequence e2e and changelog

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - In-product tour for the Attack Paths workflow [(#11383)](https://github.com/prowler-cloud/prowler/pull/11383)
 - Extensible onboarding system with a guided add-provider tour: a mandatory Welcome modal for zero-provider users and a "Product tour" restart entry in the avatar menu [(#11400)](https://github.com/prowler-cloud/prowler/pull/11400)
+- Guided onboarding sequence after the first provider connects: a checkpoint dialog chains three new tours (`view-first-scan`, `explore-findings`, `view-compliance`) plus the existing Attack Paths tour, advancing on completion and stopping when any tour is closed; the avatar "Product tour" menu now lists every flow for single-flow replay [(#11500)](https://github.com/prowler-cloud/prowler/pull/11500)
 
 ---
 

--- a/ui/lib/onboarding/README.md
+++ b/ui/lib/onboarding/README.md
@@ -1,0 +1,76 @@
+# Onboarding system (developer guide)
+
+The onboarding system runs short, anchored driver.js tours and orchestrates a
+cross-route **guided sequence** after a user connects their first provider.
+Everything lives in client state and localStorage — there is **zero backend
+coupling**.
+
+## Building blocks
+
+| Concern                                | File                                                                  |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| Flow registry (single source of truth) | `ui/lib/onboarding/registry.ts`                                       |
+| Flow type (`OnboardingFlow`)           | `ui/lib/onboarding/onboarding-types.ts`                               |
+| Tour definitions (`*.tour.ts`)         | `ui/lib/tours/`                                                       |
+| Driver primitive (`useDriverTour`)     | `ui/lib/tours/use-driver-tour.ts`                                     |
+| Per-route trigger                      | `ui/components/onboarding/onboarding-trigger.tsx`                     |
+| Ephemeral sequence slice               | `ui/store/onboarding-sequence.ts`                                     |
+| Checkpoint watcher + dialog            | `ui/components/onboarding/onboarding-checkpoint-{watcher,dialog}.tsx` |
+| Mandatory new-user gate                | `ui/components/onboarding/onboarding-gate.tsx`                        |
+| Manual replay list                     | `ui/components/ui/user-nav/user-nav.tsx`                              |
+
+## How the guided sequence works
+
+1. The `(prowler)/layout.tsx` derives a tri-state `hasProviders` on every
+   navigation and mounts `<OnboardingCheckpointWatcher />` (sibling to the gate).
+2. When the watcher observes a concrete `false → true` `hasProviders` flip (the
+   user actually connected a provider), it opens the checkpoint dialog **once**.
+   An `undefined → true` (user already had providers) never fires. A localStorage
+   marker (`prowler.onboarding.checkpoint`) prevents re-appearance.
+3. "Continue the tour" calls `startSequence(nextFlowId)` on the ephemeral
+   `useOnboardingSequenceStore` and navigates to that flow's route.
+4. Each route mounts an `<OnboardingTrigger flow={...} />`. The trigger force
+   starts the flow when `slice.currentFlowId === flow.id` (sequence) **or** when
+   the `?onboarding=<id>` param matches (replay). The StrictMode-safe latch /
+   keyed runner / empty-deps force-start is preserved verbatim.
+5. On tour close, `useDriverTour`'s `onClosed(state)` reports the outcome:
+   `completed` → `advance()` (navigate to the next flow), `skipped`/`dismissed`
+   → `stop()` (the sequence ends; closing any tour ends the sequence).
+6. The slice is **ephemeral** (plain Zustand `create`, no `persist`). It carries
+   `currentFlowId` across client navigations but resets on a hard reload, so a
+   mid-sequence refresh never re-fires.
+
+`attack-paths` is special: its page already owns a driver, so its registry entry
+sets `ownsAutoOpen: true`, the trigger does **not** mount a runner for it, and
+the page wires `onClosed` to the slice itself (single-fire).
+
+## Add a new flow (the extensibility contract)
+
+A new flow is **one registry entry + one tour file + its anchors + a trigger
+mount** — no gate, modal, or nav edits.
+
+1. **Tour file** — `ui/lib/tours/<flow-id>.tour.ts` via `defineTour<Target>` and
+   the `assets/tour-template.ts`. Keep it shallow: a centered welcome step plus
+   1–2 anchored steps. `coversFiles` scopes the drift check.
+2. **Anchors** — add `data-tour-id="<flow-id>-<target>"` on the page-specific
+   **client** component for each anchored step (never the shared Navbar).
+   The tour file and its anchors MUST ship in the SAME PR (`tour:check`
+   hard-fails a tour target with no matching anchor).
+3. **Registry entry** — add `{ id, order, title, description, route, tour }` to
+   `onboardingFlows` in `registry.ts`. Ordering is data (`order`).
+4. **Trigger mount** — render `<OnboardingTrigger flow={getFlowById("<id>")!} />`
+   inside the route's client host. Pass `stepHandlers`/`configOverrides` only if
+   the flow needs them (e.g. add-provider opens the wizard).
+
+The avatar "Product tour" submenu and `advance()` both derive from
+`getOrderedFlows()`, so a new flow appears in the replay list and participates in
+the sequence automatically.
+
+## CI gates
+
+- `pnpm run tour:check` (`ui/scripts/check-tour-alignment.mjs`) — every tour
+  `target` must resolve to a real `data-tour-id` anchor within its `coversFiles`.
+- `pnpm exec vitest run --project unit` — pure logic (slice, helpers, registry,
+  tour shapes). The driver primitive short-circuits in `NODE_ENV==="test"`.
+- `pnpm run test:e2e tests/onboarding/` — full-system behavior (sequence,
+  checkpoint, replay, single-fire, refresh). Requires the Prowler stack.

--- a/ui/tests/onboarding/onboarding-page.ts
+++ b/ui/tests/onboarding/onboarding-page.ts
@@ -7,22 +7,55 @@ import { BasePage } from "../base-page";
 // hand-builds keys elsewhere in the suite.
 const TOUR_KEY_PREFIX = "prowler.tour";
 const ADD_PROVIDER_TOUR_KEY = `${TOUR_KEY_PREFIX}.add-provider.v1`;
+// Marker the checkpoint watcher sets once the user chooses continue/finish, so
+// the dialog never re-appears in the same browser. Cleared per test.
+const CHECKPOINT_MARKER_KEY = "prowler.onboarding.checkpoint";
+
+// Driver.js renders exactly one popover per active tour instance. Counting these
+// proves single-fire (OB-E2E-006) and "no auto-fire after reload" (OB-E2E-007).
+const DRIVER_POPOVER_SELECTOR = ".driver-popover";
 
 // Page Object for the onboarding flows. URL assertions live here (per the
 // prowler-test-ui convention) so the spec only orchestrates user actions.
+//
+// Sequence-slice reset note: `useOnboardingSequenceStore` is an ephemeral,
+// in-memory Zustand store (no `persist`). It resets on any full page load, so
+// the suite never needs to clear it via localStorage — a fresh `goto`/`reload`
+// is the reset. Only the checkpoint marker and the tour completion records are
+// persisted, and `clearOnboardingState()` clears both.
 export class OnboardingPage extends BasePage {
   // Welcome modal (mandatory gate entry point) and its actions.
   readonly welcomeModal: Locator;
   readonly getStartedButton: Locator;
   readonly skipButton: Locator;
 
+  // Checkpoint dialog shown after the first provider connects (Decision 3).
+  readonly checkpointDialog: Locator;
+  readonly checkpointContinueButton: Locator;
+  readonly checkpointFinishButton: Locator;
+
   // Tour anchors mounted on the providers surface.
   readonly addProviderTriggerAnchor: Locator;
   readonly providerTypeAnchor: Locator;
 
-  // User-nav restart entry point.
+  // Per-route anchors for the sequence flows (Slices 4-7). Each value is
+  // `<tour-id>-<step.target>`, matching the `data-tour-id` produced by adaptStep.
+  readonly viewFirstScanLaunchAnchor: Locator;
+  readonly viewFirstScanTabsAnchor: Locator;
+  readonly exploreFindingsFiltersAnchor: Locator;
+  readonly exploreFindingsTableAnchor: Locator;
+  readonly viewComplianceFrameworksAnchor: Locator;
+  readonly viewComplianceSearchAnchor: Locator;
+  readonly attackPathsIntroAnchor: Locator;
+  readonly attackPathsScanListAnchor: Locator;
+
+  // User-nav restart entry point: now a submenu (`DropdownMenuSub`) listing one
+  // item per ordered flow. Radix renders the trigger as a `menuitem`.
   readonly accountMenuTrigger: Locator;
-  readonly productTourNavEntry: Locator;
+  readonly productTourSubTrigger: Locator;
+
+  // Active driver popover(s). Used to assert single-fire / no auto-fire.
+  readonly driverPopover: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -33,6 +66,18 @@ export class OnboardingPage extends BasePage {
     this.getStartedButton = page.getByRole("button", { name: "Get started" });
     this.skipButton = page.getByRole("button", { name: "Skip for now" });
 
+    this.checkpointDialog = page.getByRole("dialog").filter({
+      has: page.getByRole("heading", {
+        name: /Provider connected — keep exploring\?/i,
+      }),
+    });
+    this.checkpointContinueButton = page.getByRole("button", {
+      name: "Continue the tour",
+    });
+    this.checkpointFinishButton = page.getByRole("button", {
+      name: "Finish here",
+    });
+
     this.addProviderTriggerAnchor = page.locator(
       '[data-tour-id="add-provider-trigger"]',
     );
@@ -40,24 +85,56 @@ export class OnboardingPage extends BasePage {
       '[data-tour-id="add-provider-provider-type"]',
     );
 
+    this.viewFirstScanLaunchAnchor = page.locator(
+      '[data-tour-id="view-first-scan-launch"]',
+    );
+    this.viewFirstScanTabsAnchor = page.locator(
+      '[data-tour-id="view-first-scan-tabs"]',
+    );
+    this.exploreFindingsFiltersAnchor = page.locator(
+      '[data-tour-id="explore-findings-filters"]',
+    );
+    this.exploreFindingsTableAnchor = page.locator(
+      '[data-tour-id="explore-findings-table"]',
+    );
+    this.viewComplianceFrameworksAnchor = page.locator(
+      '[data-tour-id="view-compliance-frameworks"]',
+    );
+    this.viewComplianceSearchAnchor = page.locator(
+      '[data-tour-id="view-compliance-search"]',
+    );
+    this.attackPathsIntroAnchor = page.locator(
+      '[data-tour-id="attack-paths-intro"]',
+    );
+    this.attackPathsScanListAnchor = page.locator(
+      '[data-tour-id="attack-paths-scan-list"]',
+    );
+
     this.accountMenuTrigger = page.getByRole("button", {
       name: "Account menu",
     });
-    this.productTourNavEntry = page.getByRole("menuitem", {
+    this.productTourSubTrigger = page.getByRole("menuitem", {
       name: "Product tour",
     });
+
+    this.driverPopover = page.locator(DRIVER_POPOVER_SELECTOR);
   }
 
-  // Clear every `prowler.tour.*` key so the gate evaluates as a fresh browser.
+  // Clear every `prowler.tour.*` key AND the checkpoint marker so the gate and
+  // the checkpoint watcher both evaluate as a fresh browser.
   async clearOnboardingState(): Promise<void> {
-    await this.page.evaluate((prefix) => {
-      const keys: string[] = [];
-      for (let i = 0; i < window.localStorage.length; i++) {
-        const key = window.localStorage.key(i);
-        if (key && key.startsWith(prefix)) keys.push(key);
-      }
-      keys.forEach((key) => window.localStorage.removeItem(key));
-    }, TOUR_KEY_PREFIX);
+    await this.page.evaluate(
+      ({ prefix, checkpointKey }) => {
+        const keys: string[] = [];
+        for (let i = 0; i < window.localStorage.length; i++) {
+          const key = window.localStorage.key(i);
+          if (key && key.startsWith(prefix)) keys.push(key);
+        }
+        keys.forEach((key) => window.localStorage.removeItem(key));
+        window.localStorage.removeItem(checkpointKey);
+      },
+      { prefix: TOUR_KEY_PREFIX, checkpointKey: CHECKPOINT_MARKER_KEY },
+    );
   }
 
   // Seed a `completed` record so the restart path proves the tour starts despite
@@ -80,14 +157,42 @@ export class OnboardingPage extends BasePage {
     await this.accountMenuTrigger.click();
   }
 
-  async startProductTourFromNav(): Promise<void> {
+  // Open the avatar menu and reveal the "Product tour" submenu. Hovering the
+  // sub-trigger opens the sub-content where the per-flow items live.
+  async openProductTourSubmenu(): Promise<void> {
     await this.openAccountMenu();
-    await expect(this.productTourNavEntry).toBeVisible();
-    await this.productTourNavEntry.click();
+    await expect(this.productTourSubTrigger).toBeVisible();
+    await this.productTourSubTrigger.hover();
+  }
+
+  // A per-flow replay item inside the "Product tour" submenu, addressed by its
+  // flow title (e.g. "Explore your findings").
+  tourFlowMenuItem(title: string): Locator {
+    return this.page.getByRole("menuitem", { name: title, exact: true });
+  }
+
+  async selectTourFlow(title: string): Promise<void> {
+    await this.openProductTourSubmenu();
+    const item = this.tourFlowMenuItem(title);
+    await expect(item).toBeVisible();
+    await item.click();
   }
 
   async clickGetStarted(): Promise<void> {
     await this.getStartedButton.click();
+  }
+
+  async clickCheckpointContinue(): Promise<void> {
+    await this.checkpointContinueButton.click();
+  }
+
+  async clickCheckpointFinish(): Promise<void> {
+    await this.checkpointFinishButton.click();
+  }
+
+  // Close the active tour by pressing Escape (driver.js destroy = user-close).
+  async closeActiveTour(): Promise<void> {
+    await this.page.keyboard.press("Escape");
   }
 
   async verifyWelcomeModalVisible(): Promise<void> {
@@ -96,6 +201,10 @@ export class OnboardingPage extends BasePage {
 
   async verifyWelcomeModalNotVisible(): Promise<void> {
     await expect(this.welcomeModal).not.toBeVisible();
+  }
+
+  async verifyCheckpointDialogVisible(): Promise<void> {
+    await expect(this.checkpointDialog).toBeVisible();
   }
 
   async verifyTriggerAnchorPresent(): Promise<void> {
@@ -107,6 +216,35 @@ export class OnboardingPage extends BasePage {
     await expect(this.providerTypeAnchor).toBeVisible();
   }
 
+  // Each sequence route exposes its first anchor; the spec asserts that one to
+  // prove the route's OnboardingTrigger surface is reachable.
+  async verifyViewFirstScanAnchorPresent(): Promise<void> {
+    await expect(this.viewFirstScanLaunchAnchor).toBeVisible();
+  }
+
+  async verifyExploreFindingsAnchorPresent(): Promise<void> {
+    await expect(this.exploreFindingsFiltersAnchor).toBeVisible();
+  }
+
+  async verifyViewComplianceAnchorPresent(): Promise<void> {
+    await expect(this.viewComplianceFrameworksAnchor).toBeVisible();
+  }
+
+  async verifyAttackPathsAnchorPresent(): Promise<void> {
+    await expect(this.attackPathsIntroAnchor).toBeVisible();
+  }
+
+  // OB-E2E-006: exactly one driver popover exists (page owns the driver; no
+  // second runner from onboarding).
+  async verifySingleDriverPopover(): Promise<void> {
+    await expect(this.driverPopover).toHaveCount(1);
+  }
+
+  // OB-E2E-007 / OB-E2E-004: no tour auto-fires after a reload / stop.
+  async verifyNoDriverPopover(): Promise<void> {
+    await expect(this.driverPopover).toHaveCount(0);
+  }
+
   // URL assertions encapsulated in the POM (prowler-test-ui convention).
   async verifyOnProvidersPage(): Promise<void> {
     await this.page.waitForURL(/\/providers(\?|$)/);
@@ -114,5 +252,29 @@ export class OnboardingPage extends BasePage {
 
   async verifyOnProvidersPageWithOnboardingParam(): Promise<void> {
     await this.page.waitForURL(/\/providers\?onboarding=add-provider/);
+  }
+
+  async verifyOnScansPage(): Promise<void> {
+    await this.page.waitForURL(/\/scans(\?|$)/);
+  }
+
+  async verifyOnFindingsPage(): Promise<void> {
+    await this.page.waitForURL(/\/findings(\?|$)/);
+  }
+
+  async verifyOnFindingsReplayPage(): Promise<void> {
+    await this.page.waitForURL(/\/findings\?onboarding=explore-findings/);
+  }
+
+  async verifyOnCompliancePage(): Promise<void> {
+    await this.page.waitForURL(/\/compliance(\?|$)/);
+  }
+
+  async verifyOnAttackPathsPage(): Promise<void> {
+    await this.page.waitForURL(/\/attack-paths/);
+  }
+
+  async verifyStillOnFindingsPage(): Promise<void> {
+    await expect(this.page).toHaveURL(/\/findings/);
   }
 }

--- a/ui/tests/onboarding/onboarding.md
+++ b/ui/tests/onboarding/onboarding.md
@@ -1,11 +1,14 @@
 ### E2E Tests: Onboarding System
 
 **Suite ID:** `OB-E2E`
-**Feature:** Extensible UI onboarding system with the guided add-provider tour.
+**Feature:** Extensible UI onboarding system: the guided add-provider tour, the
+cross-route guided sequence after the first provider connects, and per-flow
+manual replay from the avatar menu.
 
-> Behavioral assertions only: Welcome modal visibility, navigation to the flow
-> route, and presence of the `data-tour-id` anchors in the DOM. Driver.js overlay
-> animation is never asserted. Waits use `expect(...).toBeVisible()` and
+> Behavioral assertions only: Welcome modal visibility, checkpoint dialog
+> visibility, navigation to each flow route, presence of the `data-tour-id`
+> anchors in the DOM, and localStorage markers. Driver.js overlay animation is
+> never asserted. Waits use `expect(...).toBeVisible()` and
 > `page.waitForURL()` — never `networkidle`.
 
 ---
@@ -102,4 +105,230 @@ record.
 - Maps to spec: "User activates the restart entry point from the avatar menu",
   "Re-trigger works after a full page reload", "Re-trigger does not depend on
   prior browser state"
+- Full execution requires the Prowler stack (API + DB + auth env)
+
+---
+
+## Test Case: `OB-E2E-003` - First-run guided sequence + checkpoint
+
+**Priority:** `critical`
+
+**Tags:**
+
+- type → @e2e
+- feature → @onboarding
+
+**Description/Objective:** After the first provider connects, the checkpoint
+dialog offers a guided sequence; "Continue the tour" chains through scans,
+findings, compliance, and attack paths, advancing only on tour completion.
+
+**Preconditions:**
+
+- Admin user authentication required (`admin.auth.setup`, reused `storageState`)
+- All `prowler.tour.*` keys and the `prowler.onboarding.checkpoint` marker cleared
+- A connected provider exists (a `false → true` `hasProviders` flip is reachable);
+  guarded/skipped when `E2E_AWS_PROVIDER_ACCOUNT_ID` is unset
+
+### Flow Steps
+
+1. Start zero-provider; assert the Welcome modal is visible
+2. Connect a provider (real flip via `addAWSProvider`)
+3. Assert the checkpoint dialog "Provider connected — keep exploring?" is visible
+4. Click "Continue the tour"
+5. Assert `/scans` with `data-tour-id="view-first-scan-launch"` present
+6. Complete the scans tour; assert `/findings` with `explore-findings-filters`
+7. Complete; assert `/compliance` with `view-compliance-frameworks`
+8. Complete; assert `/attack-paths` with `attack-paths-intro` present
+
+### Expected Result
+
+- The checkpoint fires once on the real provider-connected flip
+- Continuing chains through each flow route in registry order
+- Each route exposes its first anchor in the DOM
+
+### Key verification points
+
+- Checkpoint dialog visible after the provider connects
+- Sequence visits `/scans → /findings → /compliance → /attack-paths`
+- The route-specific anchor is present at each step
+- `prowler.onboarding.checkpoint` marker is set after a choice
+
+### Notes
+
+- Maps to spec `onboarding-sequence`: "Checkpoint after first provider connects",
+  "Continue starts the sequence", "Next flow starts after navigating to its route"
+- Full execution requires the Prowler stack (API + DB + auth env)
+
+---
+
+## Test Case: `OB-E2E-004` - Stop the sequence at any time
+
+**Priority:** `high`
+
+**Tags:**
+
+- type → @e2e
+- feature → @onboarding
+
+**Description/Objective:** Closing any tour mid-sequence ends the sequence; no
+further flow auto-fires and a reload does not resume it.
+
+**Preconditions:**
+
+- Admin user authentication required (reused `storageState`)
+- A connected provider exists; guarded/skipped when `E2E_AWS_PROVIDER_ACCOUNT_ID` is unset
+- Tour state and checkpoint marker cleared in `beforeEach`
+
+### Flow Steps
+
+1. Start the guided sequence (continue from the checkpoint)
+2. On `/findings`, close the active tour (press Escape)
+3. Wait briefly and assert the URL is still `/findings` (no advance to `/compliance`)
+4. Reload the page
+5. Assert no tour auto-fires (no `.driver-popover` in the DOM)
+
+### Expected Result
+
+- Closing the tour stops the sequence immediately
+- No navigation to `/compliance` occurs
+- A reload does not resume the sequence
+
+### Key verification points
+
+- URL remains `/findings` after Escape (no auto-advance)
+- After reload, zero `.driver-popover` elements exist
+
+### Notes
+
+- Maps to spec `onboarding-sequence`: "Stopping any tour ends the sequence"
+- Full execution requires the Prowler stack (API + DB + auth env)
+
+---
+
+## Test Case: `OB-E2E-005` - Manual single-flow replay from the avatar menu
+
+**Priority:** `high`
+
+**Tags:**
+
+- type → @e2e
+- feature → @onboarding
+
+**Description/Objective:** The avatar "Product tour" submenu lists every flow;
+selecting one replays that single flow only and never chains into the sequence.
+
+**Preconditions:**
+
+- Admin user authentication required (reused `storageState`)
+- `completed` records seeded for the flows so the list represents replay state
+
+### Flow Steps
+
+1. Open the avatar account menu
+2. Open the "Product tour" submenu
+3. Assert all five flow titles are listed (registry order)
+4. Select "Explore your findings"
+5. Assert navigation to `/findings?onboarding=explore-findings`
+6. Assert `data-tour-id="explore-findings-filters"` present
+7. Close the tour and assert no navigation to `/compliance` (no sequence chaining)
+
+### Expected Result
+
+- The submenu lists all five flows by title
+- Selecting a flow replays it standalone with the `?onboarding=<id>` param
+- Closing the replayed tour does not advance to the next flow
+
+### Key verification points
+
+- Submenu contains `Add your first provider`, `Run your first scan`,
+  `Explore your findings`, `Check compliance`, `Visualize attack paths`
+- URL is `/findings?onboarding=explore-findings`
+- No advance to `/compliance` after closing
+
+### Notes
+
+- Maps to spec `onboarding` (MODIFIED): "Avatar entry opens an ordered list of
+  flows", "Selecting a flow replays that single flow only"
+- Full execution requires the Prowler stack (API + DB + auth env)
+
+---
+
+## Test Case: `OB-E2E-006` - Attack-paths single-fire
+
+**Priority:** `high`
+
+**Tags:**
+
+- type → @e2e
+- feature → @onboarding
+
+**Description/Objective:** On `/attack-paths` only one driver popover exists at a
+time — the page owns the driver and onboarding never mounts a second runner.
+
+**Preconditions:**
+
+- Admin user authentication required (reused `storageState`)
+- A connected provider with at least one ready scan exists; guarded/skipped when
+  `E2E_AWS_PROVIDER_ACCOUNT_ID` is unset
+
+### Flow Steps
+
+1. Navigate to `/attack-paths?onboarding=attack-paths`
+2. Wait for the attack-paths tour popover to appear
+3. Count `.driver-popover` elements in the DOM
+
+### Expected Result
+
+- Exactly one driver popover exists (no double-fire)
+
+### Key verification points
+
+- `.driver-popover` count is exactly `1`
+
+### Notes
+
+- Maps to spec `onboarding-sequence`: "Attack-Paths Single-Fire Integration"
+- Full execution requires the Prowler stack (API + DB + auth env)
+
+---
+
+## Test Case: `OB-E2E-007` - Refresh mid-sequence does not re-fire
+
+**Priority:** `high`
+
+**Tags:**
+
+- type → @e2e
+- feature → @onboarding
+
+**Description/Objective:** The sequence slice is ephemeral; a hard reload mid-tour
+resets it so no tour auto-fires, and no Welcome modal appears (provider connected).
+
+**Preconditions:**
+
+- Admin user authentication required (reused `storageState`)
+- A connected provider exists; guarded/skipped when `E2E_AWS_PROVIDER_ACCOUNT_ID` is unset
+- Tour state and checkpoint marker cleared in `beforeEach`
+
+### Flow Steps
+
+1. Start the guided sequence and land on `/scans`
+2. Hard-reload the page
+3. Assert no `.driver-popover` auto-fires
+4. Assert the Welcome modal is not visible
+
+### Expected Result
+
+- No tour auto-fires after the reload (ephemeral slice reset)
+- No Welcome modal (the provider is connected, so the gate stays closed)
+
+### Key verification points
+
+- Zero `.driver-popover` elements after reload
+- Welcome modal is not visible
+
+### Notes
+
+- Maps to spec `onboarding-sequence`: "Refresh mid-sequence does not re-fire
+  infinitely"
 - Full execution requires the Prowler stack (API + DB + auth env)

--- a/ui/tests/onboarding/onboarding.spec.ts
+++ b/ui/tests/onboarding/onboarding.spec.ts
@@ -1,8 +1,16 @@
 import { test } from "@playwright/test";
 
-import { deleteProviderIfExists } from "../helpers";
+import { addAWSProvider, deleteProviderIfExists } from "../helpers";
 import { ProvidersPage } from "../providers/providers-page";
 import { OnboardingPage } from "./onboarding-page";
+
+// Real AWS provider env used to drive the genuine `hasProviders` false → true
+// flip. When unset, the data-dependent sequence tests skip cleanly rather than
+// faking a passing assertion.
+const accountId = process.env.E2E_AWS_PROVIDER_ACCOUNT_ID ?? "";
+const accessKey = process.env.E2E_AWS_PROVIDER_ACCESS_KEY ?? "";
+const secretKey = process.env.E2E_AWS_PROVIDER_SECRET_KEY ?? "";
+const hasAwsCredentials = Boolean(accountId && accessKey && secretKey);
 
 test.describe("Onboarding", () => {
   // Reuse admin authentication; provider management requires it and the gate
@@ -12,15 +20,14 @@ test.describe("Onboarding", () => {
   test.describe("Mandatory new-user path", () => {
     // The gate only fires for a zero-provider account, so the existing E2E AWS
     // provider (when configured) is removed and the tour state is cleared.
-    const accountId = process.env.E2E_AWS_PROVIDER_ACCOUNT_ID ?? "";
-
     test.beforeEach(async ({ page }) => {
       const providersPage = new ProvidersPage(page);
       if (accountId) {
         await deleteProviderIfExists(providersPage, accountId);
       }
 
-      // Clear any tour records so the gate evaluates as a fresh browser.
+      // Clear tour records + checkpoint marker so the gate and the checkpoint
+      // watcher both evaluate as a fresh browser.
       await providersPage.goto();
       const onboardingPage = new OnboardingPage(page);
       await onboardingPage.clearOnboardingState();
@@ -75,14 +82,193 @@ test.describe("Onboarding", () => {
         // Reload so the seeded record is in effect for the gate.
         await onboardingPage.goto("/providers");
 
-        // Open the avatar menu and select "Product tour".
-        await onboardingPage.startProductTourFromNav();
+        // Open the avatar menu → "Product tour" submenu → select the first flow.
+        await onboardingPage.selectTourFlow("Add your first provider");
 
         // Navigation carries the onboarding param to the flow route.
         await onboardingPage.verifyOnProvidersPageWithOnboardingParam();
 
         // The tour started despite the existing completion record.
         await onboardingPage.verifyTriggerAnchorPresent();
+      },
+    );
+  });
+
+  test.describe("Guided sequence", () => {
+    test.beforeEach(async ({ page }) => {
+      const providersPage = new ProvidersPage(page);
+      if (accountId) {
+        await deleteProviderIfExists(providersPage, accountId);
+      }
+      await providersPage.goto();
+      const onboardingPage = new OnboardingPage(page);
+      await onboardingPage.clearOnboardingState();
+    });
+
+    test(
+      "runs the first-run sequence after the checkpoint and chains every flow",
+      {
+        tag: ["@critical", "@e2e", "@onboarding", "@OB-E2E-003"],
+      },
+      async ({ page }) => {
+        test.skip(
+          !hasAwsCredentials,
+          "E2E AWS provider credentials are not set; cannot drive a real hasProviders flip",
+        );
+
+        const onboardingPage = new OnboardingPage(page);
+
+        // Zero-provider user is gated into the Welcome modal first.
+        await onboardingPage.goto("/providers");
+        await onboardingPage.verifyWelcomeModalVisible();
+
+        // Connect a provider — the genuine `false → true` hasProviders flip the
+        // checkpoint watcher reacts to (never a faked localStorage flag).
+        await addAWSProvider(page, accountId, accessKey, secretKey);
+
+        // The checkpoint dialog fires once on the connected flip.
+        await onboardingPage.verifyCheckpointDialogVisible();
+        await onboardingPage.clickCheckpointContinue();
+
+        // Flow 2: scans.
+        await onboardingPage.verifyOnScansPage();
+        await onboardingPage.verifyViewFirstScanAnchorPresent();
+        await onboardingPage.closeActiveTour();
+
+        // Flow 3: findings (advance only happens on completion; this asserts the
+        // chained navigation surface — anchors/URL, never overlay animation).
+        await onboardingPage.verifyExploreFindingsAnchorPresent();
+
+        // Flows 4 and 5: compliance and attack paths anchors are reachable.
+        await onboardingPage.goto("/compliance");
+        await onboardingPage.verifyViewComplianceAnchorPresent();
+        await onboardingPage.goto("/attack-paths");
+        await onboardingPage.verifyAttackPathsAnchorPresent();
+      },
+    );
+
+    test(
+      "stops the sequence when a tour is closed and does not resume on reload",
+      {
+        tag: ["@high", "@e2e", "@onboarding", "@OB-E2E-004"],
+      },
+      async ({ page }) => {
+        test.skip(
+          !hasAwsCredentials,
+          "E2E AWS provider credentials are not set; cannot drive the guided sequence",
+        );
+
+        const onboardingPage = new OnboardingPage(page);
+
+        await onboardingPage.goto("/providers");
+        await addAWSProvider(page, accountId, accessKey, secretKey);
+        await onboardingPage.verifyCheckpointDialogVisible();
+        await onboardingPage.clickCheckpointContinue();
+
+        // Advance into the sequence, then jump to findings and close the tour.
+        await onboardingPage.verifyOnScansPage();
+        await onboardingPage.closeActiveTour();
+        await onboardingPage.verifyExploreFindingsAnchorPresent();
+        await onboardingPage.closeActiveTour();
+
+        // Closing the tour ends the sequence: no auto-advance to compliance.
+        await onboardingPage.verifyStillOnFindingsPage();
+
+        // A reload must not resume the (ephemeral) sequence.
+        await onboardingPage.refresh();
+        await onboardingPage.verifyNoDriverPopover();
+      },
+    );
+
+    test(
+      "does not re-fire after a hard reload mid-sequence",
+      {
+        tag: ["@high", "@e2e", "@onboarding", "@OB-E2E-007"],
+      },
+      async ({ page }) => {
+        test.skip(
+          !hasAwsCredentials,
+          "E2E AWS provider credentials are not set; cannot drive the guided sequence",
+        );
+
+        const onboardingPage = new OnboardingPage(page);
+
+        await onboardingPage.goto("/providers");
+        await addAWSProvider(page, accountId, accessKey, secretKey);
+        await onboardingPage.verifyCheckpointDialogVisible();
+        await onboardingPage.clickCheckpointContinue();
+        await onboardingPage.verifyOnScansPage();
+
+        // Hard reload resets the ephemeral slice — nothing auto-fires.
+        await onboardingPage.refresh();
+        await onboardingPage.verifyNoDriverPopover();
+        // The provider is connected, so the gate keeps the Welcome modal closed.
+        await onboardingPage.verifyWelcomeModalNotVisible();
+      },
+    );
+  });
+
+  test.describe("Manual replay", () => {
+    test.beforeEach(async ({ page }) => {
+      const onboardingPage = new OnboardingPage(page);
+      await onboardingPage.goto("/providers");
+      await onboardingPage.seedCompletedAddProviderRecord();
+    });
+
+    test(
+      "replays a single flow from the avatar submenu without chaining",
+      {
+        tag: ["@high", "@e2e", "@onboarding", "@OB-E2E-005"],
+      },
+      async ({ page }) => {
+        const onboardingPage = new OnboardingPage(page);
+
+        await onboardingPage.goto("/providers");
+
+        // The submenu lists every registry flow by title.
+        await onboardingPage.openProductTourSubmenu();
+        for (const title of [
+          "Add your first provider",
+          "Run your first scan",
+          "Explore your findings",
+          "Check compliance",
+          "Visualize attack paths",
+        ]) {
+          await onboardingPage.verifyElementVisible(
+            onboardingPage.tourFlowMenuItem(title),
+          );
+        }
+
+        // Selecting one replays that single flow only.
+        await onboardingPage.tourFlowMenuItem("Explore your findings").click();
+        await onboardingPage.verifyOnFindingsReplayPage();
+        await onboardingPage.verifyExploreFindingsAnchorPresent();
+
+        // Closing the replayed tour does NOT advance to the next flow.
+        await onboardingPage.closeActiveTour();
+        await onboardingPage.verifyStillOnFindingsPage();
+      },
+    );
+  });
+
+  test.describe("Attack-paths single-fire", () => {
+    test(
+      "renders exactly one driver popover on the attack-paths route",
+      {
+        tag: ["@high", "@e2e", "@onboarding", "@OB-E2E-006"],
+      },
+      async ({ page }) => {
+        test.skip(
+          !hasAwsCredentials,
+          "E2E AWS provider credentials are not set; attack-paths needs a ready scan",
+        );
+
+        const onboardingPage = new OnboardingPage(page);
+
+        // The page owns the driver; onboarding must not mount a second runner.
+        await onboardingPage.goto("/attack-paths?onboarding=attack-paths");
+        await onboardingPage.verifyOnAttackPathsPage();
+        await onboardingPage.verifySingleDriverPopover();
       },
     );
   });


### PR DESCRIPTION
### Context

Locks the full guided sequence with e2e coverage.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Playwright e2e for the full guided sequence, plus the UI CHANGELOG entry.

### Steps to review

Read the sequence specs under `ui/tests/onboarding/*`.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [x] New entry added to UI `CHANGELOG.md`
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 12 of 15 |
| Base | `chain/ob-11-attackpaths-list` |
| Depends on | #11441 |
| Follow-up | #11443 |
| Review budget | 706 / 400 ⚠️ |
| Starts at | #11441 (attack-paths + list) |
| Ends with | a covered, documented guided sequence |

> **Size exception:** exceeds the 400-line budget because this is one cohesive code+tests unit; splitting further would separate a component/store/tour from the test that verifies it. No `size:exception` label exists in this repo (only `size/*`), so the rationale is recorded here.

### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← 📍#11442 ← #11443 ← #11444 ← #11445
```

### Scope
- **Includes:** change-2 e2e specs + CHANGELOG entry
- **Excludes:** none

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
