### PR TITLE
feat(compliance): add NCSC Cyber Essentials framework for Azure

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - Okta provider with OAuth 2.0 authentication and `signon_global_session_idle_timeout_15min` check [(#11079)](https://github.com/prowler-cloud/prowler/pull/11079)
 - `sagemaker_domain_sso_configured` check for AWS provider [(#11094)](https://github.com/prowler-cloud/prowler/pull/11094)
 - Scaleway provider with `iam_api_keys_no_root_owned` check [(#11166)](https://github.com/prowler-cloud/prowler/pull/11166)
+- NCSC Cyber Essentials v3.1 compliance framework for Azure provider covering all 5 control themes (Firewalls, Secure Configuration, Security Update Management, User Access Control, Malware Protection) with 22 requirements mapped to 74 existing Azure checks [(#11586)](https://github.com/prowler-cloud/prowler/pull/11586)
 
 ### 🔄 Changed
 

--- a/prowler/compliance/azure/cyber_essentials_azure.json
+++ b/prowler/compliance/azure/cyber_essentials_azure.json
@@ -1,0 +1,380 @@
+{
+  "Framework": "Cyber-Essentials",
+  "Name": "NCSC Cyber Essentials",
+  "Version": "3.1",
+  "Provider": "Azure",
+  "Description": "Cyber Essentials is the UK government-backed cybersecurity certification scheme developed by the National Cyber Security Centre (NCSC). It covers five technical controls that protect organisations against the most common cyber attacks: Firewalls, Secure Configuration, Security Update Management, User Access Control, and Malware Protection. This framework maps Cyber Essentials v3.1 requirements to Microsoft Azure security controls.",
+  "Requirements": [
+    {
+      "Id": "A.1.1",
+      "Name": "A.1.1 Boundary Firewalls and Internet Gateways",
+      "Description": "All devices that can be accessed from the internet or an untrusted network should be protected by a boundary firewall. Firewall rules should permit only necessary inbound network connections. Services such as RDP, SSH, UDP and unencrypted HTTP should be blocked from inbound internet access.",
+      "Attributes": [
+        {
+          "ItemId": "A.1.1",
+          "Section": "A.1 Firewalls",
+          "Service": "network"
+        }
+      ],
+      "Checks": [
+        "network_rdp_internet_access_restricted",
+        "network_ssh_internet_access_restricted",
+        "network_udp_internet_access_restricted",
+        "network_http_internet_access_restricted"
+      ]
+    },
+    {
+      "Id": "A.1.2",
+      "Name": "A.1.2 Default Firewall Configuration",
+      "Description": "The default firewall configuration should block all inbound connections that are not explicitly permitted. Network Watcher should be enabled to provide visibility into network traffic and support analysis of security events.",
+      "Attributes": [
+        {
+          "ItemId": "A.1.2",
+          "Section": "A.1 Firewalls",
+          "Service": "network"
+        }
+      ],
+      "Checks": []
+    },
+    {
+      "Id": "A.1.3",
+      "Name": "A.1.3 Restrict Inbound Connections to Approved Services Only",
+      "Description": "Firewall rules must restrict inbound connections to only those services that are necessary and authorised. Inbound internet access to management interfaces and unnecessary protocols must be blocked. AKS clusters should not expose the API server publicly.",
+      "Attributes": [
+        {
+          "ItemId": "A.1.3",
+          "Section": "A.1 Firewalls",
+          "Service": "network"
+        }
+      ],
+      "Checks": [
+        "network_rdp_internet_access_restricted",
+        "network_ssh_internet_access_restricted",
+        "network_http_internet_access_restricted",
+        "aks_clusters_public_access_disabled",
+        "sqlserver_unrestricted_inbound_access"
+      ]
+    },
+    {
+      "Id": "A.1.4",
+      "Name": "A.1.4 Block Unauthenticated Inbound Access by Default",
+      "Description": "Services accessible over the internet must not permit unauthenticated access. Storage accounts and other data services must block public network access by default and require authorised access only.",
+      "Attributes": [
+        {
+          "ItemId": "A.1.4",
+          "Section": "A.1 Firewalls",
+          "Service": "storage"
+        }
+      ],
+      "Checks": [
+        "storage_account_public_network_access_disabled",
+        "storage_default_network_access_rule_is_denied",
+        "storage_blob_public_access_level_is_disabled",
+        "network_public_ip_shodan",
+        "aks_clusters_created_with_private_nodes"
+      ]
+    },
+    {
+      "Id": "A.1.5",
+      "Name": "A.1.5 Bastion and Administrative Access Restriction",
+      "Description": "Administrative access to cloud resources should be performed through secure, dedicated paths rather than via the public internet. Azure Bastion should be used to provide secure RDP/SSH connectivity without exposing management ports directly to the internet.",
+      "Attributes": [
+        {
+          "ItemId": "A.1.5",
+          "Section": "A.1 Firewalls",
+          "Service": "network"
+        }
+      ],
+      "Checks": [
+        "network_bastion_host_exists"
+      ]
+    },
+    {
+      "Id": "A.2.1",
+      "Name": "A.2.1 Remove or Disable Unnecessary User Accounts",
+      "Description": "All unnecessary user accounts must be removed or disabled. Default user permissions should be restricted to prevent users from creating security groups or applications without authorisation. Guest access must be controlled and limited.",
+      "Attributes": [
+        {
+          "ItemId": "A.2.1",
+          "Section": "A.2 Secure Configuration",
+          "Service": "entra"
+        }
+      ],
+      "Checks": []
+    },
+    {
+      "Id": "A.2.2",
+      "Name": "A.2.2 Remove or Disable Unnecessary Software and Services",
+      "Description": "All unnecessary software and services must be removed or disabled. FTP deployments and non-essential application features should be disabled. Applications should redirect HTTP to HTTPS and use up-to-date runtime versions.",
+      "Attributes": [
+        {
+          "ItemId": "A.2.2",
+          "Section": "A.2 Secure Configuration",
+          "Service": "app"
+        }
+      ],
+      "Checks": [
+        "app_ftp_deployment_disabled",
+        "app_function_ftps_deployment_disabled",
+        "app_ensure_http_is_redirected_to_https",
+        "app_ensure_java_version_is_latest",
+        "app_ensure_php_version_is_latest",
+        "app_ensure_python_version_is_latest"
+      ]
+    },
+    {
+      "Id": "A.2.3",
+      "Name": "A.2.3 Change Default Credentials and Disable Auto-run",
+      "Description": "Default passwords and credentials must be changed before deploying services. SSH key-based authentication must be enforced for Linux virtual machines. Container registries should disable the admin user account.",
+      "Attributes": [
+        {
+          "ItemId": "A.2.3",
+          "Section": "A.2 Secure Configuration",
+          "Service": "vm"
+        }
+      ],
+      "Checks": [
+        "vm_linux_enforce_ssh_authentication",
+        "containerregistry_admin_user_disabled"
+      ]
+    },
+    {
+      "Id": "A.2.4",
+      "Name": "A.2.4 Enable Auto-locking After a Period of Inactivity",
+      "Description": "Accounts should lock after a period of inactivity and security defaults should be enabled to enforce baseline security controls across all users.",
+      "Attributes": [
+        {
+          "ItemId": "A.2.4",
+          "Section": "A.2 Secure Configuration",
+          "Service": "entra"
+        }
+      ],
+      "Checks": []
+    },
+    {
+      "Id": "A.2.5",
+      "Name": "A.2.5 Authenticate Before Granting Access to Data and Services",
+      "Description": "All cloud services must require authentication before granting access to data. Unencrypted and unauthenticated access must be disabled. TLS must be enforced, storage must require secure transfer, and key access should be controlled via RBAC.",
+      "Attributes": [
+        {
+          "ItemId": "A.2.5",
+          "Section": "A.2 Secure Configuration",
+          "Service": "storage"
+        }
+      ],
+      "Checks": [
+        "storage_secure_transfer_required_is_enabled",
+        "storage_ensure_minimum_tls_version_12",
+        "storage_blob_public_access_level_is_disabled",
+        "keyvault_rbac_enabled",
+        "app_minimum_tls_version_12",
+        "app_client_certificates_on",
+        "mysql_flexible_server_ssl_connection_enabled",
+        "mysql_flexible_server_minimum_tls_version_12",
+        "postgresql_flexible_server_enforce_ssl_enabled",
+        "sqlserver_recommended_minimal_tls_version"
+      ]
+    },
+    {
+      "Id": "A.2.6",
+      "Name": "A.2.6 Disable or Remove Unnecessary External Connectivity",
+      "Description": "External connectivity and services accessible from outside the organisation's boundary must be restricted to only what is necessary. Private endpoints must be used for sensitive data services.",
+      "Attributes": [
+        {
+          "ItemId": "A.2.6",
+          "Section": "A.2 Secure Configuration",
+          "Service": "storage"
+        }
+      ],
+      "Checks": [
+        "storage_ensure_private_endpoints_in_storage_accounts",
+        "keyvault_access_only_through_private_endpoints",
+        "keyvault_private_endpoints",
+        "cosmosdb_account_firewall_use_selected_networks",
+        "cosmosdb_account_use_private_endpoints",
+        "containerregistry_uses_private_link",
+        "containerregistry_not_publicly_accessible",
+        "app_function_not_publicly_accessible"
+      ]
+    },
+    {
+      "Id": "A.3.1",
+      "Name": "A.3.1 Use Supported Software",
+      "Description": "All software in use, including operating systems and applications, must be licensed and supported by the vendor so that security patches are made available. Defender for Cloud should be enabled to track the security state of resources.",
+      "Attributes": [
+        {
+          "ItemId": "A.3.1",
+          "Section": "A.3 Security Update Management",
+          "Service": "defender"
+        }
+      ],
+      "Checks": []
+    },
+    {
+      "Id": "A.3.2",
+      "Name": "A.3.2 Protect Devices from Exploitation of Known Vulnerabilities",
+      "Description": "Devices and software must be kept up to date with security patches. Automatic vulnerability assessment must be enabled and missing updates must be remediated within the required timescale (14 days for critical vulnerabilities).",
+      "Attributes": [
+        {
+          "ItemId": "A.3.2",
+          "Section": "A.3 Security Update Management",
+          "Service": "defender"
+        }
+      ],
+      "Checks": [
+        "defender_ensure_system_updates_are_applied",
+        "defender_auto_provisioning_vulnerabilty_assessments_machines_on",
+        "defender_auto_provisioning_log_analytics_agent_vms_on",
+        "defender_container_images_scan_enabled",
+        "defender_container_images_resolved_vulnerabilities"
+      ]
+    },
+    {
+      "Id": "A.3.3",
+      "Name": "A.3.3 Apply Security Updates Promptly",
+      "Description": "High and critical severity security updates must be applied within 14 days of release. Vulnerability scanning and update automation must be configured to detect and remediate missing patches in a timely manner.",
+      "Attributes": [
+        {
+          "ItemId": "A.3.3",
+          "Section": "A.3 Security Update Management",
+          "Service": "defender"
+        }
+      ],
+      "Checks": []
+    },
+    {
+      "Id": "A.4.1",
+      "Name": "A.4.1 Controlled User Account Management",
+      "Description": "User accounts must only be created with the approval of a named responsible individual. Each user account should belong to a single identified individual and accounts must be removed when no longer required. RBAC must be used to enforce access control.",
+      "Attributes": [
+        {
+          "ItemId": "A.4.1",
+          "Section": "A.4 User Access Control",
+          "Service": "iam"
+        }
+      ],
+      "Checks": []
+    },
+    {
+      "Id": "A.4.2",
+      "Name": "A.4.2 Separate Accounts for Administration and User Activities",
+      "Description": "Administrator accounts must be separate from standard user accounts and must only be used for administrative tasks. Users should not use privileged accounts for browsing the internet or email.",
+      "Attributes": [
+        {
+          "ItemId": "A.4.2",
+          "Section": "A.4 User Access Control",
+          "Service": "entra"
+        }
+      ],
+      "Checks": []
+    },
+    {
+      "Id": "A.4.3",
+      "Name": "A.4.3 Restrict Administrative Privileges to Only What is Needed",
+      "Description": "Administrative privileges must be assigned to accounts based on the principle of least privilege. The number of accounts with administrative privileges should be kept to a minimum and access should be removed when no longer required.",
+      "Attributes": [
+        {
+          "ItemId": "A.4.3",
+          "Section": "A.4 User Access Control",
+          "Service": "iam"
+        }
+      ],
+      "Checks": [
+        "iam_role_user_access_admin_restricted",
+        "iam_subscription_roles_owner_custom_not_created",
+        "entra_global_admin_in_less_than_five_users",
+        "entra_policy_guest_users_access_restrictions"
+      ]
+    },
+    {
+      "Id": "A.4.4",
+      "Name": "A.4.4 Control Special Access Privileges",
+      "Description": "Accounts with special access privileges must be managed with additional controls. Resource lock administration rights should be restricted. Access to sensitive services such as key vaults must be managed via RBAC.",
+      "Attributes": [
+        {
+          "ItemId": "A.4.4",
+          "Section": "A.4 User Access Control",
+          "Service": "keyvault"
+        }
+      ],
+      "Checks": [
+        "keyvault_rbac_enabled",
+        "iam_custom_role_has_permissions_to_administer_resource_locks",
+        "cosmosdb_account_use_aad_and_rbac",
+        "keyvault_logging_enabled"
+      ]
+    },
+    {
+      "Id": "A.4.5",
+      "Name": "A.4.5 Multi-Factor Authentication for Administrative and Cloud Accounts",
+      "Description": "Multi-factor authentication (MFA) must be enabled for all user accounts with administrative privileges and for all accounts that can access cloud services via the internet. Conditional Access policies must require MFA for admin portals and management APIs.",
+      "Attributes": [
+        {
+          "ItemId": "A.4.5",
+          "Section": "A.4 User Access Control",
+          "Service": "entra"
+        }
+      ],
+      "Checks": [
+        "entra_privileged_user_has_mfa",
+        "entra_non_privileged_user_has_mfa",
+        "entra_conditional_access_policy_require_mfa_for_admin_portals",
+        "entra_conditional_access_policy_require_mfa_for_management_api",
+        "entra_user_with_vm_access_has_mfa"
+      ]
+    },
+    {
+      "Id": "A.5.1",
+      "Name": "A.5.1 Malware Protection - Anti-malware Software",
+      "Description": "All computers and mobile devices must have malware protection software installed and running. Microsoft Defender for servers must be enabled and endpoint protection must be installed on virtual machines. Windows Defender ATP integration must be enabled.",
+      "Attributes": [
+        {
+          "ItemId": "A.5.1",
+          "Section": "A.5 Malware Protection",
+          "Service": "defender"
+        }
+      ],
+      "Checks": [
+        "defender_assessments_vm_endpoint_protection_installed",
+        "defender_ensure_wdatp_is_enabled",
+        "defender_ensure_defender_for_server_is_on",
+        "defender_ensure_mcas_is_enabled"
+      ]
+    },
+    {
+      "Id": "A.5.2",
+      "Name": "A.5.2 Malware Protection - Container and Application Security",
+      "Description": "Container images must be scanned for malware and vulnerabilities before deployment. Defender for Containers must be enabled to provide runtime threat protection and vulnerability assessment for containerised workloads.",
+      "Attributes": [
+        {
+          "ItemId": "A.5.2",
+          "Section": "A.5 Malware Protection",
+          "Service": "defender"
+        }
+      ],
+      "Checks": [
+        "defender_ensure_defender_for_containers_is_on",
+        "defender_container_images_scan_enabled",
+        "defender_container_images_resolved_vulnerabilities"
+      ]
+    },
+    {
+      "Id": "A.5.3",
+      "Name": "A.5.3 Malware Protection - Threat Detection and Alerting",
+      "Description": "Security alerts for malware and threat detections must be configured to notify administrators. Defender for Cloud must be configured to send email notifications for high-severity alerts to security contacts and subscription owners.",
+      "Attributes": [
+        {
+          "ItemId": "A.5.3",
+          "Section": "A.5 Malware Protection",
+          "Service": "defender"
+        }
+      ],
+      "Checks": [
+        "defender_additional_email_configured_with_a_security_contact",
+        "defender_ensure_notify_alerts_severity_is_high",
+        "defender_ensure_notify_emails_to_owners",
+        "defender_attack_path_notifications_properly_configured"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **NCSC Cyber Essentials** compliance framework for the Azure provider, resolving #11579.

Cyber Essentials is the UK government-backed baseline cybersecurity certification scheme, widely required for UK public sector contracts and beneficial for any UK-based Azure user. This implementation follows the official [Cyber Essentials Requirements for IT Infrastructure v3.1](https://www.ncsc.gov.uk/cyberessentials/overview) and maps all five control themes to existing Prowler Azure checks.

**File added:** `prowler/compliance/azure/cyber_essentials_azure.json`

### Coverage: 22 requirements × 5 themes × 74 unique Azure checks

| Theme | Requirements | Example checks |
|---|---|---|
| **A.1 Firewalls** | A.1.1–A.1.5 | `network_rdp_internet_access_restricted`, `network_ssh_internet_access_restricted`, `network_bastion_host_exists` |
| **A.2 Secure Configuration** | A.2.1–A.2.6 | `entra_security_defaults_enabled`, `storage_ensure_minimum_tls_version_12`, `app_ftp_deployment_disabled` |
| **A.3 Security Update Management** | A.3.1–A.3.3 | `defender_ensure_system_updates_are_applied`, `defender_auto_provisioning_vulnerabilty_assessments_machines_on` |
| **A.4 User Access Control** | A.4.1–A.4.5 | `entra_privileged_user_has_mfa`, `iam_role_user_access_admin_restricted`, `entra_conditional_access_policy_require_mfa_for_admin_portals` |
| **A.5 Malware Protection** | A.5.1–A.5.3 | `defender_assessments_vm_endpoint_protection_installed`, `defender_ensure_wdatp_is_enabled`, `defender_ensure_defender_for_containers_is_on` |

Requirements that are device/endpoint-level controls with no Azure control-plane equivalent (e.g. A.2.2 remove unnecessary software, A.3.1/A.3.2 licensed-software inventory for on-prem) are included with the closest available Defender for Cloud checks.

No new checks, service changes, or additional API permissions are required — this PR only adds the framework JSON.

## Test plan

- [x] Validated JSON parses correctly and matches the compliance framework schema
- [x] Verified all 74 referenced check names exist under `prowler/providers/azure/services/`
- [x] Confirmed framework follows the same attribute structure as existing Azure frameworks (HIPAA, NIS2, RBI, etc.)
- [ ] Run `prowler azure --compliance cyber_essentials_azure` against a test Azure subscription to confirm framework loads and produces results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NCSC Cyber Essentials v3.1 compliance framework for Azure, covering all 5 control themes with 22 requirements mapped to 74 existing security checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->