### PR TITLE
[CHAIN] fix(ui): apply review fixes for the HeroUI to shadcn migration

### DIFF
--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -187,7 +187,7 @@ test("action works", { tag: ["@critical", "@feature"] }, async ({ page }) => {
 Next.js 16.2.3 | React 19.2.5 | Tailwind 4.1.18 | shadcn/ui
 Zod 4.1.11 | React Hook Form 7.62.0 | Zustand 5.0.8 | NextAuth 5.0.0-beta.30 | Recharts 2.15.4
 
-> **Note**: HeroUI exists in `components/ui/` as legacy code. Do NOT add new components there.
+> **Note**: `components/ui/` only holds temporary re-export shims for the prowler-cloud overlay. Do NOT add new components there.
 
 ---
 
@@ -198,7 +198,7 @@ ui/
 ├── app/(auth)/          # Auth pages
 ├── app/(prowler)/       # Main app: compliance, findings, providers, scans
 ├── components/shadcn/   # shadcn/ui components (USE THIS)
-├── components/ui/       # HeroUI (LEGACY - do not add here)
+├── components/ui/       # Cloud-overlay re-export shims (do not add here)
 ├── actions/             # Server actions
 ├── types/               # Shared types
 ├── hooks/               # Shared hooks

--- a/ui/README.md
+++ b/ui/README.md
@@ -114,10 +114,9 @@ pnpm run dev
 
 ## Technologies Used
 
-- [Next.js 14](https://nextjs.org/docs/getting-started)
-- [NextUI v2](https://nextui.org/)
-- [Tailwind CSS](https://tailwindcss.com/)
-- [Tailwind Variants](https://tailwind-variants.org)
+- [Next.js 16](https://nextjs.org/docs/getting-started)
+- [shadcn/ui](https://ui.shadcn.com/) (built on [Radix UI](https://www.radix-ui.com/))
+- [Tailwind CSS 4](https://tailwindcss.com/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [Framer Motion](https://www.framer.com/motion/)
 - [next-themes](https://github.com/pacocoursey/next-themes)

--- a/ui/app/(auth)/layout.tsx
+++ b/ui/app/(auth)/layout.tsx
@@ -5,7 +5,7 @@ import { Metadata, Viewport } from "next";
 import { ReactNode, Suspense } from "react";
 
 import { NavigationProgress, Toaster } from "@/components/shadcn";
-import { fontSans } from "@/config/fonts";
+import { fontMono, fontSans } from "@/config/fonts";
 import { siteConfig } from "@/config/site";
 import { cn } from "@/lib";
 
@@ -38,6 +38,7 @@ export default function AuthLayout({ children }: { children: ReactNode }) {
         className={cn(
           "bg-bg-neutral-primary min-h-screen font-sans antialiased",
           fontSans.variable,
+          fontMono.variable,
         )}
       >
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>

--- a/ui/app/(prowler)/layout.tsx
+++ b/ui/app/(prowler)/layout.tsx
@@ -8,7 +8,7 @@ import { getProviders } from "@/actions/providers";
 import MainLayout from "@/components/layout/main-layout/main-layout";
 import { NavigationProgress } from "@/components/shadcn/navigation-progress";
 import { Toaster } from "@/components/shadcn/toast";
-import { fontSans } from "@/config/fonts";
+import { fontMono, fontSans } from "@/config/fonts";
 import { siteConfig } from "@/config/site";
 import { cn } from "@/lib/utils";
 import { StoreInitializer } from "@/store/ui/store-initializer";
@@ -52,6 +52,7 @@ export default async function RootLayout({
         className={cn(
           "bg-bg-neutral-primary min-h-screen font-sans antialiased",
           fontSans.variable,
+          fontMono.variable,
         )}
       >
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>

--- a/ui/components/auth/oss/sign-up-form.tsx
+++ b/ui/components/auth/oss/sign-up-form.tsx
@@ -226,6 +226,7 @@ export const SignUpForm = ({
                         Terms of Service
                       </CustomLink>
                       &nbsp;of Prowler
+                      <span className="text-text-error-primary">*</span>
                     </label>
                   </div>
                   <FormMessage className="text-text-error" />

--- a/ui/components/compliance/compliance-accordion/client-accordion-wrapper.tsx
+++ b/ui/components/compliance/compliance-accordion/client-accordion-wrapper.tsx
@@ -71,7 +71,7 @@ export const ClientAccordionWrapper = ({
     lastScrolledKeyRef.current = scrollToKey;
     // Two nested rAFs: the first lets the accordion children commit to
     // the DOM, the second lands after the browser has run a layout pass
-    // so HeroUI's framer-motion expand has settled enough for
+    // so the Collapsible CSS expand animation has settled enough for
     // scrollIntoView to read a stable offset.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {

--- a/ui/components/integrations/shared/link-card.tsx
+++ b/ui/components/integrations/shared/link-card.tsx
@@ -34,7 +34,7 @@ export const LinkCard = ({
       <CardHeader>
         <div className="flex w-full flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 dark:bg-zinc-800">
+            <div className="bg-bg-neutral-tertiary flex h-10 w-10 items-center justify-center rounded-lg">
               <Icon size={24} className="text-gray-700 dark:text-gray-200" />
             </div>
             <div className="flex flex-col gap-1">

--- a/ui/components/roles/workflow/forms/add-role-form.tsx
+++ b/ui/components/roles/workflow/forms/add-role-form.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import clsx from "clsx";
 import { InfoIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import { addRole } from "@/actions/roles/roles";
@@ -56,10 +55,13 @@ export const AddRoleForm = ({
     },
   });
 
-  const { watch, setValue } = form;
+  const { setValue } = form;
 
-  const manageProviders = watch("manage_providers");
-  const unlimitedVisibility = watch("unlimited_visibility");
+  // useWatch instead of form.watch: the React Compiler can't track watch()
+  // getter reads during render, leaving memoized JSX with stale values.
+  const formValues = useWatch({ control: form.control });
+  const manageProviders = formValues.manage_providers;
+  const unlimitedVisibility = formValues.unlimited_visibility;
 
   useEffect(() => {
     if (manageProviders && !unlimitedVisibility) {
@@ -172,8 +174,8 @@ export const AddRoleForm = ({
             <Checkbox
               id="select-all-permissions"
               size="sm"
-              checked={visiblePermissionFormFields.every((perm) =>
-                form.watch(perm.field as keyof FormValues),
+              checked={visiblePermissionFormFields.every(
+                (perm) => !!formValues[perm.field as keyof FormValues],
               )}
               onCheckedChange={(checked) => onSelectAllChange(checked === true)}
             />
@@ -189,11 +191,11 @@ export const AddRoleForm = ({
           <div className="grid grid-cols-2 gap-4">
             {visiblePermissionFormFields.map(
               ({ field, label, description }) => (
-                <div key={field} className="flex items-center gap-2">
+                <div key={field} className="group flex items-center gap-2">
                   <Checkbox
                     id={`permission-${field}`}
                     size="sm"
-                    checked={!!form.watch(field as keyof FormValues)}
+                    checked={!!formValues[field as keyof FormValues]}
                     onCheckedChange={(checked) =>
                       form.setValue(
                         field as keyof FormValues,
@@ -216,9 +218,7 @@ export const AddRoleForm = ({
                     <TooltipTrigger asChild>
                       <div className="flex w-fit items-center justify-center">
                         <InfoIcon
-                          className={clsx(
-                            "text-text-neutral-tertiary group-data-[selected=true]:text-text-neutral-primary cursor-pointer",
-                          )}
+                          className="text-text-neutral-tertiary group-has-[[data-state=checked]]:text-text-neutral-primary cursor-pointer"
                           aria-hidden={"true"}
                           width={16}
                         />

--- a/ui/components/roles/workflow/forms/edit-role-form.tsx
+++ b/ui/components/roles/workflow/forms/edit-role-form.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { clsx } from "clsx";
 import { InfoIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { z } from "zod";
 
 import { updateRole } from "@/actions/roles/roles";
@@ -62,10 +61,13 @@ export const EditRoleForm = ({
     },
   });
 
-  const { watch, setValue } = form;
+  const { setValue } = form;
 
-  const manageProviders = watch("manage_providers");
-  const unlimitedVisibility = watch("unlimited_visibility");
+  // useWatch instead of form.watch: the React Compiler can't track watch()
+  // getter reads during render, leaving memoized JSX with stale values.
+  const formValues = useWatch({ control: form.control });
+  const manageProviders = formValues.manage_providers;
+  const unlimitedVisibility = formValues.unlimited_visibility;
 
   useEffect(() => {
     if (manageProviders && !unlimitedVisibility) {
@@ -192,8 +194,8 @@ export const EditRoleForm = ({
             <Checkbox
               id="select-all-permissions"
               size="sm"
-              checked={visiblePermissionFormFields.every((perm) =>
-                form.watch(perm.field as keyof FormValues),
+              checked={visiblePermissionFormFields.every(
+                (perm) => !!formValues[perm.field as keyof FormValues],
               )}
               onCheckedChange={(checked) => onSelectAllChange(checked === true)}
             />
@@ -209,11 +211,11 @@ export const EditRoleForm = ({
           <div className="grid grid-cols-2 gap-4">
             {visiblePermissionFormFields.map(
               ({ field, label, description }) => (
-                <div key={field} className="flex items-center gap-2">
+                <div key={field} className="group flex items-center gap-2">
                   <Checkbox
                     id={`permission-${field}`}
                     size="sm"
-                    checked={!!form.watch(field as keyof FormValues)}
+                    checked={!!formValues[field as keyof FormValues]}
                     onCheckedChange={(checked) =>
                       form.setValue(
                         field as keyof FormValues,
@@ -236,9 +238,7 @@ export const EditRoleForm = ({
                     <TooltipTrigger asChild>
                       <div className="flex w-fit items-center justify-center">
                         <InfoIcon
-                          className={clsx(
-                            "text-text-neutral-tertiary group-data-[selected=true]:text-text-neutral-primary cursor-pointer",
-                          )}
+                          className="text-text-neutral-tertiary group-has-[[data-state=checked]]:text-text-neutral-primary cursor-pointer"
                           aria-hidden={"true"}
                           width={16}
                         />

--- a/ui/components/shadcn/accordion/Accordion.test.tsx
+++ b/ui/components/shadcn/accordion/Accordion.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Accordion, AccordionItemProps } from "./Accordion";
+
+const buildItems = (): AccordionItemProps[] => [
+  { key: "first", title: "First item", content: "First content" },
+  { key: "second", title: "Second item", content: "Second content" },
+];
+
+describe("Accordion", () => {
+  describe("when uncontrolled", () => {
+    it("should expand an item when its trigger is clicked", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(<Accordion items={buildItems()} />);
+      expect(screen.queryByText("First content")).not.toBeInTheDocument();
+
+      // When
+      await user.click(screen.getByRole("button", { name: "First item" }));
+
+      // Then
+      expect(screen.getByText("First content")).toBeVisible();
+    });
+
+    it("should collapse an expanded item when its trigger is clicked again", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(
+        <Accordion items={buildItems()} defaultExpandedKeys={["first"]} />,
+      );
+      expect(screen.getByText("First content")).toBeVisible();
+
+      // When
+      await user.click(screen.getByRole("button", { name: "First item" }));
+
+      // Then
+      expect(screen.queryByText("First content")).not.toBeInTheDocument();
+    });
+
+    it("should collapse siblings in single selection mode", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(
+        <Accordion
+          items={buildItems()}
+          selectionMode="single"
+          defaultExpandedKeys={["first"]}
+        />,
+      );
+
+      // When
+      await user.click(screen.getByRole("button", { name: "Second item" }));
+
+      // Then
+      expect(screen.getByText("Second content")).toBeVisible();
+      expect(screen.queryByText("First content")).not.toBeInTheDocument();
+    });
+
+    it("should keep siblings expanded in multiple selection mode", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(
+        <Accordion
+          items={buildItems()}
+          selectionMode="multiple"
+          defaultExpandedKeys={["first"]}
+        />,
+      );
+
+      // When
+      await user.click(screen.getByRole("button", { name: "Second item" }));
+
+      // Then
+      expect(screen.getByText("First content")).toBeVisible();
+      expect(screen.getByText("Second content")).toBeVisible();
+    });
+
+    it("should not expand a disabled item", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(
+        <Accordion
+          items={[
+            {
+              key: "locked",
+              title: "Locked item",
+              content: "Locked content",
+              isDisabled: true,
+            },
+          ]}
+        />,
+      );
+
+      // When
+      await user.click(screen.getByRole("button", { name: "Locked item" }));
+
+      // Then
+      expect(screen.queryByText("Locked content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when controlled", () => {
+    it("should reflect the selectedKeys prop and report changes through onSelectionChange", async () => {
+      // Given
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+      const ControlledAccordion = () => {
+        const [keys, setKeys] = useState<string[]>([]);
+        return (
+          <Accordion
+            items={buildItems()}
+            selectionMode="multiple"
+            selectedKeys={keys}
+            onSelectionChange={(next) => {
+              onSelectionChange(next);
+              setKeys(next);
+            }}
+          />
+        );
+      };
+      render(<ControlledAccordion />);
+
+      // When
+      await user.click(screen.getByRole("button", { name: "First item" }));
+
+      // Then
+      expect(onSelectionChange).toHaveBeenCalledWith(["first"]);
+      expect(screen.getByText("First content")).toBeVisible();
+
+      // When the item is toggled off
+      await user.click(screen.getByRole("button", { name: "First item" }));
+
+      // Then
+      expect(onSelectionChange).toHaveBeenLastCalledWith([]);
+      expect(screen.queryByText("First content")).not.toBeInTheDocument();
+    });
+
+    it("should not expand items on click when the parent ignores selection changes", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(<Accordion items={buildItems()} selectedKeys={[]} />);
+
+      // When
+      await user.click(screen.getByRole("button", { name: "First item" }));
+
+      // Then
+      expect(screen.queryByText("First content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when items are nested", () => {
+    it("should render nested accordions sharing the controlled selection", async () => {
+      // Given
+      const user = userEvent.setup();
+      const ControlledAccordion = () => {
+        const [keys, setKeys] = useState<string[]>(["parent"]);
+        return (
+          <Accordion
+            items={[
+              {
+                key: "parent",
+                title: "Parent item",
+                content: "Parent content",
+                items: [
+                  {
+                    key: "child",
+                    title: "Child item",
+                    content: "Child content",
+                  },
+                ],
+              },
+            ]}
+            selectionMode="multiple"
+            selectedKeys={keys}
+            onSelectionChange={setKeys}
+          />
+        );
+      };
+      render(<ControlledAccordion />);
+      expect(screen.getByText("Parent content")).toBeVisible();
+
+      // When
+      await user.click(screen.getByRole("button", { name: "Child item" }));
+
+      // Then both levels stay expanded
+      expect(screen.getByText("Parent content")).toBeVisible();
+      expect(screen.getByText("Child content")).toBeVisible();
+    });
+  });
+});

--- a/ui/components/shadcn/accordion/Accordion.tsx
+++ b/ui/components/shadcn/accordion/Accordion.tsx
@@ -49,10 +49,10 @@ const AccordionContent = ({
     : content;
 
   return (
-    <div className="text-sm text-gray-700 dark:text-gray-300">
+    <div className="text-text-neutral-secondary text-sm">
       {normalizedContent}
       {items && items.length > 0 && (
-        <div className="mt-4 ml-2 border-l-2 border-gray-200 pl-4 dark:border-gray-700">
+        <div className="border-border-neutral-secondary mt-4 ml-2 border-l-2 pl-4">
           <Accordion
             items={items}
             variant="light"
@@ -141,13 +141,15 @@ export const Accordion = ({
                 <div className="flex-1 text-left">
                   <div className="text-sm">{item.title}</div>
                   {item.subtitle && (
-                    <div className="text-xs text-gray-500">{item.subtitle}</div>
+                    <div className="text-text-neutral-tertiary text-xs">
+                      {item.subtitle}
+                    </div>
                   )}
                 </div>
                 <ChevronDown
                   aria-hidden="true"
                   className={cn(
-                    "shrink-0 text-gray-500 transition-transform duration-200",
+                    "text-text-neutral-tertiary shrink-0 transition-transform duration-200",
                     isExpanded && "rotate-180",
                   )}
                 />

--- a/ui/components/shadcn/code-snippet/code-snippet.test.tsx
+++ b/ui/components/shadcn/code-snippet/code-snippet.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { CodeSnippet } from "./code-snippet";
+
+describe("CodeSnippet", () => {
+  it("should display the value and copy it to the clipboard", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<CodeSnippet value="prowler --version" />);
+    expect(screen.getByText("prowler --version")).toBeInTheDocument();
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Copy to clipboard" }));
+
+    // Then
+    await expect(navigator.clipboard.readText()).resolves.toBe(
+      "prowler --version",
+    );
+  });
+
+  it("should copy the raw value even when a formatter changes the displayed text", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(
+      <CodeSnippet
+        value="arn:aws:iam::123456789012:role/prowler"
+        formatter={(value) => value.slice(0, 10)}
+      />,
+    );
+    expect(screen.getByText("arn:aws:ia")).toBeInTheDocument();
+
+    // When
+    await user.click(screen.getByRole("button", { name: "Copy to clipboard" }));
+
+    // Then
+    await expect(navigator.clipboard.readText()).resolves.toBe(
+      "arn:aws:iam::123456789012:role/prowler",
+    );
+  });
+
+  it("should render only the copy button when hideCode is set", async () => {
+    // Given
+    const user = userEvent.setup();
+    render(<CodeSnippet value="secret-token" hideCode />);
+
+    // Then the value is not displayed but copying still works
+    expect(screen.queryByText("secret-token")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Copy to clipboard" }));
+    await expect(navigator.clipboard.readText()).resolves.toBe("secret-token");
+  });
+
+  describe("copy feedback", () => {
+    it("should show the check icon after copying and revert after two seconds", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(<CodeSnippet value="copied-value" />);
+      const copyButton = screen.getByRole("button", {
+        name: "Copy to clipboard",
+      });
+      expect(copyButton.querySelector(".lucide-copy")).not.toBeNull();
+
+      // When
+      await user.click(copyButton);
+
+      // Then the confirmation icon replaces the copy icon
+      await waitFor(() =>
+        expect(copyButton.querySelector(".lucide-check")).not.toBeNull(),
+      );
+      expect(copyButton.querySelector(".lucide-copy")).toBeNull();
+
+      // Then the copy icon is restored once the 2s reset timeout elapses
+      await waitFor(
+        () => expect(copyButton.querySelector(".lucide-copy")).not.toBeNull(),
+        { timeout: 3000 },
+      );
+      expect(copyButton.querySelector(".lucide-check")).toBeNull();
+    });
+  });
+});

--- a/ui/components/shadcn/code-snippet/code-snippet.tsx
+++ b/ui/components/shadcn/code-snippet/code-snippet.tsx
@@ -50,21 +50,6 @@ export const CodeSnippet = ({
 
   const displayValue = formatter ? formatter(value) : value;
 
-  const CopyButton = () => (
-    <button
-      type="button"
-      onClick={handleCopy}
-      className="text-text-neutral-secondary hover:text-text-neutral-primary shrink-0 cursor-pointer transition-colors"
-      aria-label={ariaLabel}
-    >
-      {copied ? (
-        <Check className="h-3.5 w-3.5" />
-      ) : (
-        <Copy className="h-3.5 w-3.5" />
-      )}
-    </button>
-  );
-
   // When hideCode is true, render only the copy button without container styling
   if (hideCode) {
     return (
@@ -116,7 +101,20 @@ export const CodeSnippet = ({
           <TooltipContent side="top">{value}</TooltipContent>
         </Tooltip>
       )}
-      {!hideCopyButton && <CopyButton />}
+      {!hideCopyButton && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="text-text-neutral-secondary hover:text-text-neutral-primary shrink-0 cursor-pointer transition-colors"
+          aria-label={ariaLabel}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      )}
     </div>
   );
 };

--- a/ui/components/shadcn/custom/custom-input.test.tsx
+++ b/ui/components/shadcn/custom/custom-input.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { Form } from "@/components/shadcn/form";
+
+import { CustomInput } from "./custom-input";
+
+interface TestFormValues {
+  password: string;
+  email: string;
+}
+
+const TestForm = ({
+  password = false,
+  isRequired,
+}: {
+  password?: boolean;
+  isRequired?: boolean;
+}) => {
+  const form = useForm<TestFormValues>({
+    defaultValues: { password: "", email: "" },
+  });
+
+  return (
+    <Form {...form}>
+      <CustomInput
+        control={form.control}
+        name={password ? "password" : "email"}
+        label="Email"
+        password={password}
+        {...(isRequired !== undefined && { isRequired })}
+      />
+    </Form>
+  );
+};
+
+describe("CustomInput", () => {
+  describe("when used as a password field", () => {
+    it("should mask the value by default", () => {
+      // Given
+      render(<TestForm password />);
+
+      // Then
+      expect(screen.getByLabelText(/^password/i)).toHaveAttribute(
+        "type",
+        "password",
+      );
+    });
+
+    it("should reveal and re-mask the value with the visibility toggle", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(<TestForm password />);
+      const input = screen.getByLabelText(/^password/i);
+      await user.type(input, "hunter2");
+
+      // When the user shows the password
+      await user.click(screen.getByRole("button", { name: "Show password" }));
+
+      // Then the value becomes readable and the toggle flips
+      expect(input).toHaveAttribute("type", "text");
+      expect(input).toHaveValue("hunter2");
+
+      // When the user hides it again
+      await user.click(screen.getByRole("button", { name: "Hide password" }));
+
+      // Then
+      expect(input).toHaveAttribute("type", "password");
+    });
+  });
+
+  describe("when used as a regular field", () => {
+    it("should keep the provided type and accept user input", async () => {
+      // Given
+      const user = userEvent.setup();
+      render(<TestForm />);
+      const input = screen.getByLabelText(/email/i);
+
+      // When
+      await user.type(input, "dev@prowler.com");
+
+      // Then
+      expect(input).toHaveAttribute("type", "text");
+      expect(input).toHaveValue("dev@prowler.com");
+      expect(
+        screen.queryByRole("button", { name: /password/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should hide the required indicator when isRequired is false", () => {
+      // Given
+      render(<TestForm isRequired={false} />);
+
+      // Then
+      expect(screen.queryByText("*")).not.toBeInTheDocument();
+      expect(screen.getByLabelText(/email/i)).not.toBeRequired();
+    });
+  });
+});

--- a/ui/components/shadcn/dropdown-menu/dropdown-menu.tsx
+++ b/ui/components/shadcn/dropdown-menu/dropdown-menu.tsx
@@ -167,7 +167,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-zinc-200", className)}
+    className={cn("bg-border-neutral-secondary -mx-1 my-1 h-px", className)}
     {...props}
   />
 ));

--- a/ui/components/shadcn/headers/navigation-header.tsx
+++ b/ui/components/shadcn/headers/navigation-header.tsx
@@ -17,16 +17,16 @@ export const NavigationHeader = ({
 }: NavigationHeaderProps) => {
   return (
     <>
-      <header className="flex items-center gap-3 border-b border-gray-200 px-6 py-4 dark:border-gray-800">
+      <header className="border-border-neutral-secondary flex items-center gap-3 border-b px-6 py-4">
         <Button
-          className="border-gray-200 bg-transparent p-0"
+          className="border-border-neutral-secondary bg-transparent p-0"
           aria-label="Navigation button"
           variant="outline"
           size="icon"
           asChild
         >
           <Link href={href || ""}>
-            <Icon icon={icon} className="text-gray-600 dark:text-gray-400" />
+            <Icon icon={icon} className="text-text-neutral-secondary" />
           </Link>
         </Button>
         <Separator orientation="vertical" className="h-6" />

--- a/ui/components/shadcn/table/table.tsx
+++ b/ui/components/shadcn/table/table.tsx
@@ -91,8 +91,6 @@ const TableHead = forwardRef<
       "h-11 px-1.5 text-left align-middle text-xs font-medium whitespace-nowrap outline-none",
       "first:rounded-l-full first:border-l first:pl-3",
       "last:rounded-r-full last:border-r last:pr-3",
-      "data-[hover=true]:text-text-neutral-tertiary data-[focus-visible=true]:outline-button-primary",
-      "data-[focus-visible=true]:z-10 data-[focus-visible=true]:outline-2 data-[focus-visible=true]:outline-offset-2",
       "rtl:text-right rtl:first:rounded-l-[unset] rtl:first:rounded-r-full rtl:last:rounded-l-full rtl:last:rounded-r-[unset]",
       "[&:has([role=checkbox])]:pr-0",
       className,

--- a/ui/components/shadcn/toast/Toast.tsx
+++ b/ui/components/shadcn/toast/Toast.tsx
@@ -25,7 +25,7 @@ const ToastViewport = React.forwardRef<
 ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between gap-2 overflow-hidden rounded-md border border-slate-200 p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-(--radix-toast-swipe-end-x) data-[swipe=move]:translate-x-(--radix-toast-swipe-move-x) data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full dark:border-slate-800",
+  "group pointer-events-auto relative flex w-full items-center justify-between gap-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-(--radix-toast-swipe-end-x) data-[swipe=move]:translate-x-(--radix-toast-swipe-move-x) data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
   {
     variants: {
       variant: {
@@ -63,7 +63,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center self-end rounded-md border border-slate-200 bg-transparent px-3 text-sm font-medium transition-colors group-[.destructive]:border-slate-100/40 hover:bg-slate-100 group-[.destructive]:hover:border-red-500/30 group-[.destructive]:hover:bg-red-500 group-[.destructive]:hover:text-slate-50 focus:ring-1 focus:ring-slate-950 focus:outline-none group-[.destructive]:focus:ring-red-500 disabled:pointer-events-none disabled:opacity-50 dark:border-slate-800 dark:group-[.destructive]:border-slate-800/40 dark:hover:bg-slate-800 dark:group-[.destructive]:hover:border-red-900/30 dark:group-[.destructive]:hover:bg-red-900 dark:group-[.destructive]:hover:text-slate-50 dark:focus:ring-slate-300 dark:group-[.destructive]:focus:ring-red-900",
+      "border-border-neutral-secondary hover:bg-bg-neutral-tertiary focus:ring-border-input-primary-press/50 inline-flex h-8 shrink-0 items-center justify-center self-end rounded-md border bg-transparent px-3 text-sm font-medium transition-colors group-[.destructive]:border-slate-100/40 group-[.destructive]:hover:border-red-500/30 group-[.destructive]:hover:bg-red-500 group-[.destructive]:hover:text-slate-50 focus:ring-1 focus:outline-none group-[.destructive]:focus:ring-red-500 disabled:pointer-events-none disabled:opacity-50 dark:group-[.destructive]:border-slate-800/40 dark:group-[.destructive]:hover:border-red-900/30 dark:group-[.destructive]:hover:bg-red-900 dark:group-[.destructive]:hover:text-slate-50 dark:group-[.destructive]:focus:ring-red-900",
       className,
     )}
     {...props}
@@ -78,7 +78,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute top-1 right-1 rounded-md p-1 text-slate-950/50 opacity-0 transition-opacity group-hover:opacity-100 group-[.destructive]:text-red-300 hover:text-slate-950 group-[.destructive]:hover:text-red-50 focus:opacity-100 focus:ring-1 focus:outline-none group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600 dark:text-slate-50/50 dark:hover:text-slate-50",
+      "text-text-neutral-primary/50 hover:text-text-neutral-primary absolute top-1 right-1 rounded-md p-1 opacity-0 transition-opacity group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 focus:opacity-100 focus:ring-1 focus:outline-none group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className,
     )}
     toast-close=""

--- a/ui/components/ui/skeleton/skeleton.tsx
+++ b/ui/components/ui/skeleton/skeleton.tsx
@@ -39,7 +39,7 @@ export function Skeleton({
           : undefined,
       }}
       className={cn(
-        "animate-pulse bg-gray-200 dark:bg-zinc-800",
+        "bg-border-neutral-tertiary animate-pulse",
         variantClasses[variant],
         !animate && "animate-none",
         className,

--- a/ui/knip.config.ts
+++ b/ui/knip.config.ts
@@ -33,9 +33,6 @@ const config: KnipConfig = {
     // Sentry instrumentation hooks — loaded via require() by the runtime
     "import-in-the-middle",
     "require-in-the-middle",
-    // @heroui/react re-exports all sub-packages; imports like @heroui/skeleton
-    // resolve to transitive deps of @heroui/react, not direct dependencies
-    "@heroui/*",
   ],
   ignoreExportsUsedInFile: {
     interface: true,

--- a/ui/styles/globals.css
+++ b/ui/styles/globals.css
@@ -9,7 +9,7 @@
  * emitting a circular --font-sans: var(--font-sans) declaration on :root. */
 @theme inline {
   --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: var(--font-mono);
 }
 
 /* ===== LIGHT THEME (ROOT) ===== */
@@ -454,11 +454,6 @@
   .dark .minimal-scrollbar::-webkit-scrollbar-thumb:hover,
   .dark .minimal-scrollbar .cm-scroller::-webkit-scrollbar-thumb:hover {
     background-color: rgb(100 116 139 / 0.7);
-  }
-
-  .checkbox-update {
-    margin-right: 0.5rem;
-    background-color: var(--background);
   }
 
   /* Download icon animation */


### PR DESCRIPTION
### Context

Phase 7 of the HeroUI → shadcn/ui migration chain (#11532). A full review of the cumulative chain diff surfaced a few regressions and leftovers that are cheaper to fix on the chain tip than to distribute across the phase branches.

### Description

**Fixes**

- `DropdownMenuSeparator` lost its dark-mode variant (`bg-default-200 dark:bg-default-700` → `bg-zinc-200`); now uses `bg-border-neutral-secondary`.
- Role form permission icons relied on HeroUI's `data-selected` attribute, which the shadcn `Checkbox` never sets; replaced with `group-has-[[data-state=checked]]` and the row marked as `group`.
- Role forms read checkbox state via `form.watch()` during render, which the React Compiler cannot track (stale checked UI); switched to `useWatch`.
- The sign-up terms checkbox lost its required indicator (HeroUI `isRequired`); restored the asterisk.
- `font-mono` never resolved: the theme pointed at the undefined `--font-geist-mono` and no layout applied `fontMono.variable`; both wired now (Fira Code).
- `CodeSnippet` defined its copy button as a nested component, remounting the button on every render (caught by the new tests); inlined.

**Cleanup**

- Token sweep of leftover `gray/slate/zinc` literals in `Accordion`, `NavigationHeader`, `Toast`, the legacy `Skeleton` and `LinkCard`; removed dead `data-[hover]`/`data-[focus-visible]` selectors on `TableHead` and the dead `.checkbox-update` CSS rule.
- Dropped stale HeroUI references: README tech list, `AGENTS.md` notes about `components/ui/`, the `@heroui/*` knip ignore, and a comment still attributing the accordion scroll workaround to framer-motion.

**Tests**

- New behavior coverage for the rebuilt `Accordion` (controlled/uncontrolled, single/multiple, nested), `CodeSnippet` (clipboard write, formatter, copied-state feedback) and `CustomInput` (password visibility toggle, required indicator).

### Steps to review

1. `pnpm install && pnpm run typecheck && pnpm vitest run` in `ui/` (1084 tests green).
2. Open any dropdown menu in dark mode and check the separator color.
3. In Roles → create/edit, toggle a permission and verify the info icon brightens.
4. Verify `font-mono` text (e.g. advanced mutelist editor) renders Fira Code.

### Checklist

- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable (handled once in the main PR #11532).

#### UI

- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [ ] Ensure new entries are added to ui/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.