### PR TITLE
fix(ui): polish onboarding checkpoint copy, banner a11y, and changelog wording

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - In-product tour for the Attack Paths workflow [(#11383)](https://github.com/prowler-cloud/prowler/pull/11383)
 - Extensible onboarding system with a guided add-provider tour: a mandatory Welcome modal for zero-provider users and a "Product tour" restart entry in the avatar menu [(#11400)](https://github.com/prowler-cloud/prowler/pull/11400)
-- Guided onboarding sequence after the first provider connects: a checkpoint dialog chains three new tours (`view-first-scan`, `explore-findings`, `view-compliance`) plus the existing Attack Paths tour, advancing on completion and stopping when any tour is closed; the avatar "Product tour" menu now lists every flow for single-flow replay [(#11500)](https://github.com/prowler-cloud/prowler/pull/11500)
+- Guided onboarding sequence after the first provider is added: a checkpoint dialog starts a sequence across three new tours (`view-first-scan`, `explore-findings`, `view-compliance`) plus the existing Attack Paths tour, driven by a persistent banner to advance manually (Continue/Exit) with per-step data hints; closing a step's tour leaves the sequence active. The avatar "Product tour" menu now lists every flow for single-flow replay [(#11500)](https://github.com/prowler-cloud/prowler/pull/11500)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🚀 Added
 
 - In-product tour for the Attack Paths workflow [(#11383)](https://github.com/prowler-cloud/prowler/pull/11383)
-- Extensible onboarding system with a guided add-provider tour: a mandatory Welcome modal for zero-provider users and a "Product tour" restart entry in the avatar menu [(#11400)](https://github.com/prowler-cloud/prowler/pull/11400)
-- Guided onboarding sequence after the first provider is added: a checkpoint dialog starts a sequence across three new tours (`view-first-scan`, `explore-findings`, `view-compliance`) plus the existing Attack Paths tour, driven by a persistent banner to advance manually (Continue/Exit) with per-step data hints; closing a step's tour leaves the sequence active. The avatar "Product tour" menu now lists every flow for single-flow replay [(#11500)](https://github.com/prowler-cloud/prowler/pull/11500)
+- Extensible onboarding system with a guided add-provider tour: a mandatory Welcome modal for zero-provider users and a "Product tour" restart entry in the avatar menu [(#11430)](https://github.com/prowler-cloud/prowler/pull/11430)
+- Guided onboarding sequence after the first provider is added: a checkpoint dialog starts a sequence across three new tours (`view-first-scan`, `explore-findings`, `view-compliance`) plus the existing Attack Paths tour, driven by a persistent banner to advance manually (Continue/Exit) with per-step data hints; closing a step's tour leaves the sequence active. The avatar "Product tour" menu now lists every flow for single-flow replay [(#11430)](https://github.com/prowler-cloud/prowler/pull/11430)
 
 ---
 

--- a/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
+++ b/ui/app/(prowler)/attack-paths/(workflow)/query-builder/attack-paths-page.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/actions/attack-paths";
 import { adaptQueryResultToGraphData } from "@/actions/attack-paths/query-result.adapter";
 import { FindingDetailDrawer } from "@/components/findings/table";
-import { mapCloseToSequenceAction } from "@/components/onboarding/onboarding-trigger.logic";
 import { useFindingDetails } from "@/components/resources/table/use-finding-details";
 import { AutoRefresh } from "@/components/scans";
 import {
@@ -36,7 +35,6 @@ import { useToast } from "@/components/ui";
 import { attackPathsTour } from "@/lib/tours/attack-paths.tour";
 import { attackPathsEmptyTour } from "@/lib/tours/attack-paths-empty.tour";
 import { useDriverTour } from "@/lib/tours/use-driver-tour";
-import { useOnboardingSequenceStore } from "@/store/onboarding-sequence";
 import type {
   AttackPathQuery,
   AttackPathQueryError,
@@ -108,22 +106,11 @@ export default function AttackPathsPage() {
   useDriverTour(attackPathsTour, {
     enabled: !scansLoading && hasReadyScan,
     // Single-fire integration (Decision 4): the PAGE owns the only driver for
-    // attackPathsTour. When the guided sequence is on this flow, report the
-    // tour's outcome to the slice so completion advances (and, since
-    // attack-paths is the LAST ordered flow, advance() clears the slice) while
-    // any user-close stops it. Read live slice state at close time so the guard
-    // reflects the moment the tour ended, not the render that wired the option.
-    // Guarded by `active && currentFlowId === "attack-paths"`: a standalone
-    // visit (sequence inactive) leaves this inert, preserving today's behavior.
-    onClosed: (state) => {
-      const { active, currentFlowId } = useOnboardingSequenceStore.getState();
-      if (!active || currentFlowId !== "attack-paths") return;
-      if (mapCloseToSequenceAction(state) === "advance") {
-        useOnboardingSequenceStore.getState().advance();
-      } else {
-        useOnboardingSequenceStore.getState().stop();
-      }
-    },
+    // attackPathsTour, including its standalone auto-open. The guided sequence
+    // no longer auto-advances on tour close — the persistent
+    // OnboardingSequenceBanner is the single Continue/Exit control. So this page
+    // just RUNS its tour on arrival and never mutates the sequence slice; the
+    // user advances or exits via the banner at their own pace.
     stepHandlers: {
       "scan-list": {
         onNext: async ({ waitForStep }) => {

--- a/ui/app/(prowler)/layout.tsx
+++ b/ui/app/(prowler)/layout.tsx
@@ -8,6 +8,7 @@ import { getProviders } from "@/actions/providers";
 import {
   OnboardingCheckpointWatcher,
   OnboardingGate,
+  OnboardingSequenceBanner,
 } from "@/components/onboarding";
 import MainLayout from "@/components/ui/main-layout/main-layout";
 import { NavigationProgress } from "@/components/ui/navigation-progress";
@@ -84,6 +85,11 @@ export default async function RootLayout({
               user who simply adds another provider. One mount point so it
               survives the post-connect navigation. */}
           <OnboardingCheckpointWatcher />
+          {/* Persistent, non-blocking bottom banner shown only while a guided
+              sequence is active. It self-hides otherwise and owns the manual
+              Continue (advance + navigate) and Exit (stop) controls, replacing
+              the old auto-advance that jumped to empty pages before a scan. */}
+          <OnboardingSequenceBanner />
           <MainLayout>{children}</MainLayout>
           <Toaster />
         </Providers>

--- a/ui/components/onboarding/__tests__/onboarding-checkpoint-dialog.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-checkpoint-dialog.test.tsx
@@ -22,7 +22,10 @@ describe("OnboardingCheckpointDialog", () => {
 
       // Then - the user sees the prompt and both actions
       expect(
-        screen.getByText("Provider connected — keep exploring?"),
+        screen.getByText("Provider added — keep exploring?"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Your first provider is added\./),
       ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: /continue the tour/i }),
@@ -111,7 +114,7 @@ describe("OnboardingCheckpointDialog", () => {
 
       // Then - the prompt is not in the document
       expect(
-        screen.queryByText("Provider connected — keep exploring?"),
+        screen.queryByText("Provider added — keep exploring?"),
       ).not.toBeInTheDocument();
     });
   });

--- a/ui/components/onboarding/__tests__/onboarding-checkpoint-watcher.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-checkpoint-watcher.test.tsx
@@ -59,7 +59,7 @@ describe("OnboardingCheckpointWatcher", () => {
 
       // Then - the dialog is shown
       expect(
-        screen.getByText("Provider connected — keep exploring?"),
+        screen.getByText("Provider added — keep exploring?"),
       ).toBeInTheDocument();
     });
 
@@ -70,7 +70,7 @@ describe("OnboardingCheckpointWatcher", () => {
 
       // Then - nothing is shown
       expect(
-        screen.queryByText("Provider connected — keep exploring?"),
+        screen.queryByText("Provider added — keep exploring?"),
       ).not.toBeInTheDocument();
     });
   });
@@ -81,7 +81,7 @@ describe("OnboardingCheckpointWatcher", () => {
       const user = userEvent.setup();
       checkpointOpenState = true;
       render(<OnboardingCheckpointWatcher />);
-      await screen.findByText("Provider connected — keep exploring?");
+      await screen.findByText("Provider added — keep exploring?");
 
       // When - the user continues
       await user.click(
@@ -110,7 +110,7 @@ describe("OnboardingCheckpointWatcher", () => {
       const user = userEvent.setup();
       checkpointOpenState = true;
       render(<OnboardingCheckpointWatcher />);
-      await screen.findByText("Provider connected — keep exploring?");
+      await screen.findByText("Provider added — keep exploring?");
 
       // When - the user finishes here
       await user.click(screen.getByRole("button", { name: /finish here/i }));

--- a/ui/components/onboarding/__tests__/onboarding-sequence-banner.logic.test.ts
+++ b/ui/components/onboarding/__tests__/onboarding-sequence-banner.logic.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { OnboardingFlow } from "@/lib/onboarding";
+
+import { getSequenceProgress } from "../onboarding-sequence-banner.logic";
+
+// Minimal flow fixtures: the progress helper only reads id/order/title/route
+// and the optional dataRequirementHint, so a flat shape is sufficient.
+const buildFlow = (overrides: Partial<OnboardingFlow>): OnboardingFlow =>
+  ({
+    id: overrides.id ?? "flow",
+    order: overrides.order ?? 1,
+    title: overrides.title ?? "Title",
+    description: overrides.description ?? "Description",
+    route: overrides.route ?? "/route",
+    tour: overrides.tour ?? { id: "t", version: 1, coversFiles: [], steps: [] },
+    dataRequirementHint: overrides.dataRequirementHint,
+  }) as OnboardingFlow;
+
+const flows: OnboardingFlow[] = [
+  buildFlow({ id: "a", order: 1, title: "First", route: "/a" }),
+  buildFlow({
+    id: "b",
+    order: 2,
+    title: "Second",
+    route: "/b",
+    dataRequirementHint: "needs a scan",
+  }),
+  buildFlow({ id: "c", order: 3, title: "Third", route: "/c" }),
+];
+
+describe("getSequenceProgress", () => {
+  it("computes the index, total, current flow, and next flow for a middle step", () => {
+    // Given - the sequence points at the second flow
+    // When
+    const progress = getSequenceProgress("b", flows);
+
+    // Then - 0-based index 1 of 3, current is b, next is c
+    expect(progress).not.toBeNull();
+    expect(progress?.index).toBe(1);
+    expect(progress?.total).toBe(3);
+    expect(progress?.flow.id).toBe("b");
+    expect(progress?.nextFlow?.id).toBe("c");
+  });
+
+  it("returns a null nextFlow on the last step", () => {
+    // Given - the sequence points at the final flow
+    // When
+    const progress = getSequenceProgress("c", flows);
+
+    // Then - index 2 of 3, no next flow
+    expect(progress?.index).toBe(2);
+    expect(progress?.total).toBe(3);
+    expect(progress?.nextFlow).toBeNull();
+  });
+
+  it("returns null when the currentFlowId is unknown or null", () => {
+    // Given / When / Then - an id not in the registry or a null id yields null
+    expect(getSequenceProgress("missing", flows)).toBeNull();
+    expect(getSequenceProgress(null, flows)).toBeNull();
+  });
+
+  it("exposes the data requirement hint of the current flow when present", () => {
+    // Given - flow b carries a data hint, flow a does not
+    // When
+    const withHint = getSequenceProgress("b", flows);
+    const withoutHint = getSequenceProgress("a", flows);
+
+    // Then
+    expect(withHint?.flow.dataRequirementHint).toBe("needs a scan");
+    expect(withoutHint?.flow.dataRequirementHint).toBeUndefined();
+  });
+});

--- a/ui/components/onboarding/__tests__/onboarding-sequence-banner.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-sequence-banner.test.tsx
@@ -73,6 +73,21 @@ describe("OnboardingSequenceBanner", () => {
     expect(screen.getByText(`Step 2 of 5: ${flow.title}`)).toBeInTheDocument();
   });
 
+  it("announces step progress to screen readers via a polite live region", () => {
+    // Given - the sequence points at an active flow
+    setSlice({ active: true, currentFlowId: "view-first-scan" });
+    const flow = getFlowById("view-first-scan")!;
+
+    // When
+    render(<OnboardingSequenceBanner />);
+
+    // Then - the step-progress text is a polite live region so screen readers
+    // announce step transitions when the banner text updates.
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(`Step 2 of 5: ${flow.title}`);
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+
   it("shows the data requirement hint when the current flow has one", () => {
     // Given - explore-findings carries the scan-data hint
     setSlice({ active: true, currentFlowId: "explore-findings" });

--- a/ui/components/onboarding/__tests__/onboarding-sequence-banner.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-sequence-banner.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getFlowById } from "@/lib/onboarding";
+
+import { OnboardingSequenceBanner } from "../onboarding-sequence-banner";
+
+const pushMock = vi.fn();
+const advanceMock = vi.fn();
+const stopMock = vi.fn();
+
+// Mutable sequence-slice snapshot the mocked store hook returns. The banner
+// reads `active` + `currentFlowId` reactively and calls advance/stop via
+// getState(), mirroring the trigger's store usage.
+let sliceState = {
+  active: false,
+  currentFlowId: null as string | null,
+  advance: advanceMock,
+  stop: stopMock,
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/store/onboarding-sequence", () => {
+  const hook = (selector: (state: typeof sliceState) => unknown) =>
+    selector(sliceState);
+  hook.getState = () => sliceState;
+  return { useOnboardingSequenceStore: hook };
+});
+
+function setSlice(next: Partial<typeof sliceState>) {
+  sliceState = { ...sliceState, ...next };
+}
+
+describe("OnboardingSequenceBanner", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    advanceMock.mockClear();
+    stopMock.mockClear();
+    sliceState = {
+      active: false,
+      currentFlowId: null,
+      advance: advanceMock,
+      stop: stopMock,
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders nothing when the sequence is inactive", () => {
+    // Given - the sequence slice is not active
+    // When
+    const { container } = render(<OnboardingSequenceBanner />);
+
+    // Then - the banner self-hides
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the step progress for the active flow", () => {
+    // Given - the sequence points at the second ordered flow (view-first-scan)
+    setSlice({ active: true, currentFlowId: "view-first-scan" });
+    const flow = getFlowById("view-first-scan")!;
+
+    // When
+    render(<OnboardingSequenceBanner />);
+
+    // Then - "Step 2 of 5: Run your first scan"
+    expect(screen.getByText(`Step 2 of 5: ${flow.title}`)).toBeInTheDocument();
+  });
+
+  it("shows the data requirement hint when the current flow has one", () => {
+    // Given - explore-findings carries the scan-data hint
+    setSlice({ active: true, currentFlowId: "explore-findings" });
+
+    // When
+    render(<OnboardingSequenceBanner />);
+
+    // Then - the hint is visible in the banner
+    expect(
+      screen.getByText(/needs a completed scan to show data/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show a hint for a flow without one", () => {
+    // Given - view-first-scan has no data requirement hint
+    setSlice({ active: true, currentFlowId: "view-first-scan" });
+
+    // When
+    render(<OnboardingSequenceBanner />);
+
+    // Then - no scan-data hint is rendered
+    expect(
+      screen.queryByText(/needs a completed scan to show data/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("advances and navigates to the next flow when Continue is clicked", async () => {
+    // Given - the sequence is on view-first-scan; next is explore-findings
+    setSlice({ active: true, currentFlowId: "view-first-scan" });
+    const nextFlow = getFlowById("explore-findings")!;
+    const user = userEvent.setup();
+
+    // When
+    render(<OnboardingSequenceBanner />);
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    // Then - advance the slice and push to the next flow's route
+    expect(advanceMock).toHaveBeenCalledTimes(1);
+    expect(pushMock).toHaveBeenCalledWith(nextFlow.route);
+    expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  it("stops the sequence without navigating when Continue is clicked on the last step", async () => {
+    // Given - the sequence is on the final ordered flow (attack-paths)
+    setSlice({ active: true, currentFlowId: "attack-paths" });
+    const user = userEvent.setup();
+
+    // When
+    render(<OnboardingSequenceBanner />);
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    // Then - the sequence ends and no navigation occurs
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("stops the sequence when Exit is clicked", async () => {
+    // Given - the sequence is active mid-way
+    setSlice({ active: true, currentFlowId: "explore-findings" });
+    const user = userEvent.setup();
+
+    // When
+    render(<OnboardingSequenceBanner />);
+    await user.click(screen.getByRole("button", { name: /exit/i }));
+
+    // Then - the sequence ends without advancing or navigating
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(advanceMock).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/components/onboarding/__tests__/onboarding-trigger.test.tsx
+++ b/ui/components/onboarding/__tests__/onboarding-trigger.test.tsx
@@ -156,9 +156,8 @@ describe("OnboardingTrigger", () => {
   });
 
   describe("when a sequence tour completes", () => {
-    it("advances the sequence and navigates to the next flow route", async () => {
-      // Given - the sequence is on add-provider; the next ordered flow exists
-      const nextFlow = getFlowById("view-first-scan");
+    it("leaves the sequence slice untouched (the banner owns advance now)", async () => {
+      // Given - the sequence is on add-provider
       setSlice({
         active: true,
         currentFlowId: "add-provider",
@@ -170,20 +169,17 @@ describe("OnboardingTrigger", () => {
       await waitFor(() => expect(capturedOnClosed).toBeDefined());
       capturedOnClosed?.("completed");
 
-      // Then - it advances the slice and pushes to the next flow's route. When
-      // there is no next flow yet (registry not extended), it advances without
-      // navigating.
-      expect(advanceMock).toHaveBeenCalledTimes(1);
-      if (nextFlow) {
-        expect(pushMock).toHaveBeenCalledWith(nextFlow.route);
-      } else {
-        expect(pushMock).not.toHaveBeenCalled();
-      }
+      // Then - closing the tour no longer auto-advances or navigates. The
+      // persistent banner is the only advance/exit control: the user stays on
+      // the page until they explicitly click Continue.
+      expect(advanceMock).not.toHaveBeenCalled();
+      expect(stopMock).not.toHaveBeenCalled();
+      expect(pushMock).not.toHaveBeenCalled();
     });
   });
 
   describe("when a sequence tour is dismissed", () => {
-    it("stops the sequence and does not navigate", async () => {
+    it("leaves the sequence slice untouched (no auto-stop on close)", async () => {
       // Given - the sequence is on add-provider
       setSlice({
         active: true,
@@ -196,8 +192,8 @@ describe("OnboardingTrigger", () => {
       await waitFor(() => expect(capturedOnClosed).toBeDefined());
       capturedOnClosed?.("skipped");
 
-      // Then - it ends the sequence and never navigates or advances
-      expect(stopMock).toHaveBeenCalledTimes(1);
+      // Then - closing leaves the sequence active; only the banner Exit ends it
+      expect(stopMock).not.toHaveBeenCalled();
       expect(advanceMock).not.toHaveBeenCalled();
       expect(pushMock).not.toHaveBeenCalled();
     });

--- a/ui/components/onboarding/index.ts
+++ b/ui/components/onboarding/index.ts
@@ -3,5 +3,6 @@
 
 export { OnboardingCheckpointWatcher } from "./onboarding-checkpoint-watcher";
 export { OnboardingGate } from "./onboarding-gate";
+export { OnboardingSequenceBanner } from "./onboarding-sequence-banner";
 export { OnboardingTrigger } from "./onboarding-trigger";
 export { OnboardingWelcomeModal } from "./onboarding-welcome-modal";

--- a/ui/components/onboarding/onboarding-checkpoint-dialog.tsx
+++ b/ui/components/onboarding/onboarding-checkpoint-dialog.tsx
@@ -19,7 +19,7 @@ interface OnboardingCheckpointDialogProps {
   onFinish: () => void;
 }
 
-// Presentational checkpoint shown after the first provider connects. It owns no
+// Presentational checkpoint shown after the first provider is added. It owns no
 // navigation, persistence, or sequence state: the watcher decides what to do on
 // each choice so this component stays a pure render of the prompt.
 export function OnboardingCheckpointDialog({
@@ -38,9 +38,9 @@ export function OnboardingCheckpointDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Provider connected — keep exploring?</DialogTitle>
+          <DialogTitle>Provider added — keep exploring?</DialogTitle>
           <DialogDescription>
-            Your first provider is connected. Want a quick guided tour of scans,
+            Your first provider is added. Want a quick guided tour of scans,
             findings, compliance, and attack paths? You can stop anytime.
           </DialogDescription>
         </DialogHeader>

--- a/ui/components/onboarding/onboarding-sequence-banner.logic.ts
+++ b/ui/components/onboarding/onboarding-sequence-banner.logic.ts
@@ -1,0 +1,36 @@
+import { getOrderedFlows, type OnboardingFlow } from "@/lib/onboarding";
+
+// Pure projection of the active sequence's position, derived entirely from the
+// registry. Keeping this framework-free makes the banner's progress + advance
+// logic unit-testable without React or the Zustand store.
+export interface SequenceProgress {
+  // 0-based index of the current flow within the ordered registry.
+  index: number;
+  // Total number of ordered flows in the sequence.
+  total: number;
+  // The flow the sequence currently points at.
+  flow: OnboardingFlow;
+  // The next ordered flow, or null when the current flow is the last step.
+  nextFlow: OnboardingFlow | null;
+}
+
+// Resolves the sequence position for `currentFlowId` against the ordered
+// registry. Returns null when there is no active flow id or the id is unknown,
+// so callers can render nothing without special-casing.
+export function getSequenceProgress(
+  currentFlowId: string | null,
+  flows: readonly OnboardingFlow[] = getOrderedFlows(),
+): SequenceProgress | null {
+  if (!currentFlowId) return null;
+
+  const ordered = getOrderedFlows(flows);
+  const index = ordered.findIndex((flow) => flow.id === currentFlowId);
+  if (index < 0) return null;
+
+  return {
+    index,
+    total: ordered.length,
+    flow: ordered[index],
+    nextFlow: ordered[index + 1] ?? null,
+  };
+}

--- a/ui/components/onboarding/onboarding-sequence-banner.tsx
+++ b/ui/components/onboarding/onboarding-sequence-banner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/shadcn";
+import { cn } from "@/lib/utils";
+import { useOnboardingSequenceStore } from "@/store/onboarding-sequence";
+
+import { getSequenceProgress } from "./onboarding-sequence-banner.logic";
+
+// Persistent, NON-blocking bottom banner shown while a guided sequence is
+// active. Unlike a Dialog it never traps focus or covers the page, so the user
+// can perform the step's real action (e.g. launch a scan) at their own pace and
+// then click Continue. The banner owns sequence advance/exit; the per-route
+// tour only shows on arrival and no longer auto-advances on close.
+export function OnboardingSequenceBanner() {
+  const router = useRouter();
+  const active = useOnboardingSequenceStore((state) => state.active);
+  const currentFlowId = useOnboardingSequenceStore(
+    (state) => state.currentFlowId,
+  );
+
+  // Self-hide: render nothing unless an active sequence resolves to a known
+  // flow. Derived entirely from the registry — no hardcoded flow list.
+  const progress = getSequenceProgress(currentFlowId);
+  if (!active || !progress) return null;
+
+  const { index, total, flow, nextFlow } = progress;
+
+  const handleContinue = () => {
+    const sequence = useOnboardingSequenceStore.getState();
+    if (!nextFlow) {
+      // Last step: end the sequence in place, no navigation.
+      sequence.stop();
+      return;
+    }
+    sequence.advance();
+    router.push(nextFlow.route);
+  };
+
+  const handleExit = () => {
+    useOnboardingSequenceStore.getState().stop();
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="Onboarding tour progress"
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-40",
+        "border-border-neutral-secondary bg-bg-neutral-secondary border-t",
+        "px-4 py-3 shadow-lg",
+      )}
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <p className="text-text-neutral-primary text-sm font-medium">
+            Step {index + 1} of {total}: {flow.title}
+          </p>
+          {flow.dataRequirementHint ? (
+            <p className="text-text-warning text-xs">
+              {flow.dataRequirementHint}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={handleExit}>
+            Exit
+          </Button>
+          <Button variant="default" size="sm" onClick={handleContinue}>
+            Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/onboarding/onboarding-sequence-banner.tsx
+++ b/ui/components/onboarding/onboarding-sequence-banner.tsx
@@ -54,7 +54,13 @@ export function OnboardingSequenceBanner() {
     >
       <div className="mx-auto flex max-w-5xl flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-col gap-1">
-          <p className="text-text-neutral-primary text-sm font-medium">
+          {/* Polite live region so screen readers announce step transitions
+              when the banner's step-progress text updates on advance. */}
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-text-neutral-primary text-sm font-medium"
+          >
             Step {index + 1} of {total}: {flow.title}
           </p>
           {flow.dataRequirementHint ? (

--- a/ui/components/onboarding/onboarding-trigger.tsx
+++ b/ui/components/onboarding/onboarding-trigger.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { Config } from "driver.js";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
-import { getOrderedFlows, type OnboardingFlow } from "@/lib/onboarding";
+import { type OnboardingFlow } from "@/lib/onboarding";
 import type { TourStepHandlers } from "@/lib/tours/tour-types";
 import { useDriverTour } from "@/lib/tours/use-driver-tour";
 import {
@@ -12,10 +12,7 @@ import {
   useOnboardingSequenceStore,
 } from "@/store/onboarding-sequence";
 
-import {
-  mapCloseToSequenceAction,
-  resolveTriggerRequest,
-} from "./onboarding-trigger.logic";
+import { resolveTriggerRequest } from "./onboarding-trigger.logic";
 
 const ONBOARDING_PARAM = "onboarding";
 
@@ -94,7 +91,6 @@ export function OnboardingTrigger<TTarget extends string = string>({
     <OnboardingTourRunner<TTarget>
       key={request.key}
       flow={request.flow}
-      mode={request.mode}
       stepHandlers={stepHandlers}
       configOverrides={configOverrides}
     />
@@ -103,44 +99,30 @@ export function OnboardingTrigger<TTarget extends string = string>({
 
 interface OnboardingTourRunnerProps<TTarget extends string> {
   flow: OnboardingFlow;
-  mode: OnboardingSequenceMode;
   stepHandlers?: { [K in TTarget]?: TourStepHandlers<TTarget> };
   configOverrides?: Partial<Config>;
 }
 
 function OnboardingTourRunner<TTarget extends string>({
   flow,
-  mode,
   stepHandlers,
   configOverrides,
 }: OnboardingTourRunnerProps<TTarget>) {
-  const router = useRouter();
-
+  // The trigger only STARTS the current flow's tour on arrival. It no longer
+  // owns sequence advance/exit: closing a tour in sequence mode leaves the
+  // slice untouched, and the persistent OnboardingSequenceBanner is the single
+  // control for Continue (advance + navigate) and Exit (stop). This prevents
+  // the old auto-advance that jumped to empty pages before a scan completed.
+  // The `onClosed` handler is intentionally inert for BOTH replay and sequence
+  // modes: the tour just shows on arrival, and the banner owns what happens
+  // next.
   const { start } = useDriverTour(flow.tour, {
     autoOpen: false,
     stepHandlers,
     configOverrides,
-    onClosed: (state) => {
-      // Replay is single-flow: never touch the sequence slice.
-      if (mode === "replay") return;
-
-      const action = mapCloseToSequenceAction(state);
-      const sequence = useOnboardingSequenceStore.getState();
-      if (action === "stop") {
-        sequence.stop();
-        return;
-      }
-
-      // Advance, then own the cross-route navigation (the slice stays
-      // framework-agnostic). Resolve the next flow from the registry using the
-      // pre-advance currentFlowId so navigation is deterministic.
-      const ordered = getOrderedFlows();
-      const currentIdx = ordered.findIndex((f) => f.id === flow.id);
-      const nextFlow = currentIdx >= 0 ? ordered[currentIdx + 1] : undefined;
-      sequence.advance();
-      if (nextFlow) {
-        router.push(nextFlow.route);
-      }
+    onClosed: () => {
+      // No-op: neither replay nor sequence mutates the slice on tour close. The
+      // banner is the single advance/exit control while a sequence is active.
     },
   });
 

--- a/ui/lib/onboarding/__tests__/registry.test.ts
+++ b/ui/lib/onboarding/__tests__/registry.test.ts
@@ -168,6 +168,30 @@ describe("onboardingFlows (production registry)", () => {
     }
   });
 
+  it("sets a data requirement hint on the scan-dependent flows only", () => {
+    // Given / When - the flows whose pages render nothing without scan data
+    const scanDependent = [
+      "explore-findings",
+      "view-compliance",
+      "attack-paths",
+    ];
+    const standalone = ["add-provider", "view-first-scan"];
+    const expectedHint =
+      "This step needs a completed scan to show data. Launch a scan first, or continue anyway.";
+
+    // Then - the three data-dependent steps carry the hint verbatim
+    for (const id of scanDependent) {
+      const flow = getFlowById(id, onboardingFlows);
+      expect(flow?.dataRequirementHint).toBe(expectedHint);
+    }
+
+    // And - the self-contained steps carry no hint
+    for (const id of standalone) {
+      const flow = getFlowById(id, onboardingFlows);
+      expect(flow?.dataRequirementHint).toBeUndefined();
+    }
+  });
+
   it("orders the five sequence flows 1..5 by registry order", () => {
     // Given / When - the production registry after Slices 4-7 registration
     const ordered = getOrderedFlows(onboardingFlows);

--- a/ui/lib/onboarding/onboarding-types.ts
+++ b/ui/lib/onboarding/onboarding-types.ts
@@ -24,4 +24,9 @@ export interface OnboardingFlow {
   // the page owns auto-open and reports completion to the sequence slice.
   // Additive, optional, defaults to undefined/false.
   ownsAutoOpen?: boolean;
+  // Optional hint shown in the sequence banner when this step needs scan data
+  // to display anything meaningful (e.g. findings, compliance, attack-paths).
+  // The banner surfaces it as a muted/warning note so the user knows they can
+  // launch a scan first or continue anyway. Additive, optional.
+  dataRequirementHint?: string;
 }

--- a/ui/lib/onboarding/registry.ts
+++ b/ui/lib/onboarding/registry.ts
@@ -8,6 +8,12 @@ import { viewFirstScanTour } from "@/lib/tours/view-first-scan.tour";
 
 import type { OnboardingContext, OnboardingFlow } from "./onboarding-types";
 
+// Shared hint for steps whose pages render nothing until a scan has completed.
+// Surfaced in the sequence banner so the user can launch a scan first or move
+// on at their own pace.
+const SCAN_DATA_HINT =
+  "This step needs a completed scan to show data. Launch a scan first, or continue anyway.";
+
 // Single source of truth for onboarding flows. Adding a flow is one entry here
 // plus its `*.tour.ts` file — no gate, modal, or nav edits required. `order`
 // is an explicit integer (gaps allowed) so reordering is a data edit.
@@ -40,6 +46,7 @@ export const onboardingFlows: readonly OnboardingFlow[] = [
     description: "See what Prowler detected and how to fix it.",
     route: "/findings",
     tour: exploreFindingsTour,
+    dataRequirementHint: SCAN_DATA_HINT,
   },
   {
     id: "view-compliance",
@@ -48,6 +55,7 @@ export const onboardingFlows: readonly OnboardingFlow[] = [
     description: "Map your findings to frameworks like CIS.",
     route: "/compliance",
     tour: viewComplianceTour,
+    dataRequirementHint: SCAN_DATA_HINT,
   },
   {
     id: "attack-paths",
@@ -56,6 +64,7 @@ export const onboardingFlows: readonly OnboardingFlow[] = [
     description: "See how a compromise could spread across your cloud.",
     route: "/attack-paths",
     tour: attackPathsTour,
+    dataRequirementHint: SCAN_DATA_HINT,
     // The attack-paths PAGE already drives this tour (its own auto-open +
     // rich stepHandlers). The shared OnboardingTrigger must NOT mount a second
     // runner; the page reports completion to the sequence slice instead.

--- a/ui/tests/onboarding/onboarding-page.ts
+++ b/ui/tests/onboarding/onboarding-page.ts
@@ -68,7 +68,7 @@ export class OnboardingPage extends BasePage {
 
     this.checkpointDialog = page.getByRole("dialog").filter({
       has: page.getByRole("heading", {
-        name: /Provider connected — keep exploring\?/i,
+        name: /Provider added — keep exploring\?/i,
       }),
     });
     this.checkpointContinueButton = page.getByRole("button", {

--- a/ui/tests/onboarding/onboarding.md
+++ b/ui/tests/onboarding/onboarding.md
@@ -133,7 +133,7 @@ findings, compliance, and attack paths, advancing only on tour completion.
 
 1. Start zero-provider; assert the Welcome modal is visible
 2. Connect a provider (real flip via `addAWSProvider`)
-3. Assert the checkpoint dialog "Provider connected — keep exploring?" is visible
+3. Assert the checkpoint dialog "Provider added — keep exploring?" is visible
 4. Click "Continue the tour"
 5. Assert `/scans` with `data-tour-id="view-first-scan-launch"` present
 6. Complete the scans tour; assert `/findings` with `explore-findings-filters`


### PR DESCRIPTION
### Context

Final UX: manual, non-blocking sequence navigation + copy/a11y polish.

Part of the **UI onboarding system**, delivered as a Feature Branch Chain (tracker #11430 → `master`).

### Description

Persistent bottom sequence banner (manual Continue/Exit, per-step data hints, `aria-live` progress) and polishes checkpoint copy, CHANGELOG wording and the onboarding changelog links.

### Steps to review

Read `onboarding-sequence-banner*`. Confirm manual advance (no auto-advance to empty pages) and the a11y live region.

### Checklist

- [x] Code is covered by tests (unit and/or e2e within the change).
- [ ] Backport needed: No.

#### UI
- [x] Requirements work as expected on the UI.
- [x] No new npm dependencies are added by this PR.
- [ ] CHANGELOG: covered by the change's e2e slice (#11435 / #11442)
- [ ] Screenshots/video of the flow — see the tracker #11430.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

## Chain Context

| Field | Value |
|-------|-------|
| Chain | UI onboarding system |
| Tracker PR | #11430 |
| Position | 15 of 15 |
| Base | `chain/ob-14-suspense-fix` |
| Depends on | #11444 |
| Follow-up | None — last child |
| Review budget | 522 / 400 ⚠️ |
| Starts at | #11444 (suspense fix) |
| Ends with | the complete, polished guided onboarding system |

> **Size exception:** exceeds the 400-line budget because this is one cohesive code+tests unit; splitting further would separate a component/store/tour from the test that verifies it. No `size:exception` label exists in this repo (only `size/*`), so the rationale is recorded here.

### Chain Overview

```text
master ← #11430 tracker(draft) ← #11431 ← #11432 ← #11433 ← #11434 ← #11435 ← #11436 ← #11437 ← #11438 ← #11439 ← #11440 ← #11441 ← #11442 ← #11443 ← #11444 ← 📍#11445
```

### Scope
- **Includes:** sequence banner + copy/a11y polish + CHANGELOG link fix
- **Excludes:** none

### Autonomy
- [x] This PR has one deliverable scope.
- [x] Can be rolled back without unrelated changes.
- [x] Tests / docs / manual verification cover this unit.
- [ ] CI expected to pass — currently blocked only by an unrelated `vitest` audit debt on `master` (see tracker #11430), not by this change.
