### PR TITLE
feat(stackit): add iaas_server_public_ip_attached check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `exchange_mailbox_primary_smtp_uses_custom_domain` check for M365 provider [(#11215)](https://github.com/prowler-cloud/prowler/pull/11215)
 - `bedrock_agent_role_least_privilege` check for AWS provider, flagging Bedrock Agent execution roles with full-access managed policies, broad `Resource:*` inline statements, or missing permissions boundaries [(#11335)](https://github.com/prowler-cloud/prowler/pull/11335)
 - STACKIT ObjectStorage service with Object Lock, default retention policy, and access key expiration checks [(#11397)](https://github.com/prowler-cloud/prowler/pull/11397)
-- `iaas_server_public_ip_attached` check for STACKIT provider, flagging IaaS servers that have a public IP address directly attached to a network interface [(#11541)](https://github.com/prowler-cloud/prowler/pull/11541)
+- `iaas_server_public_ip_attached` check for STACKIT provider, flagging IaaS servers that have a public IP address directly attached to a network interface [(#11549)](https://github.com/prowler-cloud/prowler/pull/11549)
 
 ### 🐞 Fixed
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `exchange_mailbox_primary_smtp_uses_custom_domain` check for M365 provider [(#11215)](https://github.com/prowler-cloud/prowler/pull/11215)
 - `bedrock_agent_role_least_privilege` check for AWS provider, flagging Bedrock Agent execution roles with full-access managed policies, broad `Resource:*` inline statements, or missing permissions boundaries [(#11335)](https://github.com/prowler-cloud/prowler/pull/11335)
 - STACKIT ObjectStorage service with Object Lock, default retention policy, and access key expiration checks [(#11397)](https://github.com/prowler-cloud/prowler/pull/11397)
+- `iaas_server_public_ip_attached` check for STACKIT provider, flagging IaaS servers that have a public IP address directly attached to a network interface [(#11541)](https://github.com/prowler-cloud/prowler/pull/11541)
 
 ### 🐞 Fixed
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -22,7 +22,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - `exchange_mailbox_primary_smtp_uses_custom_domain` check for M365 provider [(#11215)](https://github.com/prowler-cloud/prowler/pull/11215)
 - `bedrock_agent_role_least_privilege` check for AWS provider, flagging Bedrock Agent execution roles with full-access managed policies, broad `Resource:*` inline statements, or missing permissions boundaries [(#11335)](https://github.com/prowler-cloud/prowler/pull/11335)
 - STACKIT ObjectStorage service with Object Lock, default retention policy, and access key expiration checks [(#11397)](https://github.com/prowler-cloud/prowler/pull/11397)
-- `iaas_server_public_ip_attached` check for STACKIT provider, flagging IaaS servers that have a public IP address directly attached to a network interface [(#11549)](https://github.com/prowler-cloud/prowler/pull/11549)
 
 ### 🐞 Fixed
 

--- a/prowler/changelog.d/iaas-server-public-ip-attached.added.md
+++ b/prowler/changelog.d/iaas-server-public-ip-attached.added.md
@@ -1,0 +1,1 @@
+`iaas_server_public_ip_attached` check for STACKIT provider, flagging IaaS servers that have a public IP address directly attached to a network interface

--- a/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.metadata.json
+++ b/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.metadata.json
@@ -1,0 +1,37 @@
+{
+  "Provider": "stackit",
+  "CheckID": "iaas_server_public_ip_attached",
+  "CheckTitle": "IaaS servers do not have public IP addresses directly attached",
+  "CheckType": [],
+  "ServiceName": "iaas",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "medium",
+  "ResourceType": "NotDefined",
+  "ResourceGroup": "network",
+  "Description": "Servers should not have public IP addresses directly attached to their network interfaces unless strictly required. A public IP exposes the server to inbound traffic from the internet on all ports not blocked by a security group, increasing the attack surface.",
+  "Risk": "A server with a directly attached public IP is reachable from the internet. Combined with overly permissive security group rules, this can lead to unauthorized access, data exfiltration, or server compromise.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.stackit.cloud/products/network/core-networking/public-ip-address/",
+    "https://docs.stackit.cloud/products/network/core-networking/security-groups/"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. In the StackIT Portal open Networking > Public IPs and identify the IP attached to the affected server's network interface. 2. Detach the public IP from the server. 3. Use a load balancer for internet-facing workloads or a bastion host / VPN for administrative access. 4. Re-run Prowler to confirm the finding is resolved.",
+      "Terraform": ""
+    },
+    "Recommendation": {
+      "Text": "Remove the directly attached public IP and route internet traffic through a load balancer, bastion host, or VPN instead.",
+      "Url": "https://hub.prowler.com/check/iaas_server_public_ip_attached"
+    }
+  },
+  "Categories": [
+    "internet-exposed"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "This check flags servers that have a public IP attached directly to a NIC. Evaluate whether internet exposure is intentional and whether appropriate security groups are in place."
+}

--- a/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.metadata.json
+++ b/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.metadata.json
@@ -10,7 +10,7 @@
   "ResourceType": "NotDefined",
   "ResourceGroup": "network",
   "Description": "Servers should not have public IP addresses directly attached to their network interfaces unless strictly required. A public IP exposes the server to inbound traffic from the internet on all ports not blocked by a security group, increasing the attack surface.",
-  "Risk": "A server with a directly attached public IP is reachable from the internet. Combined with overly permissive security group rules, this can lead to unauthorized access, data exfiltration, or server compromise.",
+  "Risk": "**Direct internet exposure.** A server with a directly attached public IP can be reached from the internet. If its security groups allow broad inbound traffic, this exposure can enable unauthorized access, data exfiltration, or server compromise.",
   "RelatedUrl": "",
   "AdditionalURLs": [
     "https://docs.stackit.cloud/products/network/core-networking/public-ip-address/",
@@ -24,7 +24,7 @@
       "Terraform": ""
     },
     "Recommendation": {
-      "Text": "Remove the directly attached public IP and route internet traffic through a load balancer, bastion host, or VPN instead.",
+      "Text": "**Remove direct public exposure.** Detach the public IP from the server network interface unless it is strictly required. Route internet-facing workloads through a load balancer, and use a bastion host or VPN for administrative access.",
       "Url": "https://hub.prowler.com/check/iaas_server_public_ip_attached"
     }
   },

--- a/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.py
+++ b/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.py
@@ -1,0 +1,29 @@
+from prowler.lib.check.models import Check, CheckReportStackIT
+from prowler.providers.stackit.services.iaas.iaas_client import iaas_client
+
+
+class iaas_server_public_ip_attached(Check):
+    def execute(self):
+        findings = []
+
+        for server in iaas_client.servers:
+            report = CheckReportStackIT(
+                metadata=self.metadata(),
+                resource=server,
+            )
+
+            if server.has_public_ip:
+                report.status = "FAIL"
+                report.status_extended = (
+                    f"Server {server.name} has a public IP address directly attached, "
+                    f"exposing it to the internet."
+                )
+            else:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Server {server.name} does not have a public IP address attached."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.py
+++ b/prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached.py
@@ -3,7 +3,21 @@ from prowler.providers.stackit.services.iaas.iaas_client import iaas_client
 
 
 class iaas_server_public_ip_attached(Check):
+    """
+    Check if IaaS servers have public IP addresses directly attached.
+
+    This check verifies that servers do not have a public IP address
+    directly attached to their network interfaces, which would expose
+    them to inbound traffic from the internet.
+    """
+
     def execute(self):
+        """
+        Execute the check for all servers in the StackIT project.
+
+        Returns:
+            list: A list of CheckReportStackIT findings
+        """
         findings = []
 
         for server in iaas_client.servers:

--- a/prowler/providers/stackit/services/iaas/iaas_service.py
+++ b/prowler/providers/stackit/services/iaas/iaas_service.py
@@ -39,6 +39,11 @@ class IaaSService:
         self.server_nics: list = []
         self.in_use_sg_ids: set[str] = set()
 
+        # Initialize server list and supporting indices
+        self.servers: list[Server] = []
+        self._nic_device_index: dict[str, str] = {}  # nic_id → server_id
+        self._public_ip_server_ids: set[str] = set()
+
         # Fetch resources from all regions
         self._fetch_all_regions()
         self._log_skipped_security_groups()
@@ -83,6 +88,8 @@ class IaaSService:
             try:
                 self._list_server_nics(client, region)
                 self._list_security_groups(client, region)
+                self._list_public_ips(client, region)
+                self._list_servers(client, region)
             except Exception as error:
                 if getattr(error, "status", None) == 404:
                     logger.info(
@@ -334,9 +341,94 @@ class IaaSService:
         used_sg_ids = self._get_used_security_group_ids(nics_list)
         self.in_use_sg_ids.update(used_sg_ids)
 
+        # Build nic_id → server_id index for public IP cross-reference
+        for nic in nics_list:
+            try:
+                nic_id = str(getattr(nic, "id", None) or "")
+                device = getattr(nic, "device", None)
+                if nic_id and device:
+                    self._nic_device_index[nic_id] = str(device)
+            except Exception as e:
+                logger.debug(f"Error indexing NIC device: {e}")
+                continue
+
         logger.info(
             f"Successfully listed {len(nics_list)} NICs in {region}. "
             f"Found {len(used_sg_ids)} security groups attached to NICs."
+        )
+
+    def _list_public_ips(self, client, region: str):
+        """
+        List all public IPs in the project and record which servers have one attached.
+
+        A public IP is considered attached to a server when its ``network_interface``
+        field (a NIC UUID) matches a NIC whose ``device`` field points to a server.
+        The result is stored in ``self._public_ip_server_ids`` so that
+        ``_list_servers`` can set ``has_public_ip`` when creating Server objects.
+        """
+        if not client:
+            logger.warning(
+                f"Cannot list public IPs in {region}: StackIT IaaS client not available"
+            )
+            return
+
+        response = self._handle_api_call(
+            client.list_public_ips, project_id=self.project_id, region=region
+        )
+        ips_list = self._extract_items(response, "list_public_ips")
+
+        for ip_data in ips_list:
+            try:
+                network_interface = getattr(ip_data, "network_interface", None)
+                if network_interface is None:
+                    continue
+                server_id = self._nic_device_index.get(str(network_interface))
+                if server_id:
+                    self._public_ip_server_ids.add(server_id)
+            except Exception as e:
+                logger.debug(f"Error processing public IP: {e}")
+                continue
+
+        logger.info(
+            f"Successfully listed {len(ips_list)} public IPs in {region}"
+        )
+
+    def _list_servers(self, client, region: str):
+        """
+        List all servers in the project and populate ``self.servers``.
+
+        ``has_public_ip`` is set to True for any server whose ID appears in
+        ``self._public_ip_server_ids`` (populated by ``_list_public_ips``).
+        """
+        if not client:
+            logger.warning(
+                f"Cannot list servers in {region}: StackIT IaaS client not available"
+            )
+            return
+
+        response = self._handle_api_call(
+            client.list_servers, project_id=self.project_id, region=region
+        )
+        servers_list = self._extract_items(response, "list_servers")
+
+        for server_data in servers_list:
+            try:
+                server_id = str(getattr(server_data, "id", "") or "")
+                server_name = getattr(server_data, "name", server_id) or server_id
+                server = Server(
+                    id=server_id,
+                    name=server_name,
+                    project_id=self.project_id,
+                    region=region,
+                    has_public_ip=server_id in self._public_ip_server_ids,
+                )
+                self.servers.append(server)
+            except Exception as e:
+                logger.error(f"Error processing server: {e}")
+                continue
+
+        logger.info(
+            f"Successfully listed {len(servers_list)} servers in {region}"
         )
 
     def _get_used_security_group_ids(self, nics_list) -> set[str]:
@@ -475,3 +567,22 @@ class SecurityGroup(BaseModel):
     region: str
     rules: list[SecurityGroupRule] = []
     in_use: bool = False
+
+
+class Server(BaseModel):
+    """
+    Represents a StackIT IaaS Server.
+
+    Attributes:
+        id: The unique identifier of the server
+        name: The name of the server
+        project_id: The StackIT project ID containing the server
+        region: The region where the server is located
+        has_public_ip: Whether a public IP is directly attached to any of the server's NICs
+    """
+
+    id: str
+    name: str
+    project_id: str
+    region: str
+    has_public_ip: bool = False

--- a/prowler/providers/stackit/services/iaas/iaas_service.py
+++ b/prowler/providers/stackit/services/iaas/iaas_service.py
@@ -125,6 +125,28 @@ class IaaSService:
         )
         return []
 
+    @staticmethod
+    def _get_item_field(item, *keys, default=None):
+        """Read a field from an SDK model (attribute) or a raw ``dict`` (key).
+
+        ``_extract_items`` already yields either SDK models or raw dicts, so the
+        correlation logic must read fields from both shapes. Multiple key aliases
+        are accepted so snake_case SDK attributes and camelCase API/dict keys are
+        both supported (e.g. ``network_interface`` / ``networkInterface``).
+        Returns the first non-None match, otherwise ``default``.
+        """
+        if isinstance(item, dict):
+            for key in keys:
+                value = item.get(key)
+                if value is not None:
+                    return value
+            return default
+        for key in keys:
+            value = getattr(item, key, None)
+            if value is not None:
+                return value
+        return default
+
     def _handle_api_call(self, api_function, *args, **kwargs):
         """
         Centralized API call handler with authentication error detection.
@@ -344,8 +366,8 @@ class IaaSService:
         # Build nic_id → server_id index for public IP cross-reference
         for nic in nics_list:
             try:
-                nic_id = str(getattr(nic, "id", None) or "")
-                device = getattr(nic, "device", None)
+                nic_id = str(self._get_item_field(nic, "id") or "")
+                device = self._get_item_field(nic, "device")
                 if nic_id and device:
                     self._nic_device_index[nic_id] = str(device)
             except Exception as e:
@@ -379,7 +401,9 @@ class IaaSService:
 
         for ip_data in ips_list:
             try:
-                network_interface = getattr(ip_data, "network_interface", None)
+                network_interface = self._get_item_field(
+                    ip_data, "network_interface", "networkInterface"
+                )
                 if network_interface is None:
                     continue
                 server_id = self._nic_device_index.get(str(network_interface))
@@ -411,8 +435,8 @@ class IaaSService:
 
         for server_data in servers_list:
             try:
-                server_id = str(getattr(server_data, "id", "") or "")
-                server_name = getattr(server_data, "name", server_id) or server_id
+                server_id = str(self._get_item_field(server_data, "id") or "")
+                server_name = self._get_item_field(server_data, "name") or server_id
                 server = Server(
                     id=server_id,
                     name=server_name,

--- a/prowler/providers/stackit/services/iaas/iaas_service.py
+++ b/prowler/providers/stackit/services/iaas/iaas_service.py
@@ -389,9 +389,7 @@ class IaaSService:
                 logger.debug(f"Error processing public IP: {e}")
                 continue
 
-        logger.info(
-            f"Successfully listed {len(ips_list)} public IPs in {region}"
-        )
+        logger.info(f"Successfully listed {len(ips_list)} public IPs in {region}")
 
     def _list_servers(self, client, region: str):
         """
@@ -427,9 +425,7 @@ class IaaSService:
                 logger.error(f"Error processing server: {e}")
                 continue
 
-        logger.info(
-            f"Successfully listed {len(servers_list)} servers in {region}"
-        )
+        logger.info(f"Successfully listed {len(servers_list)} servers in {region}")
 
     def _get_used_security_group_ids(self, nics_list) -> set[str]:
         """

--- a/tests/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached_test.py
+++ b/tests/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached_test.py
@@ -1,0 +1,114 @@
+from unittest import mock
+from uuid import uuid4
+
+from prowler.providers.stackit.services.iaas.iaas_service import Server
+from tests.providers.stackit.stackit_fixtures import (
+    STACKIT_PROJECT_ID,
+    set_mocked_stackit_provider,
+)
+
+
+class Test_iaas_server_public_ip_attached:
+    def _run_check(self, iaas_client):
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_stackit_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.stackit.services.iaas.iaas_service.IaaSService",
+                new=iaas_client,
+            ) as service_client,
+            mock.patch(
+                "prowler.providers.stackit.services.iaas.iaas_client.iaas_client",
+                new=service_client,
+            ),
+        ):
+            from prowler.providers.stackit.services.iaas.iaas_server_public_ip_attached.iaas_server_public_ip_attached import (
+                iaas_server_public_ip_attached,
+            )
+
+            check = iaas_server_public_ip_attached()
+            return check.execute()
+
+    def test_no_servers(self):
+        iaas_client = mock.MagicMock
+        iaas_client.servers = []
+
+        result = self._run_check(iaas_client)
+        assert len(result) == 0
+
+    def test_server_without_public_ip(self):
+        iaas_client = mock.MagicMock
+        server_id = str(uuid4())
+        server_name = "private-server"
+
+        iaas_client.servers = [
+            Server(
+                id=server_id,
+                name=server_name,
+                project_id=STACKIT_PROJECT_ID,
+                region="eu01",
+                has_public_ip=False,
+            )
+        ]
+
+        result = self._run_check(iaas_client)
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert result[0].status_extended == f"Server {server_name} does not have a public IP address attached."
+        assert result[0].resource_id == server_id
+        assert result[0].resource_name == server_name
+        assert result[0].location == "eu01"
+
+    def test_server_with_public_ip(self):
+        iaas_client = mock.MagicMock
+        server_id = str(uuid4())
+        server_name = "public-server"
+
+        iaas_client.servers = [
+            Server(
+                id=server_id,
+                name=server_name,
+                project_id=STACKIT_PROJECT_ID,
+                region="eu01",
+                has_public_ip=True,
+            )
+        ]
+
+        result = self._run_check(iaas_client)
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert "has a public IP address directly attached" in result[0].status_extended
+        assert result[0].resource_id == server_id
+        assert result[0].resource_name == server_name
+        assert result[0].location == "eu01"
+
+    def test_multiple_servers_mixed(self):
+        iaas_client = mock.MagicMock
+        private_id = str(uuid4())
+        public_id = str(uuid4())
+
+        iaas_client.servers = [
+            Server(
+                id=private_id,
+                name="private-server",
+                project_id=STACKIT_PROJECT_ID,
+                region="eu01",
+                has_public_ip=False,
+            ),
+            Server(
+                id=public_id,
+                name="public-server",
+                project_id=STACKIT_PROJECT_ID,
+                region="eu01",
+                has_public_ip=True,
+            ),
+        ]
+
+        result = self._run_check(iaas_client)
+        assert len(result) == 2
+
+        by_id = {r.resource_id: r for r in result}
+        assert by_id[private_id].status == "PASS"
+        assert by_id[public_id].status == "FAIL"

--- a/tests/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached_test.py
+++ b/tests/providers/stackit/services/iaas/iaas_server_public_ip_attached/iaas_server_public_ip_attached_test.py
@@ -56,7 +56,10 @@ class Test_iaas_server_public_ip_attached:
         result = self._run_check(iaas_client)
         assert len(result) == 1
         assert result[0].status == "PASS"
-        assert result[0].status_extended == f"Server {server_name} does not have a public IP address attached."
+        assert (
+            result[0].status_extended
+            == f"Server {server_name} does not have a public IP address attached."
+        )
         assert result[0].resource_id == server_id
         assert result[0].resource_name == server_name
         assert result[0].location == "eu01"

--- a/tests/providers/stackit/services/iaas/iaas_service_test.py
+++ b/tests/providers/stackit/services/iaas/iaas_service_test.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
 
@@ -32,6 +33,9 @@ class Test_IaaS_Service:
         assert isinstance(iaas_service.server_nics, list)
         assert isinstance(iaas_service.in_use_sg_ids, set)
         assert iaas_service.scan_unused_services is False
+        assert isinstance(iaas_service.servers, list)
+        assert isinstance(iaas_service._nic_device_index, dict)
+        assert isinstance(iaas_service._public_ip_server_ids, set)
 
     def test_service_project_id(self):
         """Test that the service correctly extracts project_id from provider."""
@@ -63,6 +67,8 @@ class Test_IaaS_Service:
             ("_list_server_nics", "list_project_nics"),
             ("_list_security_groups", "list_security_groups"),
             ("_list_security_group_rules", "list_security_group_rules"),
+            ("_list_public_ips", "list_public_ips"),
+            ("_list_servers", "list_servers"),
         ],
     )
     def test_list_methods_propagate_api_errors(self, method_name, client_method_name):
@@ -432,6 +438,9 @@ class Test_IaaS_Service_Fetch_All_Regions:
         service.security_groups = []
         service.server_nics = []
         service.in_use_sg_ids = set()
+        service.servers = []
+        service._nic_device_index = {}
+        service._public_ip_server_ids = set()
         return service
 
     def _good_client(self, sg_id="sg-eu01"):
@@ -439,6 +448,8 @@ class Test_IaaS_Service_Fetch_All_Regions:
         client.list_project_nics.return_value = {"items": []}
         client.list_security_groups.return_value = {"items": [{"id": sg_id}]}
         client.list_security_group_rules.return_value = {"items": []}
+        client.list_public_ips.return_value = {"items": []}
+        client.list_servers.return_value = {"items": []}
         return client
 
     def _missing_region_client(self):
@@ -513,3 +524,198 @@ class Test_IaaS_Service_Log_Skipped_Security_Groups:
         with caplog.at_level(logging.INFO):
             service._log_skipped_security_groups()
         assert "scan-unused-services" not in caplog.text
+
+
+class Test_IaaS_Service_NIC_Device_Index:
+    """NIC device index is built during _list_server_nics to enable
+    public IP → server cross-reference.
+    """
+
+    def _service(self):
+        from prowler.providers.stackit.stackit_provider import StackitProvider
+
+        service = object.__new__(IaaSService)
+        service.provider = MagicMock()
+        service.provider.handle_api_error = StackitProvider.handle_api_error
+        service.project_id = STACKIT_PROJECT_ID
+        service.server_nics = []
+        service.in_use_sg_ids = set()
+        service._nic_device_index = {}
+        return service
+
+    def test_nic_with_id_and_device_is_indexed(self):
+        service = self._service()
+        nic_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        device_id = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+        nic = MagicMock()
+        nic.id = nic_id
+        nic.device = device_id
+        nic.security_groups = []
+        client = MagicMock()
+        client.list_project_nics.return_value = {"items": [nic]}
+
+        service._list_server_nics(client, "eu01")
+
+        assert str(nic_id) in service._nic_device_index
+        assert service._nic_device_index[str(nic_id)] == str(device_id)
+
+    def test_nic_without_device_is_not_indexed(self):
+        service = self._service()
+        nic = MagicMock()
+        nic.id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        nic.device = None
+        nic.security_groups = []
+        client = MagicMock()
+        client.list_project_nics.return_value = {"items": [nic]}
+
+        service._list_server_nics(client, "eu01")
+
+        assert service._nic_device_index == {}
+
+
+class Test_IaaS_Service_PublicIps:
+    """Tests for _list_public_ips."""
+
+    def _service(self):
+        from prowler.providers.stackit.stackit_provider import StackitProvider
+
+        service = object.__new__(IaaSService)
+        service.provider = MagicMock()
+        service.provider.handle_api_error = StackitProvider.handle_api_error
+        service.project_id = STACKIT_PROJECT_ID
+        service._nic_device_index = {}
+        service._public_ip_server_ids = set()
+        return service
+
+    def test_unattached_ip_is_ignored(self):
+        service = self._service()
+        ip = MagicMock()
+        ip.network_interface = None
+        client = MagicMock()
+        client.list_public_ips.return_value = {"items": [ip]}
+
+        service._list_public_ips(client, "eu01")
+
+        assert service._public_ip_server_ids == set()
+
+    def test_attached_ip_with_known_nic_marks_server(self):
+        nic_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        server_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        service = self._service()
+        service._nic_device_index = {str(nic_id): server_id}
+        ip = MagicMock()
+        ip.network_interface = nic_id
+        client = MagicMock()
+        client.list_public_ips.return_value = {"items": [ip]}
+
+        service._list_public_ips(client, "eu01")
+
+        assert server_id in service._public_ip_server_ids
+
+    def test_attached_ip_with_unknown_nic_is_ignored(self):
+        service = self._service()
+        service._nic_device_index = {}
+        ip = MagicMock()
+        ip.network_interface = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        client = MagicMock()
+        client.list_public_ips.return_value = {"items": [ip]}
+
+        service._list_public_ips(client, "eu01")
+
+        assert service._public_ip_server_ids == set()
+
+
+class Test_IaaS_Service_Servers:
+    """Tests for _list_servers."""
+
+    def _service(self):
+        from prowler.providers.stackit.stackit_provider import StackitProvider
+
+        service = object.__new__(IaaSService)
+        service.provider = MagicMock()
+        service.provider.handle_api_error = StackitProvider.handle_api_error
+        service.project_id = STACKIT_PROJECT_ID
+        service.servers = []
+        service._public_ip_server_ids = set()
+        return service
+
+    def test_server_without_public_ip(self):
+        server_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        service = self._service()
+        server_data = MagicMock()
+        server_data.id = server_id
+        server_data.name = "my-server"
+        client = MagicMock()
+        client.list_servers.return_value = {"items": [server_data]}
+
+        service._list_servers(client, "eu01")
+
+        assert len(service.servers) == 1
+        assert service.servers[0].has_public_ip is False
+
+    def test_server_with_public_ip(self):
+        server_id = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        service = self._service()
+        service._public_ip_server_ids = {str(server_id)}
+        server_data = MagicMock()
+        server_data.id = server_id
+        server_data.name = "my-server"
+        client = MagicMock()
+        client.list_servers.return_value = {"items": [server_data]}
+
+        service._list_servers(client, "eu01")
+
+        assert len(service.servers) == 1
+        assert service.servers[0].has_public_ip is True
+
+    def test_empty_response(self):
+        service = self._service()
+        client = MagicMock()
+        client.list_servers.return_value = {"items": []}
+
+        service._list_servers(client, "eu01")
+
+        assert service.servers == []
+
+    def test_server_public_ip_detected_end_to_end(self):
+        """Full cross-reference: NIC → public IP → server flagged has_public_ip."""
+        from prowler.providers.stackit.stackit_provider import StackitProvider
+
+        nic_id = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+        server_id = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+
+        nic = MagicMock()
+        nic.id = nic_id
+        nic.device = server_id
+        nic.security_groups = []
+
+        ip = MagicMock()
+        ip.network_interface = nic_id
+
+        server_data = MagicMock()
+        server_data.id = server_id
+        server_data.name = "internet-server"
+
+        client = MagicMock()
+        client.list_project_nics.return_value = {"items": [nic]}
+        client.list_security_groups.return_value = {"items": []}
+        client.list_public_ips.return_value = {"items": [ip]}
+        client.list_servers.return_value = {"items": [server_data]}
+
+        service = object.__new__(IaaSService)
+        service.provider = MagicMock()
+        service.provider.handle_api_error = StackitProvider.handle_api_error
+        service.project_id = STACKIT_PROJECT_ID
+        service.scan_unused_services = False
+        service.regional_clients = {"eu01": client}
+        service.security_groups = []
+        service.server_nics = []
+        service.in_use_sg_ids = set()
+        service.servers = []
+        service._nic_device_index = {}
+        service._public_ip_server_ids = set()
+
+        service._fetch_all_regions()
+
+        assert len(service.servers) == 1
+        assert service.servers[0].has_public_ip is True

--- a/tests/providers/stackit/services/iaas/iaas_service_test.py
+++ b/tests/providers/stackit/services/iaas/iaas_service_test.py
@@ -572,6 +572,22 @@ class Test_IaaS_Service_NIC_Device_Index:
 
         assert service._nic_device_index == {}
 
+    def test_nic_indexing_error_is_skipped(self):
+        """A NIC that raises while reading its id is skipped, not fatal."""
+
+        class MalformedNIC:
+            @property
+            def id(self):
+                raise ValueError("malformed nic")
+
+        service = self._service()
+        client = MagicMock()
+        client.list_project_nics.return_value = {"items": [MalformedNIC()]}
+
+        service._list_server_nics(client, "eu01")
+
+        assert service._nic_device_index == {}
+
 
 class Test_IaaS_Service_PublicIps:
     """Tests for _list_public_ips."""
@@ -619,6 +635,30 @@ class Test_IaaS_Service_PublicIps:
         ip.network_interface = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
         client = MagicMock()
         client.list_public_ips.return_value = {"items": [ip]}
+
+        service._list_public_ips(client, "eu01")
+
+        assert service._public_ip_server_ids == set()
+
+    def test_list_public_ips_without_client_is_noop(self):
+        """A missing regional client is logged and skipped, not fatal."""
+        service = self._service()
+
+        service._list_public_ips(None, "eu01")
+
+        assert service._public_ip_server_ids == set()
+
+    def test_public_ip_processing_error_is_skipped(self):
+        """A public IP that raises while being read is skipped, not fatal."""
+
+        class MalformedIP:
+            @property
+            def network_interface(self):
+                raise ValueError("malformed public ip")
+
+        service = self._service()
+        client = MagicMock()
+        client.list_public_ips.return_value = {"items": [MalformedIP()]}
 
         service._list_public_ips(client, "eu01")
 
@@ -719,3 +759,27 @@ class Test_IaaS_Service_Servers:
 
         assert len(service.servers) == 1
         assert service.servers[0].has_public_ip is True
+
+    def test_list_servers_without_client_is_noop(self):
+        """A missing regional client is logged and skipped, not fatal."""
+        service = self._service()
+
+        service._list_servers(None, "eu01")
+
+        assert service.servers == []
+
+    def test_server_processing_error_is_skipped(self):
+        """A server that raises while being read is skipped, not fatal."""
+
+        class MalformedServer:
+            @property
+            def id(self):
+                raise ValueError("malformed server")
+
+        service = self._service()
+        client = MagicMock()
+        client.list_servers.return_value = {"items": [MalformedServer()]}
+
+        service._list_servers(client, "eu01")
+
+        assert service.servers == []

--- a/tests/providers/stackit/services/iaas/iaas_service_test.py
+++ b/tests/providers/stackit/services/iaas/iaas_service_test.py
@@ -588,6 +588,18 @@ class Test_IaaS_Service_NIC_Device_Index:
 
         assert service._nic_device_index == {}
 
+    def test_dict_shaped_nic_is_indexed(self):
+        """Raw dict NICs are indexed the same as SDK model NICs."""
+        service = self._service()
+        client = MagicMock()
+        client.list_project_nics.return_value = {
+            "items": [{"id": "nic-1", "device": "server-1", "security_groups": []}]
+        }
+
+        service._list_server_nics(client, "eu01")
+
+        assert service._nic_device_index == {"nic-1": "server-1"}
+
 
 class Test_IaaS_Service_PublicIps:
     """Tests for _list_public_ips."""
@@ -663,6 +675,17 @@ class Test_IaaS_Service_PublicIps:
         service._list_public_ips(client, "eu01")
 
         assert service._public_ip_server_ids == set()
+
+    def test_dict_shaped_public_ip_marks_server(self):
+        """Raw dict public IPs (camelCase networkInterface) mark the server."""
+        service = self._service()
+        service._nic_device_index = {"nic-1": "server-1"}
+        client = MagicMock()
+        client.list_public_ips.return_value = {"items": [{"networkInterface": "nic-1"}]}
+
+        service._list_public_ips(client, "eu01")
+
+        assert "server-1" in service._public_ip_server_ids
 
 
 class Test_IaaS_Service_Servers:
@@ -783,3 +806,54 @@ class Test_IaaS_Service_Servers:
         service._list_servers(client, "eu01")
 
         assert service.servers == []
+
+    def test_dict_shaped_server_is_created(self):
+        """Raw dict servers are created and flagged from _public_ip_server_ids."""
+        service = self._service()
+        service._public_ip_server_ids = {"server-1"}
+        client = MagicMock()
+        client.list_servers.return_value = {
+            "items": [{"id": "server-1", "name": "dict-server"}]
+        }
+
+        service._list_servers(client, "eu01")
+
+        assert len(service.servers) == 1
+        assert service.servers[0].name == "dict-server"
+        assert service.servers[0].has_public_ip is True
+
+    def test_dict_shaped_public_ip_detected_end_to_end(self):
+        """Dict-shaped NIC/IP/server still correlate to has_public_ip=True.
+
+        Regression for the getattr-only correlation path: a dict-shaped
+        response must not silently report a PASS for an exposed server.
+        """
+        from prowler.providers.stackit.stackit_provider import StackitProvider
+
+        client = MagicMock()
+        client.list_project_nics.return_value = {
+            "items": [{"id": "nic-1", "device": "server-1", "security_groups": []}]
+        }
+        client.list_security_groups.return_value = {"items": []}
+        client.list_public_ips.return_value = {"items": [{"networkInterface": "nic-1"}]}
+        client.list_servers.return_value = {
+            "items": [{"id": "server-1", "name": "dict-server"}]
+        }
+
+        service = object.__new__(IaaSService)
+        service.provider = MagicMock()
+        service.provider.handle_api_error = StackitProvider.handle_api_error
+        service.project_id = STACKIT_PROJECT_ID
+        service.scan_unused_services = False
+        service.regional_clients = {"eu01": client}
+        service.security_groups = []
+        service.server_nics = []
+        service.in_use_sg_ids = set()
+        service.servers = []
+        service._nic_device_index = {}
+        service._public_ip_server_ids = set()
+
+        service._fetch_all_regions()
+
+        assert len(service.servers) == 1
+        assert service.servers[0].has_public_ip is True


### PR DESCRIPTION
### Context

Adds the `iaas_server_public_ip_attached` check for the STACKIT provider. This check is part of the ongoing effort to build STACKIT IaaS coverage in Prowler.

### Description

Extends `IaaSService` to fetch servers and public IPs from all project regions, then cross-references them via NIC device indices to determine whether any server has a public IP directly attached to one of its network interfaces.

**New check:** `iaas_server_public_ip_attached`
- **Severity:** Medium
- **Service:** `iaas`
- **Resource group:** `network`
- **Category:** `internet-exposed`

The check flags servers whose NICs have a public IP attached, exposing them to inbound internet traffic outside of load-balancer or bastion-host patterns.

**Files changed:**
- `prowler/providers/stackit/services/iaas/iaas_service.py` — new `_list_servers`, `_list_public_ips` methods and NIC device-index build-up inside `_list_server_nics`
- `prowler/providers/stackit/services/iaas/iaas_server_public_ip_attached/` — check, metadata, `__init__`
- `tests/providers/stackit/services/iaas/iaas_server_public_ip_attached_test.py` — unit tests covering PASS, FAIL, and empty-server scenarios

### Steps to review

1. Check out the branch and run the unit tests:
   ```
   uv run pytest tests/providers/stackit/services/iaas/iaas_server_public_ip_attached_test.py -v
   ```
2. Inspect `iaas_service.py` — particularly `_list_public_ips` and `_list_servers` — to verify the NIC → server cross-reference logic.
3. Review the metadata JSON for accuracy (severity, remediation text, AdditionalURLs).

### Checklist

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? **Yes**
    - No permission changes required — uses existing STACKIT IaaS API credentials already configured for the provider.

#### UI
N/A

#### API
N/A

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a StackIT IaaS check that flags servers with a public IP directly attached as internet-exposed.

* **Tests**
  * Added unit tests covering no servers, servers without public IPs, servers with public IPs, and mixed scenarios.
  * Expanded service tests to validate public-IP discovery and correct server public-IP status reporting.

* **Chores**
  * Updated the changelog to include the new StackIT check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->