### PR TITLE
chore(api): opt out of PowerShell telemetry in the API image

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the **Prowler API** are documented in this file.
 
 - Attack Paths: AWS Neptune is now supported as a persistent sink database, selectable via `ATTACK_PATHS_SINK_DATABASE=neptune` (default `neo4j`), Cartography's (bumped to 0.138.1) per-scan ingest database stays on Neo4j [(#11524)](https://github.com/prowler-cloud/prowler/pull/11524)
 - Attack Paths: Scan task now checks the ingest Neo4j database and configured graph sink before starting graph ingestion [(#11743)](https://github.com/prowler-cloud/prowler/pull/11743)
+- Disable PowerShell telemetry in the API container image [(#11746)](https://github.com/prowler-cloud/prowler/pull/11746)
 
 ---
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer="https://github.com/prowler-cloud/api"
 
 ARG POWERSHELL_VERSION=7.5.0
 ENV POWERSHELL_VERSION=${POWERSHELL_VERSION}
+# Opt out of PowerShell telemetry (Application Insights -> dc.services.visualstudio.com)
+ENV POWERSHELL_TELEMETRY_OPTOUT=1
 
 ARG TRIVY_VERSION=0.71.2
 ENV TRIVY_VERSION=${TRIVY_VERSION}


### PR DESCRIPTION
### Context

The PowerShell binary (`pwsh`) bundled in the API container image emits Application Insights telemetry to `dc.services.visualstudio.com` on every invocation. StepSecurity/Harden-Runner flags this endpoint as a blocked egress in `api-container-checks.yml` (and other container-check workflows), producing recurring blocked-endpoint alerts. The same telemetry also ships in the customer-facing image.

### Description

Set `ENV POWERSHELL_TELEMETRY_OPTOUT=1` in the `build` stage of `api/Dockerfile`, right after the existing `POWERSHELL_VERSION` ENV. PowerShell reads this variable to disable its telemetry, so `pwsh` no longer phones home to `dc.services.visualstudio.com`. This removes the blocked-endpoint noise from Harden-Runner in CI and strips the telemetry from the shipped API image. No runtime behavior or API surface changes.

### Steps to review

- Confirm the new `ENV POWERSHELL_TELEMETRY_OPTOUT=1` (and its comment) is placed in the `build` stage immediately after `ENV POWERSHELL_VERSION=${POWERSHELL_VERSION}`.
- Confirm the value is inherited where `pwsh` runs.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? N/A

#### UI
- [ ] All issue/task requirements work as expected on the UI

_N/A - no UI changes._

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [x] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated. _N/A - container-only change._
- [ ] Check if version updates are required (e.g., specs, uv, etc.). _N/A._
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled PowerShell telemetry in the API container image.
  * Updated the release notes to reflect this container change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->