### PR TITLE
fix(api): drop_subgraph deletes relationships then nodes to cut Neo4j memory

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [1.31.1] (Prowler UNRELEASED)
+
+
+### 🐞 Fixed
+
+- Attack Paths: `drop_subgraph` now deletes relationships first and then nodes in batches, using less memory on Neo4j when clearing a dense provider graph [(#11557)](https://github.com/prowler-cloud/prowler/pull/11557)
+
+---
+
 ## [1.31.0] (Prowler v5.30.0)
 
 ### 🚀 Added

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -176,7 +176,7 @@ def drop_subgraph(database: str, provider_id: str) -> int:
     Delete all nodes for a provider from the tenant database.
 
     Deletes relationships then nodes in batches (not `DETACH DELETE`) so a dense
-    provider's graph cannot exceed Neo4j's transaction limit.
+    provider's graph cannot exceed Neo4j's transaction memory limit.
     Silently returns 0 if the database doesn't exist.
     """
     provider_label = get_provider_label(provider_id)
@@ -190,7 +190,7 @@ def drop_subgraph(database: str, provider_id: str) -> int:
                 result = session.run(
                     f"""
                     MATCH (:`{provider_label}`)-[r]-()
-                    WITH r LIMIT $batch_size
+                    WITH DISTINCT r LIMIT $batch_size
                     DELETE r
                     RETURN COUNT(r) AS deleted_rels_count
                     """,

--- a/api/src/backend/api/attack_paths/database.py
+++ b/api/src/backend/api/attack_paths/database.py
@@ -175,7 +175,8 @@ def drop_subgraph(database: str, provider_id: str) -> int:
     """
     Delete all nodes for a provider from the tenant database.
 
-    Uses batched deletion to avoid memory issues with large graphs.
+    Deletes relationships then nodes in batches (not `DETACH DELETE`) so a dense
+    provider's graph cannot exceed Neo4j's transaction limit.
     Silently returns 0 if the database doesn't exist.
     """
     provider_label = get_provider_label(provider_id)
@@ -183,13 +184,28 @@ def drop_subgraph(database: str, provider_id: str) -> int:
 
     try:
         with get_session(database) as session:
+            # Phase 1: delete relationships incident to provider nodes in batches.
+            deleted_count = 1
+            while deleted_count > 0:
+                result = session.run(
+                    f"""
+                    MATCH (:`{provider_label}`)-[r]-()
+                    WITH r LIMIT $batch_size
+                    DELETE r
+                    RETURN COUNT(r) AS deleted_rels_count
+                    """,
+                    {"batch_size": BATCH_SIZE},
+                )
+                deleted_count = result.single().get("deleted_rels_count", 0)
+
+            # Phase 2: delete the now relationship-free nodes in batches.
             deleted_count = 1
             while deleted_count > 0:
                 result = session.run(
                     f"""
                     MATCH (n:{PROVIDER_RESOURCE_LABEL}:`{provider_label}`)
                     WITH n LIMIT $batch_size
-                    DETACH DELETE n
+                    DELETE n
                     RETURN COUNT(n) AS deleted_nodes_count
                     """,
                     {"batch_size": BATCH_SIZE},

--- a/api/src/backend/api/tests/test_attack_paths_database.py
+++ b/api/src/backend/api/tests/test_attack_paths_database.py
@@ -542,3 +542,84 @@ class TestHasProviderData:
         ):
             with pytest.raises(db_module.GraphDatabaseQueryException):
                 db_module.has_provider_data("db-tenant-abc", "provider-123")
+
+
+class TestDropSubgraph:
+    """Test drop_subgraph two-phase batched deletion of a provider's graph."""
+
+    @staticmethod
+    def _result(count):
+        result = MagicMock()
+        result.single.return_value.get.return_value = count
+        return result
+
+    @staticmethod
+    def _session_ctx(session):
+        ctx = MagicMock()
+        ctx.__enter__.return_value = session
+        ctx.__exit__.return_value = False
+        return ctx
+
+    def test_deletes_relationships_then_nodes_in_batches(self):
+        session = MagicMock()
+        # Phase 1 (relationships): one full batch then empty.
+        # Phase 2 (nodes): one full batch then empty.
+        session.run.side_effect = [
+            self._result(1000),
+            self._result(0),
+            self._result(1000),
+            self._result(0),
+        ]
+
+        with patch(
+            "api.attack_paths.database.get_session",
+            return_value=self._session_ctx(session),
+        ):
+            deleted = db_module.drop_subgraph("db-tenant-abc", "provider-123")
+
+        # Only phase-2 node counts contribute to the return value.
+        assert deleted == 1000
+        assert session.run.call_count == 4
+
+        queries = [call.args[0] for call in session.run.call_args_list]
+
+        # Regression guard: the memory blow-up was caused by DETACH DELETE.
+        assert all("DETACH DELETE" not in query for query in queries)
+
+        rel_queries = [query for query in queries if "DELETE r" in query]
+        node_queries = [query for query in queries if "DELETE n" in query]
+        assert rel_queries and node_queries
+        # DISTINCT avoids double-counting relationships matched from both ends.
+        assert all("DISTINCT r" in query for query in rel_queries)
+
+        # Relationships must be fully drained before nodes are deleted.
+        first_node = next(i for i, q in enumerate(queries) if "DELETE n" in q)
+        last_rel = max(i for i, q in enumerate(queries) if "DELETE r" in q)
+        assert last_rel < first_node
+
+    def test_returns_zero_when_database_not_found(self):
+        session_ctx = MagicMock()
+        session_ctx.__enter__.side_effect = db_module.GraphDatabaseQueryException(
+            message="Database does not exist",
+            code="Neo.ClientError.Database.DatabaseNotFound",
+        )
+
+        with patch(
+            "api.attack_paths.database.get_session",
+            return_value=session_ctx,
+        ):
+            assert db_module.drop_subgraph("db-tenant-gone", "provider-123") == 0
+
+    def test_raises_on_other_errors(self):
+        session_ctx = MagicMock()
+        session_ctx.__enter__.side_effect = db_module.GraphDatabaseQueryException(
+            message="Connection refused",
+            code="Neo.TransientError.General.UnknownError",
+        )
+
+        with patch(
+            "api.attack_paths.database.get_session",
+            return_value=session_ctx,
+        ):
+            with pytest.raises(db_module.GraphDatabaseQueryException):
+                db_module.drop_subgraph("db-tenant-abc", "provider-123")


### PR DESCRIPTION
### Context

Attack Paths scans clear the old provider graph with `drop_subgraph`, which used a node-batched `DETACH DELETE`. That pulls every relationship of the batched nodes into a single transaction, so on a dense provider it can blow past Neo4j's transaction memory limit and the scan fails.

### Description

`drop_subgraph` now deletes in two batched phases: relationships first, then the relationship-free nodes. Each transaction is bounded by `BATCH_SIZE` no matter how dense the graph is, so peak memory stays flat. Same end result, lower memory. One function changed in `api/src/backend/api/attack_paths/database.py`.

### Steps to review

- Run tests suite.
- Run a few Attack Paths scans in a local environment.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Attack Paths cleanup to reduce memory use on large provider graphs by performing deletions in two batched phases (relationships first, then nodes), fixing incomplete results for some provider frameworks.

* **Tests**
  * Added tests covering the two-phase batched deletion, deleted-count reporting, error handling, and deletion ordering guarantees.

* **Documentation**
  * Added an unreleased changelog entry for the fix (Prowler API 1.31.1).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->