### PR TITLE
fix(azure): support explicit AuditEvent log category in keyvault_logging_enabled check (#11656)

### DIFF
--- a/prowler/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled.py
+++ b/prowler/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled.py
@@ -19,9 +19,9 @@ class keyvault_logging_enabled(Check):
                     has_audit = False
                     has_all_logs = False
                     for log in diagnostic_setting.logs:
-                        if log.category_group == "audit" and log.enabled:
+                        if (log.category_group == "audit" or log.category == "AuditEvent") and log.enabled:
                             has_audit = True
-                        if log.category_group == "allLogs" and log.enabled:
+                        if (log.category_group == "allLogs" or log.category == "AuditEvent") and log.enabled:
                             has_all_logs = True
                     if has_audit and has_all_logs:
                         report.status = "PASS"

--- a/tests/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled_test.py
+++ b/tests/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled_test.py
@@ -244,6 +244,77 @@ class Test_keyvault_logging_enabled:
             assert result[0].resource_name == "name_keyvault"
             assert result[0].resource_id == "id"
 
+    def test_diagnostic_setting_with_audit_event_category(self):
+        keyvault_client = mock.MagicMock
+        keyvault_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.monitor.monitor_service.Monitor",
+                new=mock.MagicMock(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.keyvault.keyvault_logging_enabled.keyvault_logging_enabled.keyvault_client",
+                new=keyvault_client,
+            ),
+        ):
+            from prowler.providers.azure.services.keyvault.keyvault_logging_enabled.keyvault_logging_enabled import (
+                keyvault_logging_enabled,
+            )
+            from prowler.providers.azure.services.keyvault.keyvault_service import (
+                KeyVaultInfo,
+            )
+            from prowler.providers.azure.services.monitor.monitor_service import (
+                DiagnosticSetting,
+            )
+
+            keyvault_client.key_vaults = {
+                AZURE_SUBSCRIPTION_ID: [
+                    KeyVaultInfo(
+                        id="id",
+                        name="name_keyvault",
+                        location="westeurope",
+                        resource_group="resource_group",
+                        properties=VaultProperties(
+                            tenant_id="tenantid",
+                            sku="sku",
+                            enable_rbac_authorization=False,
+                        ),
+                        keys=[],
+                        secrets=[],
+                        monitor_diagnostic_settings=[
+                            DiagnosticSetting(
+                                id="id/ds1",
+                                logs=[
+                                    mock.MagicMock(
+                                        category_group=None,
+                                        category="AuditEvent",
+                                        enabled=True,
+                                    ),
+                                ],
+                                storage_account_name="sa1",
+                                storage_account_id="sa_id1",
+                                name="ds_audit_event",
+                            ),
+                        ],
+                    ),
+                ]
+            }
+            check = keyvault_logging_enabled()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Key Vault name_keyvault in subscription {AZURE_SUBSCRIPTION_DISPLAY} has a diagnostic setting with audit logging."
+            )
+            assert result[0].resource_name == "name_keyvault"
+            assert result[0].resource_id == "id"
+
     def test_multiple_diagnostic_settings_one_compliant(self):
         keyvault_client = mock.MagicMock
         keyvault_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}


### PR DESCRIPTION
### Summary
Fixes #11656 by updating `keyvault_logging_enabled` to treat explicit `AuditEvent` log categories as compliant audit logging for Azure Key Vault instances.

### Key Changes
1. **AuditEvent Category Support:** Updated `keyvault_logging_enabled.py` (`prowler/providers/azure/services/keyvault/keyvault_logging_enabled/keyvault_logging_enabled.py`) to check both `log.category_group` and `log.category == "AuditEvent"`.
2. **Regression Unit Test:** Added `test_diagnostic_setting_with_audit_event_category` in `keyvault_logging_enabled_test.py` verifying compliant evaluation for diagnostic settings using explicit `AuditEvent` categories.
