### PR TITLE
fix(m365): paginate admincenter group enumeration

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🐞 Fixed
 
 - `load_and_validate_config_file` now unwraps namespaced config for every built-in and external provider, and no longer leaks the full file as the provider's config when the file is namespaced [(#10700)](https://github.com/prowler-cloud/prowler/pull/10700)
+- M365 Admin Center group enumeration now follows Microsoft Graph pagination so group-scoped checks include groups beyond the first page [(#11510)](https://github.com/prowler-cloud/prowler/pull/11510)
 
 ---
 

--- a/prowler/providers/m365/services/admincenter/admincenter_service.py
+++ b/prowler/providers/m365/services/admincenter/admincenter_service.py
@@ -175,17 +175,23 @@ class AdminCenter(M365Service):
         try:
             groups_list = await self.client.groups.get()
             groups.update({})
-            for group in groups_list.value:
-                groups.update(
-                    {
-                        group.id: Group(
-                            id=group.id,
-                            name=getattr(group, "display_name", ""),
-                            visibility=getattr(group, "visibility", ""),
-                            group_types=getattr(group, "group_types", []) or [],
-                        )
-                    }
-                )
+            while groups_list:
+                for group in getattr(groups_list, "value", []) or []:
+                    groups.update(
+                        {
+                            group.id: Group(
+                                id=group.id,
+                                name=getattr(group, "display_name", ""),
+                                visibility=getattr(group, "visibility", ""),
+                                group_types=getattr(group, "group_types", []) or [],
+                            )
+                        }
+                    )
+
+                next_link = getattr(groups_list, "odata_next_link", None)
+                if not next_link:
+                    break
+                groups_list = await self.client.groups.with_url(next_link).get()
 
         except Exception as error:
             logger.error(

--- a/tests/providers/m365/services/admincenter/admincenter_service_test.py
+++ b/tests/providers/m365/services/admincenter/admincenter_service_test.py
@@ -252,3 +252,49 @@ def test_admincenter__get_groups_maps_group_types():
     assert groups["id-2"].group_types == []
     assert groups["id-3"].group_types == []
     assert groups["id-3"].visibility == "Public"
+
+
+def test_admincenter__get_groups_handles_pagination():
+    admincenter_service = AdminCenter.__new__(AdminCenter)
+
+    groups_response_page_one = SimpleNamespace(
+        value=[
+            SimpleNamespace(
+                id="id-1",
+                display_name="First Unified Group",
+                visibility="Private",
+                group_types=["Unified"],
+            )
+        ],
+        odata_next_link="next-link",
+    )
+    groups_response_page_two = SimpleNamespace(
+        value=[
+            SimpleNamespace(
+                id="id-2",
+                display_name="Second Unified Group",
+                visibility="Public",
+                group_types=["Unified"],
+            )
+        ],
+        odata_next_link=None,
+    )
+
+    groups_with_url_builder = SimpleNamespace(
+        get=AsyncMock(return_value=groups_response_page_two)
+    )
+    with_url_mock = MagicMock(return_value=groups_with_url_builder)
+    groups_builder = SimpleNamespace(
+        get=AsyncMock(return_value=groups_response_page_one),
+        with_url=with_url_mock,
+    )
+    admincenter_service.client = SimpleNamespace(groups=groups_builder)
+
+    groups = asyncio.run(admincenter_service._get_groups())
+
+    assert len(groups) == 2
+    assert groups_builder.get.await_count == 1
+    with_url_mock.assert_called_once_with("next-link")
+    assert groups["id-1"].name == "First Unified Group"
+    assert groups["id-2"].name == "Second Unified Group"
+    assert groups["id-2"].visibility == "Public"


### PR DESCRIPTION
### Context

Fix #11469

M365 Admin Center group-scoped checks only evaluated the first Microsoft Graph `/groups` page, so Unified groups beyond page 1 could be silently omitted from checks such as `admincenter_groups_not_public_visibility`.

### Description

- Follow `odata_next_link` in `AdminCenter._get_groups` to collect paginated group results.
- Add regression coverage proving groups from the next Graph page are included.

### Steps to review

1. Review `AdminCenter._get_groups` pagination flow.
2. Review the new `test_admincenter__get_groups_handles_pagination` coverage.
3. Run:

```bash
uv run pytest tests/providers/m365/services/admincenter/admincenter_service_test.py tests/providers/m365/services/admincenter/admincenter_groups_not_public_visibility/admincenter_groups_not_public_visibility_test.py -v
```

Local result: `15 passed, 9 warnings`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [x] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved incomplete retrieval of Microsoft 365 groups: paginated group results are now fully fetched so all groups are available for checks and reporting.

* **Tests**
  * Added a unit test verifying correct handling of paginated Microsoft Graph group results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->