### PR TITLE
fix(api): set gunicorn keep-alive above the load balancer idle timeout to stop 502s

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the **Prowler API** are documented in this file.
 ### 🐞 Fixed
 
 - Database connections no longer leak under the ASGI worker, which previously exhausted the read replica's connection slots and caused 500s on read endpoints [(#11640)](https://github.com/prowler-cloud/prowler/pull/11640)
+- Gunicorn keep-alive timeout now exceeds the load balancer idle timeout, stopping 502s from reused connections [(#11647)](https://github.com/prowler-cloud/prowler/pull/11647)
 
 ### 🔐 Security
 

--- a/api/src/backend/config/guniconf.py
+++ b/api/src/backend/config/guniconf.py
@@ -56,9 +56,11 @@ preload_app = not DEBUG
 # that may take longer, such as complex API operations.
 timeout = env.int("GUNICORN_TIMEOUT", default=120)
 
-# HTTP keep-alive idle timeout. Must exceed the load balancer's idle timeout, or
-# the balancer reuses a connection gunicorn just closed and returns a 502.
-keepalive = env.int("GUNICORN_KEEPALIVE", default=315)
+# HTTP keep-alive idle timeout. Must exceed the idle timeout of the proxy or load
+# balancer in front of gunicorn, or it reuses a connection gunicorn just closed
+# and returns a 502. Default clears the common 60s; raise `GUNICORN_KEEPALIVE` to
+# stay above a longer one.
+keepalive = env.int("GUNICORN_KEEPALIVE", default=75)
 
 # Logging
 logconfig_dict = DJANGO_LOGGERS

--- a/api/src/backend/config/guniconf.py
+++ b/api/src/backend/config/guniconf.py
@@ -56,6 +56,10 @@ preload_app = not DEBUG
 # that may take longer, such as complex API operations.
 timeout = env.int("GUNICORN_TIMEOUT", default=120)
 
+# HTTP keep-alive idle timeout. Must exceed the load balancer's idle timeout, or
+# the balancer reuses a connection gunicorn just closed and returns a 502.
+keepalive = env.int("GUNICORN_KEEPALIVE", default=315)
+
 # Logging
 logconfig_dict = DJANGO_LOGGERS
 gunicorn_logger = logging.getLogger(BackendLogger.GUNICORN)


### PR DESCRIPTION
### Context

Behind a load balancer, gunicorn's keep-alive timeout must exceed the balancer's idle timeout. Otherwise the balancer can reuse a connection the worker has already closed, producing 502s.

### Description

Add a `keepalive` setting (default 315s, overridable via `GUNICORN_KEEPALIVE`) so it stays above the load balancer idle timeout.

### Steps to review

- `keepalive` default exceeds the fronting load balancer's idle timeout

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed 502 errors caused by reused connections by increasing Gunicorn keep-alive timeout to exceed load balancer idle timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->