### PR TITLE
feat(ui): add expandable microinteractions

### DIFF
--- a/ui/components/shadcn/collapsible.test.tsx
+++ b/ui/components/shadcn/collapsible.test.tsx
@@ -24,16 +24,8 @@ describe("Collapsible", () => {
     expect(content).toHaveAttribute("data-slot", "collapsible-content");
     expect(content).toHaveClass(
       "overflow-hidden",
-      "duration-200",
-      "ease-out",
-      "data-[state=open]:animate-in",
-      "data-[state=open]:fade-in-0",
-      "data-[state=open]:slide-in-from-top-1",
-      "data-[state=closed]:animate-out",
-      "data-[state=closed]:fade-out-0",
-      "data-[state=closed]:slide-out-to-top-1",
-      "data-[state=closed]:duration-150",
-      "data-[state=closed]:ease-in",
+      "data-[state=open]:animate-collapsible-down",
+      "data-[state=closed]:animate-collapsible-up",
     );
   });
 
@@ -52,7 +44,6 @@ describe("Collapsible", () => {
     // Then
     expect(content).toHaveClass(
       "motion-reduce:animate-none",
-      "motion-reduce:transform-none",
       "motion-reduce:transition-none",
     );
   });

--- a/ui/components/shadcn/collapsible.test.tsx
+++ b/ui/components/shadcn/collapsible.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./collapsible";
+
+describe("Collapsible", () => {
+  it("uses an intentional open and close motion contract", () => {
+    // Given
+    render(
+      <Collapsible open>
+        <CollapsibleTrigger>Toggle details</CollapsibleTrigger>
+        <CollapsibleContent>Expandable content</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    // When
+    const content = screen.getByText("Expandable content");
+
+    // Then
+    expect(content).toHaveAttribute("data-slot", "collapsible-content");
+    expect(content).toHaveClass(
+      "overflow-hidden",
+      "duration-200",
+      "ease-out",
+      "data-[state=open]:animate-in",
+      "data-[state=open]:fade-in-0",
+      "data-[state=open]:slide-in-from-top-1",
+      "data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0",
+      "data-[state=closed]:slide-out-to-top-1",
+      "data-[state=closed]:duration-150",
+      "data-[state=closed]:ease-in",
+    );
+  });
+
+  it("removes transform-heavy motion for reduced-motion users", () => {
+    // Given
+    render(
+      <Collapsible open>
+        <CollapsibleTrigger>Toggle details</CollapsibleTrigger>
+        <CollapsibleContent>Expandable content</CollapsibleContent>
+      </Collapsible>,
+    );
+
+    // When
+    const content = screen.getByText("Expandable content");
+
+    // Then
+    expect(content).toHaveClass(
+      "motion-reduce:animate-none",
+      "motion-reduce:transform-none",
+      "motion-reduce:transition-none",
+    );
+  });
+});

--- a/ui/components/shadcn/collapsible.tsx
+++ b/ui/components/shadcn/collapsible.tsx
@@ -29,11 +29,10 @@ function CollapsibleContent({
     <CollapsiblePrimitive.CollapsibleContent
       data-slot="collapsible-content"
       className={cn(
-        "overflow-hidden duration-200 ease-out",
-        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1",
-        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1",
-        "data-[state=closed]:duration-150 data-[state=closed]:ease-in",
-        "motion-reduce:transform-none motion-reduce:animate-none motion-reduce:transition-none",
+        "overflow-hidden",
+        "data-[state=open]:animate-collapsible-down",
+        "data-[state=closed]:animate-collapsible-up",
+        "motion-reduce:animate-none motion-reduce:transition-none",
         className,
       )}
       {...props}

--- a/ui/components/shadcn/collapsible.tsx
+++ b/ui/components/shadcn/collapsible.tsx
@@ -2,6 +2,8 @@
 
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
 
+import { cn } from "@/lib/utils";
+
 function Collapsible({
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
@@ -20,11 +22,20 @@ function CollapsibleTrigger({
 }
 
 function CollapsibleContent({
+  className,
   ...props
 }: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
   return (
     <CollapsiblePrimitive.CollapsibleContent
       data-slot="collapsible-content"
+      className={cn(
+        "overflow-hidden duration-200 ease-out",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-top-1",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-1",
+        "data-[state=closed]:duration-150 data-[state=closed]:ease-in",
+        "motion-reduce:transform-none motion-reduce:animate-none motion-reduce:transition-none",
+        className,
+      )}
       {...props}
     />
   );

--- a/ui/components/shadcn/tree-view/tree-leaf.tsx
+++ b/ui/components/shadcn/tree-view/tree-leaf.tsx
@@ -58,7 +58,9 @@ export function TreeLeaf({
       className={cn(
         "flex items-center gap-2 rounded-md px-2 py-1.5",
         "hover:bg-prowler-white/5 cursor-pointer",
+        "transition-[background-color,box-shadow,color] duration-150 ease-out motion-reduce:transition-none",
         "focus-visible:ring-border-input-primary-press focus-visible:ring-2 focus-visible:outline-none",
+        isSelected && "bg-prowler-white/5",
         item.disabled && "cursor-not-allowed opacity-50",
         item.className,
       )}

--- a/ui/components/shadcn/tree-view/tree-node.tsx
+++ b/ui/components/shadcn/tree-view/tree-node.tsx
@@ -96,7 +96,9 @@ export function TreeNode({
         className={cn(
           "flex items-center gap-2 rounded-md px-2 py-1.5",
           "hover:bg-prowler-white/5 cursor-pointer",
+          "transition-[background-color,box-shadow,color] duration-150 ease-out motion-reduce:transition-none",
           "focus-visible:ring-border-input-primary-press focus-visible:ring-2 focus-visible:outline-none",
+          isSelected && "bg-prowler-white/5",
           item.disabled && "cursor-not-allowed opacity-50",
           item.className,
         )}
@@ -110,7 +112,7 @@ export function TreeNode({
         onKeyDown={handleKeyDown}
       >
         <button
-          className="hover:bg-prowler-white/10 shrink-0 rounded p-0.5"
+          className="hover:bg-prowler-white/10 shrink-0 rounded p-0.5 transition-colors duration-150 ease-out motion-reduce:transition-none"
           aria-label={isExpanded ? "Collapse" : "Expand"}
           onClick={(e) => {
             e.stopPropagation();
@@ -123,7 +125,7 @@ export function TreeNode({
           ) : (
             <ChevronRightIcon
               className={cn(
-                "h-4 w-4 transition-transform duration-200",
+                "h-4 w-4 transition-transform duration-200 ease-out motion-reduce:transition-none",
                 isExpanded && "rotate-90",
               )}
             />

--- a/ui/components/shadcn/tree-view/tree-node.tsx
+++ b/ui/components/shadcn/tree-view/tree-node.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { ChevronRightIcon } from "lucide-react";
 import { KeyboardEvent } from "react";
 
@@ -13,6 +13,24 @@ import { TreeLeaf } from "./tree-leaf";
 import { TreeSpinner } from "./tree-spinner";
 import { TreeStatusIndicator } from "./tree-status-indicator";
 import { getAllDescendantIds, getTreeNodePadding } from "./utils";
+
+export function getTreeChildrenMotion(shouldReduceMotion: boolean) {
+  if (shouldReduceMotion) {
+    return {
+      initial: { opacity: 0 },
+      animate: { opacity: 1 },
+      exit: { opacity: 0 },
+      transition: { duration: 0, ease: "easeInOut" as const },
+    };
+  }
+
+  return {
+    initial: { opacity: 0, height: 0 },
+    animate: { opacity: 1, height: "auto" as const },
+    exit: { opacity: 0, height: 0 },
+    transition: { duration: 0.2, ease: "easeInOut" as const },
+  };
+}
 
 /**
  * TreeNode component for rendering expandable nodes with children.
@@ -36,6 +54,8 @@ export function TreeNode({
   renderItem,
   enableSelectChildren,
 }: TreeNodeProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const childrenMotion = getTreeChildrenMotion(!!shouldReduceMotion);
   const isExpanded = expandedIds.includes(item.id);
   const isSelected = selectedIds.includes(item.id);
   const statusIcon =
@@ -166,10 +186,10 @@ export function TreeNode({
         {isExpanded && (
           <motion.ul
             key={`children-${item.id}`}
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.2, ease: "easeInOut" }}
+            initial={childrenMotion.initial}
+            animate={childrenMotion.animate}
+            exit={childrenMotion.exit}
+            transition={childrenMotion.transition}
             className="mt-1 space-y-1 overflow-hidden"
             role="group"
           >

--- a/ui/components/shadcn/tree-view/tree-view.test.tsx
+++ b/ui/components/shadcn/tree-view/tree-view.test.tsx
@@ -1,7 +1,31 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { getTreeChildrenMotion } from "./tree-node";
 import { TreeView } from "./tree-view";
+
+describe("getTreeChildrenMotion", () => {
+  it("animates height when motion is allowed", () => {
+    // Given / When
+    const motion = getTreeChildrenMotion(false);
+
+    // Then
+    expect(motion.initial).toHaveProperty("height", 0);
+    expect(motion.animate).toHaveProperty("height", "auto");
+    expect(motion.transition.duration).toBeGreaterThan(0);
+  });
+
+  it("degrades to opacity-only with no height under reduced motion", () => {
+    // Given / When
+    const motion = getTreeChildrenMotion(true);
+
+    // Then
+    expect(motion.initial).not.toHaveProperty("height");
+    expect(motion.animate).not.toHaveProperty("height");
+    expect(motion.exit).not.toHaveProperty("height");
+    expect(motion.transition.duration).toBe(0);
+  });
+});
 
 const treeData = [
   {

--- a/ui/components/shadcn/tree-view/tree-view.test.tsx
+++ b/ui/components/shadcn/tree-view/tree-view.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TreeView } from "./tree-view";
+
+const treeData = [
+  {
+    id: "org-1",
+    name: "Organization",
+    children: [
+      { id: "account-1", name: "Production" },
+      { id: "account-2", name: "Development" },
+    ],
+  },
+];
+
+describe("TreeView", () => {
+  it("animates node affordances and expanded content", () => {
+    // Given
+    render(<TreeView data={treeData} expandedIds={["org-1"]} showCheckboxes />);
+
+    // When
+    const node = screen.getByRole("treeitem", { name: /organization/i });
+    const expandButton = screen.getByRole("button", { name: /collapse/i });
+    const chevron = expandButton.querySelector("svg");
+    const group = screen.getByRole("group");
+
+    // Then
+    expect(node).toHaveClass(
+      "transition-[background-color,box-shadow,color]",
+      "duration-150",
+      "ease-out",
+      "motion-reduce:transition-none",
+    );
+    expect(expandButton).toHaveClass(
+      "transition-colors",
+      "duration-150",
+      "ease-out",
+      "motion-reduce:transition-none",
+    );
+    expect(chevron).toHaveClass(
+      "transition-transform",
+      "duration-200",
+      "ease-out",
+      "motion-reduce:transition-none",
+      "rotate-90",
+    );
+    expect(group).toHaveClass("overflow-hidden");
+  });
+
+  it("animates selected leaf row feedback", () => {
+    // Given
+    render(
+      <TreeView
+        data={treeData}
+        expandedIds={["org-1"]}
+        selectedIds={["account-1"]}
+        onSelectionChange={vi.fn()}
+        showCheckboxes
+      />,
+    );
+
+    // When
+    const selectedLeaf = screen.getByRole("treeitem", { name: /production/i });
+
+    // Then
+    expect(selectedLeaf).toHaveAttribute("aria-selected", "true");
+    expect(selectedLeaf).toHaveClass(
+      "bg-prowler-white/5",
+      "transition-[background-color,box-shadow,color]",
+      "duration-150",
+      "ease-out",
+      "motion-reduce:transition-none",
+    );
+  });
+});


### PR DESCRIPTION
### Context

Continues the UI motion chain with a focused stacked slice for expandable/tree interactions.

## Chain Context

| Field         | Value                                                       |
|---------------|-------------------------------------------------------------|
| Chain         | UI motion / microinteractions                               |
| Tracker PR    | Not needed (stacked chain)                                  |
| Position      | 3 of 6                                                      |
| Base          | `feat/ui-form-microinteractions` (head of #11483)          |
| Depends on    | #11483 → #11478                                             |
| Follow-up     | #11480                                                      |
| Review budget | 154 / 400                                                   |
| Starts at     | Form control microinteractions (#11483)                    |
| Ends with     | Collapsible + tree-view motion contracts                   |

### Chain Overview

```text
master
└── #11478 Visible microinteractions
     └── #11483 Form control microinteractions
          └── 📍 #11479 Expandable microinteractions (this PR)
               └── #11480 Skeleton loading handoffs
                    └── #11481 Nested skeleton handoffs
                         └── #11482 UI motion docs
```

### Scope
- Includes: open/close motion on shared `CollapsibleContent`; tree row, chevron, and selected-state transitions on `TreeNode`/`TreeLeaf`; unit coverage for the collapsible and tree-view contracts
- Excludes: skeleton handoffs (#11480/#11481), docs (#11482)

### Autonomy
- [ ] CI is expected to pass for this PR branch
- [ ] This PR has one deliverable scope
- [ ] This PR can be rolled back without unrelated changes
- [ ] Tests cover this unit

### Description

- Add visible open/close motion classes to shared `CollapsibleContent`.
- Add tree row, chevron, and selected-state transitions to `TreeNode` and `TreeLeaf`.
- Add focused unit coverage for collapsible and tree-view motion contracts.

### Steps to review

- Run `cd ui && pnpm test:unit components/shadcn/collapsible.test.tsx components/shadcn/tree-view/tree-view.test.tsx`.
- Run `cd ui && pnpm run typecheck`.
- Manually test the organization account selection tree by expanding/collapsing OUs and selecting accounts.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [ ] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
