### PR TITLE
fix(api): close DB connections per request to stop ASGI replica connection leak

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to the **Prowler API** are documented in this file.
 - Gunicorn worker timeout raised from the 30s default to 120s, so long-running requests are no longer killed prematurely [(#11631)](https://github.com/prowler-cloud/prowler/pull/11631)
 - Sentry now drops ASGI's `RequestAborted` errors from health-check probe disconnects on `/health/live` [(#11632)](https://github.com/prowler-cloud/prowler/pull/11632)
 
+### 🐞 Fixed
+
+- Database connections no longer leak under the ASGI worker, which previously exhausted the read replica's connection slots and caused 500s on read endpoints [(#11640)](https://github.com/prowler-cloud/prowler/pull/11640)
+
 ### 🔐 Security
 
 - `aiohttp` to 3.14.0 and `idna` to 3.15, patching known CVEs [(#11596)](https://github.com/prowler-cloud/prowler/pull/11596)

--- a/api/src/backend/api/middleware.py
+++ b/api/src/backend/api/middleware.py
@@ -1,7 +1,31 @@
 import logging
 import time
 
+from django.db import close_old_connections
+
 from config.custom_logging import BackendLogger
+
+
+class CloseDBConnectionsMiddleware:
+    """Release request-scoped DB connections at the request boundary.
+
+    Under the native ASGI worker, sync views run on a thread-sensitive
+    executor thread; the connections they open live in that thread's context.
+    Django's request_finished -> close_old_connections fires in a different
+    context and never frees them, so they pile up idle until Postgres runs out
+    of slots. Closing here, on the same thread-sensitive context as the view,
+    releases them. close_old_connections respects CONN_MAX_AGE, so it keeps
+    working if persistent connections are enabled later.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        try:
+            return self.get_response(request)
+        finally:
+            close_old_connections()
 
 
 def extract_auth_info(request) -> dict:

--- a/api/src/backend/api/middleware.py
+++ b/api/src/backend/api/middleware.py
@@ -1,6 +1,7 @@
 import logging
 import time
 
+from django.core.handlers.asgi import ASGIRequest
 from django.db import connections
 
 from config.custom_logging import BackendLogger
@@ -8,12 +9,12 @@ from config.custom_logging import BackendLogger
 
 class CloseDBConnectionsMiddleware:
     """
-    Close request-scoped DB connections at the end of each request.
+    Close request-scoped DB connections at the end of each ASGI request.
 
     Under the ASGI worker, connections opened by sync views are not released
     by Django's normal request-boundary cleanup, so they accumulate idle until
-    Postgres runs out of slots. Connections in an atomic block are skipped to
-    avoid closing the test client's transaction-wrapped connection mid-request.
+    Postgres runs out of slots. Only ASGI requests are handled; the sync WSGI
+    test client manages its own connections and must be left alone.
     """
 
     def __init__(self, get_response):
@@ -23,9 +24,10 @@ class CloseDBConnectionsMiddleware:
         try:
             return self.get_response(request)
         finally:
-            for conn in connections.all(initialized_only=True):
-                if not conn.in_atomic_block:
-                    conn.close_if_unusable_or_obsolete()
+            if isinstance(request, ASGIRequest):
+                for conn in connections.all(initialized_only=True):
+                    if not conn.in_atomic_block:
+                        conn.close_if_unusable_or_obsolete()
 
 
 def extract_auth_info(request) -> dict:

--- a/api/src/backend/api/middleware.py
+++ b/api/src/backend/api/middleware.py
@@ -1,21 +1,19 @@
 import logging
 import time
 
-from django.db import close_old_connections
+from django.db import connections
 
 from config.custom_logging import BackendLogger
 
 
 class CloseDBConnectionsMiddleware:
-    """Release request-scoped DB connections at the request boundary.
+    """
+    Close request-scoped DB connections at the end of each request.
 
-    Under the native ASGI worker, sync views run on a thread-sensitive
-    executor thread; the connections they open live in that thread's context.
-    Django's request_finished -> close_old_connections fires in a different
-    context and never frees them, so they pile up idle until Postgres runs out
-    of slots. Closing here, on the same thread-sensitive context as the view,
-    releases them. close_old_connections respects CONN_MAX_AGE, so it keeps
-    working if persistent connections are enabled later.
+    Under the ASGI worker, connections opened by sync views are not released
+    by Django's normal request-boundary cleanup, so they accumulate idle until
+    Postgres runs out of slots. Connections in an atomic block are skipped to
+    avoid closing the test client's transaction-wrapped connection mid-request.
     """
 
     def __init__(self, get_response):
@@ -25,7 +23,9 @@ class CloseDBConnectionsMiddleware:
         try:
             return self.get_response(request)
         finally:
-            close_old_connections()
+            for conn in connections.all(initialized_only=True):
+                if not conn.in_atomic_block:
+                    conn.close_if_unusable_or_obsolete()
 
 
 def extract_auth_info(request) -> dict:

--- a/api/src/backend/config/django/base.py
+++ b/api/src/backend/config/django/base.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "api.middleware.CloseDBConnectionsMiddleware",
     "django_guid.middleware.guid_middleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
### Context
  
Under the ASGI worker, sync views open DB connections that Django's request-end cleanup never closes, so they pile up idle until the read replica runs out of connection slots and read endpoints start returning 500s.
  
### Description

Adds `CloseDBConnectionsMiddleware`, registered first in `MIDDLEWARE`, that closes each request's DB connections at the request boundary with `close_if_unusable_or_obsolete` (which honors `CONN_MAX_AGE`). It only acts on ASGI requests and skips connections inside an atomic block, so the sync WSGI test client keeps managing its own connections.

### Steps to review
  
Run the API test suite (the sync test-client path is unaffected). On a deployed environment, watch `pg_stat_activity` filtered to `application_name LIKE 'api:%'` under read load: idle `api:replica` connections stay flat instead of climbing toward `max_connections`.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a database connection leak in ASGI workers, preventing read-replica connection slot exhaustion and eliminating 500 errors on read endpoints.
* **Internal Improvements**
  * Added middleware to safely close initialized database connections for ASGI requests when not inside an atomic transaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->