### PR TITLE
refactor(ui): migrate compliance detail badges to shadcn Badge

### DIFF
--- a/ui/components/compliance/compliance-custom-details/asd-essential-eight-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/asd-essential-eight-details.tsx
@@ -85,7 +85,7 @@ export const ASDEssentialEightCustomDetails = ({
           <ComplianceBadge
             label="Maturity Level"
             value={maturityLevel}
-            color="purple"
+            variant="secondary"
           />
         )}
 
@@ -93,7 +93,7 @@ export const ASDEssentialEightCustomDetails = ({
           <ComplianceBadge
             label="Assessment"
             value={assessmentStatus}
-            color="blue"
+            variant="info"
           />
         )}
 
@@ -101,7 +101,7 @@ export const ASDEssentialEightCustomDetails = ({
           <ComplianceBadge
             label="Cloud Applicability"
             value={cloudApplicability}
-            color="orange"
+            variant="secondary"
           />
         )}
       </ComplianceBadgeContainer>

--- a/ui/components/compliance/compliance-custom-details/aws-well-architected-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/aws-well-architected-details.tsx
@@ -52,7 +52,7 @@ export const AWSWellArchitectedCustomDetails = ({
           <ComplianceBadge
             label="Question ID"
             value={requirement.well_architected_question_id as string}
-            color="indigo"
+            variant="tag"
           />
         )}
 
@@ -60,7 +60,7 @@ export const AWSWellArchitectedCustomDetails = ({
           <ComplianceBadge
             label="Practice ID"
             value={requirement.well_architected_practice_id as string}
-            color="indigo"
+            variant="tag"
           />
         )}
 
@@ -68,7 +68,7 @@ export const AWSWellArchitectedCustomDetails = ({
           <ComplianceBadge
             label="Assessment"
             value={requirement.assessment_method as string}
-            color="blue"
+            variant="info"
           />
         )}
       </ComplianceBadgeContainer>

--- a/ui/components/compliance/compliance-custom-details/ccc-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/ccc-details.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib";
+import { Badge } from "@/components/shadcn/badge/badge";
 import { CCC_MAPPING_SECTIONS, CCC_TEXT_SECTIONS } from "@/lib/compliance/ccc";
 import { Requirement } from "@/types/compliance";
 
@@ -46,7 +46,7 @@ export const CCCCustomDetails = ({ requirement }: CCCDetailsProps) => {
           <ComplianceBadge
             label="Family"
             value={requirement.family_name as string}
-            color="purple"
+            variant="secondary"
           />
         </ComplianceBadgeContainer>
       )}
@@ -68,15 +68,9 @@ export const CCCCustomDetails = ({ requirement }: CCCDetailsProps) => {
                 </span>
                 <div className="flex flex-wrap gap-2">
                   {mapping.Identifiers.map((identifier, idx) => (
-                    <span
-                      key={idx}
-                      className={cn(
-                        "inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset",
-                        section.colorClasses,
-                      )}
-                    >
+                    <Badge key={idx} variant={section.variant}>
                       {identifier}
-                    </span>
+                    </Badge>
                   ))}
                 </div>
               </div>

--- a/ui/components/compliance/compliance-custom-details/cis-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/cis-details.tsx
@@ -41,7 +41,7 @@ export const CISCustomDetails = ({ requirement }: CISDetailsProps) => {
           <ComplianceBadge
             label="Profile"
             value={requirement.profile as string}
-            color="purple"
+            variant="secondary"
           />
         )}
 
@@ -49,7 +49,7 @@ export const CISCustomDetails = ({ requirement }: CISDetailsProps) => {
           <ComplianceBadge
             label="Assessment"
             value={requirement.assessment_status as string}
-            color="blue"
+            variant="info"
           />
         )}
       </ComplianceBadgeContainer>

--- a/ui/components/compliance/compliance-custom-details/csa-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/csa-details.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib";
+import { Badge } from "@/components/shadcn/badge/badge";
 import { CSA_MAPPING_SECTIONS } from "@/lib/compliance/csa";
 import { Requirement } from "@/types/compliance";
 
