### PR TITLE
ci: right-size E2E API gunicorn workers to prevent CI overload

### DIFF
--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -138,6 +138,19 @@ jobs:
           echo "AWS_ACCESS_KEY_ID=${{ secrets.E2E_AWS_PROVIDER_ACCESS_KEY }}" >> .env
           echo "AWS_SECRET_ACCESS_KEY=${{ secrets.E2E_AWS_PROVIDER_SECRET_KEY }}" >> .env
 
+      - name: Tune API gunicorn for CI capacity
+        # The runner is a 4-vCPU box. The image default DJANGO_WORKERS is
+        # cpu_count()*2+1 = 9 workers, each preloading the full SDK + a live
+        # Neo4j driver. Under the concurrent server-side fan-out of a single
+        # serial E2E test the box over-subscribes, workers exceed the timeout,
+        # get recycled mid-request, and the API drops the keep-alive pool ->
+        # "other side closed" then sustained 503s. Right-size workers to the box
+        # and add timeout headroom. Scoped to CI via .env (read by compose
+        # env_file); production gunicorn settings are untouched.
+        run: |
+          echo "DJANGO_WORKERS=4" >> .env
+          echo "GUNICORN_TIMEOUT=180" >> .env
+
       - name: Build API image from current code
         # docker-compose.yml references prowlercloud/prowler-api:latest from the registry,
         # which lags behind PR changes; build locally so E2E exercises the API image


### PR DESCRIPTION
### Context

The UI E2E suite ("UI - E2E Tests (Optimized)") fails intermittently. The Next.js webserver loses connectivity to the Django API ~2 min into the suite (`UND_ERR_SOCKET: other side closed`) followed by sustained `503 "Server is temporarily unavailable"` for the rest of the run. The API container does not crash — gunicorn workers time out under load and are recycled mid-request, dropping the keep-alive pool. Reproduces on multiple unrelated branches (e.g. PR #11521 feat/scan-schedule-ui and feat/oci-multi-region), confirming it is environmental, not a product bug.

### Description

The CI runner is 4 vCPU, but with no override the API defaults to `DJANGO_WORKERS = cpu_count()*2+1 = 9` gunicorn workers, each preloading the full SDK + a Neo4j driver. That oversubscribes the box under the per-page server-side fetch fan-out. This pins `DJANGO_WORKERS=4` (one per core) and raises `GUNICORN_TIMEOUT=180`, injected via `.env` (which compose reads through `env_file`). Both knobs are already env-overridable in `config/guniconf.py`, so no image, entrypoint, Dockerfile, or production runtime change is needed. Scoped entirely to the E2E CI job. Playwright parallelism (`workers: 1`) and `retries: 2` are unchanged.

### Steps to review

Note `.github/workflows/**` is a critical path in `test-impact.yml`, so this change forces `run-all=true` and the full E2E suite runs on this PR. Confirm the run is green and that `other side closed` / `Server is temporarily unavailable` no longer appear in the `e2e-tests` job log. Because the failure is intermittent, the `e2e-tests` job should be re-run 2-3× to confirm stability.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
