### PR TITLE
feat(m365): block Entra directory sync object takeover

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `cloudsql_instance_high_availability_enabled` check for GCP provider, verifying Cloud SQL primary instances use `REGIONAL` availability for automatic zone failover [(#11024)](https://github.com/prowler-cloud/prowler/pull/11024)
 - `identity_storage_service_level_admins_scoped` check for OCI provider CIS 3.1 control 1.15, ensuring storage service-level administrators exclude delete permissions [(#11523)](https://github.com/prowler-cloud/prowler/pull/11523)
 - `cosmosdb_account_automatic_failover_enabled` check for Azure provider [(#11031)](https://github.com/prowler-cloud/prowler/pull/11031)
+- `entra_directory_sync_object_takeover_blocked` check for the M365 provider, verifying that hybrid Entra tenants block cloud object takeover through both soft and hard directory matching [(#11068)](https://github.com/prowler-cloud/prowler/issues/11068)
 
 ---
 

--- a/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/__init__.py
+++ b/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/__init__.py
@@ -1,0 +1,1 @@
+"""Microsoft Entra directory sync object takeover check."""

--- a/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.metadata.json
+++ b/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.metadata.json
@@ -1,0 +1,42 @@
+{
+  "Provider": "m365",
+  "CheckID": "entra_directory_sync_object_takeover_blocked",
+  "CheckTitle": "Directory synchronization blocks cloud object takeover through soft and hard matching",
+  "CheckType": [],
+  "ServiceName": "entra",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "IAM",
+  "Description": "Microsoft Entra hybrid tenants can block on-premises directory objects from taking over existing cloud objects through **soft matching** or **hard matching**. This check verifies that both `blockSoftMatchEnabled` and `blockCloudObjectTakeoverThroughHardMatchEnabled` are enabled.",
+  "Risk": "An attacker who can create or modify an on-premises Active Directory object may craft matching identity attributes or a source anchor that attaches the object to an existing privileged cloud identity. Successful object takeover can provide unauthorized access to the cloud account and its assigned roles.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/graph/api/resources/onpremisesdirectorysynchronization?view=graph-rest-1.0",
+    "https://learn.microsoft.com/en-us/graph/api/resources/onpremisesdirectorysynchronizationfeature?view=graph-rest-1.0",
+    "https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/how-to-connect-syncservice-features"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "Use Microsoft Graph to update the tenant's onPremisesDirectorySynchronization resource so that both `features.blockSoftMatchEnabled` and `features.blockCloudObjectTakeoverThroughHardMatchEnabled` are `true`. Confirm that the flags remain enabled after any time-boxed migration activity.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Enable both **soft-match blocking** and **hard-match cloud object takeover blocking** for hybrid identity synchronization. Monitor changes to these controls and permit temporary exceptions only through an approved, time-limited migration procedure.",
+      "Url": "https://hub.prowler.com/check/entra_directory_sync_object_takeover_blocked"
+    }
+  },
+  "Categories": [
+    "identity-access",
+    "e3"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [
+    "entra_password_hash_sync_enabled",
+    "entra_seamless_sso_disabled"
+  ],
+  "Notes": "This check applies only to hybrid Microsoft Entra tenants with on-premises directory synchronization enabled. It requires permission to read onPremisesDirectorySynchronization through Microsoft Graph."
+}

--- a/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.py
+++ b/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.py
@@ -8,6 +8,17 @@ class entra_directory_sync_object_takeover_blocked(Check):
     """Check that hybrid Entra tenants block soft- and hard-match takeover."""
 
     def execute(self) -> List[CheckReportM365]:
+        """Verify directory sync object takeover protections.
+
+        Builds reports from the Entra client's directory sync settings. Hybrid
+        tenants pass when both soft- and hard-match protections are enabled,
+        fail when either protection is disabled, and require manual review when
+        settings cannot be read. Cloud-only tenants pass as not applicable.
+
+        Returns:
+            List[CheckReportM365]: Reports for each sync configuration or
+                organization.
+        """
         findings = []
 
         if entra_client.directory_sync_error:

--- a/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.py
+++ b/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.py
@@ -1,0 +1,88 @@
+from typing import List
+
+from prowler.lib.check.models import Check, CheckReportM365
+from prowler.providers.m365.services.entra.entra_client import entra_client
+
+
+class entra_directory_sync_object_takeover_blocked(Check):
+    """Check that hybrid Entra tenants block soft- and hard-match takeover."""
+
+    def execute(self) -> List[CheckReportM365]:
+        findings = []
+
+        if entra_client.directory_sync_error:
+            for organization in entra_client.organizations:
+                report = CheckReportM365(
+                    self.metadata(),
+                    resource=organization,
+                    resource_id=organization.id,
+                    resource_name=organization.name,
+                )
+                if organization.on_premises_sync_enabled:
+                    report.status = "MANUAL"
+                    report.status_extended = (
+                        f"Cannot verify directory sync object takeover protections for "
+                        f"{organization.name}: {entra_client.directory_sync_error}."
+                    )
+                else:
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"Entra organization {organization.name} is cloud-only "
+                        "(no on-premises sync), so directory sync object takeover "
+                        "protections are not applicable."
+                    )
+                findings.append(report)
+            return findings
+
+        for sync_settings in entra_client.directory_sync_settings:
+            report = CheckReportM365(
+                self.metadata(),
+                resource=sync_settings,
+                resource_id=sync_settings.id,
+                resource_name=f"Directory Sync {sync_settings.id}",
+            )
+            disabled_protections = []
+            if not sync_settings.block_soft_match_enabled:
+                disabled_protections.append("soft match")
+            if not sync_settings.block_cloud_object_takeover_through_hard_match_enabled:
+                disabled_protections.append("hard match")
+
+            if disabled_protections:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"Entra directory sync {sync_settings.id} does not block object "
+                    f"takeover through {' and '.join(disabled_protections)}."
+                )
+            else:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Entra directory sync {sync_settings.id} blocks object takeover "
+                    "through both soft and hard matching."
+                )
+            findings.append(report)
+
+        if not entra_client.directory_sync_settings:
+            for organization in entra_client.organizations:
+                report = CheckReportM365(
+                    self.metadata(),
+                    resource=organization,
+                    resource_id=organization.id,
+                    resource_name=organization.name,
+                )
+                if organization.on_premises_sync_enabled:
+                    report.status = "MANUAL"
+                    report.status_extended = (
+                        f"Entra organization {organization.name} has on-premises sync "
+                        "enabled, but no directory sync settings were returned. Review "
+                        "the tenant configuration manually."
+                    )
+                else:
+                    report.status = "PASS"
+                    report.status_extended = (
+                        f"Entra organization {organization.name} is cloud-only "
+                        "(no on-premises sync), so directory sync object takeover "
+                        "protections are not applicable."
+                    )
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.py
+++ b/prowler/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked.py
@@ -13,7 +13,8 @@ class entra_directory_sync_object_takeover_blocked(Check):
         Builds reports from the Entra client's directory sync settings. Hybrid
         tenants pass when both soft- and hard-match protections are enabled,
         fail when either protection is disabled, and require manual review when
-        settings cannot be read. Cloud-only tenants pass as not applicable.
+        settings cannot be read. Cloud-only tenants are reported as manual
+        guidance because the check is not applicable.
 
         Returns:
             List[CheckReportM365]: Reports for each sync configuration or
@@ -36,11 +37,12 @@ class entra_directory_sync_object_takeover_blocked(Check):
                         f"{organization.name}: {entra_client.directory_sync_error}."
                     )
                 else:
-                    report.status = "PASS"
+                    report.status = "MANUAL"
                     report.status_extended = (
                         f"Entra organization {organization.name} is cloud-only "
                         "(no on-premises sync), so directory sync object takeover "
-                        "protections are not applicable."
+                        "protections are not applicable. No action is required "
+                        "unless on-premises synchronization is enabled."
                     )
                 findings.append(report)
             return findings
@@ -88,11 +90,12 @@ class entra_directory_sync_object_takeover_blocked(Check):
                         "the tenant configuration manually."
                     )
                 else:
-                    report.status = "PASS"
+                    report.status = "MANUAL"
                     report.status_extended = (
                         f"Entra organization {organization.name} is cloud-only "
                         "(no on-premises sync), so directory sync object takeover "
-                        "protections are not applicable."
+                        "protections are not applicable. No action is required "
+                        "unless on-premises synchronization is enabled."
                     )
                 findings.append(report)
 

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -793,14 +793,12 @@ class Entra(M365Service):
                         or False,
                         block_soft_match_enabled=getattr(
                             features, "block_soft_match_enabled", False
-                        )
-                        or False,
+                        ),
                         block_cloud_object_takeover_through_hard_match_enabled=getattr(
                             features,
                             "block_cloud_object_takeover_through_hard_match_enabled",
                             False,
-                        )
-                        or False,
+                        ),
                     )
                 )
         except ODataError as error:

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -791,6 +791,16 @@ class Entra(M365Service):
                             features, "seamless_sso_enabled", False
                         )
                         or False,
