### PR TITLE
fix: skip archived repos in repository_has_codeowners_file check

### DIFF
--- a/prowler/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file.py
+++ b/prowler/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file.py
@@ -10,6 +10,8 @@ class repository_has_codeowners_file(Check):
     """Check if a repository has a CODEOWNERS file
 
     This class verifies whether each repository has a CODEOWNERS file.
+    Archived repositories are skipped since they are read-only and
+    cannot be modified without first being unarchived.
     """
 
     def execute(self) -> List[CheckReportGithub]:
@@ -22,6 +24,10 @@ class repository_has_codeowners_file(Check):
         """
         findings = []
         for repo in repository_client.repositories.values():
+            # Archived repos are read-only and cannot be updated without
+            # first being unarchived, so this check is not actionable for them.
+            if repo.archived:
+                continue
             if repo.codeowners_exists is not None:
                 report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 if repo.codeowners_exists:

--- a/tests/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file_test.py
+++ b/tests/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file_test.py
@@ -145,3 +145,55 @@ class Test_repository_has_codeowners_file:
                 result[0].status_extended
                 == f"Repository {repo_name} does have a CODEOWNERS file."
             )
+
+    def test_one_repository_archived(self):
+        repository_client = mock.MagicMock
+        repo_name = "repo3"
+        repository_client.repositories = {
+            3: Repo(
+                id=3,
+                name=repo_name,
+                owner="account-name",
+                full_name="account-name/repo3",
+                default_branch=Branch(
+                    name="main",
+                    protected=False,
+                    default_branch=True,
+                    require_pull_request=False,
+                    approval_count=0,
+                    required_linear_history=False,
+                    allow_force_pushes=True,
+                    branch_deletion=True,
+                    status_checks=False,
+                    enforce_admins=False,
+                    require_code_owner_reviews=False,
+                    require_signed_commits=False,
+                    conversation_resolution=False,
+                ),
+                private=False,
+                securitymd=True,
+                codeowners_exists=False,
+                secret_scanning_enabled=False,
+                archived=True,
+                pushed_at=datetime.now(timezone.utc),
+                delete_branch_on_merge=False,
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.repository.repository_has_codeowners_file.repository_has_codeowners_file.repository_client",
+                new=repository_client,
+            ),
+        ):
+            from prowler.providers.github.services.repository.repository_has_codeowners_file.repository_has_codeowners_file import (
+                repository_has_codeowners_file,
+            )
+
+            check = repository_has_codeowners_file()
+            result = check.execute()
+            assert len(result) == 0


### PR DESCRIPTION
Fixes #11734

## Description

The `repository_has_codeowners_file` check currently flags archived repositories as failing. Since archived GitHub repositories are read-only and cannot be modified without first being unarchived, this finding is not actionable.

## Changes

- Added `repo.archived` check in the `execute()` method to skip archived repositories
- Added a test case for archived repositories to verify they are properly excluded
- Updated docstring to document this behavior

## Testing

Added `test_one_repository_archived` test case that verifies archived repositories are skipped and produce no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived repositories are now skipped in the CODEOWNERS check, avoiding results for read-only repos that can’t be modified.
  * Added test coverage to confirm archived repositories are excluded from the check output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->