### PR TITLE
fix(ui): contain launch scan modal layout

### DIFF
--- a/ui/components/scans/launch-scan-modal.test.tsx
+++ b/ui/components/scans/launch-scan-modal.test.tsx
@@ -164,6 +164,18 @@ describe("LaunchScanModal", () => {
     expect(screen.getByPlaceholderText("Search Providers...")).toBeVisible();
   });
 
+  it("keeps modal form controls constrained to the dialog width", () => {
+    render(
+      <LaunchScanModal open onOpenChange={vi.fn()} providers={[provider]} />,
+    );
+
+    const form = screen
+      .getByRole("button", { name: /launch scan/i })
+      .closest("form");
+
+    expect(form).toHaveClass("w-full", "min-w-0");
+  });
+
   it("disables disconnected providers in the launch selector", () => {
     render(
       <LaunchScanModal

--- a/ui/components/scans/launch-scan-modal.tsx
+++ b/ui/components/scans/launch-scan-modal.tsx
@@ -9,9 +9,15 @@ import { z } from "zod";
 
 import { scanOnDemand } from "@/actions/scans";
 import { AccountsSelector } from "@/app/(prowler)/_overview/_components/accounts-selector";
-import { Field, FieldError, FieldLabel, Input } from "@/components/shadcn";
+import {
+  Button,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+} from "@/components/shadcn";
+import { DialogFooter } from "@/components/shadcn/dialog";
 import { Modal } from "@/components/shadcn/modal";
-import { FormButtons } from "@/components/ui/form";
 import { toast, ToastAction } from "@/components/ui/toast";
 import { SCAN_JOBS_TAB } from "@/types";
 import type { ProviderProps } from "@/types/providers";
@@ -93,7 +99,7 @@ function LaunchScanForm({ providers, onClose }: LaunchScanFormProps) {
   const isSubmitting = form.formState.isSubmitting;
 
   return (
-    <form onSubmit={onSubmit} className="flex flex-col gap-8">
+    <form onSubmit={onSubmit} className="flex w-full min-w-0 flex-col gap-8">
       <div className="flex items-center gap-2">
         <CloudCog className="text-text-neutral-secondary size-4" />
         <span className="text-text-neutral-secondary text-sm">
@@ -101,7 +107,7 @@ function LaunchScanForm({ providers, onClose }: LaunchScanFormProps) {
         </span>
       </div>
 
-      <Field>
+      <Field className="min-w-0">
         <FieldLabel htmlFor="launch-scan-account">Providers</FieldLabel>
         <AccountsSelector
           id="launch-scan-account"
@@ -130,13 +136,26 @@ function LaunchScanForm({ providers, onClose }: LaunchScanFormProps) {
 
       {rootError && <FieldError>{rootError}</FieldError>}
 
-      <FormButtons
-        onCancel={onClose}
-        submitText={isSubmitting ? "Launching..." : "Launch Scan"}
-        loadingText="Launching..."
-        isDisabled={isSubmitting || !providers.length}
-        rightIcon={<Rocket className="size-4" />}
-      />
+      <DialogFooter className="w-full min-w-0 gap-4">
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          onClick={onClose}
+          className="w-full sm:w-40"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          size="lg"
+          disabled={isSubmitting || !providers.length}
+          className="w-full sm:w-40"
+        >
+          <Rocket className="size-4" />
+          {isSubmitting ? "Launching..." : "Launch Scan"}
+        </Button>
+      </DialogFooter>
     </form>
   );
 }

--- a/ui/components/scans/launch-scan-modal.tsx
+++ b/ui/components/scans/launch-scan-modal.tsx
@@ -9,15 +9,9 @@ import { z } from "zod";
 
 import { scanOnDemand } from "@/actions/scans";
 import { AccountsSelector } from "@/app/(prowler)/_overview/_components/accounts-selector";
-import {
-  Button,
-  Field,
-  FieldError,
-  FieldLabel,
-  Input,
-} from "@/components/shadcn";
-import { DialogFooter } from "@/components/shadcn/dialog";
+import { Field, FieldError, FieldLabel, Input } from "@/components/shadcn";
 import { Modal } from "@/components/shadcn/modal";
+import { FormButtons } from "@/components/ui/form";
 import { toast, ToastAction } from "@/components/ui/toast";
 import { SCAN_JOBS_TAB } from "@/types";
 import type { ProviderProps } from "@/types/providers";
@@ -136,26 +130,13 @@ function LaunchScanForm({ providers, onClose }: LaunchScanFormProps) {
 
       {rootError && <FieldError>{rootError}</FieldError>}
 
-      <DialogFooter className="w-full min-w-0 gap-4">
-        <Button
-          type="button"
-          variant="outline"
-          size="lg"
-          onClick={onClose}
-          className="w-full sm:w-40"
-        >
-          Cancel
-        </Button>
-        <Button
-          type="submit"
-          size="lg"
-          disabled={isSubmitting || !providers.length}
-          className="w-full sm:w-40"
-        >
-          <Rocket className="size-4" />
-          {isSubmitting ? "Launching..." : "Launch Scan"}
-        </Button>
-      </DialogFooter>
+      <FormButtons
+        onCancel={onClose}
+        submitText={isSubmitting ? "Launching..." : "Launch Scan"}
+        loadingText="Launching..."
+        isDisabled={isSubmitting || !providers.length}
+        rightIcon={<Rocket className="size-4" />}
+      />
     </form>
   );
 }


### PR DESCRIPTION
### Context

The `Launch A Scan` modal on `master` can overflow its dialog bounds when a long provider identifier is selected. The provider selector and submit action may render outside the modal container on desktop.

### Description

This PR contains the launch scan form layout within the shadcn dialog:

- Add width containment to the modal form and provider field.
- Replace the modal-local legacy footer buttons with shadcn `DialogFooter` and `Button` components.
- Add a focused regression test for the modal form containment classes.

### Steps to review

1. Open the Scans page.
2. Click `Launch A Scan`.
3. Select or display a provider with a long identifier.
4. Confirm the provider selector and footer buttons remain inside the modal bounds.
5. Optional local checks:
   - `cd ui && pnpm test:unit components/scans/launch-scan-modal.test.tsx`
   - `cd ui && pnpm run typecheck`

Verified locally:

- `pnpm test:unit components/scans/launch-scan-modal.test.tsx` — passed
- `pnpm exec eslint components/scans/launch-scan-modal.tsx components/scans/launch-scan-modal.test.tsx --max-warnings 40` — passed
- `pnpm run typecheck` — passed
- Commit hooks: UI Prettier, ESLint, TypeScript Check, and Unit Tests — passed

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable. Not applicable for this small UI layout fix.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure new entries are added to ui/CHANGELOG.md. Not applicable for this small UI layout fix.

#### API (if applicable)
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the launch scan modal’s form layout to better respect the dialog width by tightening width/min-width handling for the form and its first field.
* **Tests**
  * Added a test to confirm the modal form controls apply the expected width-constraining classes (`w-full` and `min-w-0`) for correct dialog display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->