### PR TITLE
feat(api): add compliance provider filters

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🚀 Added
 
 - Provider group filters for API endpoints that support cloud provider filtering, including exact and `__in` variants [(#11573)](https://github.com/prowler-cloud/prowler/pull/11573)
+- Provider filters for `GET /api/v1/compliance-overviews`, `/metadata`, and `/requirements`, using latest completed scans per matching provider [(#11587)](https://github.com/prowler-cloud/prowler/pull/11587)
 
 ---
 

--- a/api/src/backend/api/filters.py
+++ b/api/src/backend/api/filters.py
@@ -1346,12 +1346,12 @@ class RoleFilter(FilterSet):
         }
 
 
-class ComplianceOverviewFilter(FilterSet):
+class ComplianceOverviewFilter(BaseScanProviderFilter):
     inserted_at = DateFilter(field_name="inserted_at", lookup_expr="date")
-    scan_id = UUIDFilter(field_name="scan_id", required=True)
+    scan_id = UUIDFilter(field_name="scan_id")
     region = CharFilter(field_name="region")
 
-    class Meta:
+    class Meta(BaseScanProviderFilter.Meta):
         model = ComplianceRequirementOverview
         fields = {
             "inserted_at": ["date", "gte", "lte"],

--- a/api/src/backend/api/filters.py
+++ b/api/src/backend/api/filters.py
@@ -1347,6 +1347,13 @@ class RoleFilter(FilterSet):
 
 
 class ComplianceOverviewFilter(BaseScanProviderFilter):
+    """
+    Keep provider filters in the schema while runtime filtering resolves scans first.
+
+    Compliance overview provider filters are applied to the latest completed scans
+    in the viewset, then this filterset handles the remaining compliance fields.
+    """
+
     inserted_at = DateFilter(field_name="inserted_at", lookup_expr="date")
     scan_id = UUIDFilter(field_name="scan_id")
     region = CharFilter(field_name="region")

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -9426,6 +9426,116 @@ class TestComplianceOverviewViewSet:
         with patch("api.v1.views.backfill_compliance_summaries_task.delay") as mock:
             yield mock
 
+    def _create_completed_scan(self, provider, name):
+        return Scan.objects.create(
+            name=name,
+            provider=provider,
+            trigger=Scan.TriggerChoices.MANUAL,
+            state=StateChoices.COMPLETED,
+            tenant_id=provider.tenant_id,
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc),
+        )
+
+    def _create_requirement(
+        self,
+        scan,
+        requirement_id,
+        status_choice,
+        region="eu-west-1",
+        compliance_id="cis_1.4_aws",
+    ):
+        passed = 1 if status_choice == StatusChoices.PASS else 0
+        total = 1 if status_choice != StatusChoices.MANUAL else 0
+        return ComplianceRequirementOverview.objects.create(
+            tenant_id=scan.tenant_id,
+            scan=scan,
+            compliance_id=compliance_id,
+            framework="CIS-1.4-AWS",
+            version="1.4",
+            description="CIS AWS Foundations Benchmark v1.4.0",
+            region=region,
+            requirement_id=requirement_id,
+            requirement_status=status_choice,
+            passed_checks=passed,
+            failed_checks=0 if status_choice == StatusChoices.PASS else 1,
+            total_checks=total,
+            passed_findings=passed,
+            total_findings=total,
+        )
+
+    def _create_compliance_summary(
+        self,
+        scan,
+        *,
+        passed,
+        failed,
+        manual=0,
+        compliance_id="cis_1.4_aws",
+    ):
+        return ComplianceOverviewSummary.objects.create(
+            tenant_id=scan.tenant_id,
+            scan=scan,
+            compliance_id=compliance_id,
+            requirements_passed=passed,
+            requirements_failed=failed,
+            requirements_manual=manual,
+            total_requirements=passed + failed + manual,
+        )
+
+    def _overview_attrs_by_id(self, response):
+        assert response.status_code == status.HTTP_200_OK
+        return {item["id"]: item["attributes"] for item in response.json()["data"]}
+
+    def _prepare_latest_compliance_data(self, providers_fixture):
+        provider1, provider2, provider3, *_ = providers_fixture
+        old_scan = self._create_completed_scan(provider1, "old aws compliance scan")
+        latest_scan1 = self._create_completed_scan(
+            provider1, "latest aws compliance scan 1"
+        )
+        latest_scan2 = self._create_completed_scan(
+            provider2, "latest aws compliance scan 2"
+        )
+        latest_gcp_scan = self._create_completed_scan(
+            provider3, "latest gcp compliance scan"
+        )
+
+        self._create_requirement(old_scan, "1.1", StatusChoices.FAIL)
+        self._create_requirement(old_scan, "1.2", StatusChoices.FAIL)
+        self._create_compliance_summary(old_scan, passed=0, failed=2)
+
+        self._create_requirement(
+            latest_scan1, "1.1", StatusChoices.PASS, region="eu-west-1"
+        )
+        self._create_requirement(
+            latest_scan1, "1.2", StatusChoices.PASS, region="eu-west-1"
+        )
+        self._create_compliance_summary(latest_scan1, passed=2, failed=0)
+
+        self._create_requirement(
+            latest_scan2, "1.1", StatusChoices.FAIL, region="us-east-1"
+        )
+        self._create_requirement(
+            latest_scan2, "1.2", StatusChoices.PASS, region="us-east-1"
+        )
+        self._create_compliance_summary(latest_scan2, passed=1, failed=1)
+
+        self._create_requirement(
+            latest_gcp_scan,
+            "gcp-1.1",
+            StatusChoices.FAIL,
+            region="europe-west1",
+            compliance_id="cis_1.3_gcp",
+        )
+        self._create_compliance_summary(
+            latest_gcp_scan,
+            passed=0,
+            failed=1,
+            compliance_id="cis_1.3_gcp",
+        )
+
+        return old_scan, latest_scan1, latest_scan2, latest_gcp_scan
+
     def test_compliance_overview_list_none(
         self,
         authenticated_client,
@@ -9572,6 +9682,154 @@ class TestComplianceOverviewViewSet:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()["data"]) >= 1
         mock_backfill_task.assert_not_called()
+
+    def test_compliance_overview_provider_id_filter_uses_latest_scan(
+        self,
+        authenticated_client,
+        providers_fixture,
+        mock_backfill_task,
+    ):
+        _, latest_scan, *_ = self._prepare_latest_compliance_data(providers_fixture)
+
+        response = authenticated_client.get(
+            reverse("complianceoverview-list"),
+            {"filter[provider_id]": str(latest_scan.provider_id)},
+        )
+
+        attrs_by_id = self._overview_attrs_by_id(response)
+        assert attrs_by_id["cis_1.4_aws"]["requirements_passed"] == 2
+        assert attrs_by_id["cis_1.4_aws"]["requirements_failed"] == 0
+        assert "cis_1.3_gcp" not in attrs_by_id
+        mock_backfill_task.assert_not_called()
+
+    def test_compliance_overview_provider_id_in_filter_aggregates_latest_scans(
+        self,
+        authenticated_client,
+        providers_fixture,
+    ):
+        _, latest_scan1, latest_scan2, *_ = self._prepare_latest_compliance_data(
+            providers_fixture
+        )
+
+        response = authenticated_client.get(
+            reverse("complianceoverview-list"),
+            {
+                "filter[provider_id__in]": (
+                    f"{latest_scan1.provider_id},{latest_scan2.provider_id}"
+                )
+            },
+        )
+
+        attrs_by_id = self._overview_attrs_by_id(response)
+        assert attrs_by_id["cis_1.4_aws"]["requirements_passed"] == 1
+        assert attrs_by_id["cis_1.4_aws"]["requirements_failed"] == 1
+        assert attrs_by_id["cis_1.4_aws"]["total_requirements"] == 2
+        assert "cis_1.3_gcp" not in attrs_by_id
+
+    def test_compliance_overview_provider_type_filter_uses_latest_scans(
+        self,
+        authenticated_client,
+        providers_fixture,
+    ):
+        self._prepare_latest_compliance_data(providers_fixture)
+
+        response = authenticated_client.get(
+            reverse("complianceoverview-list"),
+            {"filter[provider_type]": Provider.ProviderChoices.AWS.value},
+        )
+
+        attrs_by_id = self._overview_attrs_by_id(response)
+        assert attrs_by_id["cis_1.4_aws"]["requirements_passed"] == 1
+        assert attrs_by_id["cis_1.4_aws"]["requirements_failed"] == 1
+        assert attrs_by_id["cis_1.4_aws"]["total_requirements"] == 2
+        assert "cis_1.3_gcp" not in attrs_by_id
+
+    def test_compliance_overview_provider_groups_filters_use_latest_scans(
+        self,
+        authenticated_client,
+        providers_fixture,
+        provider_groups_fixture,
+        tenants_fixture,
+    ):
+        tenant = tenants_fixture[0]
+        provider1, provider2, *_ = providers_fixture
+        group1, group2, *_ = provider_groups_fixture
+        _, latest_scan1, latest_scan2, *_ = self._prepare_latest_compliance_data(
+            providers_fixture
+        )
+        ProviderGroupMembership.objects.create(
+            tenant_id=tenant.id,
+            provider=provider1,
+            provider_group=group1,
+        )
+        ProviderGroupMembership.objects.create(
+            tenant_id=tenant.id,
+            provider=provider2,
+            provider_group=group2,
+        )
+
+        response = authenticated_client.get(
+            reverse("complianceoverview-list"),
+            {"filter[provider_groups]": str(group1.id)},
+        )
+
+        attrs_by_id = self._overview_attrs_by_id(response)
+        assert latest_scan1.provider_id == provider1.id
+        assert attrs_by_id["cis_1.4_aws"]["requirements_passed"] == 2
+        assert attrs_by_id["cis_1.4_aws"]["requirements_failed"] == 0
+
+        response = authenticated_client.get(
+            reverse("complianceoverview-list"),
+            {"filter[provider_groups__in]": f"{group1.id},{group2.id}"},
+        )
+
+        attrs_by_id = self._overview_attrs_by_id(response)
+        assert latest_scan2.provider_id == provider2.id
+        assert attrs_by_id["cis_1.4_aws"]["requirements_passed"] == 1
+        assert attrs_by_id["cis_1.4_aws"]["requirements_failed"] == 1
+        assert attrs_by_id["cis_1.4_aws"]["total_requirements"] == 2
+
+    def test_compliance_overview_metadata_accepts_provider_filters(
+        self,
+        authenticated_client,
+        providers_fixture,
+    ):
+        _, latest_scan, *_ = self._prepare_latest_compliance_data(providers_fixture)
+
+        response = authenticated_client.get(
+            reverse("complianceoverview-metadata"),
+            {"filter[provider_id]": str(latest_scan.provider_id)},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        regions = response.json()["data"]["attributes"]["regions"]
+        assert regions == ["eu-west-1"]
+
+    def test_compliance_overview_requirements_accepts_provider_filters(
+        self,
+        authenticated_client,
+        providers_fixture,
+    ):
+        _, latest_scan1, latest_scan2, *_ = self._prepare_latest_compliance_data(
+            providers_fixture
+        )
+
+        response = authenticated_client.get(
+            reverse("complianceoverview-requirements"),
+            {
+                "filter[provider_id__in]": (
+                    f"{latest_scan1.provider_id},{latest_scan2.provider_id}"
+                ),
+                "filter[compliance_id]": "cis_1.4_aws",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        requirements_by_id = {
+            item["id"]: item["attributes"] for item in response.json()["data"]
+        }
+        assert requirements_by_id["1.1"]["status"] == "FAIL"
+        assert requirements_by_id["1.2"]["status"] == "PASS"
 
     def test_compliance_overview_metadata(
         self, authenticated_client, compliance_requirements_overviews_fixture

--- a/api/src/backend/api/v1/mixins.py
+++ b/api/src/backend/api/v1/mixins.py
@@ -1,6 +1,10 @@
+import uuid
+
+from django.http import QueryDict
 from django.urls import reverse
 from django_celery_results.models import TaskResult
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from api.exceptions import (
@@ -8,7 +12,7 @@ from api.exceptions import (
     TaskInProgressException,
     TaskNotFoundException,
 )
-from api.models import StateChoices, Task
+from api.models import Provider, StateChoices, Task
 from api.v1.serializers import TaskSerializer
 
 
@@ -72,6 +76,162 @@ class PaginateByPkMixin:
 
         serialized = self.get_serializer(queryset, many=True).data
         return self.get_paginated_response(serialized)
+
+
+class JsonApiFilterMixin:
+    """Shared helpers for manually applying django-filter to JSON:API params."""
+
+    jsonapi_filter_replace_dots = False
+
+    def _normalize_jsonapi_params(
+        self,
+        query_params,
+        exclude_keys=None,
+        replace_dots=None,
+    ):
+        exclude_keys = exclude_keys or set()
+        if replace_dots is None:
+            replace_dots = self.jsonapi_filter_replace_dots
+
+        normalized = QueryDict(mutable=True)
+        for key, values in query_params.lists():
+            normalized_key = (
+                key[7:-1] if key.startswith("filter[") and key.endswith("]") else key
+            )
+            if replace_dots:
+                normalized_key = normalized_key.replace(".", "__")
+            if normalized_key not in exclude_keys:
+                normalized.setlist(normalized_key, values)
+        return normalized
+
+    def _apply_filterset(
+        self,
+        queryset,
+        filterset_class,
+        exclude_keys=None,
+        replace_dots=None,
+    ):
+        normalized_params = self._normalize_jsonapi_params(
+            self.request.query_params,
+            exclude_keys=set(exclude_keys or []),
+            replace_dots=replace_dots,
+        )
+        filterset = filterset_class(normalized_params, queryset=queryset)
+        if not filterset.is_valid():
+            raise ValidationError(filterset.errors)
+        return filterset.qs
+
+
+class ProviderFilterParamsMixin(JsonApiFilterMixin):
+    """Shared extraction of provider filters from JSON:API query params."""
+
+    PROVIDER_FILTER_KEYS = frozenset(
+        {
+            "provider_id",
+            "provider_id__in",
+            "provider_type",
+            "provider_type__in",
+            "provider_groups",
+            "provider_groups__in",
+        }
+    )
+    PROVIDER_FILTER_DOT_ALIAS_KEYS = frozenset(
+        {
+            "provider_id.in",
+            "provider_type.in",
+            "provider_groups.in",
+        }
+    )
+    PROVIDER_FILTER_QUERY_KEYS = PROVIDER_FILTER_KEYS | PROVIDER_FILTER_DOT_ALIAS_KEYS
+
+    def _csv_filter_values(self, value):
+        return [item.strip() for item in value.split(",") if item.strip()]
+
+    def _validate_uuid_filter_values(self, field_name, values):
+        try:
+            for value in values:
+                uuid.UUID(str(value))
+        except (TypeError, ValueError, AttributeError):
+            raise ValidationError({field_name: ["Enter a valid UUID."]})
+
+    def _has_provider_filters(self, include_dot_aliases=False):
+        provider_filter_keys = (
+            self.PROVIDER_FILTER_QUERY_KEYS
+            if include_dot_aliases
+            else self.PROVIDER_FILTER_KEYS
+        )
+        return any(
+            self.request.query_params.get(f"filter[{key}]")
+            for key in provider_filter_keys
+        )
+
+    def _extract_provider_filters_from_params(
+        self,
+        *,
+        validate_uuids=False,
+        include_dot_aliases=False,
+    ):
+        params = self.request.query_params
+        filters = {}
+        valid_provider_types = {
+            choice[0] for choice in Provider.ProviderChoices.choices
+        }
+
+        provider_id = params.get("filter[provider_id]")
+        if provider_id:
+            if validate_uuids:
+                self._validate_uuid_filter_values("provider_id", [provider_id])
+            filters["provider_id"] = provider_id
+
+        provider_id_in = params.get("filter[provider_id__in]")
+        if include_dot_aliases:
+            provider_id_in = provider_id_in or params.get("filter[provider_id.in]")
+        if provider_id_in:
+            values = self._csv_filter_values(provider_id_in)
+            if validate_uuids:
+                self._validate_uuid_filter_values("provider_id__in", values)
+            filters["provider_id__in"] = values
+
+        provider_type = params.get("filter[provider_type]")
+        if provider_type:
+            if provider_type not in valid_provider_types:
+                raise ValidationError(
+                    {"provider_type": f"Invalid choice: {provider_type}"}
+                )
+            filters["provider__provider"] = provider_type
+
+        provider_type_in = params.get("filter[provider_type__in]")
+        if include_dot_aliases:
+            provider_type_in = provider_type_in or params.get(
+                "filter[provider_type.in]"
+            )
+        if provider_type_in:
+            values = self._csv_filter_values(provider_type_in)
+            invalid = [value for value in values if value not in valid_provider_types]
+            if invalid:
+                raise ValidationError(
+                    {"provider_type__in": f"Invalid choices: {', '.join(invalid)}"}
+                )
+            filters["provider__provider__in"] = values
+
+        provider_groups = params.get("filter[provider_groups]")
+        if provider_groups:
+            if validate_uuids:
+                self._validate_uuid_filter_values("provider_groups", [provider_groups])
+            filters["provider__provider_groups__id"] = provider_groups
+
+        provider_groups_in = params.get("filter[provider_groups__in]")
+        if include_dot_aliases:
+            provider_groups_in = provider_groups_in or params.get(
+                "filter[provider_groups.in]"
+            )
+        if provider_groups_in:
+            values = self._csv_filter_values(provider_groups_in)
+            if validate_uuids:
+                self._validate_uuid_filter_values("provider_groups__in", values)
+            filters["provider__provider_groups__id__in"] = values
+
+        return filters
 
 
 class TaskManagementMixin:

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -228,7 +228,13 @@ from api.utils import (
     validate_invitation,
 )
 from api.uuid_utils import datetime_to_uuid7, uuid7_start
-from api.v1.mixins import DisablePaginationMixin, PaginateByPkMixin, TaskManagementMixin
+from api.v1.mixins import (
+    DisablePaginationMixin,
+    JsonApiFilterMixin,
+    PaginateByPkMixin,
+    ProviderFilterParamsMixin,
+    TaskManagementMixin,
+)
 from api.v1.serializers import (
     AttackPathsCartographySchemaSerializer,
     AttackPathsCustomQueryRunRequestSerializer,
@@ -4680,24 +4686,10 @@ class RoleProviderGroupRelationshipView(RelationshipView, BaseRLSViewSet):
 @method_decorator(CACHE_DECORATOR, name="list")
 @method_decorator(CACHE_DECORATOR, name="requirements")
 @method_decorator(CACHE_DECORATOR, name="attributes")
-class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
-    PROVIDER_FILTER_KEYS = frozenset(
-        {
-            "provider_id",
-            "provider_id__in",
-            "provider_type",
-            "provider_type__in",
-            "provider_groups",
-            "provider_groups__in",
-        }
-    )
-    PROVIDER_FILTER_QUERY_KEYS = PROVIDER_FILTER_KEYS | frozenset(
-        {
-            "provider_id.in",
-            "provider_type.in",
-            "provider_groups.in",
-        }
-    )
+class ComplianceOverviewViewSet(
+    ProviderFilterParamsMixin, BaseRLSViewSet, TaskManagementMixin
+):
+    jsonapi_filter_replace_dots = True
     pagination_class = ComplianceOverviewPagination
     queryset = ComplianceRequirementOverview.objects.all()
     serializer_class = ComplianceOverviewSerializer
@@ -4764,45 +4756,6 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
 
         return summaries
 
-    def _normalize_jsonapi_params(self, query_params, exclude_keys=None):
-        """Convert JSON:API filter params into django-filter keys."""
-        exclude_keys = exclude_keys or set()
-        normalized = QueryDict(mutable=True)
-        for key, values in query_params.lists():
-            normalized_key = (
-                key[7:-1] if key.startswith("filter[") and key.endswith("]") else key
-            )
-            normalized_key = normalized_key.replace(".", "__")
-            if normalized_key not in exclude_keys:
-                normalized.setlist(normalized_key, values)
-        return normalized
-
-    def _apply_compliance_filterset(self, queryset, exclude_keys=None):
-        normalized_params = self._normalize_jsonapi_params(
-            self.request.query_params,
-            exclude_keys=set(exclude_keys or []),
-        )
-        filterset = self.filterset_class(normalized_params, queryset=queryset)
-        if not filterset.is_valid():
-            raise ValidationError(filterset.errors)
-        return filterset.qs
-
-    def _csv_filter_values(self, value):
-        return [item.strip() for item in value.split(",") if item.strip()]
-
-    def _validate_uuid_filter_values(self, field_name, values):
-        try:
-            for value in values:
-                uuid.UUID(str(value))
-        except (TypeError, ValueError, AttributeError):
-            raise ValidationError({field_name: ["Enter a valid UUID."]})
-
-    def _has_provider_filters(self):
-        return any(
-            self.request.query_params.get(f"filter[{key}]")
-            for key in self.PROVIDER_FILTER_QUERY_KEYS
-        )
-
     def _validate_scan_selection(self, scan_id, has_provider_filters):
         if scan_id and has_provider_filters:
             raise ValidationError(
@@ -4834,62 +4787,6 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
             ]
         )
 
-    def _extract_provider_filters_from_params(self):
-        """Extract provider filters for the Scan queryset."""
-        params = self.request.query_params
-        filters = {}
-        valid_provider_types = {
-            choice[0] for choice in Provider.ProviderChoices.choices
-        }
-
-        provider_id = params.get("filter[provider_id]")
-        if provider_id:
-            self._validate_uuid_filter_values("provider_id", [provider_id])
-            filters["provider_id"] = provider_id
-
-        provider_id_in = params.get("filter[provider_id__in]") or params.get(
-            "filter[provider_id.in]"
-        )
-        if provider_id_in:
-            values = self._csv_filter_values(provider_id_in)
-            self._validate_uuid_filter_values("provider_id__in", values)
-            filters["provider_id__in"] = values
-
-        provider_type = params.get("filter[provider_type]")
-        if provider_type:
-            if provider_type not in valid_provider_types:
-                raise ValidationError(
-                    {"provider_type": f"Invalid choice: {provider_type}"}
-                )
-            filters["provider__provider"] = provider_type
-
-        provider_type_in = params.get("filter[provider_type__in]") or params.get(
-            "filter[provider_type.in]"
-        )
-        if provider_type_in:
-            values = self._csv_filter_values(provider_type_in)
-            invalid = [value for value in values if value not in valid_provider_types]
-            if invalid:
-                raise ValidationError(
-                    {"provider_type__in": f"Invalid choices: {', '.join(invalid)}"}
-                )
-            filters["provider__provider__in"] = values
-
-        provider_groups = params.get("filter[provider_groups]")
-        if provider_groups:
-            self._validate_uuid_filter_values("provider_groups", [provider_groups])
-            filters["provider__provider_groups__id"] = provider_groups
-
-        provider_groups_in = params.get("filter[provider_groups__in]") or params.get(
-            "filter[provider_groups.in]"
-        )
-        if provider_groups_in:
-            values = self._csv_filter_values(provider_groups_in)
-            self._validate_uuid_filter_values("provider_groups__in", values)
-            filters["provider__provider_groups__id__in"] = values
-
-        return filters
-
     def _latest_scan_ids_for_provider_filters(self):
         role = get_role(self.request.user, self.request.tenant_id)
         scans = Scan.all_objects.filter(
@@ -4900,7 +4797,10 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
         if not getattr(role, Permissions.UNLIMITED_VISIBILITY.value, False):
             scans = scans.filter(provider__in=get_providers(role))
 
-        provider_filters = self._extract_provider_filters_from_params()
+        provider_filters = self._extract_provider_filters_from_params(
+            validate_uuids=True,
+            include_dot_aliases=True,
+        )
         if provider_filters:
             scans = scans.filter(**provider_filters)
 
@@ -4913,8 +4813,11 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
     def _filtered_queryset_for_latest_provider_scans(self):
         latest_scan_ids = self._latest_scan_ids_for_provider_filters()
         queryset = self.get_queryset().filter(scan_id__in=latest_scan_ids)
-        return self._apply_compliance_filterset(
+        # Provider filters stay on the filterset for OpenAPI docs, but runtime
+        # filtering happens on Scan first so compliance queries use scan IDs.
+        return self._apply_filterset(
             queryset,
+            self.filterset_class,
             exclude_keys=self.PROVIDER_FILTER_KEYS | {"scan_id"},
         )
 
@@ -5080,7 +4983,7 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
 
     def list(self, request, *args, **kwargs):
         scan_id = request.query_params.get("filter[scan_id]")
-        has_provider_filters = self._has_provider_filters()
+        has_provider_filters = self._has_provider_filters(include_dot_aliases=True)
         self._validate_scan_selection(scan_id, has_provider_filters)
 
         if has_provider_filters:
@@ -5130,13 +5033,13 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
     @action(detail=False, methods=["get"], url_name="metadata")
     def metadata(self, request):
         scan_id = request.query_params.get("filter[scan_id]")
-        has_provider_filters = self._has_provider_filters()
+        has_provider_filters = self._has_provider_filters(include_dot_aliases=True)
         self._validate_scan_selection(scan_id, has_provider_filters)
 
         queryset = (
             self._filtered_queryset_for_latest_provider_scans()
             if has_provider_filters
-            else self._apply_compliance_filterset(self.get_queryset())
+            else self._apply_filterset(self.get_queryset(), self.filterset_class)
         )
 
         regions = list(
@@ -5160,7 +5063,7 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
     @action(detail=False, methods=["get"], url_name="requirements")
     def requirements(self, request):
         scan_id = request.query_params.get("filter[scan_id]")
-        has_provider_filters = self._has_provider_filters()
+        has_provider_filters = self._has_provider_filters(include_dot_aliases=True)
         compliance_id = request.query_params.get("filter[compliance_id]")
 
         self._validate_scan_selection(scan_id, has_provider_filters)
@@ -5179,7 +5082,7 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
         filtered_queryset = (
             self._filtered_queryset_for_latest_provider_scans()
             if has_provider_filters
-            else self._apply_compliance_filterset(self.get_queryset())
+            else self._apply_filterset(self.get_queryset(), self.filterset_class)
         )
 
         all_requirements = filtered_queryset.values(
@@ -5484,7 +5387,7 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
     ),
 )
 @method_decorator(CACHE_DECORATOR, name="list")
-class OverviewViewSet(BaseRLSViewSet):
+class OverviewViewSet(ProviderFilterParamsMixin, BaseRLSViewSet):
     queryset = ScanSummary.objects.all()
     http_method_names = ["get"]
     ordering = ["-inserted_at"]
@@ -5601,18 +5504,6 @@ class OverviewViewSet(BaseRLSViewSet):
             tenant_id=tenant_id, scan_id__in=latest_scan_ids
         )
 
-    def _normalize_jsonapi_params(self, query_params, exclude_keys=None):
-        """Convert JSON:API filter params (filter[X]) to flat params (X)."""
-        exclude_keys = exclude_keys or set()
-        normalized = QueryDict(mutable=True)
-        for key, values in query_params.lists():
-            normalized_key = (
-                key[7:-1] if key.startswith("filter[") and key.endswith("]") else key
-            )
-            if normalized_key not in exclude_keys:
-                normalized.setlist(normalized_key, values)
-        return normalized
-
     def _ensure_allowed_providers(self):
         """Populate allowed providers for RBAC-aware queries once per request."""
         if getattr(self, "_providers_initialized", False):
@@ -5632,15 +5523,6 @@ class OverviewViewSet(BaseRLSViewSet):
             return queryset.filter(**provider_filter)
         return queryset
 
-    def _apply_filterset(self, queryset, filterset_class, exclude_keys=None):
-        normalized_params = self._normalize_jsonapi_params(
-            self.request.query_params, exclude_keys=set(exclude_keys or [])
-        )
-        filterset = filterset_class(normalized_params, queryset=queryset)
-        if not filterset.is_valid():
-            raise ValidationError(filterset.errors)
-        return filterset.qs
-
     def _latest_scan_ids_for_allowed_providers(self, tenant_id, provider_filters=None):
         provider_filter = self._get_provider_filter()
         queryset = Scan.all_objects.filter(
@@ -5653,48 +5535,6 @@ class OverviewViewSet(BaseRLSViewSet):
             .distinct("provider_id")
             .values_list("id", flat=True)
         )
-
-    def _extract_provider_filters_from_params(self):
-        """Extract and validate provider filters from query params."""
-        params = self.request.query_params
-        filters = {}
-        valid_provider_types = {c[0] for c in Provider.ProviderChoices.choices}
-
-        provider_id = params.get("filter[provider_id]")
-        if provider_id:
-            filters["provider_id"] = provider_id
-
-        provider_id_in = params.get("filter[provider_id__in]")
-        if provider_id_in:
-            filters["provider_id__in"] = provider_id_in.split(",")
-
-        provider_type = params.get("filter[provider_type]")
-        if provider_type:
-            if provider_type not in valid_provider_types:
-                raise ValidationError(
-                    {"provider_type": f"Invalid choice: {provider_type}"}
-                )
-            filters["provider__provider"] = provider_type
-
-        provider_type_in = params.get("filter[provider_type__in]")
-        if provider_type_in:
-            types = provider_type_in.split(",")
-            invalid = [t for t in types if t not in valid_provider_types]
-            if invalid:
-                raise ValidationError(
-                    {"provider_type__in": f"Invalid choices: {', '.join(invalid)}"}
-                )
-            filters["provider__provider__in"] = types
-
-        provider_groups = params.get("filter[provider_groups]")
-        if provider_groups:
-            filters["provider__provider_groups__id"] = provider_groups
-
-        provider_groups_in = params.get("filter[provider_groups__in]")
-        if provider_groups_in:
-            filters["provider__provider_groups__id__in"] = provider_groups_in.split(",")
-
-        return filters
 
     @action(detail=False, methods=["get"], url_name="providers")
     def providers(self, request):
@@ -7489,7 +7329,7 @@ SEVERITY_ORDER_REVERSE = {v: k for k, v in SEVERITY_ORDER.items()}
     ),
     retrieve=extend_schema(exclude=True),
 )
-class FindingGroupViewSet(BaseRLSViewSet):
+class FindingGroupViewSet(JsonApiFilterMixin, BaseRLSViewSet):
     """
     ViewSet for Finding Groups - aggregates findings by check_id.
 
@@ -7505,6 +7345,7 @@ class FindingGroupViewSet(BaseRLSViewSet):
     queryset = FindingGroupDailySummary.objects.all()
     serializer_class = FindingGroupSerializer
     filterset_class = FindingGroupFilter
+    jsonapi_filter_replace_dots = True
     filter_backends = [
         jsonapi_filters.QueryParameterValidationFilter,
         jsonapi_filters.OrderingFilter,
@@ -7554,18 +7395,6 @@ class FindingGroupViewSet(BaseRLSViewSet):
             queryset = queryset.filter(scan__provider_id__in=providers)
 
         return queryset
-
-    def _normalize_jsonapi_params(self, query_params):
-        """Convert JSON:API filter params (filter[X]) to flat params (X)."""
-        normalized = QueryDict(mutable=True)
-        for key, values in query_params.lists():
-            normalized_key = (
-                key[7:-1] if key.startswith("filter[") and key.endswith("]") else key
-            )
-            # Convert JSON:API dot notation to Django double underscore
-            normalized_key = normalized_key.replace(".", "__")
-            normalized.setlist(normalized_key, values)
-        return normalized
 
     @extend_schema(exclude=True)
     def retrieve(self, request, *args, **kwargs):

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -4546,15 +4546,19 @@ class RoleProviderGroupRelationshipView(RelationshipView, BaseRLSViewSet):
 @extend_schema_view(
     list=extend_schema(
         tags=["Compliance Overview"],
-        summary="List compliance overviews for a scan",
-        description="Retrieve an overview of all the compliance in a given scan.",
+        summary="List compliance overviews",
+        description=(
+            "Retrieve compliance overview data for a scan. When provider filters "
+            "are provided, the endpoint uses the latest completed scan for each "
+            "matching provider."
+        ),
         parameters=[
             OpenApiParameter(
                 name="filter[scan_id]",
-                required=True,
+                required=False,
                 type=OpenApiTypes.UUID,
                 location=OpenApiParameter.QUERY,
-                description="Related scan ID.",
+                description="Related scan ID. Required unless a provider filter is provided.",
             ),
         ],
         responses={
@@ -4569,19 +4573,23 @@ class RoleProviderGroupRelationshipView(RelationshipView, BaseRLSViewSet):
                 description="Compliance overviews generation task failed"
             ),
         },
+        filters=True,
     ),
     metadata=extend_schema(
         tags=["Compliance Overview"],
         summary="Retrieve metadata values from compliance overviews",
-        description="Fetch unique metadata values from a set of compliance overviews. This is useful for dynamic "
-        "filtering.",
+        description=(
+            "Fetch unique metadata values from compliance overviews. This is useful "
+            "for dynamic filtering. When provider filters are provided, metadata is "
+            "computed from the latest completed scan for each matching provider."
+        ),
         parameters=[
             OpenApiParameter(
                 name="filter[scan_id]",
-                required=True,
+                required=False,
                 type=OpenApiTypes.UUID,
                 location=OpenApiParameter.QUERY,
-                description="Related scan ID.",
+                description="Related scan ID. Required unless a provider filter is provided.",
             ),
         ],
         responses={
@@ -4596,19 +4604,24 @@ class RoleProviderGroupRelationshipView(RelationshipView, BaseRLSViewSet):
                 description="Compliance overviews generation task failed"
             ),
         },
+        filters=True,
     ),
     requirements=extend_schema(
         tags=["Compliance Overview"],
-        summary="List compliance requirements overview for a scan",
-        description="Retrieve a detailed overview of compliance requirements in a given scan, grouped by compliance "
-        "framework. This endpoint provides requirement-level details and aggregates status across regions.",
+        summary="List compliance requirements overview",
+        description=(
+            "Retrieve a detailed overview of compliance requirements, grouped by "
+            "compliance framework. This endpoint provides requirement-level details "
+            "and aggregates status across regions. When provider filters are provided, "
+            "the endpoint uses the latest completed scan for each matching provider."
+        ),
         parameters=[
             OpenApiParameter(
                 name="filter[scan_id]",
-                required=True,
+                required=False,
                 type=OpenApiTypes.UUID,
                 location=OpenApiParameter.QUERY,
-                description="Related scan ID.",
+                description="Related scan ID. Required unless a provider filter is provided.",
             ),
             OpenApiParameter(
                 name="filter[compliance_id]",
@@ -4668,6 +4681,23 @@ class RoleProviderGroupRelationshipView(RelationshipView, BaseRLSViewSet):
 @method_decorator(CACHE_DECORATOR, name="requirements")
 @method_decorator(CACHE_DECORATOR, name="attributes")
 class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
+    PROVIDER_FILTER_KEYS = frozenset(
+        {
+            "provider_id",
+            "provider_id__in",
+            "provider_type",
+            "provider_type__in",
+            "provider_groups",
+            "provider_groups__in",
+        }
+    )
+    PROVIDER_FILTER_QUERY_KEYS = PROVIDER_FILTER_KEYS | frozenset(
+        {
+            "provider_id.in",
+            "provider_type.in",
+            "provider_groups.in",
+        }
+    )
     pagination_class = ComplianceOverviewPagination
     queryset = ComplianceRequirementOverview.objects.all()
     serializer_class = ComplianceOverviewSerializer
@@ -4681,28 +4711,22 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
     required_permissions = []
 
     def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return ComplianceRequirementOverview.objects.none()
+
         role = get_role(self.request.user, self.request.tenant_id)
         unlimited_visibility = getattr(
             role, Permissions.UNLIMITED_VISIBILITY.value, False
         )
 
-        if unlimited_visibility:
-            base_queryset = self.filter_queryset(
-                ComplianceRequirementOverview.objects.filter(
-                    tenant_id=self.request.tenant_id
-                )
-            )
-        else:
-            providers = Provider.objects.filter(
-                provider_groups__in=role.provider_groups.all()
-            ).distinct()
-            base_queryset = self.filter_queryset(
-                ComplianceRequirementOverview.objects.filter(
-                    tenant_id=self.request.tenant_id, scan__provider__in=providers
-                )
-            )
+        base_queryset = ComplianceRequirementOverview.objects.filter(
+            tenant_id=self.request.tenant_id
+        )
 
-        return base_queryset
+        if unlimited_visibility:
+            return base_queryset
+
+        return base_queryset.filter(scan__provider__in=get_providers(role))
 
     def get_serializer_class(self):
         if hasattr(self, "response_serializer_class"):
@@ -4739,6 +4763,160 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
             summaries = summaries.filter(scan__provider__in=providers)
 
         return summaries
+
+    def _normalize_jsonapi_params(self, query_params, exclude_keys=None):
+        """Convert JSON:API filter params into django-filter keys."""
+        exclude_keys = exclude_keys or set()
+        normalized = QueryDict(mutable=True)
+        for key, values in query_params.lists():
+            normalized_key = (
+                key[7:-1] if key.startswith("filter[") and key.endswith("]") else key
+            )
+            normalized_key = normalized_key.replace(".", "__")
+            if normalized_key not in exclude_keys:
+                normalized.setlist(normalized_key, values)
+        return normalized
+
+    def _apply_compliance_filterset(self, queryset, exclude_keys=None):
+        normalized_params = self._normalize_jsonapi_params(
+            self.request.query_params,
+            exclude_keys=set(exclude_keys or []),
+        )
+        filterset = self.filterset_class(normalized_params, queryset=queryset)
+        if not filterset.is_valid():
+            raise ValidationError(filterset.errors)
+        return filterset.qs
+
+    def _csv_filter_values(self, value):
+        return [item.strip() for item in value.split(",") if item.strip()]
+
+    def _validate_uuid_filter_values(self, field_name, values):
+        try:
+            for value in values:
+                uuid.UUID(str(value))
+        except (TypeError, ValueError, AttributeError):
+            raise ValidationError({field_name: ["Enter a valid UUID."]})
+
+    def _has_provider_filters(self):
+        return any(
+            self.request.query_params.get(f"filter[{key}]")
+            for key in self.PROVIDER_FILTER_QUERY_KEYS
+        )
+
+    def _validate_scan_selection(self, scan_id, has_provider_filters):
+        if scan_id and has_provider_filters:
+            raise ValidationError(
+                [
+                    {
+                        "detail": "Use either filter[scan_id] or provider filters.",
+                        "status": 400,
+                        "source": {"pointer": "filter[scan_id]"},
+                        "code": "invalid",
+                    }
+                ]
+            )
+
+        if scan_id:
+            self._validate_uuid_filter_values("scan_id", [scan_id])
+            return
+
+        if has_provider_filters:
+            return
+
+        raise ValidationError(
+            [
+                {
+                    "detail": "This query parameter is required unless a provider filter is provided.",
+                    "status": 400,
+                    "source": {"pointer": "filter[scan_id]"},
+                    "code": "required",
+                }
+            ]
+        )
+
+    def _extract_provider_filters_from_params(self):
+        """Extract provider filters for the Scan queryset."""
+        params = self.request.query_params
+        filters = {}
+        valid_provider_types = {
+            choice[0] for choice in Provider.ProviderChoices.choices
+        }
+
+        provider_id = params.get("filter[provider_id]")
+        if provider_id:
+            self._validate_uuid_filter_values("provider_id", [provider_id])
+            filters["provider_id"] = provider_id
+
+        provider_id_in = params.get("filter[provider_id__in]") or params.get(
+            "filter[provider_id.in]"
+        )
+        if provider_id_in:
+            values = self._csv_filter_values(provider_id_in)
+            self._validate_uuid_filter_values("provider_id__in", values)
+            filters["provider_id__in"] = values
+
+        provider_type = params.get("filter[provider_type]")
+        if provider_type:
+            if provider_type not in valid_provider_types:
+                raise ValidationError(
+                    {"provider_type": f"Invalid choice: {provider_type}"}
+                )
+            filters["provider__provider"] = provider_type
+
+        provider_type_in = params.get("filter[provider_type__in]") or params.get(
+            "filter[provider_type.in]"
+        )
+        if provider_type_in:
+            values = self._csv_filter_values(provider_type_in)
+            invalid = [value for value in values if value not in valid_provider_types]
+            if invalid:
+                raise ValidationError(
+                    {"provider_type__in": f"Invalid choices: {', '.join(invalid)}"}
+                )
+            filters["provider__provider__in"] = values
+
+        provider_groups = params.get("filter[provider_groups]")
+        if provider_groups:
+            self._validate_uuid_filter_values("provider_groups", [provider_groups])
+            filters["provider__provider_groups__id"] = provider_groups
+
+        provider_groups_in = params.get("filter[provider_groups__in]") or params.get(
+            "filter[provider_groups.in]"
+        )
+        if provider_groups_in:
+            values = self._csv_filter_values(provider_groups_in)
+            self._validate_uuid_filter_values("provider_groups__in", values)
+            filters["provider__provider_groups__id__in"] = values
+
+        return filters
+
+    def _latest_scan_ids_for_provider_filters(self):
+        role = get_role(self.request.user, self.request.tenant_id)
+        scans = Scan.all_objects.filter(
+            tenant_id=self.request.tenant_id,
+            state=StateChoices.COMPLETED,
+        )
+
+        if not getattr(role, Permissions.UNLIMITED_VISIBILITY.value, False):
+            scans = scans.filter(provider__in=get_providers(role))
+
+        provider_filters = self._extract_provider_filters_from_params()
+        if provider_filters:
+            scans = scans.filter(**provider_filters)
+
+        return (
+            scans.order_by("provider_id", "-inserted_at")
+            .distinct("provider_id")
+            .values_list("id", flat=True)
+        )
+
+    def _filtered_queryset_for_latest_provider_scans(self):
+        latest_scan_ids = self._latest_scan_ids_for_provider_filters()
+        queryset = self.get_queryset().filter(scan_id__in=latest_scan_ids)
+        return self._apply_compliance_filterset(
+            queryset,
+            exclude_keys=self.PROVIDER_FILTER_KEYS | {"scan_id"},
+        )
 
     def _get_compliance_template(self, *, provider=None, scan_id=None):
         """Return the compliance template for the given provider or scan."""
@@ -4895,8 +5073,18 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
 
         return Response(data)
 
+    def _list_with_latest_provider_filters(self):
+        queryset = self._filtered_queryset_for_latest_provider_scans()
+        data = self._aggregate_compliance_overview(queryset)
+        return Response(data)
+
     def list(self, request, *args, **kwargs):
         scan_id = request.query_params.get("filter[scan_id]")
+        has_provider_filters = self._has_provider_filters()
+        self._validate_scan_selection(scan_id, has_provider_filters)
+
+        if has_provider_filters:
+            return self._list_with_latest_provider_filters()
 
         # Specific scan requested - use optimized summaries with region support
         region_filter = request.query_params.get(
@@ -4942,27 +5130,21 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
     @action(detail=False, methods=["get"], url_name="metadata")
     def metadata(self, request):
         scan_id = request.query_params.get("filter[scan_id]")
-        if not scan_id:
-            raise ValidationError(
-                [
-                    {
-                        "detail": "This query parameter is required.",
-                        "status": 400,
-                        "source": {"pointer": "filter[scan_id]"},
-                        "code": "required",
-                    }
-                ]
-            )
+        has_provider_filters = self._has_provider_filters()
+        self._validate_scan_selection(scan_id, has_provider_filters)
+
+        queryset = (
+            self._filtered_queryset_for_latest_provider_scans()
+            if has_provider_filters
+            else self._apply_compliance_filterset(self.get_queryset())
+        )
+
         regions = list(
-            self.get_queryset()
-            .filter(scan_id=scan_id)
-            .values_list("region", flat=True)
-            .order_by("region")
-            .distinct()
+            queryset.values_list("region", flat=True).order_by("region").distinct()
         )
         result = {"regions": regions}
 
-        if regions:
+        if regions or has_provider_filters:
             serializer = self.get_serializer(data=result)
             serializer.is_valid(raise_exception=True)
             return Response(serializer.data, status=status.HTTP_200_OK)
@@ -4978,19 +5160,10 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
     @action(detail=False, methods=["get"], url_name="requirements")
     def requirements(self, request):
         scan_id = request.query_params.get("filter[scan_id]")
+        has_provider_filters = self._has_provider_filters()
         compliance_id = request.query_params.get("filter[compliance_id]")
 
-        if not scan_id:
-            raise ValidationError(
-                [
-                    {
-                        "detail": "This query parameter is required.",
-                        "status": 400,
-                        "source": {"pointer": "filter[scan_id]"},
-                        "code": "required",
-                    }
-                ]
-            )
+        self._validate_scan_selection(scan_id, has_provider_filters)
 
         if not compliance_id:
             raise ValidationError(
@@ -5003,7 +5176,11 @@ class ComplianceOverviewViewSet(BaseRLSViewSet, TaskManagementMixin):
                     }
                 ]
             )
-        filtered_queryset = self.filter_queryset(self.get_queryset())
+        filtered_queryset = (
+            self._filtered_queryset_for_latest_provider_scans()
+            if has_provider_filters
+            else self._apply_compliance_filterset(self.get_queryset())
+        )
 
         all_requirements = filtered_queryset.values(
             "requirement_id",


### PR DESCRIPTION
### Context

Compliance overview consumers can currently request data by `filter[scan_id]`. This PR adds provider-scoped filtering to the compliance overview endpoints so callers can request the latest completed scan per matching provider, consistent with the provider filtering added in the parent branch.

### Description

- Add `provider_id`, `provider_id__in`, `provider_type`, `provider_type__in`, `provider_groups`, and `provider_groups__in` filters to compliance overviews.
- Resolve provider filters through the latest completed scan per provider before aggregating compliance data.
- Keep existing `filter[scan_id]` behavior for scan-scoped callers.
- Extend OpenAPI documentation for list, metadata, and requirements actions.
- Add API tests covering exact and multi-value provider filters, provider groups, metadata, requirements, and latest-scan behavior.

### Steps to review

1. Run `cd api && uv run pytest src/backend/api/tests/test_views.py::TestComplianceOverviewViewSet -q`.
2. Run `cd api && uv run ruff format --check src/backend/api/filters.py src/backend/api/v1/views.py src/backend/api/tests/test_views.py && uv run ruff check src/backend/api/filters.py src/backend/api/v1/views.py src/backend/api/tests/test_views.py`.
3. Start the local API and request `/api/v1/compliance-overviews` with `filter[provider_id]`, `filter[provider_id__in]`, `filter[provider_type]`, `filter[provider_groups]`, and `filter[provider_groups__in]`.
4. Verify `/api/v1/docs#tag/Compliance-Overview/operation/api_v1_compliance_overviews_list` shows the new provider filters.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

API verification performed locally:

- `uv run pytest src/backend/api/tests/test_views.py::TestComplianceOverviewViewSet -q`: 30 passed, 1 xpassed.
- `uv run ruff format --check src/backend/api/filters.py src/backend/api/v1/views.py src/backend/api/tests/test_views.py && uv run ruff check src/backend/api/filters.py src/backend/api/v1/views.py src/backend/api/tests/test_views.py`: passed.
- Real local API E2E created providers, provider groups, old scans, latest scans, and compliance rows, then verified requests and responses for all new filters.
- Chrome verification confirmed the Redoc operation documents the new filters in `/api/v1/docs#tag/Compliance-Overview/operation/api_v1_compliance_overviews_list`.

Performance details:

- The provider filter path first resolves latest completed scans per matching provider with `ORDER BY provider_id, -inserted_at` and `DISTINCT ON (provider_id)`, then filters compliance rows by `scan_id__in`. Provider filters are excluded from the compliance filterset after scan resolution so the large compliance table does not repeat provider joins.
- Existing indexes are used in the measured query plan: `scans_prov_ins_desc_idx` for latest completed scan lookup and `cro_scan_comp_reg_idx` for compliance overview rows.
- Latest local E2E run used 10 measured HTTP samples per path after one warm-up call:
  - `GET /api/v1/compliance-overviews?filter[provider_type]=aws`: median `30.82 ms`, max `34.84 ms`.
  - `GET /api/v1/compliance-overviews?filter[provider_groups__in]=...`: median `25.26 ms`, max `31.24 ms`.
  - `GET /api/v1/compliance-overviews/requirements?filter[provider_id__in]=...&filter[compliance_id]=cis_1.4_aws`: median `24.16 ms`, max `31.90 ms`.
- `EXPLAIN ANALYZE` for the latest-scan compliance aggregation completed in `0.504 ms`, with `82` shared buffer hits and no sequential scan on `compliance_requirements_overviews`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.