### PR TITLE
fix(ui): handle alert form errors

### DIFF
--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -701,6 +701,29 @@ describe("AlertFormModal", () => {
     expect(errorMessage).toHaveClass("text-text-error-primary");
   });
 
+  it("should clear the preview error when save shows the form error", async () => {
+    // Given
+    const user = userEvent.setup();
+    alertsActionMocks.seedAlertRule.mockResolvedValue({
+      error: "No alert-compatible filters",
+    });
+    mockRecipientsList();
+    renderCreateModal({ editingAlert: createEditingAlert() });
+
+    // When
+    await user.click(screen.getByRole("button", { name: /^test$/i }));
+    expect(await screen.findByText("Test result")).toBeVisible();
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(screen.queryByText("Test result")).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.getAllByText("Apply at least one alert-compatible Findings filter."),
+    ).toHaveLength(1);
+  });
+
   it("should hydrate advanced edit mode filters and normalize them on save", async () => {
     // Given
     const user = userEvent.setup();

--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -720,7 +720,9 @@ describe("AlertFormModal", () => {
       expect(screen.queryByText("Test result")).not.toBeInTheDocument(),
     );
     expect(
-      screen.getAllByText("Apply at least one alert-compatible Findings filter."),
+      screen.getAllByText(
+        "Apply at least one alert-compatible Findings filter.",
+      ),
     ).toHaveLength(1);
   });
 

--- a/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
@@ -1,17 +1,17 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { isValidElement, useState, type ReactNode } from "react";
+import { isValidElement, type ReactNode, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type {
-  AlertFormSubmitResult,
-  AlertFormValues,
-} from "@/app/(prowler)/alerts/_types/alert-form";
 import {
   ALERT_AGGREGATE_OPS,
   ALERT_TRIGGER_KINDS,
   type AlertRule,
 } from "@/app/(prowler)/alerts/_types";
+import type {
+  AlertFormSubmitResult,
+  AlertFormValues,
+} from "@/app/(prowler)/alerts/_types/alert-form";
 
 import { AlertsManager } from "../alerts-manager";
 

--- a/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { isValidElement, type ReactNode } from "react";
+import { isValidElement, useState, type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type {
+  AlertFormSubmitResult,
+  AlertFormValues,
+} from "@/app/(prowler)/alerts/_types/alert-form";
 import {
   ALERT_AGGREGATE_OPS,
   ALERT_TRIGGER_KINDS,
@@ -96,12 +100,32 @@ vi.mock("../alert-form-modal", () => ({
     open,
     editingAlert,
     onOpenChange,
+    onSubmit,
   }: {
     open: boolean;
     editingAlert?: AlertRule | null;
     onOpenChange: (open: boolean) => void;
-  }) =>
-    open ? (
+    onSubmit: (values: AlertFormValues) => Promise<AlertFormSubmitResult>;
+  }) => {
+    const [error, setError] = useState<string | null>(null);
+
+    const submit = async () => {
+      const result = await onSubmit({
+        name: "Updated alert",
+        description: "",
+        method: "email",
+        frequency: ALERT_TRIGGER_KINDS.AFTER_SCAN,
+        condition: {
+          op: ALERT_AGGREGATE_OPS.ANY,
+          filter: { severity: ["critical"] },
+        },
+        recipientEmails: [],
+        enabled: true,
+      });
+      setError(result.ok ? null : (result.error ?? null));
+    };
+
+    return open ? (
       <div
         role="dialog"
         aria-label={editingAlert ? "Edit Alert" : "Create Alert"}
@@ -109,9 +133,14 @@ vi.mock("../alert-form-modal", () => ({
         <button type="button" onClick={() => onOpenChange(false)}>
           Close modal
         </button>
+        <button type="button" onClick={submit}>
+          Submit alert
+        </button>
         {editingAlert?.attributes.name}
+        {error && <p>{error}</p>}
       </div>
-    ) : null,
+    ) : null;
+  },
 }));
 
 vi.mock("../alerts-empty-state", () => ({
@@ -257,6 +286,42 @@ describe("AlertsManager", () => {
     expect(routerMocks.replace).toHaveBeenCalledWith("/alerts?page=2", {
       scroll: false,
     });
+  });
+
+  it("shows a manage alerts permission message for edit 403 errors", async () => {
+    // Given
+    const user = userEvent.setup();
+    const alert = makeAlert(true);
+    actionMocks.updateAlert.mockResolvedValue({
+      error: "You do not have permission to perform this action.",
+      status: 403,
+    });
+    render(
+      <AlertsManager
+        alerts={[alert]}
+        loadError={null}
+        providers={[]}
+        completedScanIds={[]}
+        scanDetails={[]}
+        uniqueRegions={[]}
+        uniqueServices={[]}
+        uniqueResourceTypes={[]}
+        uniqueCategories={[]}
+        uniqueGroups={[]}
+        initialEditingAlert={alert}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button", { name: /submit alert/i }));
+
+    // Then
+    expect(
+      await screen.findByText(
+        "You don't have permission to manage alerts. Ask an administrator to update your role.",
+      ),
+    ).toBeVisible();
+    expect(toastMock).not.toHaveBeenCalled();
   });
 
   it("shows a success toast after disabling an alert", async () => {

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -451,6 +451,7 @@ const AlertFormModalContent = ({
       ? await seedAlertRule(pendingFilters)
       : null;
     if (seedResult?.error) {
+      setPreview(null);
       setErrors({ root: ALERT_SEED_ERROR });
       return;
     }

--- a/ui/app/(prowler)/alerts/_components/alerts-manager.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-manager.tsx
@@ -49,6 +49,8 @@ interface AlertsManagerProps {
 
 const ALERTS_FINDINGS_HREF =
   "/findings?filter[muted]=false&filter[status__in]=FAIL";
+const ALERTS_PERMISSION_ERROR =
+  "You don't have permission to manage alerts. Ask an administrator to update your role.";
 
 export const AlertsManager = ({
   alerts,
@@ -108,7 +110,12 @@ export const AlertsManager = ({
     }
     const payload = toAlertPayload(values);
     const result = await updateAlert(editingAlert.id, payload);
-    if (result?.error) return { ok: false, error: result.error };
+    if (result?.error) {
+      return {
+        ok: false,
+        error: result.status === 403 ? ALERTS_PERMISSION_ERROR : result.error,
+      };
+    }
     toast({
       title: "Alert updated",
       description: result.data.attributes.name,


### PR DESCRIPTION
### Context

Users editing alerts can hit expected RBAC failures or alert filter validation errors. The alert form was surfacing the same filter error twice when a failed Test result remained visible and Save added the form-level error below it.

### Description

- Clear the alert preview result when Save surfaces the form-level filter error.
- Map alert edit `403` responses to a contextual Manage Alerts permission message in the UI.
- Add UI tests covering the duplicate-error case and the alert-specific RBAC message.

### Steps to review

1. Open an existing alert from `/alerts`.
2. Run Test with an invalid/no compatible findings filter so the Test result error appears.
3. Click Save and verify only the form-level error remains.
4. Edit an alert as a user without Manage Alerts permission and verify the form shows: `You don't have permission to manage alerts. Ask an administrator to update your role.`
5. Run:

```bash
cd ui
pnpm test -- app/\(prowler\)/alerts/_components/__tests__/alert-form-modal.test.tsx app/\(prowler\)/alerts/_components/__tests__/alerts-manager.test.tsx
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Alert previews now clear appropriately when alert-rule seeding fails during save, keeping the form state consistent for retries.
  * Permission-denied errors during alert updates now show a clear, user-friendly message instead of raw technical details.

* **Tests**
  * Extended alert modal and alerts manager test coverage to validate edit-mode error handling and preview cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->