### PR TITLE
ci(ui): guard e2e fork secrets

### DIFF
--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -238,7 +238,23 @@ jobs:
 
       - name: Run E2E tests
         working-directory: ./ui
+        env:
+          PR_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPOSITORY: ${{ github.repository }}
         run: |
+          if [[ -z "${E2E_ADMIN_USER}" || -z "${E2E_ADMIN_PASSWORD}" || -z "${E2E_NEW_USER_PASSWORD}" ]]; then
+            if [[ "${PR_HEAD_REPOSITORY}" != "${BASE_REPOSITORY}" ]]; then
+              echo "Required E2E secrets are unavailable for forked PRs. Skipping E2E tests for this PR context."
+              echo "## E2E Tests Skipped" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "Required E2E secrets are unavailable for forked PRs, so auth/signup E2E tests cannot run." >> $GITHUB_STEP_SUMMARY
+              exit 0
+            fi
+
+            echo "Required E2E secrets are missing for an internal PR context."
+            exit 1
+          fi
+
           if [[ "${RUN_ALL_TESTS}" == "true" ]]; then
             echo "Running ALL E2E tests..."
             pnpm run test:e2e


### PR DESCRIPTION
### Context

This PR is the first slice of the exact upstream split of #11565.

The original PR #11565 is the source of truth. The four chained PRs together must contain the same line-level changes as #11565, with no extra or missing changes.

### Description

This slice adds the platform/CI guard for UI E2E tests so forked pull requests without repository secrets do not fail on unavailable secret-dependent steps.

Changed files:

| File | Change |
|------|--------|
| `.github/workflows/ui-e2e-tests-v2.yml` | Adds fork-secret guards for the UI E2E workflow. |

### Steps to review

1. Review only `.github/workflows/ui-e2e-tests-v2.yml`.
2. Confirm the workflow behavior matches the platform change from #11565.
3. Confirm this PR is the first chained slice and the next PR builds on this branch.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | OCI regionless provider setup split from #11565 |
| Tracker PR | #11565 |
| Position | 1 of 4 |
| Base | `master` |
| Depends on | None |
| Follow-up | #11740 |
| Review budget | 16 / 400 |
| Starts at | `master` |
| Ends with | Platform CI guard for UI E2E fork secrets |

### Chain Overview

```text
master
 └── 📍 #11739 Platform CI guard
      └── #11740 SDK regionless OCI setup
           └── #11741 API regionless OCI credentials
                └── #11742 UI regionless OCI credentials
```

### Scope
- Includes: platform/CI guard from #11565.
- Excludes: SDK, API, and UI functional changes.

### Autonomy
- [ ] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit