### PR TITLE
fix(ui): prevent findings timeline axis overflow

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🐞 Fixed
 
-- Findings Severity Over Time chart Y-axis labels no longer overflow for large findings counts [(#PR)](https://github.com/prowler-cloud/prowler/pull/PR)
+- Findings Severity Over Time chart Y-axis labels no longer overflow for large findings counts [(#11545)](https://github.com/prowler-cloud/prowler/pull/11545)
 
 ---
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.30.1] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Findings Severity Over Time chart Y-axis labels no longer overflow for large findings counts [(#PR)](https://github.com/prowler-cloud/prowler/pull/PR)
+
+---
+
 ## [1.30.0] (Prowler v5.30.0)
 
 ### 🚀 Added

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.30.1] (Prowler UNRELEASED)
-
-### 🐞 Fixed
-
-- Findings Severity Over Time chart Y-axis labels no longer overflow for large findings counts [(#11545)](https://github.com/prowler-cloud/prowler/pull/11545)
-
----
-
 ## [1.30.0] (Prowler v5.30.0)
 
 ### 🚀 Added

--- a/ui/changelog.d/findings-timeline-y-axis.fixed.md
+++ b/ui/changelog.d/findings-timeline-y-axis.fixed.md
@@ -1,0 +1,1 @@
+Findings Severity Over Time chart Y-axis labels no longer overflow for large findings counts

--- a/ui/components/graphs/line-chart.test.tsx
+++ b/ui/components/graphs/line-chart.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { formatYAxisTick } from "./line-chart.utils";
+
+describe("formatYAxisTick", () => {
+  describe("when findings counts are large", () => {
+    it("should compact six-digit values so Y-axis labels do not overflow", () => {
+      // Given
+      const tickValue = 150000;
+
+      // When
+      const formattedValue = formatYAxisTick(tickValue);
+
+      // Then
+      expect(formattedValue).toBe("150K");
+    });
+
+    it("should compact million-scale values", () => {
+      // Given
+      const tickValue = 1200000;
+
+      // When
+      const formattedValue = formatYAxisTick(tickValue);
+
+      // Then
+      expect(formattedValue).toBe("1.2M");
+    });
+  });
+
+  describe("when findings counts are small", () => {
+    it("should keep values below 1000 readable without compact notation", () => {
+      // Given
+      const tickValue = 999;
+
+      // When
+      const formattedValue = formatYAxisTick(tickValue);
+
+      // Then
+      expect(formattedValue).toBe("999");
+    });
+  });
+});

--- a/ui/components/graphs/line-chart.tsx
+++ b/ui/components/graphs/line-chart.tsx
@@ -17,6 +17,7 @@ import {
   ChartTooltip,
 } from "@/components/ui/chart/Chart";
 
+import { formatYAxisTick } from "./line-chart.utils";
 import { AlertPill } from "./shared/alert-pill";
 import { ChartLegend } from "./shared/chart-legend";
 import { CustomActiveDot, PointClickData } from "./shared/custom-active-dot";
@@ -222,6 +223,8 @@ export function LineChart({
             tickLine={false}
             axisLine={false}
             tickMargin={8}
+            tickFormatter={formatYAxisTick}
+            width={56}
             padding={{ top: 20 }}
             tick={{
               fill: "var(--color-text-neutral-secondary)",

--- a/ui/components/graphs/line-chart.utils.ts
+++ b/ui/components/graphs/line-chart.utils.ts
@@ -1,0 +1,8 @@
+const Y_AXIS_TICK_FORMATTER = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+export function formatYAxisTick(value: number) {
+  return Y_AXIS_TICK_FORMATTER.format(value);
+}


### PR DESCRIPTION
### Context

The Findings Severity Over Time chart could visually break for tenants with six-digit findings counts because the Y-axis rendered raw large tick labels.

### Description

- Compact large Y-axis labels in the shared line chart, e.g. `150000` renders as `150K`.
- Reserve stable Y-axis width for readable chart layout.
- Add unit coverage for large and small tick values.


### Desktop preview

![Findings Severity Over Time chart with compact Y-axis labels](https://tmpfiles.org/dl/w3w8camYBMS3/prowler-pr-11545-findings-severity-over-time.png)

### Steps to review

1. Review the Findings Severity Over Time chart with a dataset above 100k findings.
2. Confirm the Y-axis labels render compact values and no longer overflow.
3. Run:
   - `cd ui && pnpm test:unit components/graphs/line-chart.test.tsx`
   - `cd ui && pnpm run typecheck`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. N/A, no dependency changes.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API. N/A
- [x] Endpoint response output (if applicable). N/A
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable). N/A
- [x] Performance test results (if applicable). N/A
- [x] Any other relevant evidence of the implementation (if applicable). N/A
- [x] Verify if API specs need to be regenerated. N/A
- [x] Check if version updates are required (e.g., specs, uv, etc.). N/A
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Y-axis labels on the “Findings Severity Over Time” chart.
  * Large finding counts are now displayed in a compact format, preventing label overflow.

* **Tests**
  * Added coverage for compact formatting of large values and unchanged display of smaller values.

* **Documentation**
  * Added a changelog entry describing the chart label improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->