### PR TITLE
fix(ui): bump transitive dompurify to 3.4.10 to patch XSS advisories

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the **Prowler UI** are documented in this file.
 ### 🔐 Security
 
 - Bump vulnerable `Next.js`, React, AI SDK, `postcss`, `hono`, `qs`, `esbuild`, and Alpine OpenSSL packages (`libcrypto3` and `libssl3`) [(#11581)](https://github.com/prowler-cloud/prowler/pull/11581)
+- Bump transitive `dompurify` from 3.4.2 to 3.4.10, patching XSS sanitization bypass advisories [(#11636)](https://github.com/prowler-cloud/prowler/pull/11636)
 
 ---
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -29,6 +29,7 @@ overrides:
   qs: 6.15.2
   express-rate-limit: 8.5.1
   uuid: 11.1.1
+  dompurify: 3.4.10
 
 importers:
 
@@ -5593,8 +5594,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.2:
-    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   dotenv-expand@12.0.3:
     resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
@@ -15168,7 +15169,7 @@ snapshots:
       '@babel/runtime': 7.28.6
       csstype: 3.2.3
 
-  dompurify@3.4.2:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -16682,7 +16683,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.19
-      dompurify: 3.4.2
+      dompurify: 3.4.10
       es-toolkit: 1.46.1
       katex: 0.16.27
       khroma: 2.1.0

--- a/ui/pnpm-workspace.yaml
+++ b/ui/pnpm-workspace.yaml
@@ -45,6 +45,10 @@ overrides:
   # use the random v4 generator only, so the bug isn't reachable in practice,
   # but the override unifies the tree on a patched version.
   "uuid": "11.1.1"
+  # GHSA-vxr8-fq34-vvx9 (+ several related XSS sanitization bypasses): DOMPurify < 3.4.9,
+  # pulled in transitively via streamdown > mermaid (which wants ^3.3.1). Pinned to 3.4.10
+  # (fixes all open advisories; 3.4.11 is < 24h old and blocked by minimumReleaseAge).
+  "dompurify": "3.4.10"
 
 # --- Level 1: Minimum Release Age ---
 # Packages must be published for at least 1 day before they can be installed.


### PR DESCRIPTION
### Context

Dependabot flagged the transitive `dompurify` dependency (resolved at `3.4.2`) against several XSS sanitization-bypass advisories (e.g. GHSA-vxr8-fq34-vvx9, GHSA-x4vx-rjvf-j5p4, CVE-2026-49458/49459/49978, GHSA-76mc-f452-cxcm, GHSA-gvmj-g25r-r7wr). `dompurify` is not a direct dependency; it is pulled in via `streamdown` → `mermaid` (which requires `^3.3.1`).

### Description

Pins `dompurify` to `3.4.10` via the existing `overrides` block in `ui/pnpm-workspace.yaml`, regenerating `ui/pnpm-lock.yaml`. `3.4.10` fixes all open advisories (the highest required patch is `>= 3.4.9`) and satisfies mermaid's `^3.3.1` range. `3.4.11` was intentionally avoided because at the time of the bump it was published less than 24h ago and is blocked by the repo's `minimumReleaseAge: 1440` policy.

- No source changes; `dompurify` has no direct imports in the UI.
- `mermaid@11.15.0` now links to `dompurify@3.4.10`; the lockfile no longer references `3.4.2`.

### Steps to review

1. `cd ui && pnpm install`
2. Confirm `node_modules/.pnpm/mermaid@11.15.0/node_modules/dompurify` resolves to `dompurify@3.4.10`.
3. `grep "dompurify" ui/pnpm-lock.yaml` shows only `3.4.10`.

### Checklist

#### UI
- [x] If this PR adds or updates npm dependencies: this is a transitive security override (no new direct dependency). `dompurify` is the widely-used DOM sanitizer; `3.4.10` is a patch release that fixes the open XSS advisories with no API changes, and is the highest version satisfying the repo's 24h minimum-release-age policy.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enhanced application security by updating the DOMPurify dependency to version **3.4.10**, addressing a reported XSS sanitization bypass advisory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->