### PR TITLE
Rename services to align with main docker-compose service names

### DIFF
--- a/contrib/reverse-proxy/docker-compose.reverse-proxy.yml
+++ b/contrib/reverse-proxy/docker-compose.reverse-proxy.yml
@@ -24,17 +24,17 @@ services:
     volumes:
       - ./contrib/reverse-proxy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
-      - prowler-ui
-      - prowler-api
+      - ui
+      - api
     networks:
       - prowler-network
 
   # Override UI to not expose port externally (nginx handles it)
-  prowler-ui:
+  ui:
     ports: !reset []
 
   # Override API to not expose port externally (nginx handles it)
-  prowler-api:
+  api:
     ports: !reset []
 
 networks:


### PR DESCRIPTION
### Context

Prepending prowler- to the service names breaks the docker compose commands as the services don't exist in the main docker-compose.yml file.

### Description

Removed prepended 'prowler-' to align with the correct service names. 

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated reverse-proxy configuration to align with the current service names, helping ensure the UI and API continue to load correctly through the main gateway.
  * Kept external port exposure disabled for those services so traffic is still handled through the proxy as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->