### PR TITLE
fix(docker): remove build dependencies from images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,18 @@ RUN uv sync --locked --compile-bytecode && \
 # Install PowerShell modules
 RUN .venv/bin/python prowler/providers/m365/lib/powershell/m365_powershell.py
 
+USER root
+
+# Remove build-only packages from the final image after Python dependencies are installed.
+RUN apt-get purge -y --auto-remove \
+    build-essential \
+    pkg-config \
+    libzstd-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+USER prowler
+
 # Remove deprecated dash dependencies
 RUN pip uninstall dash-html-components -y && \
     pip uninstall dash-core-components -y

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -102,6 +102,23 @@ RUN uv sync --locked --no-install-project && \
 
 RUN .venv/bin/python .venv/lib/python3.12/site-packages/prowler/providers/m365/lib/powershell/m365_powershell.py
 
+USER root
+
+# Remove build-only packages from the final image after Python dependencies are installed.
+RUN apt-get purge -y --auto-remove \
+    gcc \
+    g++ \
+    make \
+    libxml2-dev \
+    libxmlsec1-dev \
+    pkg-config \
+    libtool \
+    libxslt1-dev \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+USER prowler
+
 COPY --chown=prowler:prowler src/backend/ ./backend/
 COPY --chown=prowler:prowler docker-entrypoint.sh ./docker-entrypoint.sh
 


### PR DESCRIPTION
### Context

Trivy container scans started reporting CRITICAL CVE-2026-53215 in the Debian linux-libc-dev package installed in the SDK and API images. Debian Bookworm still marks linux-libc-dev 6.1.174-1 as vulnerable, so this PR removes build-only packages from the final images instead of suppressing the finding.

### Description

- Purge SDK build-only packages after Python dependencies and PowerShell modules are installed.
- Purge API compiler/dev packages after Python dependencies and PowerShell modules are installed.
- Keep runtime packages and tools needed by the images, including PowerShell, Trivy, zizmor, and API xmlsec runtime support.

### Steps to review

- Review the cleanup steps added to Dockerfile and api/Dockerfile.
- Build the SDK image and confirm linux-libc-dev is absent from the final image.
- Build the API image and confirm linux-libc-dev is absent from the final image.
- Confirm runtime tools still resolve: pwsh, trivy, zizmor, and API xmlsec/lxml imports.

Verification performed locally:

- docker build -t prowler-sdk-linux-libc-dev-test -f Dockerfile .
- docker build -t prowler-api-linux-libc-dev-test -f api/Dockerfile api
- dpkg -l linux-libc-dev returned no installed package in both images
- pwsh, trivy, and zizmor were present in both images
- API import smoke test for xmlsec and lxml.etree passed
- Local Trivy 0.70.0 scan found 0 matches for linux-libc-dev/CVE-2026-53215 in both images

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [x] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [x] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output (if applicable)
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [x] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up the container build process to remove temporary build dependencies from the final image.
  * Reduced the final image footprint, which can improve download and deployment efficiency.
  * Preserved the existing runtime behavior and startup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->