### PR TITLE
fix(ui): show alert permission errors

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ## [1.31.0] (Prowler UNRELEASED)
 
+### 🚀 Added
+
+- Controlled `402` and `403` Server Action error messages for alert seed and mutation flows [(#11629)](https://github.com/prowler-cloud/prowler/pull/11629)
+
 ### 🐞 Fixed
 
 - Radio button no longer shifts vertically when selected [(#11608)](https://github.com/prowler-cloud/prowler/pull/11608)

--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -726,6 +726,32 @@ describe("AlertFormModal", () => {
     ).toHaveLength(1);
   });
 
+  it("should show the manage alerts permission error when save seed is forbidden", async () => {
+    // Given
+    const user = userEvent.setup();
+    alertsActionMocks.seedAlertRule.mockResolvedValue({
+      error: "You do not have permission to perform this action.",
+      status: 403,
+    });
+    mockRecipientsList();
+    renderCreateModal({ editingAlert: createEditingAlert() });
+
+    // When
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    // Then
+    expect(
+      await screen.findByText(
+        "You don't have permission to manage alerts. Ask an administrator to update your role.",
+      ),
+    ).toBeVisible();
+    expect(
+      screen.queryByText(
+        "Apply at least one alert-compatible Findings filter.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("should hydrate advanced edit mode filters and normalize them on save", async () => {
     // Given
     const user = userEvent.setup();

--- a/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alert-form-modal.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/app/(prowler)/alerts/_types";
 import type { ProviderProps } from "@/types/providers";
 
+import { ALERTS_PERMISSION_ERROR } from "../../_lib/alert-errors";
 import { AlertFormModal } from "../alert-form-modal";
 
 const recipientsActionMocks = vi.hoisted(() => ({
@@ -740,11 +741,7 @@ describe("AlertFormModal", () => {
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 
     // Then
-    expect(
-      await screen.findByText(
-        "You don't have permission to manage alerts. Ask an administrator to update your role.",
-      ),
-    ).toBeVisible();
+    expect(await screen.findByText(ALERTS_PERMISSION_ERROR)).toBeVisible();
     expect(
       screen.queryByText(
         "Apply at least one alert-compatible Findings filter.",

--- a/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
@@ -346,6 +346,33 @@ describe("AlertsManager", () => {
     );
   });
 
+  it("shows a manage alerts permission toast for disable 403 errors", async () => {
+    // Given
+    const user = userEvent.setup();
+    const alert = makeAlert(true);
+    actionMocks.disableAlert.mockResolvedValue({
+      error: "You do not have permission to perform this action.",
+      status: 403,
+    });
+    renderManager([alert]);
+
+    // When
+    await user.click(
+      screen.getByRole("button", { name: /actions for enabled alert/i }),
+    );
+    await user.click(screen.getByRole("menuitem", { name: /disable/i }));
+
+    // Then
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith({
+        variant: "destructive",
+        title: "Alert update failed",
+        description:
+          "You don't have permission to manage alerts. Ask an administrator to update your role.",
+      }),
+    );
+  });
+
   it("shows a success toast after enabling an alert", async () => {
     // Given
     const user = userEvent.setup();

--- a/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
+++ b/ui/app/(prowler)/alerts/_components/__tests__/alerts-manager.test.tsx
@@ -13,6 +13,7 @@ import type {
   AlertFormValues,
 } from "@/app/(prowler)/alerts/_types/alert-form";
 
+import { ALERTS_PERMISSION_ERROR } from "../../_lib/alert-errors";
 import { AlertsManager } from "../alerts-manager";
 
 const actionMocks = vi.hoisted(() => ({
@@ -316,11 +317,7 @@ describe("AlertsManager", () => {
     await user.click(screen.getByRole("button", { name: /submit alert/i }));
 
     // Then
-    expect(
-      await screen.findByText(
-        "You don't have permission to manage alerts. Ask an administrator to update your role.",
-      ),
-    ).toBeVisible();
+    expect(await screen.findByText(ALERTS_PERMISSION_ERROR)).toBeVisible();
     expect(toastMock).not.toHaveBeenCalled();
   });
 
@@ -367,8 +364,7 @@ describe("AlertsManager", () => {
       expect(toastMock).toHaveBeenCalledWith({
         variant: "destructive",
         title: "Alert update failed",
-        description:
-          "You don't have permission to manage alerts. Ask an administrator to update your role.",
+        description: ALERTS_PERMISSION_ERROR,
       }),
     );
   });

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -409,10 +409,7 @@ const AlertFormModalContent = ({
     if (seedResult?.error) {
       setPreview({
         status: "error",
-        error:
-          seedResult.status === 403
-            ? getAlertMutationError(seedResult)
-            : ALERT_SEED_ERROR,
+        error: getAlertMutationError(seedResult, ALERT_SEED_ERROR),
       });
       return;
     }
@@ -457,10 +454,7 @@ const AlertFormModalContent = ({
     if (seedResult?.error) {
       setPreview(null);
       setErrors({
-        root:
-          seedResult.status === 403
-            ? getAlertMutationError(seedResult)
-            : ALERT_SEED_ERROR,
+        root: getAlertMutationError(seedResult, ALERT_SEED_ERROR),
       });
       return;
     }

--- a/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
+++ b/ui/app/(prowler)/alerts/_components/alert-form-modal.tsx
@@ -54,6 +54,7 @@ import {
   getEmptyAlertFormDefaults,
   getFindingsFiltersFromAlertCondition,
 } from "../_lib/alert-adapter";
+import { getAlertMutationError } from "../_lib/alert-errors";
 import { alertFormSchema } from "../_lib/alert-form-schema";
 import type {
   AlertFormSubmitResult,
@@ -408,7 +409,10 @@ const AlertFormModalContent = ({
     if (seedResult?.error) {
       setPreview({
         status: "error",
-        error: ALERT_SEED_ERROR,
+        error:
+          seedResult.status === 403
+            ? getAlertMutationError(seedResult)
+            : ALERT_SEED_ERROR,
       });
       return;
     }
@@ -452,7 +456,12 @@ const AlertFormModalContent = ({
       : null;
     if (seedResult?.error) {
       setPreview(null);
-      setErrors({ root: ALERT_SEED_ERROR });
+      setErrors({
+        root:
+          seedResult.status === 403
+            ? getAlertMutationError(seedResult)
+            : ALERT_SEED_ERROR,
+      });
       return;
     }
 

--- a/ui/app/(prowler)/alerts/_components/alerts-manager.tsx
+++ b/ui/app/(prowler)/alerts/_components/alerts-manager.tsx
@@ -24,6 +24,7 @@ import type { ScanEntity } from "@/types";
 import type { ProviderProps } from "@/types/providers";
 
 import { toAlertPayload } from "../_lib/alert-adapter";
+import { getAlertMutationError } from "../_lib/alert-errors";
 import type {
   AlertFormSubmitResult,
   AlertFormValues,
@@ -49,8 +50,6 @@ interface AlertsManagerProps {
 
 const ALERTS_FINDINGS_HREF =
   "/findings?filter[muted]=false&filter[status__in]=FAIL";
-const ALERTS_PERMISSION_ERROR =
-  "You don't have permission to manage alerts. Ask an administrator to update your role.";
 
 export const AlertsManager = ({
   alerts,
@@ -113,7 +112,7 @@ export const AlertsManager = ({
     if (result?.error) {
       return {
         ok: false,
-        error: result.status === 403 ? ALERTS_PERMISSION_ERROR : result.error,
+        error: getAlertMutationError(result),
       };
     }
     toast({
@@ -134,7 +133,7 @@ export const AlertsManager = ({
       toast({
         variant: "destructive",
         title: "Alert update failed",
-        description: result.error,
+        description: getAlertMutationError(result),
       });
       return;
     }
@@ -154,7 +153,7 @@ export const AlertsManager = ({
       toast({
         variant: "destructive",
         title: "Alert delete failed",
-        description: result.error,
+        description: getAlertMutationError(result),
       });
       return;
     }

--- a/ui/app/(prowler)/alerts/_lib/alert-errors.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-errors.ts
@@ -1,3 +1,8 @@
+import {
+  ACTION_ERROR_STATUS,
+  getActionErrorMessage,
+} from "@/lib/action-errors";
+
 export const ALERTS_PERMISSION_ERROR =
   "You don't have permission to manage alerts. Ask an administrator to update your role.";
 
@@ -6,6 +11,9 @@ interface AlertActionErrorResult {
   status?: number;
 }
 
-export const getAlertMutationError = (
-  result: AlertActionErrorResult,
-): string => (result.status === 403 ? ALERTS_PERMISSION_ERROR : result.error);
+export const getAlertMutationError = (result: AlertActionErrorResult): string =>
+  getActionErrorMessage(result, {
+    messages: {
+      [ACTION_ERROR_STATUS.FORBIDDEN]: ALERTS_PERMISSION_ERROR,
+    },
+  });

--- a/ui/app/(prowler)/alerts/_lib/alert-errors.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-errors.ts
@@ -1,0 +1,11 @@
+export const ALERTS_PERMISSION_ERROR =
+  "You don't have permission to manage alerts. Ask an administrator to update your role.";
+
+interface AlertActionErrorResult {
+  error: string;
+  status?: number;
+}
+
+export const getAlertMutationError = (
+  result: AlertActionErrorResult,
+): string => (result.status === 403 ? ALERTS_PERMISSION_ERROR : result.error);

--- a/ui/app/(prowler)/alerts/_lib/alert-errors.ts
+++ b/ui/app/(prowler)/alerts/_lib/alert-errors.ts
@@ -11,9 +11,15 @@ interface AlertActionErrorResult {
   status?: number;
 }
 
-export const getAlertMutationError = (result: AlertActionErrorResult): string =>
-  getActionErrorMessage(result, {
-    messages: {
-      [ACTION_ERROR_STATUS.FORBIDDEN]: ALERTS_PERMISSION_ERROR,
+export const getAlertMutationError = (
+  result: AlertActionErrorResult,
+  fallback = result.error,
+): string =>
+  getActionErrorMessage(
+    { ...result, error: fallback },
+    {
+      messages: {
+        [ACTION_ERROR_STATUS.FORBIDDEN]: ALERTS_PERMISSION_ERROR,
+      },
     },
-  });
+  );

--- a/ui/lib/action-errors.test.ts
+++ b/ui/lib/action-errors.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTION_ERROR_MESSAGES,
+  ACTION_ERROR_STATUS,
+  getActionErrorMessage,
+} from "./action-errors";
+
+describe("getActionErrorMessage", () => {
+  it("should use the default permission error for forbidden responses", () => {
+    // Given
+    const result = {
+      error: "You do not have permission to perform this action.",
+      status: ACTION_ERROR_STATUS.FORBIDDEN,
+    };
+
+    // When
+    const message = getActionErrorMessage(result);
+
+    // Then
+    expect(message).toBe(ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.FORBIDDEN]);
+  });
+
+  it("should use the default subscription error for payment-required responses", () => {
+    // Given
+    const result = {
+      error: "Payment required.",
+      status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+    };
+
+    // When
+    const message = getActionErrorMessage(result);
+
+    // Then
+    expect(message).toBe(
+      ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+    );
+  });
+
+  it("should use a feature override for handled statuses", () => {
+    // Given
+    const result = {
+      error: "You do not have permission to perform this action.",
+      status: ACTION_ERROR_STATUS.FORBIDDEN,
+    };
+    const override = "You don't have permission to manage alerts.";
+
+    // When
+    const message = getActionErrorMessage(result, {
+      messages: {
+        [ACTION_ERROR_STATUS.FORBIDDEN]: override,
+      },
+    });
+
+    // Then
+    expect(message).toBe(override);
+  });
+
+  it("should keep the API error for unhandled statuses", () => {
+    // Given
+    const result = {
+      error: "Apply at least one alert-compatible Findings filter.",
+      status: 400,
+    };
+
+    // When
+    const message = getActionErrorMessage(result);
+
+    // Then
+    expect(message).toBe(result.error);
+  });
+});

--- a/ui/lib/action-errors.ts
+++ b/ui/lib/action-errors.ts
@@ -1,0 +1,43 @@
+export const ACTION_ERROR_STATUS = {
+  PAYMENT_REQUIRED: 402,
+  FORBIDDEN: 403,
+} as const;
+
+export type ActionErrorStatus =
+  (typeof ACTION_ERROR_STATUS)[keyof typeof ACTION_ERROR_STATUS];
+
+export const ACTION_ERROR_MESSAGES = {
+  [ACTION_ERROR_STATUS.PAYMENT_REQUIRED]:
+    "Your subscription doesn't allow this action. Upgrade your plan or contact an administrator.",
+  [ACTION_ERROR_STATUS.FORBIDDEN]:
+    "You don't have permission to perform this action. Ask an administrator to update your role.",
+} as const satisfies Record<ActionErrorStatus, string>;
+
+interface ActionErrorResult {
+  error?: string;
+  status?: number;
+}
+
+interface GetActionErrorMessageOptions {
+  messages?: Partial<Record<ActionErrorStatus, string>>;
+  fallback?: string;
+}
+
+const isActionErrorStatus = (
+  status: number | undefined,
+): status is ActionErrorStatus =>
+  status === ACTION_ERROR_STATUS.PAYMENT_REQUIRED ||
+  status === ACTION_ERROR_STATUS.FORBIDDEN;
+
+export const getActionErrorMessage = (
+  result: ActionErrorResult,
+  options: GetActionErrorMessageOptions = {},
+): string => {
+  if (isActionErrorStatus(result.status)) {
+    return (
+      options.messages?.[result.status] ?? ACTION_ERROR_MESSAGES[result.status]
+    );
+  }
+
+  return result.error ?? options.fallback ?? "Oops! Something went wrong.";
+};


### PR DESCRIPTION
### Context

The previous alert form fix covered duplicate filter errors and the main alert edit submit path. A remaining path still hid RBAC failures: the edit modal calls `seedAlertRule` before saving, and enable/disable actions call their own PATCH endpoint. When those calls return `403`, the UI could show the filter compatibility message or the raw API permission text instead of the Manage Alerts permission message.

### Description

- Share alert mutation error mapping across alert form and alert manager code.
- Show the Manage Alerts permission message when `seedAlertRule` returns `403` during Save/Test.
- Show the same permission message for enable/disable/delete alert mutations returning `403`.
- Add tests covering Save seed `403` and disable `403` behavior.

### Steps to review

1. Open an existing alert as a user without Manage Alerts permission.
2. Click Save and verify the modal shows: `You don't have permission to manage alerts. Ask an administrator to update your role.`
3. Disable an alert as the same user and verify the error toast uses the same permission message.
4. Run:

```bash
cd ui
pnpm test -- app/\(prowler\)/alerts/_components/__tests__/alert-form-modal.test.tsx app/\(prowler\)/alerts/_components/__tests__/alerts-manager.test.tsx
pnpm run healthcheck
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission-based error messaging across alert workflows, including preview (“Test”), saving/creating, updating, enabling/disabling, and deleting.
  * HTTP 403 (forbidden) and other action-related failures now show consistent, user-friendly text generated from a shared error-mapping helper.

* **Tests**
  * Added/updated automated coverage to verify forbidden (403) UI states, including modal messaging and destructive toast content, plus error-message mapping behavior.

* **Documentation**
  * Updated the changelog to note controlled server-action error messages for alert seed/mutation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->