### PR TITLE
chore: configure vulture to ignore known false positives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -364,3 +364,13 @@ constraint-dependencies = [
   "zstd==1.5.7.3"
 ]
 override-dependencies = ["okta==3.4.2"]
+
+[tool.vulture]
+# Suppress known false positives. The CI command only passes --exclude and
+# --min-confidence on the CLI, so ignore_names from here still applies (vulture
+# only overrides the keys set on the CLI).
+# - mock_* : pytest fixtures injected as test params but unused in the body
+# (e.g. mock_sensitive_args in tests/lib/cli/redact_test.py)
+# - view   : DRF BasePermission.has_object_permission(self, request, view, obj)
+# framework-required signature param in skills/django-drf template assets
+ignore_names = ["mock_*", "view"]


### PR DESCRIPTION
### Context

The Vulture dead-code scan flags a small set of names that are not actually dead code. These false positives currently stand in the way of promoting the container/dependency security scans to required checks.

### Description

Adds a `[tool.vulture]` section to `pyproject.toml` with a name-scoped `ignore_names` allowlist for two known false positives:

- `mock_*` — pytest fixtures injected as test parameters but unused in the test body (e.g. `mock_sensitive_args` in `tests/lib/cli/redact_test.py`).
- `view` — the framework-required `view` parameter in `BasePermission.has_object_permission(self, request, view, obj)`, present in the `skills/django-drf` template assets.

The CI command only passes `--exclude` and `--min-confidence` on the CLI, so the config `ignore_names` still applies (Vulture only overrides the keys explicitly set on the CLI). Because the allowlist is name-scoped, genuine unused code is still detected.

Verified locally: `uv run vulture --exclude ".venv,contrib,api,ui" --min-confidence 100 .` exits 0, while genuine unused parameters are still flagged.

This unblocks making the security scans required checks.

> Note: the `pretty-format-toml` pre-commit hook relocates the `[tool.vulture]` table to the end of the file and normalizes the comment indentation. The committed form is the hook's canonical output so it passes CI; the change remains purely additive (no version or dependency changes).

### Steps to review

1. Confirm the diff is limited to the added `[tool.vulture]` block in `pyproject.toml` (no version or dependency changes).
2. Run `uv run vulture --exclude ".venv,contrib,api,ui" --min-confidence 100 .` — it should exit 0.

### Checklist

- [x] Review if the code is being covered by tests.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to improve code quality tooling with refined settings for ignoring false positives during static analysis checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->