### PR TITLE
fix(metadata): tag IAM policy privilege escalation check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 ### 🐞 Fixed
 
 - Azure PostgreSQL flexible server inventory no longer aborts the whole subscription when the `connection_throttle.enable` parameter is missing (e.g. PostgreSQL v18), and logs the expected "Entra ID authentication not enabled" case as a warning instead of an error, so servers are still scanned [(#11045)](https://github.com/prowler-cloud/prowler/pull/11045)
+- `iam_policy_allows_privilege_escalation` now includes the `privilege-escalation` category [(#11648)](https://github.com/prowler-cloud/prowler/pull/11648)
 
 ### 🔐 Security
 

--- a/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.metadata.json
+++ b/prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.metadata.json
@@ -37,7 +37,8 @@
     }
   },
   "Categories": [
-    "identity-access"
+    "identity-access",
+    "privilege-escalation"
   ],
   "DependsOn": [],
   "RelatedTo": [],


### PR DESCRIPTION
### Context

The `iam_policy_allows_privilege_escalation` check already detects AWS IAM customer-managed policies that can allow privilege escalation, but its metadata categories did not include `privilege-escalation`.

### Description

- Adds `privilege-escalation` to the check metadata categories
- Keeps the existing `identity-access` category

### Steps to review

- Confirm `prowler/providers/aws/services/iam/iam_policy_allows_privilege_escalation/iam_policy_allows_privilege_escalation.metadata.json` includes both categories
- Validation run locally:
  - Metadata loads with `CheckMetadata.parse_file`
  - `privilege-escalation` is present in `VALID_CATEGORIES`
  - `uv run pytest tests/lib/check/models_test.py::TestCheckMetadataValidators::test_valid_category_all_predefined_values -q`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in Jira as PROWLER-1796
- [x] Is it assigned to me

</details>

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed
- [x] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.