### PR TITLE
test(ui): add Vercel provider E2E tests

### DIFF
--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -77,6 +77,8 @@ jobs:
       E2E_ALIBABACLOUD_ACCESS_KEY_ID: ${{ secrets.E2E_ALIBABACLOUD_ACCESS_KEY_ID }}
       E2E_ALIBABACLOUD_ACCESS_KEY_SECRET: ${{ secrets.E2E_ALIBABACLOUD_ACCESS_KEY_SECRET }}
       E2E_ALIBABACLOUD_ROLE_ARN: ${{ secrets.E2E_ALIBABACLOUD_ROLE_ARN }}
+      E2E_VERCEL_TEAM_ID: ${{ secrets.E2E_VERCEL_TEAM_ID }}
+      E2E_VERCEL_API_TOKEN: ${{ secrets.E2E_VERCEL_API_TOKEN }}
       # Pass E2E paths from impact analysis
       E2E_TEST_PATHS: ${{ needs.impact-analysis.outputs.ui-e2e }}
       RUN_ALL_TESTS: ${{ needs.impact-analysis.outputs.run-all }}

--- a/ui/tests/providers/providers-page.ts
+++ b/ui/tests/providers/providers-page.ts
@@ -224,6 +224,27 @@ export interface AlibabaCloudProviderCredential {
   roleSessionName?: string;
 }
 
