### PR TITLE
ci: always run container and dependency vulnerability scans on PRs

### DIFF
--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/api-security.yml
+++ b/.github/workflows/api-security.yml
@@ -16,13 +16,6 @@ on:
     branches:
       - "master"
       - "v5.*"
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-tests.yml'
-      - '.github/workflows/api-security.yml'
-      - '.github/actions/setup-python-uv/**'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'mcp_server/**'
-      - '.github/workflows/mcp-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mcp-security.yml
+++ b/.github/workflows/mcp-security.yml
@@ -15,12 +15,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'mcp_server/pyproject.toml'
-      - 'mcp_server/uv.lock'
-      - '.github/workflows/mcp-security.yml'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -15,12 +15,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'Dockerfile*'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/sdk-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -111,25 +105,14 @@ jobs:
         id: check-changes
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files: ./**
+          files: |
+            prowler/**
+            Dockerfile*
+            pyproject.toml
+            uv.lock
+            .github/workflows/sdk-container-checks.yml
           files_ignore: |
-            .github/**
             prowler/CHANGELOG.md
-            docs/**
-            permissions/**
-            api/**
-            ui/**
-            dashboard/**
-            mcp_server/**
-            skills/**
-            README.md
-            mkdocs.yml
-            .backportrc.json
-            .env
-            docker-compose*
-            examples/**
-            .gitignore
-            contrib/**
             **/AGENTS.md
 
       - name: Set up Docker Buildx

--- a/.github/workflows/sdk-security.yml
+++ b/.github/workflows/sdk-security.yml
@@ -19,16 +19,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/sdk-tests.yml'
-      - '.github/workflows/sdk-security.yml'
-      - '.github/actions/setup-python-uv/**'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,27 +61,18 @@ jobs:
         id: check-changes
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
-          files:
-            ./**
+          files: |
+            prowler/**
+            tests/**
+            pyproject.toml
+            uv.lock
+            .github/workflows/sdk-tests.yml
             .github/workflows/sdk-security.yml
+            .github/actions/setup-python-uv/**
+            .github/actions/osv-scanner/**
+            .github/scripts/osv-scan.sh
           files_ignore: |
-            .github/**
             prowler/CHANGELOG.md
-            docs/**
-            permissions/**
-            api/**
-            ui/**
-            dashboard/**
-            mcp_server/**
-            skills/**
-            README.md
-            mkdocs.yml
-            .backportrc.json
-            .env
-            docker-compose*
-            examples/**
-            .gitignore
-            contrib/**
             **/AGENTS.md
 
       - name: Setup Python with uv

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'ui/**'
-      - '.github/workflows/ui-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ui-security.yml
+++ b/.github/workflows/ui-security.yml
@@ -15,12 +15,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'ui/package.json'
-      - 'ui/pnpm-lock.yaml'
-      - '.github/workflows/ui-security.yml'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Context

The container image and dependency vulnerability scans (Trivy fail-on-critical + osv-scanner CRITICAL) were enabled in #11580. To make these 8 scan workflows usable as **required status checks** in branch protection, they must report a status on every PR — otherwise a PR that doesn't touch the scanned paths would hang forever on a required check that never runs.

### Description

This PR removes the `pull_request.paths` filters from the 8 scan workflows so they are always triggered on PRs:

- `.github/workflows/{sdk,api,ui,mcp}-security.yml` (dependency vulnerability scans)
- `.github/workflows/{sdk,api,ui,mcp}-container-checks.yml` (container image scans)

The PR-trigger `paths` filters are removed from all 8 workflows. The existing **step-level `changed-files` gate inside each workflow still skips the heavy build/scan work** when no relevant files changed, so unrelated PRs get a fast, green check instead of a hang. This is the prerequisite for adding these 8 jobs as required status checks in branch protection.

Additionally, in `sdk-security.yml` and `sdk-container-checks.yml` the step-level `changed-files` filter was converted from the broad `./**` minus a denylist to an explicit allowlist, for parity with the `api`/`ui`/`mcp` workflows. This ensures edits to the scanner tooling itself (`.github/actions/osv-scanner/**`, `.github/scripts/osv-scan.sh`) re-trigger the sdk scans, which the previous denylist-based filter excluded.

### Steps to review

- Confirm the diff removes the `pull_request.paths` blocks across the 8 workflow files, plus the `sdk-{security,container-checks}.yml` `changed-files` allowlist conversion described above.
- Confirm each workflow retains its step-level `changed-files` gate that short-circuits the expensive steps when nothing relevant changed.
- Open a PR touching none of the scanned paths and confirm the 8 checks report green quickly without building/scanning.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if backport is needed.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow trigger configurations across multiple CI pipelines.
  * Standardized pull request filtering to target specific branches and cleaned up mispositioned or redundant trigger filters.
  * Tightened change-detection inputs so security/build checks run only for relevant file changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
