### PR TITLE
fix(gcp): pass iam_service_account_unused for disabled service accounts

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🐞 Fixed
 
 - GCP `logging_sink_created` now recognizes organization-level aggregated sinks with `includeChildren=True`, avoiding false failures for covered projects [(#11355)](https://github.com/prowler-cloud/prowler/pull/11355)
+- GCP `iam_service_account_unused` now passes disabled service accounts instead of failing them, since a disabled account cannot authenticate or be used [(#11467)](https://github.com/prowler-cloud/prowler/pull/11467)
 
 ---
 

--- a/prowler/providers/gcp/services/iam/iam_service.py
+++ b/prowler/providers/gcp/services/iam/iam_service.py
@@ -37,6 +37,7 @@ class IAM(GCPService):
                                 display_name=account.get("displayName", ""),
                                 project_id=project_id,
                                 uniqueId=account.get("uniqueId", ""),
+                                disabled=account.get("disabled", False),
                             )
                         )
 
@@ -102,6 +103,7 @@ class ServiceAccount(BaseModel):
     keys: list[Key] = []
     project_id: str
     uniqueId: str
+    disabled: bool = False
 
 
 class AccessApproval(GCPService):

--- a/prowler/providers/gcp/services/iam/iam_service_account_unused/iam_service_account_unused.py
+++ b/prowler/providers/gcp/services/iam/iam_service_account_unused/iam_service_account_unused.py
@@ -19,7 +19,12 @@ class iam_service_account_unused(Check):
                 resource_id=account.email,
                 location=iam_client.region,
             )
-            if account.uniqueId in sa_ids_used:
+            if account.disabled:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Service Account {account.email} is disabled and cannot be used."
+                )
+            elif account.uniqueId in sa_ids_used:
                 report.status = "PASS"
                 report.status_extended = f"Service Account {account.email} was used over the last {max_unused_days} days."
             else:

--- a/tests/providers/gcp/services/iam/iam_service_account_unused/iam_service_account_unused_test.py
+++ b/tests/providers/gcp/services/iam/iam_service_account_unused/iam_service_account_unused_test.py
@@ -179,3 +179,60 @@ class Test_iam_service_account_unused:
             assert result[1].project_id == GCP_PROJECT_ID
             assert result[1].location == GCP_US_CENTER1_LOCATION
             assert result[1].resource == iam_client.service_accounts[1]
+
+    def test_iam_service_account_disabled(self):
+        iam_client = mock.MagicMock()
+        monitoring_client = mock.MagicMock()
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_gcp_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.gcp.services.iam.iam_service_account_unused.iam_service_account_unused.iam_client",
+                new=iam_client,
+            ),
+            mock.patch(
+                "prowler.providers.gcp.services.iam.iam_service_account_unused.iam_service_account_unused.monitoring_client",
+                new=monitoring_client,
+            ),
+        ):
+            from prowler.providers.gcp.services.iam.iam_service import ServiceAccount
+            from prowler.providers.gcp.services.iam.iam_service_account_unused.iam_service_account_unused import (
+                iam_service_account_unused,
+            )
+
+            iam_client.project_ids = [GCP_PROJECT_ID]
+            iam_client.region = GCP_US_CENTER1_LOCATION
+
+            iam_client.service_accounts = [
+                ServiceAccount(
+                    name="projects/my-project/serviceAccounts/disabled-sa@my-project.iam.gserviceaccount.com",
+                    email="disabled-sa@my-project.iam.gserviceaccount.com",
+                    display_name="Disabled service account",
+                    keys=[],
+                    project_id=GCP_PROJECT_ID,
+                    uniqueId="999888877776666",
+                    disabled=True,
+                )
+            ]
+
+            # The account is absent from the usage metrics, so a non-disabled
+            # account here would FAIL. Being disabled must take precedence and
+            # PASS, since a disabled account cannot authenticate or be used.
+            monitoring_client.sa_api_metrics = set()
+            monitoring_client.audit_config = {"max_unused_account_days": 30}
+
+            check = iam_service_account_unused()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Service Account {iam_client.service_accounts[0].email} is disabled and cannot be used."
+            )
+            assert result[0].resource_id == iam_client.service_accounts[0].email
+            assert result[0].project_id == GCP_PROJECT_ID
+            assert result[0].location == GCP_US_CENTER1_LOCATION
+            assert result[0].resource == iam_client.service_accounts[0]


### PR DESCRIPTION
### Context

Fix #11466

The GCP `iam_service_account_unused` check reports **FAIL** for *disabled* service accounts. Usage is judged only from Cloud Monitoring authentication metrics, and a disabled account cannot authenticate — so it never appears there and is permanently flagged as unused. A disabled account cannot be impersonated, mint tokens, or be used with keys, so it is not the "dormant **but permissioned**" risk the check targets. Disabling is in fact the first step of the remediation this very check recommends: *"Verify inactivity, then disable and later delete unused accounts."*

### Description

- `prowler/providers/gcp/services/iam/iam_service.py`: add a `disabled: bool = False` field to the `ServiceAccount` model and populate it from `projects.serviceAccounts.list` via `account.get("disabled", False)`.
- `prowler/providers/gcp/services/iam/iam_service_account_unused/iam_service_account_unused.py`: short-circuit disabled accounts to **PASS** before the usage check, with `"Service Account <email> is disabled and cannot be used."`.
- Added a unit test for a disabled account that is absent from the usage metrics (where a non-disabled account would FAIL) and asserts it PASSes.

The default `disabled=False` keeps every existing `ServiceAccount` construction valid and all current PASS/FAIL behaviour unchanged. No metadata/severity change — the check just becomes more accurate.

### Steps to review

1. `iam_service.py` — `disabled` added to the model and read from the API response.
2. `iam_service_account_unused.py` — the new `if account.disabled:` PASS branch sits ahead of the existing used/not-used logic, which is unchanged.
3. Run the tests:
   ```
   uv run pytest tests/providers/gcp/services/iam/iam_service_account_unused/ -v
   ```
   `test_iam_service_account_disabled` asserts a disabled, metrics-absent account PASSes; the existing single/mix/empty tests still pass.

### Checklist

<details>
<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues) (#11466)
- [ ] Is it assigned to me, if not, request it via the issue/feature

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — not needed.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **No** — behaviour fix to an existing check; no permission changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