+// Vercel provider data
+export interface VercelProviderData {
+  teamId: string;
+  alias?: string;
+}
+
+// Vercel credential options
+export const VERCEL_CREDENTIAL_OPTIONS = {
+  VERCEL_API_TOKEN: "api_token",
+} as const;
+
+// Vercel credential type
+type VercelCredentialType =
+  (typeof VERCEL_CREDENTIAL_OPTIONS)[keyof typeof VERCEL_CREDENTIAL_OPTIONS];
+
+// Vercel provider credential
+export interface VercelProviderCredential {
+  type: VercelCredentialType;
+  apiToken: string;
+}
+
 // Providers page
 export class ProvidersPage extends BasePage {
   readonly wizardModal: Locator;
@@ -251,6 +272,11 @@ export class ProvidersPage extends BasePage {
   readonly googleworkspaceCustomerIdInput: Locator;
   readonly googleworkspaceServiceAccountJsonInput: Locator;
   readonly googleworkspaceDelegatedUserInput: Locator;
+
+  // Vercel provider form elements
+  readonly vercelProviderRadio: Locator;
+  readonly vercelTeamIdInput: Locator;
+  readonly vercelApiTokenInput: Locator;
 
   // AWS provider form elements
   readonly accountIdInput: Locator;
@@ -495,6 +521,14 @@ export class ProvidersPage extends BasePage {
     this.googleworkspaceDelegatedUserInput = page.getByRole("textbox", {
       name: /Delegated User Email/i,
     });
+
+    // Vercel
+    this.vercelProviderRadio = page.getByRole("option", {
+      name: /Vercel/i,
+    });
+    this.vercelTeamIdInput = page.getByRole("textbox", { name: "Team ID" });
+    // API Token is a type="password" field (no textbox role); target by label.
+    this.vercelApiTokenInput = page.getByLabel(/API Token/i);
 
     // Alias input
     this.aliasInput = page.getByRole("textbox", {
@@ -1288,6 +1322,37 @@ export class ProvidersPage extends BasePage {
     await expect(this.googleworkspaceDelegatedUserInput).toBeVisible();
   }
 
+  async selectVercelProvider(): Promise<void> {
+    await this.selectProviderRadio(this.vercelProviderRadio);
+  }
+
+  async fillVercelProviderDetails(data: VercelProviderData): Promise<void> {
+    // Fill the Vercel provider details (Team ID is the provider UID)
+
+    await this.vercelTeamIdInput.fill(data.teamId);
+
+    if (data.alias) {
+      await this.aliasInput.fill(data.alias);
+    }
+  }
+
+  async fillVercelCredentials(
+    credentials: VercelProviderCredential,
+  ): Promise<void> {
+    // Fill the Vercel credentials form
+
+    if (credentials.apiToken) {
+      await this.vercelApiTokenInput.fill(credentials.apiToken);
+    }
+  }
+
+  async verifyVercelCredentialsPageLoaded(): Promise<void> {
+    // Verify the Vercel credentials page is loaded
+
+    await this.verifyPageHasProwlerTitle();
+    await expect(this.vercelApiTokenInput).toBeVisible();
+  }
+
   async verifyPageLoaded(): Promise<void> {
     // Verify the providers page is loaded
 
@@ -1309,6 +1374,7 @@ export class ProvidersPage extends BasePage {
     await expect(this.githubProviderRadio).toBeVisible();
     await expect(this.alibabacloudProviderRadio).toBeVisible();
     await expect(this.googleworkspaceProviderRadio).toBeVisible();
+    await expect(this.vercelProviderRadio).toBeVisible();
   }
 
   async verifyCredentialsPageLoaded(): Promise<void> {

--- a/ui/tests/providers/providers.md
+++ b/ui/tests/providers/providers.md
@@ -1012,3 +1012,62 @@
 - Provider cleanup performed before each test to ensure clean state
 - Requires valid Google Workspace account with Service Account having domain-wide delegation enabled
 - Service Account must have appropriate Google Workspace API scopes for security scanning
+
+---
+
+## Test Case: `PROVIDER-E2E-018` - Add Vercel Provider with API Token
+
+**Priority:** `critical`
+
+**Tags:**
+
+- type → @e2e, @serial
+- feature → @providers
+- provider → @vercel
+
+**Description/Objective:** Validates the complete flow of adding a new Vercel provider using API Token authentication, with a Team ID as the provider UID.
+
+**Preconditions:**
+
+- Admin user authentication required (admin.auth.setup setup)
+- Environment variables configured: E2E_VERCEL_TEAM_ID, E2E_VERCEL_API_TOKEN
+- Remove any existing provider with the same Team ID before starting the test
+- This test must be run serially and never in parallel with other tests, as it requires the Team ID not to be already registered beforehand.
+
+### Flow Steps
+
+1. Navigate to providers page
+2. Click "Add Provider" button
+3. Select Vercel provider type
+4. Fill provider details (team ID and alias)
+5. Verify Vercel credentials page is loaded
+6. Fill Vercel credentials (API token)
+7. Launch initial scan
+8. Verify redirect to Scans page
+9. Verify scheduled scan status in Scans table (provider exists and scan name is "scheduled scan")
+
+### Expected Result
+
+- Vercel provider successfully added with API Token credentials
+- Initial scan launched successfully
+- User redirected to Scans page
+- Scheduled scan appears in Scans table with correct provider and scan name
+
+### Key verification points
+
+- Provider page loads correctly
+- Connect account page displays Vercel option
+- Provider details form accepts team ID and alias
+- Credentials page loads with the API Token field
+- API Token is properly filled in the correct (masked) field
+- Launch scan page appears
+- Successful redirect to Scans page after scan launch
+- Provider exists in Scans table (verified by team ID)
+- Scan name field contains "scheduled scan"
+
+### Notes
+
+- Test uses environment variables for the Vercel Team ID and API Token
+- API Token is a masked (password) field; the only credential required for Vercel
+- Provider cleanup performed before each test to ensure clean state
+- Requires a valid Vercel API Token with read permissions to the resources to assess

--- a/ui/tests/providers/providers.spec.ts
+++ b/ui/tests/providers/providers.spec.ts
@@ -30,6 +30,9 @@ import {
   GoogleWorkspaceProviderData,
   GoogleWorkspaceProviderCredential,
   GOOGLEWORKSPACE_CREDENTIAL_OPTIONS,
+  VercelProviderData,
+  VercelProviderCredential,
+  VERCEL_CREDENTIAL_OPTIONS,
 } from "./providers-page";
 import { ScansPage } from "../scans/scans-page";
 import fs from "fs";
@@ -1432,6 +1435,85 @@ test.describe("Add Provider", () => {
 
         // Verify scan status is "Scheduled scan"
         await scansPage.verifyScheduledScanStatus(customerId);
+      },
+    );
+  });
+
+  test.describe.serial("Add Vercel Provider", () => {
+    let providersPage: ProvidersPage;
+    let scansPage: ScansPage;
+
+    // Test data from environment variables
+    const teamId = process.env.E2E_VERCEL_TEAM_ID ?? "";
+    const apiToken = process.env.E2E_VERCEL_API_TOKEN ?? "";
+
+    // Setup before each test
+    test.beforeEach(async ({ page }) => {
+      test.skip(!teamId || !apiToken, "Vercel E2E env vars are not set");
+      providersPage = new ProvidersPage(page);
+      await deleteProviderIfExists(providersPage, teamId!);
+    });
+
+    // Use admin authentication for provider management
+    test.use({ storageState: "playwright/.auth/admin_user.json" });
+
+    test(
+      "should add a new Vercel provider with API token",
+      {
+        tag: [
+          "@critical",
+          "@e2e",
+          "@providers",
+          "@vercel",
+          "@serial",
+          "@PROVIDER-E2E-018",
+        ],
+      },
+      async ({ page }) => {
+        // Prepare test data for Vercel provider (Team ID is the provider UID)
+        const vercelProviderData: VercelProviderData = {
+          teamId: teamId,
+          alias: "Test E2E Vercel Account - API Token",
+        };
+
+        // Prepare API token credentials
+        const vercelCredentials: VercelProviderCredential = {
+          type: VERCEL_CREDENTIAL_OPTIONS.VERCEL_API_TOKEN,
+          apiToken: apiToken,
+        };
+
+        // Navigate to providers page
+        await providersPage.goto();
+        await providersPage.verifyPageLoaded();
+
+        // Start adding new provider
+        await providersPage.clickAddProvider();
+        await providersPage.verifyConnectAccountPageLoaded();
+
+        // Select Vercel provider
+        await providersPage.selectVercelProvider();
+
+        // Fill provider details (team ID and alias)
+        await providersPage.fillVercelProviderDetails(vercelProviderData);
+        await providersPage.clickNext();
+
+        // Verify credentials page is loaded
+        await providersPage.verifyVercelCredentialsPageLoaded();
+
+        // Fill credentials (API token)
+        await providersPage.fillVercelCredentials(vercelCredentials);
+        await providersPage.clickNext();
+
+        // Launch scan
+        await providersPage.verifyLaunchScanPageLoaded();
+        await providersPage.clickNext();
+
+        // Wait for redirect to scan page
+        scansPage = new ScansPage(page);
+        await scansPage.verifyPageLoaded();
+
+        // Verify scan status is "Scheduled scan"
+        await scansPage.verifyScheduledScanStatus(teamId);
       },
     );
   });

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -118,6 +118,10 @@ declare global {
       E2E_GOOGLEWORKSPACE_CUSTOMER_ID?: string;
       E2E_GOOGLEWORKSPACE_SERVICE_ACCOUNT_JSON?: string;
       E2E_GOOGLEWORKSPACE_DELEGATED_USER?: string;
+
+      // E2E Vercel
+      E2E_VERCEL_TEAM_ID?: string;
+      E2E_VERCEL_API_TOKEN?: string;
     }
   }
 }


### PR DESCRIPTION
### Context

The Vercel provider is available in the UI provider wizard, but unlike the other providers it had no end-to-end coverage. This PR adds the missing Playwright E2E test for adding a Vercel provider and wires its credentials into the E2E CI workflow, mirroring the existing providers.

### Description

- Add `PROVIDER-E2E-018`: add a Vercel provider via API Token (Team ID as provider UID + API token), launch the initial scan, and verify the scheduled scan — same flow/shape as the other provider E2E tests (closest precedent: Google Workspace).
- Extend the providers Page Object Model with Vercel locators and methods (`selectVercelProvider`, `fillVercelProviderDetails`, `fillVercelCredentials`, `verifyVercelCredentialsPageLoaded`) and assert the Vercel option on the connect-account step.
- Document the case in `ui/tests/providers/providers.md` and declare `E2E_VERCEL_TEAM_ID` / `E2E_VERCEL_API_TOKEN` in `ui/types/env.d.ts`.
- Wire `E2E_VERCEL_TEAM_ID` / `E2E_VERCEL_API_TOKEN` into `.github/workflows/ui-e2e-tests-v2.yml`.

Test-only + CI change; no runtime/user-facing behavior is modified.

### Steps to review

1. With a backend available and `E2E_VERCEL_TEAM_ID` + `E2E_VERCEL_API_TOKEN` set:
   ```bash
   cd ui && pnpm run test:e2e tests/providers/ --grep "@PROVIDER-E2E-018"
   ```
   Without those env vars the test skips, exactly like the other provider tests.
2. Confirm static checks pass: `cd ui && pnpm run typecheck && pnpm run lint && pnpm run format:write`.
3. Confirm `.md` ↔ `.spec.ts` stay in sync (test id `PROVIDER-E2E-018`, tags).

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests. — this PR _is_ E2E test coverage for the Vercel provider.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings — test case documented in `providers.md`.
- [ ] Review if backport is needed. — not needed (test/CI only).
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) — not needed.
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. — N/A.

#### SDK/CLI
- Are there new checks included in this PR? **No**

#### UI
- [ ] All issue/task requirements work as expected on the UI — N/A: no UI behavior change; this exercises the existing Vercel provider flow via E2E.
- [ ] If this PR adds or updates npm dependencies, include package-health evidence ... — N/A: no dependency changes.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px) — N/A: no UI change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px) — N/A: no UI change.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px) — N/A: no UI change.
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. — N/A (test + CI only); `no-changelog` label applied.

#### API
- [ ] All issue/task requirements work as expected on the API — N/A: no API change.
- [ ] Endpoint response output (if applicable) — N/A.
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable) — N/A.
- [ ] Performance test results (if applicable) — N/A.
- [ ] Any other relevant evidence of the implementation (if applicable) — N/A.
- [ ] Verify if API specs need to be regenerated. — N/A.
- [ ] Check if version updates are required (e.g., specs, uv, etc.). — N/A.
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. — N/A.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Introduced comprehensive end-to-end test coverage for Vercel provider integration with API Token authentication, validating the complete flow from provider selection through scheduled scan verification.
  * Added test infrastructure including provider page object methods and environment variable support to ensure Vercel integration functions correctly throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->