### PR TITLE
fix(api): ignore RequestAborted from health-check probe disconnects in Sentry

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🔄 Changed
 
 - Gunicorn worker timeout raised from the 30s default to 120s, so long-running requests are no longer killed prematurely [(#11631)](https://github.com/prowler-cloud/prowler/pull/11631)
+- Sentry now drops ASGI's `RequestAborted` errors from health-check probe disconnects on `/health/live` [(#11632)](https://github.com/prowler-cloud/prowler/pull/11632)
 
 ### 🔐 Security
 

--- a/api/src/backend/config/settings/sentry.py
+++ b/api/src/backend/config/settings/sentry.py
@@ -76,6 +76,8 @@ IGNORED_EXCEPTIONS = [
     # PowerShell Errors in User Authentication
     "Microsoft Teams User Auth connection failed: Please check your permissions and try again.",
     "Exchange Online User Auth connection failed: Please check your permissions and try again.",
+    # ASGI: Client disconnected before the response finished (health-check probes on /health/live)
+    "RequestAborted",
 ]
 
 


### PR DESCRIPTION
### Context

The `/health/live` liveness probe fires `RequestAborted` errors in Sentry. Django's ASGI handler raises `RequestAborted` when the client disconnects before the response finishes, which is exactly what a probe with a short timeout does. The requests themselves return `200`; these are noise, not faults.

### Description

Add `RequestAborted` to `IGNORED_EXCEPTIONS` in `config/settings/sentry.py`. The SDK's `ignore_errors` matches it by class name and drops the event before it's sent. (The `before_send` substring match alone wouldn't catch it, since `RequestAborted` carries an empty message.)

### Steps to review

1. Confirm `RequestAborted` is in `IGNORED_EXCEPTIONS`.
2. Verify the issue stops escalating in Sentry after deploy.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.