### PR TITLE
chore(ci): remove legacy prowler-api/ui/mcp cloud-deployment dispatch jobs

### DIFF
--- a/.github/workflows/api-container-build-push.yml
+++ b/.github/workflows/api-container-build-push.yml
@@ -272,27 +272,3 @@ jobs:
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
           step-outcome: ${{ steps.outcome.outputs.outcome }}
           update-ts: ${{ needs.notify-release-started.outputs.message-ts }}
-
-  trigger-deployment:
-    needs: [setup, container-build-push]
-    if: always() && github.event_name == 'push' && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-
-      - name: Trigger API deployment
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
-          repository: ${{ secrets.CLOUD_DISPATCH }}
-          event-type: api-prowler-deployment
-          client-payload: '{"sha": "${{ github.sha }}", "short_sha": "${{ needs.setup.outputs.short-sha }}"}'

--- a/.github/workflows/mcp-container-build-push.yml
+++ b/.github/workflows/mcp-container-build-push.yml
@@ -263,27 +263,3 @@ jobs:
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
           step-outcome: ${{ steps.outcome.outputs.outcome }}
           update-ts: ${{ needs.notify-release-started.outputs.message-ts }}
-
-  trigger-deployment:
-    needs: [setup, container-build-push]
-    if: always() && github.event_name == 'push' && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-
-      - name: Trigger MCP deployment
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
-          repository: ${{ secrets.CLOUD_DISPATCH }}
-          event-type: mcp-prowler-deployment
-          client-payload: '{"sha": "${{ github.sha }}", "short_sha": "${{ needs.setup.outputs.short-sha }}"}'

--- a/.github/workflows/ui-container-build-push.yml
+++ b/.github/workflows/ui-container-build-push.yml
@@ -258,27 +258,3 @@ jobs:
           payload-file-path: "./.github/scripts/slack-messages/container-release-completed.json"
           step-outcome: ${{ steps.outcome.outputs.outcome }}
           update-ts: ${{ needs.notify-release-started.outputs.message-ts }}
-
-  trigger-deployment:
-    needs: [setup, container-build-push]
-    if: always() && github.event_name == 'push' && needs.setup.result == 'success' && needs.container-build-push.result == 'success'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-
-      - name: Trigger UI deployment
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ secrets.PROWLER_BOT_ACCESS_TOKEN }}
-          repository: ${{ secrets.CLOUD_DISPATCH }}
-          event-type: ui-prowler-deployment
-          client-payload: '{"sha": "${{ github.sha }}", "short_sha": "${{ needs.setup.outputs.short-sha }}"}'


### PR DESCRIPTION
### Context

The `trigger-deployment` jobs in the api/ui/mcp container-build-push workflows fired `repository_dispatch` events (`api-prowler-deployment`, `ui-prowler-deployment`, `mcp-prowler-deployment`) to kick off the legacy cloud deployment workflows. Those cloud deployment workflows targeted dev stacks that have since been decommissioned, so these dispatch senders no longer have a receiver.

These container-build workflows are synced upstream (prowler → prowler-cloud), so the senders must be removed here too — leaving them in OSS prowler would re-introduce them on the next sync. The companion cloud-side removal is prowler-cloud PR #4691.

### Description

Removes the trailing `trigger-deployment` job from each of the three container-build-push workflows:

- `.github/workflows/api-container-build-push.yml` (`api-prowler-deployment`)
- `.github/workflows/mcp-container-build-push.yml` (`mcp-prowler-deployment`)
- `.github/workflows/ui-container-build-push.yml` (`ui-prowler-deployment`)

Each removed job was a leaf (`needs: [setup, container-build-push]`) with nothing depending on it, so no `needs:` rewiring was required. All other jobs (`setup`, `notify-release-started`, `container-build-push`, `create-manifest`, `notify-release-completed`) are untouched.

`pr-merged.yml` is intentionally left alone — it dispatches `prowler-pull-request-merged` (the PR-sync mechanism), not a deployment.

### Steps to review

- Confirm only the `trigger-deployment` job block is removed in each of the 3 files.
- `grep -rn 'trigger-deployment\|prowler-deployment' .github/workflows/` returns no matches.
- `pr-merged.yml`'s `prowler-pull-request-merged` dispatch is still present.
- Each edited workflow still parses as valid YAML and retains its other jobs.

### Checklist

- [x] Review if backport is needed. (CI-only change, no backport needed)

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated deployment triggers from CI/CD build workflows for container image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->