### PR TITLE
fix(ui): extend integration poll timeouts to 60s

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Compliance page now loads the most recent scan when opened from the sidebar instead of showing the "no compliance data available" alert [(#11374)](https://github.com/prowler-cloud/prowler/pull/11374)
 - Invitation links now show specific expired, no-longer-valid, and invalid-token messages based on API error responses [(#11376)](https://github.com/prowler-cloud/prowler/pull/11376)
+- Jira integration no longer shows a false timeout for dispatch tasks running longer than 20 seconds; the poll window now extends to 60 seconds [(#11519)](https://github.com/prowler-cloud/prowler/pull/11519)
 
 ### 🔐 Security
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - Compliance page now loads the most recent scan when opened from the sidebar instead of showing the "no compliance data available" alert [(#11374)](https://github.com/prowler-cloud/prowler/pull/11374)
 - Invitation links now show specific expired, no-longer-valid, and invalid-token messages based on API error responses [(#11376)](https://github.com/prowler-cloud/prowler/pull/11376)
-- Jira integration no longer shows a false timeout for dispatch tasks running longer than 20 seconds; the poll window now extends to 60 seconds [(#11519)](https://github.com/prowler-cloud/prowler/pull/11519)
+- Jira dispatch and provider connection-test polling no longer show a false timeout for longer-running tasks; both poll windows now extend to 60 seconds [(#11519)](https://github.com/prowler-cloud/prowler/pull/11519)
 
 ### 🔐 Security
 

--- a/ui/actions/integrations/integrations.ts
+++ b/ui/actions/integrations/integrations.ts
@@ -286,7 +286,7 @@ const pollTaskUntilComplete = async (
   taskId: string,
 ): Promise<PollConnectionResult> => {
   const settled = await pollTaskUntilSettled<ConnectionTaskResult>(taskId, {
-    maxAttempts: 10,
+    maxAttempts: 20,
     delayMs: 3000,
   });
 

--- a/ui/actions/integrations/jira-dispatch.ts
+++ b/ui/actions/integrations/jira-dispatch.ts
@@ -148,7 +148,7 @@ export const pollJiraDispatchTask = async (
   { success: true; message: string } | { success: false; error: string }
 > => {
   const res = await pollTaskUntilSettled(taskId, {
-    maxAttempts: 10,
+    maxAttempts: 30,
     delayMs: 2000,
   });
   if (!res.ok) {


### PR DESCRIPTION
### Context

Two integration flows polled their backend tasks with a short, fixed window:

- **Jira dispatch** (`pollJiraDispatchTask`): 10 × 2s = ~20s
- **Provider connection test** (`pollTaskUntilComplete`): 10 × 3s = ~30s

When a task runs longer than its window, the client stops polling and surfaces a `Task timeout` error even though the backend task is still running and completes successfully. The message is misleading: the task did not fail, the client just stopped listening.

### Description

Extend both poll windows to 60 seconds total, keeping each `delayMs` unchanged:

- Jira dispatch: `maxAttempts` 10 → 30 (`delayMs: 2000`)
- Provider connection test: `maxAttempts` 10 → 20 (`delayMs: 3000`)

Note: a fixed timeout is still a bet — tasks slower than 60s would hit the same false timeout. A push-based (SSE/WebSocket) or async-status approach would remove the bet entirely, but is out of scope here.

### Steps to review

1. Trigger a Jira dispatch action that takes 20–60s to settle; confirm the UI waits for the real result instead of a `Task timeout` at ~20s.
2. Run a provider connection test that takes 30–60s to settle; confirm the same — no false timeout at ~30s.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.