### PR TITLE
chore: prepare API and UI changelogs for 5.30.1 release

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 - Workers now shut down gracefully on deploy or restart, finishing or re-queueing in-flight tasks instead of being force-killed and leaving them stuck [(#11416)](https://github.com/prowler-cloud/prowler/pull/11416)
 - Resource `name` is now stored and refreshed on every scan, so resources no longer keep an empty name [(#11476)](https://github.com/prowler-cloud/prowler/pull/11476)
-- Compliance catalog now warms in background during startup. `compliance-overviews/attributes` returns `503` while warming, so the first request after a deploy no longer trips the API timeout [(#4554)](https://github.com/prowler-cloud/prowler-cloud/pull/4554)
+- Compliance catalog now warms in background during startup. `compliance-overviews/attributes` returns `503` while warming, so the first request after a deploy no longer trips the API timeout [(#11530)](https://github.com/prowler-cloud/prowler/pull/11530)
 
 ### 🔐 Security
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
-## [1.31.1] (Prowler UNRELEASED)
-
+## [1.31.1] (Prowler v5.30.1)
 
 ### 🐞 Fixed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔄 Changed
 
 - Renamed "Customer Support" to "Support Desk" in the side menu, showing it only in Prowler Cloud/Enterprise, while "Community Support" now shows only in Prowler OSS [(#11508)](https://github.com/prowler-cloud/prowler/pull/11508)
-- Compliance detail page now shows a "still loading" retry state while the API warms its compliance catalog, instead of rendering an empty page [(#4554)](https://github.com/prowler-cloud/prowler-cloud/pull/4554)
+- Compliance detail page now shows a "still loading" retry state while the API warms its compliance catalog, instead of rendering an empty page [(#11530)](https://github.com/prowler-cloud/prowler/pull/11530)
 
 ### 🐞 Fixed
 

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
-## [1.30.1] (Prowler UNRELEASED)
+## [1.30.1] (Prowler v5.30.1)
 
 ### 🐞 Fixed
 


### PR DESCRIPTION
### Description

Marks API changelog 1.31.1 and UI changelog 1.30.1 for releasing Prowler v5.30.1.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked API and UI changelog entries as official releases (Prowler v5.30.1).
  * Corrected referenced pull request links in both API and UI changelogs for the compliance/capability notes and compliance detail page to point to the proper PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->