### PR TITLE
ci: narrow osv-scanner gate to CRITICAL on v5.30 (backport #11580)

### DIFF
--- a/.github/actions/osv-scanner/action.yml
+++ b/.github/actions/osv-scanner/action.yml
@@ -1,5 +1,5 @@
 name: 'OSV-Scanner'
-description: 'Install osv-scanner and scan a lockfile, failing on HIGH/CRITICAL/UNKNOWN severity findings. Posts/updates a PR comment with findings on pull_request events (requires pull-requests: write).'
+description: 'Install osv-scanner and scan a lockfile, failing on CRITICAL severity findings. Posts/updates a PR comment with findings on pull_request events (requires pull-requests: write).'
 author: 'Prowler'
 
 inputs:
@@ -7,9 +7,9 @@ inputs:
     description: 'Path to the lockfile to scan, relative to the repository root (e.g. uv.lock, api/uv.lock, ui/pnpm-lock.yaml).'
     required: true
   severity-levels:
-    description: 'Comma-separated severity levels that fail the scan. Default: HIGH,CRITICAL,UNKNOWN.'
+    description: 'Comma-separated severity levels that fail the scan. Default: CRITICAL.'
     required: false
-    default: 'HIGH,CRITICAL,UNKNOWN'
+    default: 'CRITICAL'
   version:
     description: 'osv-scanner release tag to install. When overriding, you MUST also override binary-sha256.'
     required: false


### PR DESCRIPTION
### Context

Backport of the osv-scanner severity-default portion of #11580 (commit `15bfa39b2`, master) to the `v5.30` branch.

This complements the already-merged #11614, which removed the `pull_request` path gating on `v5.30`. With that gating gone, the api/ui/mcp dependency security scans now **run** on `v5.30` PRs and **fail** on `HIGH` findings (e.g. ui: `dompurify`, `esbuild`, `vite`, `ws`). Master gates the osv-scanner action on `CRITICAL` only; this change brings `v5.30` in line so the required security checks pass.

### Description

Narrows the osv-scanner gate default in `.github/actions/osv-scanner/action.yml` from `HIGH,CRITICAL,UNKNOWN` to `CRITICAL`:

- `severity-levels` input `default` value
- two description strings updated for parity with master

Scope is intentionally limited to these 3 lines in this single file. The other files from #11580 (Trivy container script + container-checks) are **not** backported — out of scope for this fix.

### Steps to review

- Confirm the diff touches only `.github/actions/osv-scanner/action.yml` (default value + 2 description strings).
- Confirm the new default matches master's osv-scanner gate (`CRITICAL`).
- Verify the api/ui/mcp dependency security scans pass on this PR (no longer failing on `HIGH`).

### Checklist

- [x] Review if backport is needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
