### PR TITLE
ci: always run container and dependency vulnerability scans on PRs (v5.30 backport)

### DIFF
--- a/.github/workflows/api-container-checks.yml
+++ b/.github/workflows/api-container-checks.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/api-security.yml
+++ b/.github/workflows/api-security.yml
@@ -16,13 +16,6 @@ on:
     branches:
       - "master"
       - "v5.*"
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-tests.yml'
-      - '.github/workflows/api-security.yml'
-      - '.github/actions/setup-python-uv/**'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mcp-container-checks.yml
+++ b/.github/workflows/mcp-container-checks.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'mcp_server/**'
-      - '.github/workflows/mcp-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mcp-security.yml
+++ b/.github/workflows/mcp-security.yml
@@ -15,12 +15,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'mcp_server/pyproject.toml'
-      - 'mcp_server/uv.lock'
-      - '.github/workflows/mcp-security.yml'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-container-checks.yml
+++ b/.github/workflows/sdk-container-checks.yml
@@ -15,12 +15,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'Dockerfile*'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/sdk-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-security.yml
+++ b/.github/workflows/sdk-security.yml
@@ -19,16 +19,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'prowler/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - 'uv.lock'
-      - '.github/workflows/sdk-tests.yml'
-      - '.github/workflows/sdk-security.yml'
-      - '.github/actions/setup-python-uv/**'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ui-container-checks.yml
+++ b/.github/workflows/ui-container-checks.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'ui/**'
-      - '.github/workflows/ui-container-checks.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ui-security.yml
+++ b/.github/workflows/ui-security.yml
@@ -15,12 +15,6 @@ on:
     branches:
       - 'master'
       - 'v5.*'
-    paths:
-      - 'ui/package.json'
-      - 'ui/pnpm-lock.yaml'
-      - '.github/workflows/ui-security.yml'
-      - '.github/actions/osv-scanner/**'
-      - '.github/scripts/osv-scan.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Context

Targeted backport of #11582 ("always run container and dependency vulnerability scans on PRs") to the **v5.30** release branch.

On `master`, #11582 removed the `pull_request.paths:` gating from the 8 container and dependency vulnerability scan workflows so their check contexts always report. That change was never backported to v5.30.

On v5.30 these 8 workflows are still path-gated, yet their check contexts are **required** in branch protection. As a result, PRs targeting v5.30 that don't touch the gated paths hang forever waiting on checks that never run (e.g. the stuck PR #11607).

### Description

Removes only the `pull_request.paths:` block from each of the 8 affected workflows so the required checks always run on PRs targeting `v5.*` branches. The `push.paths:` gating is left intact.

Affected workflows (44 lines removed, deletions only):

- `.github/workflows/api-security.yml`
- `.github/workflows/api-container-checks.yml`
- `.github/workflows/mcp-security.yml`
- `.github/workflows/mcp-container-checks.yml`
- `.github/workflows/sdk-security.yml`
- `.github/workflows/sdk-container-checks.yml`
- `.github/workflows/ui-security.yml`
- `.github/workflows/ui-container-checks.yml`

This unblocks stuck v5.30 backport PRs whose required scan checks never report.

### Steps to review

1. Confirm the diff is deletions only and each removed block is the `pull_request.paths:` list (the `push.paths:` blocks are untouched).
2. Confirm parity with #11582 on `master` for the same 8 workflows.
3. After merge, the 4 security + 4 container-check contexts will run on every PR targeting `v5.*`, allowing required checks to report on PRs like #11607.

### Checklist

- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
