### PR TITLE
fix(api): warm compliance caches in gunicorn master to stop worker-timeout crash loop

### DIFF
--- a/api/src/backend/api/tests/test_compliance.py
+++ b/api/src/backend/api/tests/test_compliance.py
@@ -414,3 +414,38 @@ class TestWarmComplianceCaches:
             warm_compliance_caches([Provider.ProviderChoices.AWS])
 
         assert compliance_module.COMPLIANCE_WARMED.is_set()
+
+
+class TestGuniconfWarmsInMaster:
+    """The gunicorn master warms the compliance caches once in `on_starting`,
+    before any worker is forked, so preloaded workers inherit the populated
+    caches via copy-on-write instead of each re-warming post-fork."""
+
+    def _on_starting(self):
+        from config import guniconf
+
+        return guniconf.on_starting
+
+    def test_warms_once_in_production(self):
+        with (
+            patch("config.guniconf.DEBUG", False),
+            patch("config.guniconf.warm_compliance_caches") as mock_warm,
+        ):
+            mock_warm.return_value = []
+            self._on_starting()(MagicMock())
+
+        mock_warm.assert_called_once_with()
+
+    def test_does_not_warm_under_debug(self):
+        with (
+            patch("config.guniconf.DEBUG", True),
+            patch("config.guniconf.warm_compliance_caches") as mock_warm,
+        ):
+            self._on_starting()(MagicMock())
+
+        mock_warm.assert_not_called()
+
+    def test_no_post_fork_warm_hook_remains(self):
+        from config import guniconf
+
+        assert not hasattr(guniconf, "post_fork")

--- a/api/src/backend/config/guniconf.py
+++ b/api/src/backend/config/guniconf.py
@@ -1,7 +1,6 @@
 import logging
 import multiprocessing
 import os
-import threading
 
 from config.env import env
 
@@ -47,6 +46,11 @@ asgi_loop = env("DJANGO_ASGI_LOOP", default="uvloop")
 # effect on ASGI workers.
 worker_connections = env.int("DJANGO_WORKER_CONNECTIONS", default=1000)
 
+# Worker timeout. Raised above the 30s default so a slow boot (e.g. a cold
+# compliance warm-up) cannot be SIGKILLed mid-startup before the worker can
+# answer the load-balancer health check.
+timeout = env.int("GUNICORN_TIMEOUT", default=120)
+
 # Preload the application before forking workers in production: the app is
 # imported once in the master and workers fork from it. In development, disable
 # preload so the server restarts on code changes.
@@ -63,6 +67,19 @@ def on_starting(_):
     if reload:
         gunicorn_logger.warning("Reload settings enabled (dev mode)")
 
+    # Warm the compliance caches once in the master, before any worker is
+    # forked. With preload_app the populated caches and readiness flags are
+    # inherited by every worker via copy-on-write, so no worker re-warms them
+    # post-fork (which previously ran the CPU-bound load N times and starved
+    # the asgi event loop past the worker timeout). Under `runserver` (DEBUG)
+    # this hook never runs, so lazy loading is preserved.
+    if not DEBUG:
+        failed = warm_compliance_caches()
+        if failed:
+            gunicorn_logger.warning("Compliance caches warmed (skipped: %s)", failed)
+        else:
+            gunicorn_logger.info("Compliance caches warmed")
+
 
 def on_reload(_):
     gunicorn_logger.warning("Gunicorn server has reloaded")
@@ -70,26 +87,3 @@ def on_reload(_):
 
 def when_ready(_):
     gunicorn_logger.info("Gunicorn server is ready")
-
-
-def _warm_compliance_caches_in_background():
-    """Warm compliance caches off the request path and log the outcome."""
-    failed = warm_compliance_caches()
-    if failed:
-        gunicorn_logger.warning("Compliance caches warmed (skipped: %s)", failed)
-    else:
-        gunicorn_logger.info("Compliance caches warmed")
-
-
-def post_fork(_server, worker):
-    """Warm compliance caches after each worker fork.
-
-    Warm compliance caches in a background thread so the worker becomes ready
-    immediately. A request for a not-yet-warmed provider lazily loads just that
-    provider, which stays well under the worker timeout.
-    """
-    threading.Thread(
-        target=_warm_compliance_caches_in_background,
-        name="warm-compliance-caches",
-        daemon=True,
-    ).start()


### PR DESCRIPTION
### Context

The prowler-api ECS deploy fails with a worker crash loop → ALB health-check failures → deployment circuit breaker → rollback.

Root cause: gunicorn's ASGI workers each re-warmed all 16 providers' compliance caches in `post_fork` (CPU-bound, in a daemon thread), starving the worker's event loop past gunicorn's default 30s timeout so it was SIGKILLed before it could answer `/health/live`. (#11626 fixed the lifespan probe but not this.) Verified on dev ECS: the image at `master` HEAD still crash-loops.

This PR is the application half of the fix; the infrastructure half (an ECS startup health-check grace period) ships in the companion prowler-cloud PR. Both are needed together.

### Description

- Warm the compliance caches **once in the gunicorn master** (`on_starting`, pre-fork) instead of in every worker's `post_fork`. With `preload_app` enabled in production, the populated caches and readiness flags are inherited by every forked worker via copy-on-write, so no worker re-warms them and no worker's event loop is starved. Under `runserver` (DEBUG) the hook does not run, so lazy per-provider loading is preserved.
- Remove the `post_fork` hook, the `_warm_compliance_caches_in_background` helper, and the now-unused `threading` import.
- Add an explicit `timeout` setting (`GUNICORN_TIMEOUT`, default `120s`, raised from the 30s gunicorn default) so a slow cold boot cannot be SIGKILLed mid-startup before the worker can answer the load-balancer health check.

### Steps to review

- `api/src/backend/config/guniconf.py`: confirm the warm-up now lives inside `on_starting` guarded by `if not DEBUG`, that `post_fork` / `_warm_compliance_caches_in_background` are gone, and the new `timeout` setting is present.
- `api/src/backend/api/tests/test_compliance.py`: `TestGuniconfWarmsInMaster` asserts the master warms exactly once in production, never under DEBUG, and that no `post_fork` warm hook remains.
- Run: `pytest api/src/backend/api/tests/test_compliance.py -k TestGuniconfWarmsInMaster`.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Verify if API specs need to be regenerated. Not needed — no API surface change.
- [x] Check if version updates are required (e.g., specs, uv, etc.). Not needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite verifying compliance cache warming behavior during Gunicorn master process startup, including DEBUG mode handling.

* **Chores**
  * Compliance cache warming mechanism moved from post-worker initialization to master process startup phase.
  * Added configurable Gunicorn timeout parameter with 120-second default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->