### PR TITLE
fix(ui): use shared scan launch action errors

### DIFF
--- a/ui/components/providers/organizations/org-launch-scan.test.tsx
+++ b/ui/components/providers/organizations/org-launch-scan.test.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ACTION_ERROR_API_MESSAGES,
   ACTION_ERROR_MESSAGES,
   ACTION_ERROR_STATUS,
 } from "@/lib/action-errors";
@@ -208,8 +209,7 @@ describe("OrgLaunchScan", () => {
       const onClose = vi.fn();
       const onFooterChange = vi.fn();
       updateSchedulesBulkMock.mockResolvedValue({
-        error:
-          "An active subscription is required to use this API endpoint in Prowler Cloud.",
+        error: ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
         status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
       });
 

--- a/ui/components/providers/organizations/org-launch-scan.test.tsx
+++ b/ui/components/providers/organizations/org-launch-scan.test.tsx
@@ -3,6 +3,10 @@ import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  ACTION_ERROR_MESSAGES,
+  ACTION_ERROR_STATUS,
+} from "@/lib/action-errors";
 import { useOrgSetupStore } from "@/store/organizations/store";
 import {
   SCAN_JOBS_TAB,
@@ -203,7 +207,11 @@ describe("OrgLaunchScan", () => {
       // Given
       const onClose = vi.fn();
       const onFooterChange = vi.fn();
-      updateSchedulesBulkMock.mockResolvedValue({ error: "Denied" });
+      updateSchedulesBulkMock.mockResolvedValue({
+        error:
+          "An active subscription is required to use this API endpoint in Prowler Cloud.",
+        status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+      });
 
       render(
         <OrgLaunchScan
@@ -226,6 +234,8 @@ describe("OrgLaunchScan", () => {
           expect.objectContaining({
             variant: "destructive",
             title: "Unable to save scan schedules",
+            description:
+              ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
           }),
         ),
       );

--- a/ui/components/providers/organizations/org-launch-scan.tsx
+++ b/ui/components/providers/organizations/org-launch-scan.tsx
@@ -24,6 +24,7 @@ import {
 import { Spinner } from "@/components/shadcn/spinner/spinner";
 import { TreeStatusIcon } from "@/components/shadcn/tree-view/tree-status-icon";
 import { ToastAction, useToast } from "@/components/ui";
+import { getActionErrorMessage } from "@/lib/action-errors";
 import {
   buildScheduleUpdatePayload,
   getScanScheduleCapability,
@@ -174,7 +175,7 @@ export function OrgLaunchScan({
       toast({
         variant: "destructive",
         title: "Unable to save scan schedules",
-        description: String(result.error),
+        description: getActionErrorMessage(result),
       });
       return;
     }

--- a/ui/components/providers/organizations/org-launch-scan.tsx
+++ b/ui/components/providers/organizations/org-launch-scan.tsx
@@ -24,7 +24,7 @@ import {
 import { Spinner } from "@/components/shadcn/spinner/spinner";
 import { TreeStatusIcon } from "@/components/shadcn/tree-view/tree-status-icon";
 import { ToastAction, useToast } from "@/components/ui";
-import { getActionErrorMessage } from "@/lib/action-errors";
+import { getActionErrorMessage, hasActionError } from "@/lib/action-errors";
 import {
   buildScheduleUpdatePayload,
   getScanScheduleCapability,
@@ -170,7 +170,7 @@ export function OrgLaunchScan({
       buildScheduleUpdatePayload(values),
     );
 
-    if (result.error) {
+    if (hasActionError(result)) {
       setIsLaunching(false);
       toast({
         variant: "destructive",

--- a/ui/components/providers/wizard/steps/launch-step.test.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.test.tsx
@@ -4,6 +4,7 @@ import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ACTION_ERROR_API_MESSAGES,
   ACTION_ERROR_MESSAGES,
   ACTION_ERROR_STATUS,
 } from "@/lib/action-errors";
@@ -385,7 +386,7 @@ describe("LaunchStep", () => {
       const onClose = vi.fn();
       const onFooterChange = vi.fn();
       const rawError =
-        "An active subscription is required to use this API endpoint in Prowler Cloud.";
+        ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED];
       seedConnectedProvider();
       scanOnDemandMock.mockResolvedValue({
         error: rawError,

--- a/ui/components/providers/wizard/steps/launch-step.test.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.test.tsx
@@ -3,6 +3,10 @@ import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  ACTION_ERROR_MESSAGES,
+  ACTION_ERROR_STATUS,
+} from "@/lib/action-errors";
 import { useProviderWizardStore } from "@/store/provider-wizard/store";
 import { SCAN_JOBS_TAB } from "@/types";
 import {
@@ -374,6 +378,47 @@ describe("LaunchStep", () => {
       expect(updateScheduleMock).not.toHaveBeenCalled();
       expect(scheduleDailyMock).not.toHaveBeenCalled();
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses the shared subscription error copy when a manual scan is blocked", async () => {
+      // Given
+      const onClose = vi.fn();
+      const onFooterChange = vi.fn();
+      const rawError =
+        "An active subscription is required to use this API endpoint in Prowler Cloud.";
+      seedConnectedProvider();
+      scanOnDemandMock.mockResolvedValue({
+        error: rawError,
+        status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+      });
+
+      render(
+        <LaunchStep
+          onBack={vi.fn()}
+          onClose={onClose}
+          onFooterChange={onFooterChange}
+          capability={SCAN_SCHEDULE_CAPABILITY.MANUAL_ONLY}
+        />,
+      );
+      await waitFor(() => expect(onFooterChange).toHaveBeenCalled());
+
+      // When
+      await act(async () => {
+        lastFooterConfig(onFooterChange)?.onAction?.();
+      });
+
+      // Then
+      await waitFor(() => expect(scanOnDemandMock).toHaveBeenCalledTimes(1));
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "Unable to launch scan",
+          description:
+            ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+        }),
+      );
+      expect(toastMock.mock.calls[0]?.[0].description).not.toContain(rawError);
+      expect(onClose).not.toHaveBeenCalled();
     });
 
     it("disables the action and shows the limit copy when over limit", async () => {

--- a/ui/components/providers/wizard/steps/launch-step.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/shared/cloud-feature-badge";
 import { ToastAction, useToast } from "@/components/ui";
 import { EntityInfo } from "@/components/ui/entities";
+import { getActionErrorMessage } from "@/lib/action-errors";
 import {
   getScanScheduleCapability,
   getScheduleFormDefaults,
@@ -129,7 +130,10 @@ export function LaunchStep({
     }
   }, [isAdvanced, mode]);
 
-  const launchOnDemandScan = async (): Promise<{ error?: unknown } | null> => {
+  const launchOnDemandScan = async (): Promise<{
+    error?: unknown;
+    status?: number;
+  } | null> => {
     if (!providerId || isBlocked) return null;
     const formData = new FormData();
     formData.set("providerId", providerId);
@@ -149,7 +153,7 @@ export function LaunchStep({
       toast({
         variant: "destructive",
         title: "Unable to launch scan",
-        description: String(scanResult.error),
+        description: getActionErrorMessage(scanResult),
       });
       return;
     }

--- a/ui/components/providers/wizard/steps/launch-step.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.tsx
@@ -24,7 +24,10 @@ import {
 } from "@/components/shared/cloud-feature-badge";
 import { ToastAction, useToast } from "@/components/ui";
 import { EntityInfo } from "@/components/ui/entities";
-import { getActionErrorMessage } from "@/lib/action-errors";
+import {
+  type ActionErrorResult,
+  getActionErrorMessage,
+} from "@/lib/action-errors";
 import {
   getScanScheduleCapability,
   getScheduleFormDefaults,
@@ -130,10 +133,7 @@ export function LaunchStep({
     }
   }, [isAdvanced, mode]);
 
-  const launchOnDemandScan = async (): Promise<{
-    error?: unknown;
-    status?: number;
-  } | null> => {
+  const launchOnDemandScan = async (): Promise<ActionErrorResult | null> => {
     if (!providerId || isBlocked) return null;
     const formData = new FormData();
     formData.set("providerId", providerId);

--- a/ui/components/providers/wizard/steps/launch-step.tsx
+++ b/ui/components/providers/wizard/steps/launch-step.tsx
@@ -27,6 +27,7 @@ import { EntityInfo } from "@/components/ui/entities";
 import {
   type ActionErrorResult,
   getActionErrorMessage,
+  hasActionError,
 } from "@/lib/action-errors";
 import {
   getScanScheduleCapability,
@@ -148,7 +149,7 @@ export function LaunchStep({
     setIsLaunching(true);
     const scanResult = await launchOnDemandScan();
 
-    if (scanResult?.error) {
+    if (hasActionError(scanResult)) {
       setIsLaunching(false);
       toast({
         variant: "destructive",

--- a/ui/components/scans/launch-scan-modal.test.tsx
+++ b/ui/components/scans/launch-scan-modal.test.tsx
@@ -123,6 +123,10 @@ vi.mock("@/app/(prowler)/_overview/_components/accounts-selector", () => ({
   ),
 }));
 
+import {
+  ACTION_ERROR_MESSAGES,
+  ACTION_ERROR_STATUS,
+} from "@/lib/action-errors";
 import { SCAN_SCHEDULE_CAPABILITY } from "@/types/schedules";
 
 import { LaunchScanModal } from "./launch-scan-modal";
@@ -329,6 +333,39 @@ describe("LaunchScanModal", () => {
     expect(
       await screen.findByText("Provider already has a scan in progress"),
     ).toBeInTheDocument();
+    expect(toastMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("maps payment-required scan errors to the shared subscription message", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    scanOnDemandMock.mockResolvedValueOnce({
+      error:
+        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+    });
+
+    render(
+      <LaunchScanModal
+        open
+        onOpenChange={onOpenChange}
+        providers={[provider]}
+      />,
+    );
+
+    await user.selectOptions(screen.getByLabelText("Providers"), provider.id);
+    await user.click(screen.getByRole("button", { name: /launch scan/i }));
+
+    expect(
+      await screen.findByText(
+        ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/An active subscription is required/i),
+    ).not.toBeInTheDocument();
     expect(toastMock).not.toHaveBeenCalled();
     expect(refreshMock).not.toHaveBeenCalled();
     expect(onOpenChange).not.toHaveBeenCalledWith(false);

--- a/ui/components/scans/launch-scan-modal.test.tsx
+++ b/ui/components/scans/launch-scan-modal.test.tsx
@@ -124,6 +124,7 @@ vi.mock("@/app/(prowler)/_overview/_components/accounts-selector", () => ({
 }));
 
 import {
+  ACTION_ERROR_API_MESSAGES,
   ACTION_ERROR_MESSAGES,
   ACTION_ERROR_STATUS,
 } from "@/lib/action-errors";
@@ -342,8 +343,7 @@ describe("LaunchScanModal", () => {
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
     scanOnDemandMock.mockResolvedValueOnce({
-      error:
-        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      error: ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
       status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
     });
 
@@ -364,7 +364,9 @@ describe("LaunchScanModal", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/An active subscription is required/i),
+      screen.queryByText(
+        ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+      ),
     ).not.toBeInTheDocument();
     expect(toastMock).not.toHaveBeenCalled();
     expect(refreshMock).not.toHaveBeenCalled();

--- a/ui/components/scans/launch-scan-modal.tsx
+++ b/ui/components/scans/launch-scan-modal.tsx
@@ -20,6 +20,7 @@ import {
 import { CloudFeatureBadgeLink } from "@/components/shared/cloud-feature-badge";
 import { FormButtons } from "@/components/ui/form";
 import { toast, ToastAction } from "@/components/ui/toast";
+import { getActionErrorMessage } from "@/lib/action-errors";
 import {
   getScanScheduleCapability,
   getScheduleFormDefaults,
@@ -173,7 +174,7 @@ function LaunchScanForm({
     const result = await scanOnDemand(formData);
 
     if (result?.error) {
-      form.setError("root", { message: String(result.error) });
+      form.setError("root", { message: getActionErrorMessage(result) });
       return;
     }
 

--- a/ui/components/scans/launch-scan-modal.tsx
+++ b/ui/components/scans/launch-scan-modal.tsx
@@ -20,7 +20,7 @@ import {
 import { CloudFeatureBadgeLink } from "@/components/shared/cloud-feature-badge";
 import { FormButtons } from "@/components/ui/form";
 import { toast, ToastAction } from "@/components/ui/toast";
-import { getActionErrorMessage } from "@/lib/action-errors";
+import { getActionErrorMessage, hasActionError } from "@/lib/action-errors";
 import {
   getScanScheduleCapability,
   getScheduleFormDefaults,
@@ -173,7 +173,7 @@ function LaunchScanForm({
 
     const result = await scanOnDemand(formData);
 
-    if (result?.error) {
+    if (hasActionError(result)) {
       form.setError("root", { message: getActionErrorMessage(result) });
       return;
     }

--- a/ui/components/scans/schedule/edit-scan-schedule-modal.test.tsx
+++ b/ui/components/scans/schedule/edit-scan-schedule-modal.test.tsx
@@ -80,6 +80,10 @@ vi.mock("@/components/shadcn/modal", () => ({
     ) : null,
 }));
 
+import {
+  ACTION_ERROR_MESSAGES,
+  ACTION_ERROR_STATUS,
+} from "@/lib/action-errors";
 import type { ScheduleProps } from "@/types/schedules";
 
 import {
@@ -290,6 +294,57 @@ describe("EditScanScheduleModal remove flow", () => {
         description: "The scan schedule was updated for 3 providers.",
       }),
     );
+  });
+
+  it("uses the shared subscription error copy when saving is blocked", async () => {
+    const user = userEvent.setup();
+    updateScheduleMock.mockResolvedValue({
+      error:
+        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+    });
+
+    renderLoaded();
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByText(
+        ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/An active subscription is required/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the shared subscription error copy when removing is blocked", async () => {
+    const user = userEvent.setup();
+    removeScheduleMock.mockResolvedValue({
+      error:
+        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+    });
+    renderLoaded();
+
+    await user.click(
+      screen.getByRole("button", { name: /remove scan schedule/i }),
+    );
+    const confirmDialog = screen.getByRole("dialog", {
+      name: "Are you absolutely sure?",
+    });
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "Remove" }),
+    );
+
+    expect(
+      await screen.findByText(
+        ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/An active subscription is required/i),
+    ).not.toBeInTheDocument();
   });
 
   it("shows one logo per selected provider type in bulk mode", () => {

--- a/ui/components/scans/schedule/edit-scan-schedule-modal.test.tsx
+++ b/ui/components/scans/schedule/edit-scan-schedule-modal.test.tsx
@@ -81,6 +81,7 @@ vi.mock("@/components/shadcn/modal", () => ({
 }));
 
 import {
+  ACTION_ERROR_API_MESSAGES,
   ACTION_ERROR_MESSAGES,
   ACTION_ERROR_STATUS,
 } from "@/lib/action-errors";
@@ -299,8 +300,7 @@ describe("EditScanScheduleModal remove flow", () => {
   it("uses the shared subscription error copy when saving is blocked", async () => {
     const user = userEvent.setup();
     updateScheduleMock.mockResolvedValue({
-      error:
-        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      error: ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
       status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
     });
 
@@ -314,15 +314,16 @@ describe("EditScanScheduleModal remove flow", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/An active subscription is required/i),
+      screen.queryByText(
+        ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+      ),
     ).not.toBeInTheDocument();
   });
 
   it("uses the shared subscription error copy when removing is blocked", async () => {
     const user = userEvent.setup();
     removeScheduleMock.mockResolvedValue({
-      error:
-        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      error: ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
       status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
     });
     renderLoaded();
@@ -343,7 +344,9 @@ describe("EditScanScheduleModal remove flow", () => {
       ),
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/An active subscription is required/i),
+      screen.queryByText(
+        ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+      ),
     ).not.toBeInTheDocument();
   });
 

--- a/ui/components/scans/schedule/edit-scan-schedule-modal.tsx
+++ b/ui/components/scans/schedule/edit-scan-schedule-modal.tsx
@@ -20,6 +20,7 @@ import { Modal } from "@/components/shadcn/modal";
 import { EntityInfo } from "@/components/ui/entities";
 import { FormButtons } from "@/components/ui/form";
 import { toast } from "@/components/ui/toast";
+import { getActionErrorMessage } from "@/lib/action-errors";
 import { runWithConcurrencyLimit } from "@/lib/concurrency";
 import {
   buildScheduleUpdatePayload,
@@ -130,7 +131,7 @@ function EditScanScheduleForm({
       : await updateSchedule(targetProviderIds[0], payload);
 
     if (result?.error) {
-      form.setError("root", { message: String(result.error) });
+      form.setError("root", { message: getActionErrorMessage(result) });
       return;
     }
 
@@ -157,7 +158,7 @@ function EditScanScheduleForm({
 
     const failedResult = results.find((result) => result?.error);
     if (failedResult?.error) {
-      form.setError("root", { message: String(failedResult.error) });
+      form.setError("root", { message: getActionErrorMessage(failedResult) });
       return;
     }
 

--- a/ui/components/scans/schedule/edit-scan-schedule-modal.tsx
+++ b/ui/components/scans/schedule/edit-scan-schedule-modal.tsx
@@ -20,7 +20,7 @@ import { Modal } from "@/components/shadcn/modal";
 import { EntityInfo } from "@/components/ui/entities";
 import { FormButtons } from "@/components/ui/form";
 import { toast } from "@/components/ui/toast";
-import { getActionErrorMessage } from "@/lib/action-errors";
+import { getActionErrorMessage, hasActionError } from "@/lib/action-errors";
 import { runWithConcurrencyLimit } from "@/lib/concurrency";
 import {
   buildScheduleUpdatePayload,
@@ -130,7 +130,7 @@ function EditScanScheduleForm({
       ? await updateSchedulesBulk(targetProviderIds, payload)
       : await updateSchedule(targetProviderIds[0], payload);
 
-    if (result?.error) {
+    if (hasActionError(result)) {
       form.setError("root", { message: getActionErrorMessage(result) });
       return;
     }
@@ -156,8 +156,8 @@ function EditScanScheduleForm({
     setIsRemoving(false);
     setIsConfirmRemoveOpen(false);
 
-    const failedResult = results.find((result) => result?.error);
-    if (failedResult?.error) {
+    const failedResult = results.find(hasActionError);
+    if (failedResult) {
       form.setError("root", { message: getActionErrorMessage(failedResult) });
       return;
     }

--- a/ui/components/scans/schedule/save-schedule.test.ts
+++ b/ui/components/scans/schedule/save-schedule.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  ACTION_ERROR_MESSAGES,
+  ACTION_ERROR_STATUS,
+} from "@/lib/action-errors";
 import { SCHEDULE_FREQUENCY, type ScheduleFormValues } from "@/types/schedules";
 
 const { scanOnDemandMock, scheduleDailyMock, updateScheduleMock } = vi.hoisted(
@@ -88,6 +92,25 @@ describe("saveScheduleWithInitialScan", () => {
     expect(scanOnDemandMock).not.toHaveBeenCalled();
   });
 
+  it("maps subscription errors when the schedule save is blocked", async () => {
+    updateScheduleMock.mockResolvedValue({
+      error:
+        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+    });
+
+    const result = await saveScheduleWithInitialScan({
+      providerId: "p1",
+      values,
+    });
+
+    expect(result).toEqual({
+      status: SAVE_SCHEDULE_STATUS.ERROR,
+      message: ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
+    });
+    expect(scanOnDemandMock).not.toHaveBeenCalled();
+  });
+
   it("launches the initial scan when requested", async () => {
     const result = await saveScheduleWithInitialScan({
       providerId: "p1",
@@ -110,6 +133,24 @@ describe("saveScheduleWithInitialScan", () => {
     expect(result).toEqual({
       status: SAVE_SCHEDULE_STATUS.SAVED_SCAN_FAILED,
       message: "limit reached",
+    });
+  });
+
+  it("maps subscription errors when the initial scan is blocked", async () => {
+    scanOnDemandMock.mockResolvedValue({
+      error:
+        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
+    });
+
+    const result = await saveScheduleWithInitialScan({
+      providerId: "p1",
+      values: { ...values, launchInitialScan: true },
+    });
+
+    expect(result).toEqual({
+      status: SAVE_SCHEDULE_STATUS.SAVED_SCAN_FAILED,
+      message: ACTION_ERROR_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
     });
   });
 });

--- a/ui/components/scans/schedule/save-schedule.test.ts
+++ b/ui/components/scans/schedule/save-schedule.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  ACTION_ERROR_API_MESSAGES,
   ACTION_ERROR_MESSAGES,
   ACTION_ERROR_STATUS,
 } from "@/lib/action-errors";
@@ -94,8 +95,7 @@ describe("saveScheduleWithInitialScan", () => {
 
   it("maps subscription errors when the schedule save is blocked", async () => {
     updateScheduleMock.mockResolvedValue({
-      error:
-        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      error: ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
       status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
     });
 
@@ -138,8 +138,7 @@ describe("saveScheduleWithInitialScan", () => {
 
   it("maps subscription errors when the initial scan is blocked", async () => {
     scanOnDemandMock.mockResolvedValue({
-      error:
-        "An active subscription is required to use this API endpoint in Prowler Cloud.",
+      error: ACTION_ERROR_API_MESSAGES[ACTION_ERROR_STATUS.PAYMENT_REQUIRED],
       status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED,
     });
 

--- a/ui/components/scans/schedule/save-schedule.ts
+++ b/ui/components/scans/schedule/save-schedule.ts
@@ -1,5 +1,6 @@
 import { scanOnDemand, scheduleDaily } from "@/actions/scans";
 import { updateSchedule } from "@/actions/schedules";
+import type { ActionErrorResult } from "@/lib/action-errors";
 import { getActionErrorMessage } from "@/lib/action-errors";
 import { buildScheduleUpdatePayload } from "@/lib/schedules";
 import type { ScheduleFormValues } from "@/types/schedules";
@@ -26,18 +27,13 @@ export interface SaveScheduleResult {
   message?: string;
 }
 
-interface ActionResult {
-  error?: unknown;
-  status?: number;
-}
-
 /** Saves a provider's scan schedule and optionally launches the initial scan. */
 export async function saveScheduleWithInitialScan({
   providerId,
   values,
   useLegacyDaily = false,
 }: SaveScheduleParams): Promise<SaveScheduleResult> {
-  let scheduleResult: ActionResult | null;
+  let scheduleResult: ActionErrorResult | null;
 
   if (useLegacyDaily) {
     const formData = new FormData();

--- a/ui/components/scans/schedule/save-schedule.ts
+++ b/ui/components/scans/schedule/save-schedule.ts
@@ -1,7 +1,7 @@
 import { scanOnDemand, scheduleDaily } from "@/actions/scans";
 import { updateSchedule } from "@/actions/schedules";
 import type { ActionErrorResult } from "@/lib/action-errors";
-import { getActionErrorMessage } from "@/lib/action-errors";
+import { getActionErrorMessage, hasActionError } from "@/lib/action-errors";
 import { buildScheduleUpdatePayload } from "@/lib/schedules";
 import type { ScheduleFormValues } from "@/types/schedules";
 
@@ -46,7 +46,7 @@ export async function saveScheduleWithInitialScan({
     );
   }
 
-  if (scheduleResult?.error) {
+  if (hasActionError(scheduleResult)) {
     return {
       status: SAVE_SCHEDULE_STATUS.ERROR,
       message: getActionErrorMessage(scheduleResult),
@@ -61,7 +61,7 @@ export async function saveScheduleWithInitialScan({
   formData.set("providerId", providerId);
   const scanResult = await scanOnDemand(formData);
 
-  if (scanResult?.error) {
+  if (hasActionError(scanResult)) {
     return {
       status: SAVE_SCHEDULE_STATUS.SAVED_SCAN_FAILED,
       message: getActionErrorMessage(scanResult),

--- a/ui/components/scans/schedule/save-schedule.ts
+++ b/ui/components/scans/schedule/save-schedule.ts
@@ -1,5 +1,6 @@
 import { scanOnDemand, scheduleDaily } from "@/actions/scans";
 import { updateSchedule } from "@/actions/schedules";
+import { getActionErrorMessage } from "@/lib/action-errors";
 import { buildScheduleUpdatePayload } from "@/lib/schedules";
 import type { ScheduleFormValues } from "@/types/schedules";
 
@@ -25,13 +26,18 @@ export interface SaveScheduleResult {
   message?: string;
 }
 
+interface ActionResult {
+  error?: unknown;
+  status?: number;
+}
+
 /** Saves a provider's scan schedule and optionally launches the initial scan. */
 export async function saveScheduleWithInitialScan({
   providerId,
   values,
   useLegacyDaily = false,
 }: SaveScheduleParams): Promise<SaveScheduleResult> {
-  let scheduleResult: { error?: unknown } | null;
+  let scheduleResult: ActionResult | null;
 
   if (useLegacyDaily) {
     const formData = new FormData();
@@ -47,7 +53,7 @@ export async function saveScheduleWithInitialScan({
   if (scheduleResult?.error) {
     return {
       status: SAVE_SCHEDULE_STATUS.ERROR,
-      message: String(scheduleResult.error),
+      message: getActionErrorMessage(scheduleResult),
     };
   }
 
@@ -62,7 +68,7 @@ export async function saveScheduleWithInitialScan({
   if (scanResult?.error) {
     return {
       status: SAVE_SCHEDULE_STATUS.SAVED_SCAN_FAILED,
-      message: String(scanResult.error),
+      message: getActionErrorMessage(scanResult),
     };
   }
 

--- a/ui/lib/action-errors.test.ts
+++ b/ui/lib/action-errors.test.ts
@@ -4,6 +4,7 @@ import {
   ACTION_ERROR_MESSAGES,
   ACTION_ERROR_STATUS,
   getActionErrorMessage,
+  hasActionError,
 } from "./action-errors";
 
 describe("getActionErrorMessage", () => {
@@ -68,5 +69,38 @@ describe("getActionErrorMessage", () => {
 
     // Then
     expect(message).toBe(result.error);
+  });
+
+  it("should identify action errors by error payload", () => {
+    // Given
+    const result = { error: "Payment required." };
+
+    // When
+    const hasError = hasActionError(result);
+
+    // Then
+    expect(hasError).toBe(true);
+  });
+
+  it("should identify action errors by HTTP error status", () => {
+    // Given
+    const result = { status: ACTION_ERROR_STATUS.PAYMENT_REQUIRED };
+
+    // When
+    const hasError = hasActionError(result);
+
+    // Then
+    expect(hasError).toBe(true);
+  });
+
+  it("should ignore successful status-only action results", () => {
+    // Given
+    const result = { status: 204 };
+
+    // When
+    const hasError = hasActionError(result);
+
+    // Then
+    expect(hasError).toBe(false);
   });
 });

--- a/ui/lib/action-errors.ts
+++ b/ui/lib/action-errors.ts
@@ -13,7 +13,7 @@ export const ACTION_ERROR_MESSAGES = {
     "You don't have permission to perform this action. Ask an administrator to update your role.",
 } as const satisfies Record<ActionErrorStatus, string>;
 
-interface ActionErrorResult {
+export interface ActionErrorResult {
   error?: unknown;
   status?: number;
 }

--- a/ui/lib/action-errors.ts
+++ b/ui/lib/action-errors.ts
@@ -13,6 +13,11 @@ export const ACTION_ERROR_MESSAGES = {
     "You don't have permission to perform this action. Ask an administrator to update your role.",
 } as const satisfies Record<ActionErrorStatus, string>;
 
+export const ACTION_ERROR_API_MESSAGES = {
+  [ACTION_ERROR_STATUS.PAYMENT_REQUIRED]:
+    "An active subscription is required to use this API endpoint in Prowler Cloud.",
+} as const satisfies Partial<Record<ActionErrorStatus, string>>;
+
 export interface ActionErrorResult {
   error?: unknown;
   status?: number;

--- a/ui/lib/action-errors.ts
+++ b/ui/lib/action-errors.ts
@@ -34,6 +34,17 @@ const isActionErrorStatus = (
   status === ACTION_ERROR_STATUS.PAYMENT_REQUIRED ||
   status === ACTION_ERROR_STATUS.FORBIDDEN;
 
+const isHttpErrorStatus = (status: number | undefined): boolean =>
+  typeof status === "number" && status >= 400;
+
+export const hasActionError = (
+  result: ActionErrorResult | null | undefined,
+): result is ActionErrorResult =>
+  result !== undefined &&
+  result !== null &&
+  ((result.error !== undefined && result.error !== null) ||
+    isHttpErrorStatus(result.status));
+
 export const getActionErrorMessage = (
   result: ActionErrorResult,
   options: GetActionErrorMessageOptions = {},

--- a/ui/lib/action-errors.ts
+++ b/ui/lib/action-errors.ts
@@ -14,7 +14,7 @@ export const ACTION_ERROR_MESSAGES = {
 } as const satisfies Record<ActionErrorStatus, string>;
 
 interface ActionErrorResult {
-  error?: string;
+  error?: unknown;
   status?: number;
 }
 
@@ -39,5 +39,9 @@ export const getActionErrorMessage = (
     );
   }
 
-  return result.error ?? options.fallback ?? "Oops! Something went wrong.";
+  if (result.error !== undefined && result.error !== null) {
+    return String(result.error);
+  }
+
+  return options.fallback ?? "Oops! Something went wrong.";
 };


### PR DESCRIPTION
### Context

Scan and schedule actions that return handled Server Action statuses should use the shared UI copy from `action-errors.ts` instead of showing raw API messages like `An active subscription is required to use this API endpoint in Prowler Cloud.`

### Description

- Routes scan launch errors in `LaunchScanModal` and provider wizard `LaunchStep` through `getActionErrorMessage`.
- Reuses the same mapping for schedule save/remove surfaces that expose `{ error, status }` to users.
- Maps `saveScheduleWithInitialScan` failures for both schedule save and initial scan launch.
- Allows `getActionErrorMessage` to accept unknown action error payloads while preserving the existing fallback behavior.
- Adds coverage for `402 Payment Required` across direct launch, initial scan, edit schedule, and org bulk schedule flows.

### Steps to review

- `cd ui && pnpm test:unit components/scans/launch-scan-modal.test.tsx components/providers/wizard/steps/launch-step.test.tsx components/scans/schedule/save-schedule.test.ts components/scans/schedule/edit-scan-schedule-modal.test.tsx components/providers/organizations/org-launch-scan.test.tsx`
- `cd ui && pnpm exec eslint components/scans/launch-scan-modal.tsx components/scans/launch-scan-modal.test.tsx components/providers/organizations/org-launch-scan.tsx components/providers/organizations/org-launch-scan.test.tsx components/providers/wizard/steps/launch-step.tsx components/providers/wizard/steps/launch-step.test.tsx components/scans/schedule/edit-scan-schedule-modal.tsx components/scans/schedule/edit-scan-schedule-modal.test.tsx components/scans/schedule/save-schedule.ts components/scans/schedule/save-schedule.test.ts lib/action-errors.ts`
- `cd ui && pnpm typecheck`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [ ] Ensure new entries are added to CHANGELOG.md, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [ ] Ensure new entries are added to ui/CHANGELOG.md

#### API (if applicable)
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required.
- [ ] Ensure new entries are added to api/CHANGELOG.md

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved subscription/payment-required error handling across scan launch and schedule workflows, including launch modals, wizard manual scan mode, organization bulk launches, and schedule edit/save/remove flows.
  * Standardized user-facing toast and form-level error messages to use consistent, subscription-aware copy and avoid exposing raw backend error text while preserving correct UI side effects.

* **Tests**
  * Expanded test coverage to verify payment-required messaging renders correctly and raw provider/API error strings are not shown for launch, save, update, and remove flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->