### PR TITLE
fix(alibabacloud): implement `ram_password_policy_number` and fix cs weekly check loading

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
+## [5.31.1] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Alibaba Cloud `ram_password_policy_number` and `cs_kubernetes_cluster_check_weekly` checks not being loaded due to missing implementation and package files [(#11683)](https://github.com/prowler-cloud/prowler/pull/11683)
+
+---
+
 ## [5.31.0] (Prowler v5.31.0)
 
 ### 🚀 Added

--- a/prowler/providers/alibabacloud/services/ram/ram_password_policy_number/ram_password_policy_number.py
+++ b/prowler/providers/alibabacloud/services/ram/ram_password_policy_number/ram_password_policy_number.py
@@ -1,0 +1,34 @@
+from prowler.lib.check.models import Check, CheckReportAlibabaCloud
+from prowler.providers.alibabacloud.services.ram.ram_client import ram_client
+
+
+class ram_password_policy_number(Check):
+    """Check if RAM password policy requires at least one number."""
+
+    def execute(self) -> list[CheckReportAlibabaCloud]:
+        findings = []
+
+        if ram_client.password_policy:
+            report = CheckReportAlibabaCloud(
+                metadata=self.metadata(), resource=ram_client.password_policy
+            )
+            report.region = ram_client.region
+            report.resource_id = f"{ram_client.audited_account}-password-policy"
+            report.resource_arn = (
+                f"acs:ram::{ram_client.audited_account}:password-policy"
+            )
+
+            if ram_client.password_policy.require_numbers:
+                report.status = "PASS"
+                report.status_extended = (
+                    "RAM password policy requires at least one number."
+                )
+            else:
+                report.status = "FAIL"
+                report.status_extended = (
+                    "RAM password policy does not require at least one number."
+                )
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/alibabacloud/services/ram/ram_password_policy_number/ram_password_policy_number_test.py
+++ b/tests/providers/alibabacloud/services/ram/ram_password_policy_number/ram_password_policy_number_test.py
@@ -1,0 +1,67 @@
+from unittest import mock
+
+from tests.providers.alibabacloud.alibabacloud_fixtures import (
+    set_mocked_alibabacloud_provider,
+)
+
+
+class TestRamPasswordPolicyNumber:
+    def test_numbers_not_required_fails(self):
+        ram_client = mock.MagicMock()
+        ram_client.audited_account = "1234567890"
+        ram_client.region = "cn-hangzhou"
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_alibabacloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.alibabacloud.services.ram.ram_password_policy_number.ram_password_policy_number.ram_client",
+                new=ram_client,
+            ),
+        ):
+            from prowler.providers.alibabacloud.services.ram.ram_password_policy_number.ram_password_policy_number import (
+                ram_password_policy_number,
+            )
+            from prowler.providers.alibabacloud.services.ram.ram_service import (
+                PasswordPolicy,
+            )
+
+            ram_client.password_policy = PasswordPolicy(require_numbers=False)
+
+            check = ram_password_policy_number()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+
+    def test_numbers_required_passes(self):
+        ram_client = mock.MagicMock()
+        ram_client.audited_account = "1234567890"
+        ram_client.region = "cn-hangzhou"
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_alibabacloud_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.alibabacloud.services.ram.ram_password_policy_number.ram_password_policy_number.ram_client",
+                new=ram_client,
+            ),
+        ):
+            from prowler.providers.alibabacloud.services.ram.ram_password_policy_number.ram_password_policy_number import (
+                ram_password_policy_number,
+            )
+            from prowler.providers.alibabacloud.services.ram.ram_service import (
+                PasswordPolicy,
+            )
+
+            ram_client.password_policy = PasswordPolicy(require_numbers=True)
+
+            check = ram_password_policy_number()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"


### PR DESCRIPTION
### Context

Two Alibaba Cloud checks shipped in the repository with their metadata but never actually loaded or ran:

- ram_password_policy_number had only __init__.py and .metadata.json — the implementation file (ram_password_policy_number.py) and its tests were never added, so the check could not execute.
- cs_kubernetes_cluster_check_weekly had its implementation and tests but was missing the __init__.py package marker, so the check loader silently skipped it.

As a result, prowler alibabacloud --list-checks reported 61 loadable checks while 63 metadata files existed on disk — the two dead checks accounted for the gap.

### Description

- Implement ram_password_policy_number, verifying that the Alibaba Cloud RAM password policy requires at least one numeric character (require_numbers). Logic mirrors the existing ram_password_policy_symbol / ram_password_policy_uppercase checks.
- Add unit tests for ram_password_policy_number (PASS when numbers are required, FAIL when not).
- Add the missing __init__.py to cs_kubernetes_cluster_check_weekly so the loader can import it.

After these changes, all metadata-defined Alibaba Cloud checks load: --list-checks now reports 63 (was 61), matching the number of metadata files.
  
### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Alibaba Cloud RAM password policy check to confirm whether passwords must include numeric characters.
  * Reporting now reflects whether number requirements are enabled (pass when required, fail when not).
* **Bug Fixes**
  * Fixed loading so the new RAM password policy check runs correctly, alongside other related weekly check coverage.
* **Tests**
  * Added tests for both the “numbers required” and “numbers not required” scenarios.
* **Documentation**
  * Updated the unreleased changelog entry with the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->