@@ -36,28 +36,28 @@ export const CSACustomDetails = ({ requirement }: CSADetailsProps) => {
           <ComplianceBadge
             label="CCM Lite"
             value={requirement.ccm_lite as string}
-            color={requirement.ccm_lite === "Yes" ? "green" : "gray"}
+            variant={requirement.ccm_lite === "Yes" ? "success" : "secondary"}
           />
         )}
         {requirement.iaas && (
           <ComplianceBadge
             label="IaaS"
             value={requirement.iaas as string}
-            color="blue"
+            variant="info"
           />
         )}
         {requirement.paas && (
           <ComplianceBadge
             label="PaaS"
             value={requirement.paas as string}
-            color="blue"
+            variant="info"
           />
         )}
         {requirement.saas && (
           <ComplianceBadge
             label="SaaS"
             value={requirement.saas as string}
-            color="blue"
+            variant="info"
           />
         )}
       </ComplianceBadgeContainer>
@@ -72,15 +72,9 @@ export const CSACustomDetails = ({ requirement }: CSADetailsProps) => {
                 </span>
                 <div className="flex flex-wrap gap-2">
                   {mapping.Identifiers.map((identifier, idx) => (
-                    <span
-                      key={idx}
-                      className={cn(
-                        "inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset",
-                        section.colorClasses,
-                      )}
-                    >
+                    <Badge key={idx} variant={section.variant}>
                       {identifier}
-                    </span>
+                    </Badge>
                   ))}
                 </div>
               </div>

--- a/ui/components/compliance/compliance-custom-details/ens-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/ens-details.tsx
@@ -28,7 +28,7 @@ export const ENSCustomDetails = ({
           <ComplianceBadge
             label="Type"
             value={translateType(requirement.type as string)}
-            color="orange"
+            variant="secondary"
           />
         )}
 
@@ -36,7 +36,7 @@ export const ENSCustomDetails = ({
           <ComplianceBadge
             label="Level"
             value={requirement.nivel as string}
-            color="red"
+            variant="error"
           />
         )}
       </ComplianceBadgeContainer>

--- a/ui/components/compliance/compliance-custom-details/generic-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/generic-details.tsx
@@ -26,7 +26,7 @@ export const GenericCustomDetails = ({
           <ComplianceBadge
             label="Item ID"
             value={requirement.item_id as string}
-            color="indigo"
+            variant="tag"
           />
         )}
 
@@ -34,7 +34,7 @@ export const GenericCustomDetails = ({
           <ComplianceBadge
             label="Service"
             value={requirement.service as string}
-            color="blue"
+            variant="info"
           />
         )}
 
@@ -42,7 +42,7 @@ export const GenericCustomDetails = ({
           <ComplianceBadge
             label="Type"
             value={requirement.type as string}
-            color="orange"
+            variant="secondary"
           />
         )}
       </ComplianceBadgeContainer>

--- a/ui/components/compliance/compliance-custom-details/mitre-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/mitre-details.tsx
@@ -37,7 +37,7 @@ export const MITRECustomDetails = ({
           <ComplianceBadge
             label="Technique ID"
             value={requirement.technique_id as string}
-            color="indigo"
+            variant="tag"
           />
         )}
       </ComplianceBadgeContainer>
@@ -81,17 +81,17 @@ export const MITRECustomDetails = ({
                   <ComplianceBadge
                     label="Service"
                     value={service.service}
-                    color="blue"
+                    variant="info"
                   />
                   <ComplianceBadge
                     label="Category"
                     value={service.category}
-                    color="indigo"
+                    variant="tag"
                   />
                   <ComplianceBadge
                     label="Coverage"
                     value={service.value}
-                    color="orange"
+                    variant="secondary"
                   />
                 </div>
                 {service.comment && (

--- a/ui/components/compliance/compliance-custom-details/okta-idaas-stig-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/okta-idaas-stig-details.tsx
@@ -1,3 +1,4 @@
+import { Severity, SeverityBadge } from "@/components/ui/table";
 import { Requirement } from "@/types/compliance";
 
 import {
@@ -7,7 +8,6 @@ import {
   ComplianceDetailContainer,
   ComplianceDetailSection,
   ComplianceDetailText,
-  getSeverityBadgeColor,
 } from "./shared-components";
 
 export const OktaIDaaSStigCustomDetails = ({
@@ -26,17 +26,18 @@ export const OktaIDaaSStigCustomDetails = ({
     <ComplianceDetailContainer>
       <ComplianceBadgeContainer>
         {severity && (
-          <ComplianceBadge
-            label="Severity"
-            value={severity}
-            color={getSeverityBadgeColor(severity)}
-          />
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-sm font-medium">
+              Severity:
+            </span>
+            <SeverityBadge severity={severity.toLowerCase() as Severity} />
+          </div>
         )}
         {stigId && (
-          <ComplianceBadge label="STIG ID" value={stigId} color="indigo" />
+          <ComplianceBadge label="STIG ID" value={stigId} variant="tag" />
         )}
         {ruleId && (
-          <ComplianceBadge label="Rule ID" value={ruleId} color="indigo" />
+          <ComplianceBadge label="Rule ID" value={ruleId} variant="tag" />
         )}
       </ComplianceBadgeContainer>
 

--- a/ui/components/compliance/compliance-custom-details/shared-components.tsx
+++ b/ui/components/compliance/compliance-custom-details/shared-components.tsx
@@ -1,4 +1,12 @@
-import { cn } from "@/lib/utils";
+import { VariantProps } from "class-variance-authority";
+
+import { Badge, badgeVariants } from "@/components/shadcn/badge/badge";
+
+// Variants come straight from the canonical shadcn Badge so compliance panels
+// share the same badge vocabulary (and tokens) as the rest of the app.
+export type ComplianceBadgeVariant = NonNullable<
+  VariantProps<typeof badgeVariants>["variant"]
+>;
 
 export const ComplianceDetailContainer = ({
   children,
@@ -43,78 +51,28 @@ export const ComplianceBadgeContainer = ({
   return <div className="flex flex-wrap items-center gap-3">{children}</div>;
 };
 
-type BadgeColor =
-  | "red" // Risk/Level/Severity
-  | "blue" // Assessment/Method
-  | "orange" // Type/Category
-  | "yellow" // Severity (medium)
-  | "green" // Weight/Score (positive)
-  | "purple" // Profile
-  | "indigo" // IDs/References
-  | "gray"; // Additional Info/Neutral
-
-// Maps a severity level to a distinct badge color so each severity is visually
-// differentiated instead of all rendering as red.
-export const getSeverityBadgeColor = (severity: string): BadgeColor => {
-  switch (severity?.toLowerCase()) {
-    case "critical":
-      return "red";
-    case "high":
-      return "orange";
-    case "medium":
-      return "yellow";
-    case "low":
-      return "green";
-    case "informational":
-    case "info":
-      return "blue";
-    default:
-      return "gray";
-  }
-};
-
 export const ComplianceBadge = ({
   label,
   value,
-  color,
+  variant,
   conditional = false,
 }: {
   label: string;
   value: string | number;
-  color: BadgeColor;
+  variant: ComplianceBadgeVariant;
   conditional?: boolean;
 }) => {
-  const actualColor = conditional && Number(value) === 0 ? "gray" : color;
-
-  const colorClasses = {
-    red: "bg-red-50 text-red-700 ring-red-600/10 dark:bg-red-400/10 dark:text-red-400 dark:ring-red-400/20",
-    blue: "bg-blue-50 text-blue-700 ring-blue-600/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/20",
-    orange:
-      "bg-orange-50 text-orange-700 ring-orange-600/10 dark:bg-orange-400/10 dark:text-orange-400 dark:ring-orange-400/20",
-    yellow:
-      "bg-yellow-50 text-yellow-700 ring-yellow-600/10 dark:bg-yellow-400/10 dark:text-yellow-400 dark:ring-yellow-400/20",
-    green:
-      "bg-green-50 text-green-700 ring-green-600/10 dark:bg-green-400/10 dark:text-green-400 dark:ring-green-400/20",
-    purple:
-      "bg-purple-50 text-purple-700 ring-purple-600/10 dark:bg-purple-400/10 dark:text-purple-400 dark:ring-purple-400/20",
-    indigo:
-      "bg-indigo-50 text-indigo-700 ring-indigo-600/10 dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/20",
-    gray: "bg-gray-50 text-gray-600 ring-gray-500/10 dark:bg-gray-400/10 dark:text-gray-400 dark:ring-gray-400/20",
-  };
+  // A "conditional" metric badge with a zero value drops to a neutral variant
+  // so empty scores don't read as a meaningful (e.g. positive) result.
+  const actualVariant: ComplianceBadgeVariant =
+    conditional && Number(value) === 0 ? "secondary" : variant;
 
   return (
     <div className="flex items-center gap-2">
       <span className="text-muted-foreground text-sm font-medium">
         {label}:
       </span>
-      <span
-        className={cn(
-          "inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset",
-          colorClasses[actualColor],
-        )}
-      >
-        {value}
-      </span>
+      <Badge variant={actualVariant}>{value}</Badge>
     </div>
   );
 };
@@ -155,12 +113,9 @@ export const ComplianceChipContainer = ({
     <ComplianceDetailSection title={title}>
       <div className="flex flex-wrap gap-2">
         {items.map((item: string, index: number) => (
-          <span
-            key={index}
-            className="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-gray-500/10 ring-inset dark:bg-gray-400/10 dark:text-gray-400 dark:ring-gray-400/20"
-          >
+          <Badge key={index} variant="tag">
             {item}
-          </span>
+          </Badge>
         ))}
       </div>
     </ComplianceDetailSection>

--- a/ui/components/compliance/compliance-custom-details/threat-details.tsx
+++ b/ui/components/compliance/compliance-custom-details/threat-details.tsx
@@ -34,7 +34,7 @@ export const ThreatCustomDetails = ({
           <ComplianceBadge
             label="Risk Level"
             value={requirement.levelOfRisk}
-            color="red"
+            variant="error"
           />
         )}
 
@@ -42,7 +42,7 @@ export const ThreatCustomDetails = ({
           <ComplianceBadge
             label="Weight"
             value={requirement.weight}
-            color="green"
+            variant="success"
           />
         )}
 
@@ -50,7 +50,7 @@ export const ThreatCustomDetails = ({
           <ComplianceBadge
             label="Score"
             value={requirement.score}
-            color="green"
+            variant="success"
             conditional={true}
           />
         )}
@@ -61,13 +61,13 @@ export const ThreatCustomDetails = ({
               <ComplianceBadge
                 label="Findings"
                 value={`${requirement.passedFindings}/${requirement.totalFindings}`}
-                color="blue"
+                variant="info"
               />
               {requirement.totalFindings > 0 && (
                 <ComplianceBadge
                   label="Pass Rate"
                   value={`${Math.round((requirement.passedFindings / requirement.totalFindings) * 100)}%`}
-                  color="green"
+                  variant="success"
                   conditional={true}
                 />
               )}

--- a/ui/components/shadcn/badge/badge.test.tsx
+++ b/ui/components/shadcn/badge/badge.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Badge } from "./badge";
+
+describe("Badge", () => {
+  it("renders its children", () => {
+    render(<Badge variant="info">Assessment</Badge>);
+    expect(screen.getByText("Assessment")).toBeInTheDocument();
+  });
+
+  it("applies the info variant token classes", () => {
+    const { container } = render(<Badge variant="info">Info</Badge>);
+    const badge = container.querySelector("[data-slot='badge']");
+    // The info variant is built from the existing design-system blue token
+    // (bg-data-info) rather than a bespoke palette.
+    expect(badge?.className).toContain("bg-bg-data-info/15");
+    expect(badge?.className).toContain("text-bg-data-info");
+  });
+
+  it("merges a custom className", () => {
+    const { container } = render(
+      <Badge variant="tag" className="extra-class">
+        Tag
+      </Badge>,
+    );
+    const badge = container.querySelector("[data-slot='badge']");
+    expect(badge?.className).toContain("extra-class");
+  });
+});

--- a/ui/components/shadcn/badge/badge.tsx
+++ b/ui/components/shadcn/badge/badge.tsx
@@ -24,6 +24,7 @@ const badgeVariants = cva(
           "border-bg-warning/30 bg-bg-warning-secondary/20 text-text-warning-primary",
         error:
           "border-transparent bg-bg-fail-secondary text-text-error-primary",
+        info: "border-transparent bg-bg-data-info/15 text-bg-data-info",
       },
     },
     defaultVariants: {

--- a/ui/lib/compliance/ccc.tsx
+++ b/ui/lib/compliance/ccc.tsx
@@ -1,6 +1,7 @@
 import { ClientAccordionContent } from "@/components/compliance/compliance-accordion/client-accordion-content";
 import { ComplianceAccordionRequirementTitle } from "@/components/compliance/compliance-accordion/compliance-accordion-requeriment-title";
 import { ComplianceAccordionTitle } from "@/components/compliance/compliance-accordion/compliance-accordion-title";
+import { ComplianceBadgeVariant } from "@/components/compliance/compliance-custom-details/shared-components";
 import { AccordionItemProps } from "@/components/ui/accordion/Accordion";
 import { FindingStatus } from "@/components/ui/table/status-finding-badge";
 import {
@@ -39,7 +40,7 @@ export interface CCCTextSection {
 export interface CCCMappingSection {
   title: string;
   key: keyof Requirement;
-  colorClasses: string;
+  variant: ComplianceBadgeVariant;
 }
 
 export const CCC_TEXT_SECTIONS: CCCTextSection[] = [
@@ -71,14 +72,12 @@ export const CCC_MAPPING_SECTIONS: CCCMappingSection[] = [
   {
     title: "Threat Mappings",
     key: "section_threat_mappings",
-    colorClasses:
-      "bg-red-50 text-red-700 ring-red-600/10 dark:bg-red-400/10 dark:text-red-400 dark:ring-red-400/20",
+    variant: "error",
   },
   {
     title: "Guideline Mappings",
     key: "section_guideline_mappings",
-    colorClasses:
-      "bg-blue-50 text-blue-700 ring-blue-600/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/20",
+    variant: "info",
   },
 ];
 

--- a/ui/lib/compliance/csa.tsx
+++ b/ui/lib/compliance/csa.tsx
@@ -1,6 +1,7 @@
 import { ClientAccordionContent } from "@/components/compliance/compliance-accordion/client-accordion-content";
 import { ComplianceAccordionRequirementTitle } from "@/components/compliance/compliance-accordion/compliance-accordion-requeriment-title";
 import { ComplianceAccordionTitle } from "@/components/compliance/compliance-accordion/compliance-accordion-title";
+import { ComplianceBadgeVariant } from "@/components/compliance/compliance-custom-details/shared-components";
 import { AccordionItemProps } from "@/components/ui/accordion/Accordion";
 import { FindingStatus } from "@/components/ui/table/status-finding-badge";
 import {
@@ -24,15 +25,14 @@ import {
 export interface CSAMappingSection {
   title: string;
   key: keyof Requirement;
-  colorClasses: string;
+  variant: ComplianceBadgeVariant;
 }
 
 export const CSA_MAPPING_SECTIONS: CSAMappingSection[] = [
   {
     title: "Scope Applicability",
     key: "scope_applicability",
-    colorClasses:
-      "bg-blue-50 text-blue-700 ring-blue-600/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/20",
+    variant: "info",
   },
 ];
 


### PR DESCRIPTION
### Context

Follow-up refactor **stacked on the Okta IDaaS STIG PR #11428** (base branch is `PROWLER-1497-create-okta-stig-compliance-framework-sdk`, not `master`). It addresses code-review feedback: the compliance detail panels rendered badges with a bespoke `ComplianceBadge` color palette — and #11428 added a `getSeverityBadgeColor` whose colors were semantically off for this UI (e.g. `low → green`, where green means *pass*) — instead of the canonical shadcn `Badge` used everywhere else in the app.

### Description

- Add an `info` variant to the shadcn `Badge`, built on the existing `bg-data-info` design token (no new tokens introduced).
- Refactor `ComplianceBadge` to render the canonical shadcn `Badge` (prop `color` → `variant`); remove the bespoke `BadgeColor` union, the `colorClasses` map, and `getSeverityBadgeColor`.
- Migrate `ComplianceChipContainer` chips and the CCC/CSA mapping-section identifiers to `Badge` (`variant="tag"` / per-section variant).
- Okta STIG severity now renders via the canonical `SeverityBadge`; STIG/Rule IDs use `variant="tag"`.
- Variant mapping applied across all panels: risk/level → `error`, positive metrics → `success`, assessment/method/findings → `info`, IDs/references → `tag`, categorical (type/profile) → `secondary`.

### Steps to review

1. `ui/components/shadcn/badge/badge.tsx` — new `info` variant from the `bg-data-info` token.
2. `ui/components/compliance/compliance-custom-details/shared-components.tsx` — `ComplianceBadge` now wraps `Badge`; bespoke palette and `getSeverityBadgeColor` removed; `ComplianceBadgeVariant` exported.
3. Each `*-details.tsx` panel — `color=` → `variant=` per the mapping above; `okta-idaas-stig-details.tsx` uses `SeverityBadge`.
4. `ui/lib/compliance/ccc.tsx` and `csa.tsx` — mapping sections expose `variant` instead of raw color-class strings.
5. `pnpm typecheck` passes; `pnpm vitest run components/shadcn/badge components/compliance lib/compliance` green (new `badge.test.tsx` + existing suites).
6. Visual pass in **light and dark** on a compliance scan: CCC (Family/mappings), MITRE (IDs/Service/chips), threat (Score/Pass Rate with conditional 0), ASD, AWS WA (`SeverityBadge`).

> Note: design trade-off — to avoid inventing new tokens, `indigo` (IDs) → `tag` and `orange`/`purple` (categorical) → `secondary`, so those collapse to neutral variants. Open to adding an `accent` token/variant if more differentiation is desired.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- No SDK/CLI changes.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. — intentionally omitted; apply the \`no-changelog\` label.

#### API
- No API changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.