### PR TITLE
ci: remove redundant compliance CODEOWNERS rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 # SDK
 /* @prowler-cloud/detection-remediation
 /prowler/ @prowler-cloud/detection-remediation
-/prowler/compliance/ @prowler-cloud/compliance
 /tests/ @prowler-cloud/detection-remediation
 /dashboard/ @prowler-cloud/detection-remediation
 /docs/ @prowler-cloud/detection-remediation


### PR DESCRIPTION
### Context

The `/prowler/compliance/` path in `.github/CODEOWNERS` was assigned to `@prowler-cloud/compliance`, a team of only two people. Ownership of that path has been reassigned to `@prowler-cloud/detection-remediation`, which the existing `/prowler/` rule already grants.

### Description

Removes the `/prowler/compliance/ @prowler-cloud/compliance` line from `.github/CODEOWNERS`. With the reassignment, `/prowler/compliance/` now inherits `@prowler-cloud/detection-remediation` from the broader `/prowler/` rule, so the dedicated line was redundant. No other lines or files are touched.

### Steps to review

- Confirm the diff removes exactly one line: `/prowler/compliance/ @prowler-cloud/compliance`.
- Confirm `/prowler/ @prowler-cloud/detection-remediation` remains and therefore covers `/prowler/compliance/`.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->