+                        block_soft_match_enabled=getattr(
+                            features, "block_soft_match_enabled", False
+                        )
+                        or False,
+                        block_cloud_object_takeover_through_hard_match_enabled=getattr(
+                            features,
+                            "block_cloud_object_takeover_through_hard_match_enabled",
+                            False,
+                        )
+                        or False,
                     )
                 )
         except ODataError as error:
@@ -1637,6 +1647,8 @@ class DirectorySyncSettings(BaseModel):
     id: str
     password_sync_enabled: bool = False
     seamless_sso_enabled: bool = False
+    block_soft_match_enabled: bool = False
+    block_cloud_object_takeover_through_hard_match_enabled: bool = False
 
 
 class AuthenticationMethodConfiguration(BaseModel):

--- a/prowler/providers/m365/services/entra/entra_service.py
+++ b/prowler/providers/m365/services/entra/entra_service.py
@@ -793,12 +793,14 @@ class Entra(M365Service):
                         or False,
                         block_soft_match_enabled=getattr(
                             features, "block_soft_match_enabled", False
-                        ),
+                        )
+                        or False,
                         block_cloud_object_takeover_through_hard_match_enabled=getattr(
                             features,
                             "block_cloud_object_takeover_through_hard_match_enabled",
                             False,
-                        ),
+                        )
+                        or False,
                     )
                 )
         except ODataError as error:

