### PR TITLE
feat(api): ECS task scale-in protection for long-running worker tasks

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -25,6 +25,11 @@ DJANGO_THROTTLE_TOKEN_OBTAIN=50/minute
 DJANGO_MANAGE_DB_PARTITIONS=[True|False]
 DJANGO_CELERY_DEADLOCK_ATTEMPTS=5
 DJANGO_BROKER_VISIBILITY_TIMEOUT=86400
+# Protect ECS workers from scale-in/rolling-deploy termination while a long task
+# (e.g. a scan) runs. No-op outside ECS. Needs ecs:UpdateTaskProtection on the task role.
+DJANGO_ECS_TASK_PROTECTION=[True|False]
+DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS=60
+DJANGO_ECS_TASK_PROTECTION_EXPIRES_MINUTES=120
 DJANGO_SENTRY_DSN=
 
 # PostgreSQL settings

--- a/api/src/backend/api/tests/test_ecs_task_protection.py
+++ b/api/src/backend/api/tests/test_ecs_task_protection.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from config import ecs_task_protection as tp
+
+
+class _Req:
+    def __init__(self, name):
+        self.name = name
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    for var in (
+        "ECS_AGENT_URI",
+        "DJANGO_ECS_TASK_PROTECTION",
+        "DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS",
+        "DJANGO_ECS_TASK_PROTECTION_EXPIRES_MINUTES",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestIsEnabled:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
+        assert tp.is_enabled() is False
+
+    def test_requires_agent_uri(self, monkeypatch):
+        monkeypatch.setenv("DJANGO_ECS_TASK_PROTECTION", "True")
+        assert tp.is_enabled() is False
+
+    def test_enabled_when_flag_and_agent_present(self, monkeypatch):
+        monkeypatch.setenv("DJANGO_ECS_TASK_PROTECTION", "true")
+        monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
+        assert tp.is_enabled() is True
+
+
+class TestSetTaskProtection:
+    def test_noop_without_agent(self):
+        assert tp.set_task_protection(True, 120) is False
+
+    def test_enable_puts_expected_payload(self, monkeypatch):
+        monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
+        with patch.object(tp.urllib_request, "urlopen") as urlopen:
+            urlopen.return_value.__enter__.return_value.read.return_value = b"{}"
+            assert tp.set_task_protection(True, 90) is True
+            request = urlopen.call_args.args[0]
+            assert request.full_url == "http://agent/task-protection/v1/state"
+            assert request.get_method() == "PUT"
+            assert request.data == (
+                b'{"ProtectionEnabled": true, "ExpiresInMinutes": 90}'
+            )
+
+    def test_disable_omits_expiry(self, monkeypatch):
+        monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
+        with patch.object(tp.urllib_request, "urlopen") as urlopen:
+            urlopen.return_value.__enter__.return_value.read.return_value = b"{}"
+            assert tp.set_task_protection(False, 90) is True
+            assert urlopen.call_args.args[0].data == b'{"ProtectionEnabled": false}'
+
+    def test_failure_is_swallowed(self, monkeypatch):
+        monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
+        with patch.object(
+            tp.urllib_request, "urlopen", side_effect=OSError("boom")
+        ):
+            assert tp.set_task_protection(True, 120) is False
+
+
+class TestECSTaskProtectionStep:
+    def _step(self):
+        return tp.ECSTaskProtectionStep(parent=MagicMock())
+
+    def test_start_is_noop_when_disabled(self):
+        step = self._step()
+        with patch.object(tp, "set_task_protection") as setter:
+            step.start(MagicMock())
+            setter.assert_not_called()
+        assert step._timer is None
+
+    def test_tick_acquires_then_releases(self, monkeypatch):
+        monkeypatch.setenv("DJANGO_ECS_TASK_PROTECTION", "true")
+        monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
+        step = self._step()
+
+        # Patch Timer so the reschedule in the `finally` block does not spawn a
+        # real thread, but the tick body still runs.
+        with patch.object(tp, "set_task_protection", return_value=True) as setter, \
+                patch.object(tp.threading, "Timer", return_value=MagicMock()), \
+                patch.object(
+                    tp.ECSTaskProtectionStep, "_protected_task_in_flight"
+                ) as in_flight:
+            in_flight.return_value = True
+            step._tick()
+            assert step._protected is True
+            assert setter.call_args.args == (True, step._expires_minutes)
+
+            in_flight.return_value = False
+            step._tick()
+            assert step._protected is False
+            assert setter.call_args.args == (False, step._expires_minutes)
+
+        step._stop.set()
+
+    def test_protected_task_detection_matches_only_protected_names(self):
+        from celery.worker import state
+
+        with patch.object(
+            state, "active_requests", [_Req("scan-summary"), _Req("scan-perform")]
+        ):
+            assert tp.ECSTaskProtectionStep._protected_task_in_flight() is True
+
+        with patch.object(
+            state, "active_requests", [_Req("scan-summary"), _Req("overview")]
+        ):
+            assert tp.ECSTaskProtectionStep._protected_task_in_flight() is False

--- a/api/src/backend/api/tests/test_ecs_task_protection.py
+++ b/api/src/backend/api/tests/test_ecs_task_protection.py
@@ -1,3 +1,6 @@
+"""Tests for the ECS task scale-in protection worker bootstep."""
+
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -6,12 +9,16 @@ from config import ecs_task_protection as tp
 
 
 class _Req:
+    """Minimal stand-in for a Celery request exposing a task ``name``."""
+
     def __init__(self, name):
+        """Store the task name used for protected-task matching."""
         self.name = name
 
 
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch):
+    """Ensure each test starts with the protection env vars unset."""
     for var in (
         "ECS_AGENT_URI",
         "DJANGO_ECS_TASK_PROTECTION",
@@ -22,25 +29,59 @@ def _clear_env(monkeypatch):
 
 
 class TestIsEnabled:
+    """`is_enabled` requires both the flag and the ECS agent endpoint."""
+
     def test_disabled_by_default(self, monkeypatch):
+        """On ECS but without the flag, protection stays disabled."""
         monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
         assert tp.is_enabled() is False
 
     def test_requires_agent_uri(self, monkeypatch):
+        """The flag alone is not enough when not running on ECS."""
         monkeypatch.setenv("DJANGO_ECS_TASK_PROTECTION", "True")
         assert tp.is_enabled() is False
 
     def test_enabled_when_flag_and_agent_present(self, monkeypatch):
+        """Both the flag and the agent endpoint enable protection."""
         monkeypatch.setenv("DJANGO_ECS_TASK_PROTECTION", "true")
         monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
         assert tp.is_enabled() is True
 
 
+class TestEnvInt:
+    """`_env_int` tolerates missing and malformed environment values."""
+
+    _VAR = "DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS"
+
+    def test_uses_default_when_unset(self):
+        """An unset variable yields the default."""
+        assert tp._env_int(self._VAR, default=60, minimum=5) == 60
+
+    def test_parses_valid_value(self, monkeypatch):
+        """A valid integer string is parsed."""
+        monkeypatch.setenv(self._VAR, "90")
+        assert tp._env_int(self._VAR, default=60, minimum=5) == 90
+
+    def test_clamps_to_minimum(self, monkeypatch):
+        """Values below the minimum are clamped up."""
+        monkeypatch.setenv(self._VAR, "1")
+        assert tp._env_int(self._VAR, default=60, minimum=5) == 5
+
+    def test_falls_back_on_malformed_value(self, monkeypatch):
+        """A non-numeric value falls back to the default instead of raising."""
+        monkeypatch.setenv(self._VAR, "sixty")
+        assert tp._env_int(self._VAR, default=60, minimum=5) == 60
+
+
 class TestSetTaskProtection:
+    """`set_task_protection` builds the correct request and never raises."""
+
     def test_noop_without_agent(self):
+        """Without the agent endpoint the call is a no-op returning False."""
         assert tp.set_task_protection(True, 120) is False
 
     def test_enable_puts_expected_payload(self, monkeypatch):
+        """Enabling sends a PUT with ProtectionEnabled and the expiry."""
         monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
         with patch.object(tp.urllib_request, "urlopen") as urlopen:
             urlopen.return_value.__enter__.return_value.read.return_value = b"{}"
@@ -48,18 +89,23 @@ class TestSetTaskProtection:
             request = urlopen.call_args.args[0]
             assert request.full_url == "http://agent/task-protection/v1/state"
             assert request.get_method() == "PUT"
-            assert request.data == (
-                b'{"ProtectionEnabled": true, "ExpiresInMinutes": 90}'
-            )
+            assert json.loads(request.data.decode("utf-8")) == {
+                "ProtectionEnabled": True,
+                "ExpiresInMinutes": 90,
+            }
 
     def test_disable_omits_expiry(self, monkeypatch):
+        """Disabling sends ProtectionEnabled=false without an expiry."""
         monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
         with patch.object(tp.urllib_request, "urlopen") as urlopen:
             urlopen.return_value.__enter__.return_value.read.return_value = b"{}"
             assert tp.set_task_protection(False, 90) is True
-            assert urlopen.call_args.args[0].data == b'{"ProtectionEnabled": false}'
+            assert json.loads(
+                urlopen.call_args.args[0].data.decode("utf-8")
+            ) == {"ProtectionEnabled": False}
 
     def test_failure_is_swallowed(self, monkeypatch):
+        """A transport error is logged and returns False, never raised."""
         monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
         with patch.object(
             tp.urllib_request, "urlopen", side_effect=OSError("boom")
@@ -68,10 +114,14 @@ class TestSetTaskProtection:
 
 
 class TestECSTaskProtectionStep:
+    """The bootstep toggles protection based on in-flight protected tasks."""
+
     def _step(self):
+        """Build a step instance with a dummy parent."""
         return tp.ECSTaskProtectionStep(parent=MagicMock())
 
     def test_start_is_noop_when_disabled(self):
+        """`start` does nothing when protection is not enabled."""
         step = self._step()
         with patch.object(tp, "set_task_protection") as setter:
             step.start(MagicMock())
@@ -79,6 +129,7 @@ class TestECSTaskProtectionStep:
         assert step._timer is None
 
     def test_tick_acquires_then_releases(self, monkeypatch):
+        """A tick acquires protection while busy and releases it when idle."""
         monkeypatch.setenv("DJANGO_ECS_TASK_PROTECTION", "true")
         monkeypatch.setenv("ECS_AGENT_URI", "http://agent")
         step = self._step()
@@ -103,6 +154,7 @@ class TestECSTaskProtectionStep:
         step._stop.set()
 
     def test_protected_task_detection_matches_only_protected_names(self):
+        """Only the protected task names count as in-flight protected work."""
         from celery.worker import state
 
         with patch.object(

--- a/api/src/backend/config/celery.py
+++ b/api/src/backend/config/celery.py
@@ -83,6 +83,14 @@ celery_app.conf.task_annotations = {
 
 celery_app.autodiscover_tasks(["api"])
 
+# Protect the ECS task from scale-in / rolling-deploy termination while a
+# long-running task (e.g. a scan) is in flight. No-op unless running on ECS
+# with DJANGO_ECS_TASK_PROTECTION enabled. Registered for the worker only; the
+# step is never started in non-worker processes that import this app.
+from config.ecs_task_protection import ECSTaskProtectionStep  # noqa: E402
+
+celery_app.steps["worker"].add(ECSTaskProtectionStep)
+
 
 class RLSTask(Task):
     def apply_async(

--- a/api/src/backend/config/ecs_task_protection.py
+++ b/api/src/backend/config/ecs_task_protection.py
@@ -1,0 +1,186 @@
+"""ECS task scale-in protection for long-running Celery tasks.
+
+When the worker runs on Amazon ECS, the service scheduler may terminate a task
+during auto scale-in or a rolling deployment without any knowledge of the work
+in flight. For long-running tasks such as scans this is disruptive: scans are
+intentionally *not* re-queued when a worker is lost (re-running a partial scan
+would duplicate ingestion), so an interrupted scan has to be started again from
+scratch.
+
+This module registers a Celery worker bootstep that enables `ECS task scale-in
+protection <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-scale-in-protection.html>`_
+while a protected task is running and disables it again once the worker is idle,
+so the scheduler terminates only idle workers. It is a no-op unless
+``DJANGO_ECS_TASK_PROTECTION`` is enabled and the task is running on ECS (the
+``ECS_AGENT_URI`` endpoint is injected by the container agent on Fargate
+platform >= 1.4.0 and the EC2 launch type).
+
+The task role needs the ``ecs:UpdateTaskProtection`` permission for the endpoint
+to succeed; if the call fails the worker keeps running normally (unprotected).
+
+Configuration (environment variables):
+
+* ``DJANGO_ECS_TASK_PROTECTION`` -- set to ``True`` to enable. Defaults to off.
+* ``DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS`` -- how often to check for in-flight
+  protected tasks. Defaults to ``60``.
+* ``DJANGO_ECS_TASK_PROTECTION_EXPIRES_MINUTES`` -- protection expiry requested
+  from ECS; refreshed at half this interval while work continues so that
+  protection lapses automatically if the worker dies. Defaults to ``120``.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from celery import bootsteps
+
+logger = logging.getLogger(__name__)
+
+# Long-running tasks that must not be interrupted by ECS scale-in or a rolling
+# deployment. These are the tasks Celery is configured to give a multi-hour
+# time limit and that are not re-queued on worker loss.
+PROTECTED_TASK_NAMES = frozenset(
+    {
+        "scan-perform",
+        "scan-perform-scheduled",
+        "provider-deletion",
+        "tenant-deletion",
+    }
+)
+
+_TASK_PROTECTION_PATH = "/task-protection/v1/state"
+_REQUEST_TIMEOUT_SECONDS = 5
+
+
+def _agent_uri():
+    """Return the ECS container agent URI, or ``None`` when not on ECS."""
+    return os.environ.get("ECS_AGENT_URI")
+
+
+def is_enabled():
+    """Whether task scale-in protection should be managed in this process."""
+    return (
+        os.environ.get("DJANGO_ECS_TASK_PROTECTION", "False").lower() == "true"
+        and _agent_uri() is not None
+    )
+
+
+def set_task_protection(enabled, expires_minutes):
+    """Enable or disable ECS task scale-in protection for the current task.
+
+    Returns ``True`` if the ECS agent accepted the request, ``False`` otherwise.
+    Never raises: a failure leaves the worker running unprotected.
+    """
+    uri = _agent_uri()
+    if uri is None:
+        return False
+
+    payload = {"ProtectionEnabled": bool(enabled)}
+    if enabled:
+        payload["ExpiresInMinutes"] = expires_minutes
+
+    request = urllib_request.Request(
+        f"{uri}{_TASK_PROTECTION_PATH}",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="PUT",
+    )
+    try:
+        with urllib_request.urlopen(
+            request, timeout=_REQUEST_TIMEOUT_SECONDS
+        ) as response:
+            response.read()
+        return True
+    except (urllib_error.URLError, OSError, ValueError) as error:
+        logger.warning("Could not update ECS task scale-in protection: %s", error)
+        return False
+
+
+class ECSTaskProtectionStep(bootsteps.StartStopStep):
+    """Worker bootstep that protects the ECS task while protected work runs.
+
+    Runs in the worker's main process and polls the set of active requests, so
+    it correctly accounts for every concurrent slot regardless of the execution
+    pool. Protection is refreshed periodically so that a long scan stays
+    protected, and released once the worker is idle so scale-in can reclaim it.
+    """
+
+    requires = {"celery.worker.components:Pool"}
+
+    def __init__(self, parent, **kwargs):
+        super().__init__(parent, **kwargs)
+        self._poll_seconds = max(
+            5,
+            int(os.environ.get("DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS", "60")),
+        )
+        self._expires_minutes = max(
+            1,
+            int(os.environ.get("DJANGO_ECS_TASK_PROTECTION_EXPIRES_MINUTES", "120")),
+        )
+        self._timer = None
+        self._stop = threading.Event()
+        self._protected = False
+        self._protected_at = 0.0
+
+    def start(self, parent):
+        if not is_enabled():
+            return
+        logger.info(
+            "ECS task scale-in protection enabled (poll=%ss, expires=%smin)",
+            self._poll_seconds,
+            self._expires_minutes,
+        )
+        self._stop.clear()
+        self._tick()
+
+    def stop(self, parent):
+        self._stop.set()
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+        if self._protected:
+            set_task_protection(False, self._expires_minutes)
+            self._protected = False
+
+    @staticmethod
+    def _protected_task_in_flight():
+        # Imported lazily so the module stays importable outside a worker.
+        from celery.worker import state
+
+        return any(
+            getattr(request, "name", None) in PROTECTED_TASK_NAMES
+            for request in list(state.active_requests)
+        )
+
+    def _tick(self):
+        if self._stop.is_set():
+            return
+        try:
+            active = self._protected_task_in_flight()
+            if active and not self._protected:
+                if set_task_protection(True, self._expires_minutes):
+                    self._protected = True
+                    self._protected_at = time.monotonic()
+                    logger.info("Acquired ECS task scale-in protection")
+            elif active and self._protected:
+                # Refresh before expiry so multi-hour work stays protected.
+                if time.monotonic() - self._protected_at >= (
+                    self._expires_minutes * 60
+                ) / 2:
+                    if set_task_protection(True, self._expires_minutes):
+                        self._protected_at = time.monotonic()
+            elif not active and self._protected:
+                if set_task_protection(False, self._expires_minutes):
+                    self._protected = False
+                    logger.info("Released ECS task scale-in protection")
+        except Exception:  # noqa: BLE001 - the monitor must never kill the worker
+            logger.warning("ECS task scale-in protection poll failed", exc_info=True)
+        finally:
+            if not self._stop.is_set():
+                self._timer = threading.Timer(self._poll_seconds, self._tick)
+                self._timer.daemon = True
+                self._timer.start()

--- a/api/src/backend/config/ecs_task_protection.py
+++ b/api/src/backend/config/ecs_task_protection.py
@@ -100,6 +100,21 @@ def set_task_protection(enabled, expires_minutes):
         return False
 
 
+def _env_int(name, default, minimum):
+    """Read an integer environment variable, tolerating malformed values.
+
+    A non-numeric value must not crash worker startup, so it is logged and the
+    ``default`` is used instead. The result is clamped to at least ``minimum``.
+    """
+    raw = os.environ.get(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        value = default
+    return max(minimum, value)
+
+
 class ECSTaskProtectionStep(bootsteps.StartStopStep):
     """Worker bootstep that protects the ECS task while protected work runs.
 
@@ -112,14 +127,13 @@ class ECSTaskProtectionStep(bootsteps.StartStopStep):
     requires = {"celery.worker.components:Pool"}
 
     def __init__(self, parent, **kwargs):
+        """Read poll interval and protection expiry from the environment."""
         super().__init__(parent, **kwargs)
-        self._poll_seconds = max(
-            5,
-            int(os.environ.get("DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS", "60")),
+        self._poll_seconds = _env_int(
+            "DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS", default=60, minimum=5
         )
-        self._expires_minutes = max(
-            1,
-            int(os.environ.get("DJANGO_ECS_TASK_PROTECTION_EXPIRES_MINUTES", "120")),
+        self._expires_minutes = _env_int(
+            "DJANGO_ECS_TASK_PROTECTION_EXPIRES_MINUTES", default=120, minimum=1
         )
         self._timer = None
         self._stop = threading.Event()
@@ -127,6 +141,7 @@ class ECSTaskProtectionStep(bootsteps.StartStopStep):
         self._protected_at = 0.0
 
     def start(self, parent):
+        """Start polling for protected tasks; no-op unless enabled on ECS."""
         if not is_enabled():
             return
         logger.info(
@@ -138,6 +153,7 @@ class ECSTaskProtectionStep(bootsteps.StartStopStep):
         self._tick()
 
     def stop(self, parent):
+        """Stop polling and release any held protection on worker shutdown."""
         self._stop.set()
         if self._timer is not None:
             self._timer.cancel()
@@ -148,6 +164,7 @@ class ECSTaskProtectionStep(bootsteps.StartStopStep):
 
     @staticmethod
     def _protected_task_in_flight():
+        """Return whether any active request is a protected long-running task."""
         # Imported lazily so the module stays importable outside a worker.
         from celery.worker import state
 
@@ -157,6 +174,7 @@ class ECSTaskProtectionStep(bootsteps.StartStopStep):
         )
 
     def _tick(self):
+        """Acquire, refresh, or release protection, then reschedule the poll."""
         if self._stop.is_set():
             return
         try:


### PR DESCRIPTION
### Context

When the API worker runs on Amazon ECS, the service scheduler can terminate a task during **auto scale-in** or a **rolling deployment** with no knowledge of the work in flight. #11416 made worker shutdown graceful and durable, but it deliberately **does not re-queue scans** (re-running a partial scan would duplicate ingestion) — they are marked terminal instead. The practical consequence is that a scale-in or deploy that lands on a worker running a multi-hour scan forces that scan to be **started again from scratch**.

AWS provides [ECS task scale-in protection](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-scale-in-protection.html) for exactly this case: a task marks itself protected while it is doing work the scheduler shouldn't interrupt, and the scheduler then scales in **idle** tasks instead.

### Description

Adds an **opt-in** Celery worker bootstep (`config/ecs_task_protection.py`) that:

- Polls the worker's active requests in the **main process** (so it counts every concurrency slot, independent of the execution pool) and enables task scale-in protection while a protected task is in flight, releasing it once the worker is idle.
- Protects the same long-running tasks Celery already gives the multi-hour time limit: `scan-perform`, `scan-perform-scheduled`, `provider-deletion`, `tenant-deletion`.
- **Refreshes** protection at half the configured expiry, so a long scan stays protected while a dead worker's protection lapses automatically (no permanently-stuck protection).
- Is a **no-op** unless `DJANGO_ECS_TASK_PROTECTION=True` **and** `ECS_AGENT_URI` is present (Fargate ≥ 1.4.0 / EC2 launch type), so non-ECS deployments (docker-compose, local, CI) are completely unaffected.
- Never raises and never blocks the worker: a failed protection call just logs a warning and the worker keeps running unprotected.

Uses only the standard library (`urllib`, `json`, `threading`) — no new dependencies.

The ECS task role needs the `ecs:UpdateTaskProtection` permission for the endpoint to succeed (documented in the module docstring and `.env.example`).

New environment variables (added to `api/.env.example`):

| Variable | Default | Purpose |
|---|---|---|
| `DJANGO_ECS_TASK_PROTECTION` | `False` | Master switch |
| `DJANGO_ECS_TASK_PROTECTION_POLL_SECONDS` | `60` | How often to check for in-flight protected tasks |
| `DJANGO_ECS_TASK_PROTECTION_EXPIRES_MINUTES` | `120` | Protection expiry requested from ECS (refreshed at half this interval) |

### Steps to review

1. `config/celery.py` — the step is registered only on `celery_app.steps["worker"]`, so it is never started in non-worker processes (gunicorn/API) that import the app.
2. `config/ecs_task_protection.py` — the bootstep lifecycle (`start`/`stop`/`_tick`), the active-request polling, and the protection refresh logic.
3. `api/src/backend/api/tests/test_ecs_task_protection.py` — covers the enable/disable gating, the PUT payload for enable vs disable, failure handling, and the acquire→release tick state machine.

Tested locally with `py_compile` on all changed files and a standalone validation of the enable/disable payloads; the unit test is written against the repo's pytest conventions for CI.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following the Google Python style guide.
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the README.md.
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable. *(happy to add an `api/CHANGELOG.md` entry referencing this PR number once assigned, or defer to maintainers' versioning.)*

#### API
- [x] All requirements work as expected (no-op off ECS; protects long tasks on ECS).
- [ ] No API spec / endpoint changes.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workers now support ECS task protection to reduce scale-in/rolling-deploy termination risk during long-running tasks.
  * Protection automatically enables/disables based on in-flight protected tasks and is active only when the feature flag and ECS agent endpoint are configured.

* **Chores**
  * Added configuration variables for enabling/disabling protection, plus polling interval and expiration window.

* **Tests**
  * Added comprehensive automated tests covering enablement rules, environment parsing/clamping, request payloads, and protection bootstep behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->