### PR TITLE
fix(ui): remove onboarding changelog entry

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -25,7 +25,6 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 - DISA Okta IDaaS STIG V1R2 compliance framework support with its dedicated mapper, details panel, and icon [(#11428)](https://github.com/prowler-cloud/prowler/pull/11428)
 - DORA compliance framework support [(#11131)](https://github.com/prowler-cloud/prowler/pull/11131)
-- Guided product onboarding for new users — step-by-step tours covering providers, scans, findings, compliance, and attack paths, replayable anytime from the info icon in the page header [(#11430)](https://github.com/prowler-cloud/prowler/pull/11430)
 
 ### 🔄 Changed
 


### PR DESCRIPTION
### Context

PR #11430 should not include a UI changelog entry.

### Description

Removes the onboarding system entry from `ui/CHANGELOG.md` in the released `1.30.0` block.

### Steps to review

- Confirm `ui/CHANGELOG.md` no longer lists PR #11430.
- Confirm no other changelog entries changed.

### Checklist

- [x] Backport needed: No.
- [x] No tests needed; changelog-only correction.
- [x] No new changelog entry needed; this PR only removes an incorrect entry.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DISA Okta IDaaS STIG V1R2 compliance framework support
  * Added DORA compliance framework support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->