--- a/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/__init__.py
+++ b/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for the Entra directory sync object takeover check."""

--- a/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/__init__.py
+++ b/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Entra directory sync object takeover check."""

--- a/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
+++ b/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
@@ -1,0 +1,166 @@
+import asyncio
+import importlib
+from types import SimpleNamespace
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import pytest
+
+from prowler.providers.m365.services.entra.entra_service import (
+    DirectorySyncSettings,
+    Entra,
+    Organization,
+)
+from tests.providers.m365.m365_fixtures import set_mocked_m365_provider
+
+
+@pytest.fixture
+def entra_client():
+    client = mock.MagicMock()
+    client.directory_sync_settings = []
+    client.directory_sync_error = None
+    client.organizations = []
+    return client
+
+
+class Test_entra_directory_sync_object_takeover_blocked:
+    def run_check(self, entra_client):
+        client_module = SimpleNamespace(entra_client=entra_client)
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_m365_provider(),
+            ),
+            mock.patch.dict(
+                "sys.modules",
+                {"prowler.providers.m365.services.entra.entra_client": client_module},
+            ),
+        ):
+            check_module = importlib.import_module(
+                "prowler.providers.m365.services.entra."
+                "entra_directory_sync_object_takeover_blocked."
+                "entra_directory_sync_object_takeover_blocked"
+            )
+            check_module.entra_client = entra_client
+
+            return check_module.entra_directory_sync_object_takeover_blocked().execute()
+
+    def test_both_takeover_paths_blocked(self, entra_client):
+        entra_client.directory_sync_settings = [
+            DirectorySyncSettings(
+                id="sync-001",
+                block_soft_match_enabled=True,
+                block_cloud_object_takeover_through_hard_match_enabled=True,
+            )
+        ]
+
+        result = self.run_check(entra_client)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert "both soft and hard matching" in result[0].status_extended
+        assert result[0].resource_id == "sync-001"
+
+    @pytest.mark.parametrize(
+        ("soft_match_blocked", "hard_match_blocked", "expected"),
+        [
+            (False, True, "soft match"),
+            (True, False, "hard match"),
+            (False, False, "soft match and hard match"),
+        ],
+    )
+    def test_reports_unblocked_takeover_paths(
+        self,
+        entra_client,
+        soft_match_blocked,
+        hard_match_blocked,
+        expected,
+    ):
+        entra_client.directory_sync_settings = [
+            DirectorySyncSettings(
+                id="sync-001",
+                block_soft_match_enabled=soft_match_blocked,
+                block_cloud_object_takeover_through_hard_match_enabled=hard_match_blocked,
+            )
+        ]
+
+        result = self.run_check(entra_client)
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert expected in result[0].status_extended
+
+    def test_permission_error_is_manual_for_hybrid_tenant(self, entra_client):
+        entra_client.directory_sync_error = (
+            "Insufficient privileges to read directory sync settings"
+        )
+        entra_client.organizations = [
+            Organization(
+                id="org-001",
+                name="Hybrid Tenant",
+                on_premises_sync_enabled=True,
+            )
+        ]
+
+        result = self.run_check(entra_client)
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert "Insufficient privileges" in result[0].status_extended
+
+    def test_cloud_only_tenant_is_not_applicable(self, entra_client):
+        entra_client.organizations = [
+            Organization(
+                id="org-001",
+                name="Cloud Tenant",
+                on_premises_sync_enabled=False,
+            )
+        ]
+
+        result = self.run_check(entra_client)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert "cloud-only" in result[0].status_extended
+
+    def test_missing_settings_is_manual_for_hybrid_tenant(self, entra_client):
+        entra_client.organizations = [
+            Organization(
+                id="org-001",
+                name="Hybrid Tenant",
+                on_premises_sync_enabled=True,
+            )
+        ]
+
+        result = self.run_check(entra_client)
+
+        assert len(result) == 1
+        assert result[0].status == "MANUAL"
+        assert "no directory sync settings were returned" in result[0].status_extended
+
+
+def test_directory_sync_service_loads_takeover_protection_flags():
+    features = SimpleNamespace(
+        password_sync_enabled=True,
+        seamless_sso_enabled=False,
+        block_soft_match_enabled=True,
+        block_cloud_object_takeover_through_hard_match_enabled=True,
+    )
+    response = SimpleNamespace(
+        value=[SimpleNamespace(id="sync-001", features=features)]
+    )
+    entra_service = Entra.__new__(Entra)
+    entra_service.client = SimpleNamespace(
+        directory=SimpleNamespace(
+            on_premises_synchronization=SimpleNamespace(
+                get=AsyncMock(return_value=response)
+            )
+        )
+    )
+
+    settings, error = asyncio.run(entra_service._get_directory_sync_settings())
+
+    assert error is None
+    assert len(settings) == 1
+    assert settings[0].block_soft_match_enabled is True
+    assert settings[0].block_cloud_object_takeover_through_hard_match_enabled is True

