### PR TITLE
fix(azure): keyvault_logging_enabled false-fails on explicit AuditEvent category

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -139,6 +139,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 - GCP `kms_key_rotation_enabled` check now only verifies that automatic key rotation is enabled (any interval) instead of enforcing a 90-day period, resolving the mismatch between the check and its documentation; the CIS, Prowler ThreatScore, and CCC requirements that mandate a 90-day maximum were remapped to the new `kms_key_rotation_max_90_days` check [(#11516)](https://github.com/prowler-cloud/prowler/pull/11516)
 - AWS CloudWatch log metric filter checks now validate `filterPattern` clauses regardless of order [(#11345)](https://github.com/prowler-cloud/prowler/pull/11345)
 - AWS `bedrock_api_key_no_long_term_credentials` now applies severity per finding (never-expires keys correctly flag as critical, no leak across findings) and aligns title and wording with AWS guidance to prefer short-term Bedrock API keys [(#11526)](https://github.com/prowler-cloud/prowler/pull/11526)
+- Azure `keyvault_logging_enabled` no longer false-fails when audit logging is enabled via the explicit `AuditEvent` log category (with a null category group) instead of the `audit` category group [(#11657)](https://github.com/prowler-cloud/prowler/pull/11657)
 
 ### 🔐 Security
 

--- a/prowler/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled.py
+++ b/prowler/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled.py
@@ -19,7 +19,10 @@ class keyvault_logging_enabled(Check):
                     has_audit = False
                     has_all_logs = False
                     for log in diagnostic_setting.logs:
-                        if log.category_group == "audit" and log.enabled:
+                        if (
+                            log.category_group == "audit"
+                            or log.category == "AuditEvent"
+                        ) and log.enabled:
                             has_audit = True
                         if log.category_group == "allLogs" and log.enabled:
                             has_all_logs = True

--- a/tests/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled_test.py
+++ b/tests/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled_test.py
@@ -244,6 +244,82 @@ class Test_keyvault_logging_enabled:
             assert result[0].resource_name == "name_keyvault"
             assert result[0].resource_id == "id"
 
+    def test_diagnostic_setting_with_explicit_auditevent_category(self):
+        keyvault_client = mock.MagicMock
+        keyvault_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.monitor.monitor_service.Monitor",
+                new=mock.MagicMock(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.keyvault.keyvault_logging_enabled.keyvault_logging_enabled.keyvault_client",
+                new=keyvault_client,
+            ),
+        ):
+            from prowler.providers.azure.services.keyvault.keyvault_logging_enabled.keyvault_logging_enabled import (
+                keyvault_logging_enabled,
+            )
+            from prowler.providers.azure.services.keyvault.keyvault_service import (
+                KeyVaultInfo,
+            )
+            from prowler.providers.azure.services.monitor.monitor_service import (
+                DiagnosticSetting,
+            )
+
+            keyvault_client.key_vaults = {
+                AZURE_SUBSCRIPTION_ID: [
+                    KeyVaultInfo(
+                        id="id",
+                        name="name_keyvault",
+                        location="westeurope",
+                        resource_group="resource_group",
+                        properties=VaultProperties(
+                            tenant_id="tenantid",
+                            sku="sku",
+                            enable_rbac_authorization=False,
+                        ),
+                        keys=[],
+                        secrets=[],
+                        monitor_diagnostic_settings=[
+                            DiagnosticSetting(
+                                id="id/ds1",
+                                logs=[
+                                    mock.MagicMock(
+                                        category_group=None,
+                                        category="AuditEvent",
+                                        enabled=True,
+                                    ),
+                                    mock.MagicMock(
+                                        category_group="allLogs",
+                                        category=None,
+                                        enabled=True,
+                                    ),
+                                ],
+                                storage_account_name="sa1",
+                                storage_account_id="sa_id1",
+                                name="ds_compliant",
+                            ),
+                        ],
+                    ),
+                ]
+            }
+            check = keyvault_logging_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Key Vault name_keyvault in subscription {AZURE_SUBSCRIPTION_DISPLAY} has a diagnostic setting with audit logging."
+            )
+            assert result[0].resource_name == "name_keyvault"
+            assert result[0].resource_id == "id"
+
     def test_multiple_diagnostic_settings_one_compliant(self):
         keyvault_client = mock.MagicMock
         keyvault_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}

--- a/tests/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled_test.py
+++ b/tests/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled_test.py
@@ -320,6 +320,82 @@ class Test_keyvault_logging_enabled:
             assert result[0].resource_name == "name_keyvault"
             assert result[0].resource_id == "id"
 
+    def test_diagnostic_setting_with_auditevent_category_but_no_alllogs(self):
+        keyvault_client = mock.MagicMock
+        keyvault_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.monitor.monitor_service.Monitor",
+                new=mock.MagicMock(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.keyvault.keyvault_logging_enabled.keyvault_logging_enabled.keyvault_client",
+                new=keyvault_client,
+            ),
+        ):
+            from prowler.providers.azure.services.keyvault.keyvault_logging_enabled.keyvault_logging_enabled import (
+                keyvault_logging_enabled,
+            )
+            from prowler.providers.azure.services.keyvault.keyvault_service import (
+                KeyVaultInfo,
+            )
+            from prowler.providers.azure.services.monitor.monitor_service import (
+                DiagnosticSetting,
+            )
+
+            keyvault_client.key_vaults = {
+                AZURE_SUBSCRIPTION_ID: [
+                    KeyVaultInfo(
+                        id="id",
+                        name="name_keyvault",
+                        location="westeurope",
+                        resource_group="resource_group",
+                        properties=VaultProperties(
+                            tenant_id="tenantid",
+                            sku="sku",
+                            enable_rbac_authorization=False,
+                        ),
+                        keys=[],
+                        secrets=[],
+                        monitor_diagnostic_settings=[
+                            DiagnosticSetting(
+                                id="id/ds1",
+                                logs=[
+                                    mock.MagicMock(
+                                        category_group=None,
+                                        category="AuditEvent",
+                                        enabled=True,
+                                    ),
+                                    mock.MagicMock(
+                                        category_group="allLogs",
+                                        category=None,
+                                        enabled=False,
+                                    ),
+                                ],
+                                storage_account_name="sa1",
+                                storage_account_id="sa_id1",
+                                name="ds_incomplete",
+                            ),
+                        ],
+                    ),
+                ]
+            }
+            check = keyvault_logging_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Key Vault name_keyvault in subscription {AZURE_SUBSCRIPTION_DISPLAY} does not have a diagnostic setting with audit logging."
+            )
+            assert result[0].resource_name == "name_keyvault"
+            assert result[0].resource_id == "id"
+
     def test_multiple_diagnostic_settings_one_compliant(self):
         keyvault_client = mock.MagicMock
         keyvault_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}


### PR DESCRIPTION
### Context

Fixes #11656.

`keyvault_logging_enabled` only recognized Key Vault audit logging when the diagnostic setting log used the `audit` category **group**. Azure can also represent the same audit logging via an explicit log **category** named `AuditEvent` with a `null` category group, which the check did not account for, producing a false `FAIL`.

### Description

In `prowler/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled.py`, the `has_audit` condition now also accepts `log.category == "AuditEvent"` (in addition to the existing `log.category_group == "audit"`), both gated on `log.enabled`. The `allLogs` category-group condition is unchanged.

Added `test_diagnostic_setting_with_explicit_auditevent_category` to `tests/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled_test.py`, mirroring the existing test style, covering a diagnostic setting with `category="AuditEvent"`/`category_group=None` plus `category_group="allLogs"` and asserting `PASS`.

Added a CHANGELOG.md entry under `### 🐞 Fixed`.

### Steps to review

- `uv run pytest -q tests/providers/azure/services/keyvault/keyvault_logging_enabled/` — all 7 tests pass, including the new regression test.
- `uv run pytest -q tests/providers/azure/services/keyvault/` — full keyvault service suite (52 tests) still passes.

### Checklist

- [x] This feature/issue is listed in #11656
- [x] Review if the code is being covered by tests.
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No — this is a bug fix to an existing check's logic, no permission changes needed.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Azure Key Vault audit logging check to correctly recognize audit logging when diagnostic settings use an explicitly configured `AuditEvent` log category, preventing false-negative results.

* **Tests**
  * Added unit test coverage for diagnostic configurations that enable audit logging via an explicit `AuditEvent` category.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->