### PR TITLE
docs(skills): correct setup symlink paths in README

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -23,12 +23,12 @@ Run the setup script to configure skills for all supported AI coding assistants:
 
 This creates symlinks so each tool finds skills in its expected location:
 
-| Tool | Symlink Created |
-|------|-----------------|
-| Claude Code / OpenCode | `.claude/skills/` |
-| Codex (OpenAI) | `.codex/skills/` |
-| GitHub Copilot | `.github/skills/` |
-| Gemini CLI | `.gemini/skills/` |
+| Tool | Created by setup |
+|------|------------------|
+| Claude Code | `.claude/skills/` symlink and `CLAUDE.md` |
+| Gemini CLI | `.gemini/skills/` symlink and `GEMINI.md` |
+| Codex (OpenAI) | `.codex/skills/` symlink (uses `AGENTS.md` natively) |
+| GitHub Copilot | `.github/copilot-instructions.md` symlink to `AGENTS.md` |
 
 After running setup, restart your AI coding assistant to load the skills.
 


### PR DESCRIPTION
### Context

The `skills/README.md` setup table documented the wrong symlink path for GitHub Copilot. `setup.sh` creates `.github/copilot-instructions.md` (a symlink to `AGENTS.md`), not `.github/skills/`. This broke the documented setup contract. Surfaced during the review of #11513, where the same table had been copied into the developer guide.

### Description

- Fix the GitHub Copilot path to `.github/copilot-instructions.md`, verified against `skills/setup.sh` and the current [GitHub Copilot custom instructions docs](https://docs.github.com/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot).
- Reflect the actual per-tool symlinks the script creates (each tool also links its `CLAUDE.md` / `GEMINI.md` / `AGENTS.md`).

Docs-only change. No component `CHANGELOG.md` applies, so the PR is labeled `no-changelog`.

### Steps to review

1. Compare the table in `skills/README.md` against the `setup_*` functions in `skills/setup.sh`.
2. Confirm the Copilot row matches `setup_copilot()` (`.github/copilot-instructions.md`).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to reflect current configuration for supported AI coding assistants, with corrected and standardized guidance for tool linking and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->