--- a/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
+++ b/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
@@ -123,6 +123,24 @@ class Test_entra_directory_sync_object_takeover_blocked:
         assert result[0].status == "PASS"
         assert "cloud-only" in result[0].status_extended
 
+    def test_permission_error_cloud_only_tenant_is_not_applicable(self, entra_client):
+        entra_client.directory_sync_error = (
+            "Insufficient privileges to read directory sync settings"
+        )
+        entra_client.organizations = [
+            Organization(
+                id="org-001",
+                name="Cloud Tenant",
+                on_premises_sync_enabled=False,
+            )
+        ]
+
+        result = self.run_check(entra_client)
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert "cloud-only" in result[0].status_extended
+
     def test_missing_settings_is_manual_for_hybrid_tenant(self, entra_client):
         entra_client.organizations = [
             Organization(

--- a/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
+++ b/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
@@ -15,7 +15,8 @@ from tests.providers.m365.m365_fixtures import set_mocked_m365_provider
 
 
 @pytest.fixture
-def entra_client():
+def entra_client() -> mock.MagicMock:
+    """Return a mocked Entra client with empty directory sync data."""
     client = mock.MagicMock()
     client.directory_sync_settings = []
     client.directory_sync_error = None
@@ -24,7 +25,10 @@ def entra_client():
 
 
 class Test_entra_directory_sync_object_takeover_blocked:
-    def run_check(self, entra_client):
+    """Test directory synchronization object takeover protection reporting."""
+
+    def run_check(self, entra_client: mock.MagicMock) -> list:
+        """Execute the check with the supplied mocked Entra client."""
         client_module = SimpleNamespace(entra_client=entra_client)
         with (
             mock.patch(
@@ -45,7 +49,14 @@ class Test_entra_directory_sync_object_takeover_blocked:
 
             return check_module.entra_directory_sync_object_takeover_blocked().execute()
 
-    def test_both_takeover_paths_blocked(self, entra_client):
+    def test_no_resources(self, entra_client: mock.MagicMock) -> None:
+        """Return no findings when the tenant has no applicable resources."""
+        result = self.run_check(entra_client)
+
+        assert len(result) == 0
+
+    def test_both_takeover_paths_blocked(self, entra_client: mock.MagicMock) -> None:
+        """Report PASS when both takeover protections are enabled."""
         entra_client.directory_sync_settings = [
             DirectorySyncSettings(
                 id="sync-001",
@@ -71,11 +82,12 @@ class Test_entra_directory_sync_object_takeover_blocked:
     )
     def test_reports_unblocked_takeover_paths(
         self,
-        entra_client,
-        soft_match_blocked,
-        hard_match_blocked,
-        expected,
-    ):
+        entra_client: mock.MagicMock,
+        soft_match_blocked: bool,
+        hard_match_blocked: bool,
+        expected: str,
+    ) -> None:
+        """Report FAIL and identify each disabled takeover protection."""
         entra_client.directory_sync_settings = [
             DirectorySyncSettings(
                 id="sync-001",
@@ -90,7 +102,10 @@ class Test_entra_directory_sync_object_takeover_blocked:
         assert result[0].status == "FAIL"
         assert expected in result[0].status_extended
 
-    def test_permission_error_is_manual_for_hybrid_tenant(self, entra_client):
+    def test_permission_error_is_manual_for_hybrid_tenant(
+        self, entra_client: mock.MagicMock
+    ) -> None:
+        """Report MANUAL when hybrid directory sync settings cannot be read."""
         entra_client.directory_sync_error = (
             "Insufficient privileges to read directory sync settings"
         )
@@ -108,7 +123,10 @@ class Test_entra_directory_sync_object_takeover_blocked:
         assert result[0].status == "MANUAL"
         assert "Insufficient privileges" in result[0].status_extended
 
-    def test_cloud_only_tenant_is_not_applicable(self, entra_client):
+    def test_cloud_only_tenant_is_not_applicable(
+        self, entra_client: mock.MagicMock
+    ) -> None:
+        """Report cloud-only tenants as not applicable."""
         entra_client.organizations = [
             Organization(
                 id="org-001",
@@ -123,7 +141,10 @@ class Test_entra_directory_sync_object_takeover_blocked:
         assert result[0].status == "PASS"
         assert "cloud-only" in result[0].status_extended
 
-    def test_permission_error_cloud_only_tenant_is_not_applicable(self, entra_client):
+    def test_permission_error_cloud_only_tenant_is_not_applicable(
+        self, entra_client: mock.MagicMock
+    ) -> None:
+        """Keep cloud-only tenants not applicable when sync reads fail."""
         entra_client.directory_sync_error = (
             "Insufficient privileges to read directory sync settings"
         )
@@ -141,7 +162,10 @@ class Test_entra_directory_sync_object_takeover_blocked:
         assert result[0].status == "PASS"
         assert "cloud-only" in result[0].status_extended
 
-    def test_missing_settings_is_manual_for_hybrid_tenant(self, entra_client):
+    def test_missing_settings_is_manual_for_hybrid_tenant(
+        self, entra_client: mock.MagicMock
+    ) -> None:
+        """Report MANUAL when a hybrid tenant returns no sync settings."""
         entra_client.organizations = [
             Organization(
                 id="org-001",
@@ -157,7 +181,8 @@ class Test_entra_directory_sync_object_takeover_blocked:
         assert "no directory sync settings were returned" in result[0].status_extended
 
 
-def test_directory_sync_service_loads_takeover_protection_flags():
+def test_directory_sync_service_loads_takeover_protection_flags() -> None:
+    """Load both takeover protection flags from the Graph response."""
     features = SimpleNamespace(
         password_sync_enabled=True,
         seamless_sso_enabled=False,

--- a/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
+++ b/tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked/entra_directory_sync_object_takeover_blocked_test.py
@@ -138,8 +138,9 @@ class Test_entra_directory_sync_object_takeover_blocked:
         result = self.run_check(entra_client)
 
         assert len(result) == 1
-        assert result[0].status == "PASS"
+        assert result[0].status == "MANUAL"
         assert "cloud-only" in result[0].status_extended
+        assert "No action is required" in result[0].status_extended
 
     def test_permission_error_cloud_only_tenant_is_not_applicable(
         self, entra_client: mock.MagicMock
@@ -159,8 +160,9 @@ class Test_entra_directory_sync_object_takeover_blocked:
         result = self.run_check(entra_client)
 
         assert len(result) == 1
-        assert result[0].status == "PASS"
+        assert result[0].status == "MANUAL"
         assert "cloud-only" in result[0].status_extended
+        assert "No action is required" in result[0].status_extended
 
     def test_missing_settings_is_manual_for_hybrid_tenant(
         self, entra_client: mock.MagicMock


### PR DESCRIPTION
### Context

Hybrid Microsoft Entra tenants can allow an on-premises object to take over an existing cloud object through soft or hard matching. This adds the check requested in #11068.

Fix #11068

### Description

- expose `blockSoftMatchEnabled` and `blockCloudObjectTakeoverThroughHardMatchEnabled` from the existing Graph directory-sync response
- add `entra_directory_sync_object_takeover_blocked` with PASS/FAIL/MANUAL and cloud-only handling
- identify exactly which takeover path remains unblocked
- add check metadata, remediation guidance, changelog entry, and focused tests

No new Microsoft Graph permission is required; this reuses the existing directory-sync request.

### Steps to review

1. Review the two new `DirectorySyncSettings` fields and Graph mapping.
2. Review PASS when both blocks are enabled and FAIL when either is disabled.
3. Review MANUAL for hybrid tenants when settings cannot be read or are unexpectedly absent.
4. Run:

```bash
pytest -q tests/providers/m365/services/entra/entra_directory_sync_object_takeover_blocked tests/providers/m365/services/entra/microsoft365_entra_service_test.py
```

Local result: 22 passed.

### Checklist

- [x] The feature is listed in #11068 and implementation intent was posted before work began.
- [x] Code is covered by focused tests.
- [x] New check metadata and SDK changelog entry are included.
- [x] No provider permission change is required.
- [x] Black, Flake8, Bandit on the new check, and metadata JSON validation pass.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Microsoft Entra (M365) check for hybrid tenants to verify directory sync object takeover blocking is enabled for both soft-match and hard-match protections.

* **Documentation**
  * Updated the changelog and included remediation guidance for enabling the required takeover protection settings.

* **Tests**
  * Added unit tests validating pass/fail outcomes, hybrid vs cloud-only “not applicable” behavior, permission/error handling, and correct parsing of the takeover protection feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->