### PR TITLE
fix(ui): preserve active tab styling with tooltips

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -10,6 +10,14 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ---
 
+## [1.29.3] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Finding drawer tabs now keep the active tab text and underline styling when tooltip state changes [(#11493)](https://github.com/prowler-cloud/prowler/pull/11493)
+
+---
+
 ## [1.29.2] (Prowler v5.29.2)
 
 ### 🔄 Changed

--- a/ui/components/shadcn/tabs/tabs.test.tsx
+++ b/ui/components/shadcn/tabs/tabs.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Tabs, TabsList, TabsTrigger } from "./tabs";
+
+describe("TabsTrigger", () => {
+  it("keeps active styling available when rendered with a tooltip", () => {
+    render(
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview" tooltip="Overview">
+            Overview
+          </TabsTrigger>
+          <TabsTrigger value="remediation" tooltip="Remediation">
+            Remediation
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>,
+    );
+
+    const activeTrigger = screen.getByRole("tab", { name: "Overview" });
+
+    expect(activeTrigger).toHaveAttribute("aria-selected", "true");
+    expect(activeTrigger).toHaveClass("aria-selected:text-slate-900");
+    expect(activeTrigger).toHaveClass("aria-selected:after:scale-x-100");
+  });
+});

--- a/ui/components/shadcn/tabs/tabs.tsx
+++ b/ui/components/shadcn/tabs/tabs.tsx
@@ -18,9 +18,9 @@ const TRIGGER_STYLES = {
   border: "border-r border-[#E9E9F0] last:border-r-0 dark:border-[#171D30]",
   text: "text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white",
   active:
-    "data-[state=active]:text-slate-900 dark:data-[state=active]:text-white",
+    "data-[state=active]:text-slate-900 aria-selected:text-slate-900 dark:data-[state=active]:text-white dark:aria-selected:text-white",
   underline:
-    "after:absolute after:bottom-0 after:left-0 after:right-4 after:h-0.5 after:scale-x-0 after:bg-emerald-400 after:transition-transform data-[state=active]:after:scale-x-100 [&:not(:first-child)]:after:left-4 [&:last-child]:after:right-0",
+    "after:absolute after:bottom-0 after:left-0 after:right-4 after:h-0.5 after:scale-x-0 after:bg-emerald-400 after:transition-transform data-[state=active]:after:scale-x-100 aria-selected:after:scale-x-100 [&:not(:first-child)]:after:left-4 [&:last-child]:after:right-0",
   focus:
     "focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:focus-visible:ring-offset-slate-950",
   icon: "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",


### PR DESCRIPTION
### Context

The finding resource detail drawer uses shared tabs wrapped with tooltips. TooltipTrigger and TabsTrigger both write a `data-state` attribute, so the tooltip state can overwrite the Radix Tabs active state and remove the visual active marker.

### Description
<img width="743" height="75" alt="Screenshot 2026-06-08 at 11 28 29" src="https://github.com/user-attachments/assets/3c0929bb-9a04-45ba-800a-a8501cb24b2b" />

This PR preserves active tab styling by adding `aria-selected` Tailwind variants alongside the existing `data-state=active` variants. Radix Tabs keeps `aria-selected=true` on the active tab even when tooltip state changes.

It also adds a focused unit test covering tooltip-wrapped active tabs.

### Steps to review

1. Open the Findings view and open a finding resource detail drawer.
2. Verify the active drawer tab has distinct active text styling and underline.
3. Switch between Overview, Remediation, Evidence, Other findings, Scans, and Events.
4. Verify each selected tab remains visually marked as active.

Local validation run:

- `pnpm --dir ui test:unit -- components/shadcn/tabs/tabs.test.tsx`
- `pnpm --dir ui typecheck`
- `pnpm --dir ui lint:check`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Not applicable.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. Not applicable; no dependency changes.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API. Not applicable.
- [x] Endpoint response output (if applicable). Not applicable.
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable). Not applicable.
- [x] Performance test results (if applicable). Not applicable.
- [x] Any other relevant evidence of the implementation (if applicable). Not applicable.
- [x] Verify if API specs need to be regenerated. Not applicable.
- [x] Check if version updates are required (e.g., specs, uv, etc.). Not applicable.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.