### PR TITLE
ci: allow Formbucket egress in secrets scan

### DIFF
--- a/.github/workflows/find-secrets.yml
+++ b/.github/workflows/find-secrets.yml
@@ -29,10 +29,11 @@ jobs:
         with:
           # We can't block as Trufflehog needs to verify secrets against vendors
           egress-policy: audit
-          # allowed-endpoints: >
-          #   github.com:443
-          #   ghcr.io:443
-          #   pkg-containers.githubusercontent.com:443
+          allowed-endpoints: >
+            github.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            www.formbucket.com:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
### Context

Harden Runner reported anomalous network activity to `www.formbucket.com:443` in the TruffleHog secrets workflow after PR #11714.

### Description

This PR declares the known TruffleHog verification endpoints in `.github/workflows/find-secrets.yml`, including `www.formbucket.com:443`, so the egress baseline is explicit while keeping `egress-policy: audit` for vendor verification.

### Steps to review

1. Review `.github/workflows/find-secrets.yml` and confirm the Harden Runner endpoint baseline is scoped to the secrets scan workflow.
2. Confirm the PR check for the TruffleHog workflow no longer reports `www.formbucket.com:443` as anomalous activity.
3. Verify that `egress-policy: audit` remains unchanged because TruffleHog may need vendor verification egress.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests. Not applicable; CI workflow baseline-only change.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings. Not applicable; no Python code changes.
- [x] Review if backport is needed. Not needed.
- [x] Review if is needed to change the Readme.md. Not needed.
- [x] Ensure new entries are added to CHANGELOG.md, if applicable. Not applicable; `no-changelog` label added.

#### SDK/CLI

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No.

#### UI (if applicable)

- [x] Not applicable.

#### API (if applicable)

- [x] Not applicable.

### Validation

- [x] Pre-commit hooks passed during commit, including YAML validation, zizmor, and TruffleHog.
- [x] Fresh risk review passed with no blockers.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.