### PR TITLE
ci: fail PR checks on critical container image and dependency vulnerabilities

### DIFF
--- a/.github/actions/osv-scanner/action.yml
+++ b/.github/actions/osv-scanner/action.yml
@@ -1,5 +1,5 @@
 name: 'OSV-Scanner'
-description: 'Install osv-scanner and scan a lockfile, failing on HIGH/CRITICAL/UNKNOWN severity findings. Posts/updates a PR comment with findings on pull_request events (requires pull-requests: write).'
+description: 'Install osv-scanner and scan a lockfile, failing on CRITICAL severity findings. Posts/updates a PR comment with findings on pull_request events (requires pull-requests: write).'
 author: 'Prowler'
 
 inputs:
@@ -7,9 +7,9 @@ inputs:
     description: 'Path to the lockfile to scan, relative to the repository root (e.g. uv.lock, api/uv.lock, ui/pnpm-lock.yaml).'
     required: true
   severity-levels:
-    description: 'Comma-separated severity levels that fail the scan. Default: HIGH,CRITICAL,UNKNOWN.'
+    description: 'Comma-separated severity levels that fail the scan. Default: CRITICAL.'
     required: false
-    default: 'HIGH,CRITICAL,UNKNOWN'
+    default: 'CRITICAL'
   version:
     description: 'osv-scanner release tag to install. When overriding, you MUST also override binary-sha256.'
     required: false

--- a/.github/scripts/osv-scan.sh
+++ b/.github/scripts/osv-scan.sh
@@ -6,8 +6,7 @@
 #   - .github/workflows/api-security.yml, sdk-security.yml, ui-security.yml
 #
 # Severity levels (comma-separated) are read from OSV_SEVERITY_LEVELS.
-# Default: HIGH,CRITICAL,UNKNOWN — preserves prior .safety-policy.yml policy
-#   (ignore-cvss-severity-below: 7 + ignore-cvss-unknown-severity: False).
+# Default: CRITICAL — only CVSS >= 9.0 findings fail the scan.
 # osv-scanner has no native CVSS threshold (google/osv-scanner#1400, closed
 # not-planned). Severity is derived from $group.max_severity (numeric CVSS
 # score string) which osv-scanner emits per group.
@@ -33,7 +32,7 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 CONFIG="${ROOT}/osv-scanner.toml"
-SEVERITY_LEVELS="${OSV_SEVERITY_LEVELS:-HIGH,CRITICAL,UNKNOWN}"
+SEVERITY_LEVELS="${OSV_SEVERITY_LEVELS:-CRITICAL}"
 
 for bin in osv-scanner jq; do
   if ! command -v "${bin}" >/dev/null 2>&1; then

--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -134,5 +134,5 @@ jobs:
         with:
           image-name: ${{ env.IMAGE_NAME }}
           image-tag: ${{ github.sha }}
-          fail-on-critical: 'false'
+          fail-on-critical: 'true'
           severity: 'CRITICAL'

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -127,5 +127,5 @@ jobs:
         with:
           image-name: ${{ env.IMAGE_NAME }}
           image-tag: ${{ github.sha }}
-          fail-on-critical: 'false'
+          fail-on-critical: 'true'
           severity: 'CRITICAL'

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -153,5 +153,5 @@ jobs:
         with:
           image-name: ${{ env.IMAGE_NAME }}
           image-tag: ${{ github.sha }}
-          fail-on-critical: 'false'
+          fail-on-critical: 'true'
           severity: 'CRITICAL'

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -132,5 +132,5 @@ jobs:
         with:
           image-name: ${{ env.IMAGE_NAME }}
           image-tag: ${{ github.sha }}
-          fail-on-critical: 'false'
+          fail-on-critical: 'true'
           severity: 'CRITICAL'


### PR DESCRIPTION
### Context

We did not block PRs on critical SCA/image findings. `osv-scanner` already failed the job (on HIGH/CRITICAL/UNKNOWN) but the Trivy container image scan was advisory only, so a CRITICAL vulnerability in a built image would not fail the check.

This PR makes both gates block on critical findings.

### Description

- **Trivy:** set `fail-on-critical: 'true'` in the `sdk`/`api`/`ui`/`mcp` container-checks workflows so a CRITICAL image vulnerability fails the check.
- **osv-scanner:** narrowed the shared action's `severity-levels` default (and the `osv-scan.sh` fallback) from `HIGH,CRITICAL,UNKNOWN` to `CRITICAL`, so dependency scans block on CRITICAL only. All security workflows call the action without overriding severity, so this single change governs them all.

prowler-cloud will receive these changes automatically via the standard merge sync; no manual port is required.

### Steps to review

- Confirm the 6 diffs are limited to the Trivy flag flip and the osv-scanner severity default/fallback.
- Note the trivy-scan action already exits 1 on critical when `fail-on-critical` is on.
- Note the osv-scanner action's "Enforce severity gate" step already fails the job on findings, so narrowing the default severity is sufficient to change gating behavior.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI

#### API
- [ ] All issue/task requirements work as expected on the API

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline security scanning to automatically fail builds when critical vulnerabilities are detected in container images.
  * Adjusted OSV vulnerability scanner defaults to report critical-severity findings exclusively, narrowing the failure threshold from a previous configuration that included high, critical, and unknown severity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->