### PR TITLE
fix(ui): raise node heap to fix arm64 docker build OOM

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 # Install dependencies based on the preferred package manager
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY scripts ./scripts
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN corepack install && pnpm install --frozen-lockfile
 
 


### PR DESCRIPTION
### Context

The prowler-ui AWS deployment (`ui-prowler-deployment.yml`) has failed every run since the multi-arch matrix was added (#4409). The arm64 leg OOMs node's heap at `ui/Dockerfile`'s `pnpm install --frozen-lockfile` step (`FATAL ERROR: JavaScript heap out of memory`, exit 139); the amd64 leg is then cancelled by matrix fail-fast. The parallel `ui-cloud-deployment.yml` survives only because it hits a warm gha build cache. This restores the deployment.

### Description

Set `ENV NODE_OPTIONS=--max-old-space-size=4096` in the `deps` stage of `ui/Dockerfile`, immediately before `RUN corepack install && pnpm install --frozen-lockfile`. This raises V8's old-space ceiling to 4 GB for the dependency-install layer, which is the point that OOMs on the memory-constrained arm64 build leg.

The change is scoped to the `deps` build stage only and does not affect the final `prod` runtime image.

The workflow-level mitigations (matrix `fail-fast: false` and gha cache-scope namespacing) are handled in the companion prowler-cloud PR.

### Steps to review

- Confirm the single added line `ENV NODE_OPTIONS=--max-old-space-size=4096` sits in the `deps` stage, between `COPY scripts ./scripts` and the `RUN corepack install && pnpm install --frozen-lockfile`.
- Confirm no other stage (`builder`, `dev`, `prod`) is modified.
- Verify no other files are touched.

### Checklist

- [ ] Review if backport is needed.

#### UI
- [x] All issue/task requirements work as expected on the UI

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to prevent memory-related build failures during deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->