### PR TITLE
fix(ci): harden pull_request_target workflows (persist-credentials + toJson)

### DIFF
--- a/.github/workflows/pr-conflict-checker.yml
+++ b/.github/workflows/pr-conflict-checker.yml
@@ -37,8 +37,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
-          # zizmor: ignore[artipacked]
-          persist-credentials: true # Required by tj-actions/changed-files to fetch PR branch
+          persist-credentials: false # No write token in the untrusted PR-head tree; public repo so base fetch/changed-files work unauthenticated
 
       - name: Fetch PR base ref for tj-actions/changed-files
         env:

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -56,6 +56,6 @@ jobs:
               "PROWLER_PR_BODY": ${{ toJson(github.event.pull_request.body) }},
               "PROWLER_PR_URL": ${{ toJson(github.event.pull_request.html_url) }},
               "PROWLER_PR_MERGED_BY": "${{ github.event.pull_request.merged_by.login }}",
-              "PROWLER_PR_BASE_BRANCH": "${{ github.event.pull_request.base.ref }}",
-              "PROWLER_PR_HEAD_BRANCH": "${{ github.event.pull_request.head.ref }}"
+              "PROWLER_PR_BASE_BRANCH": ${{ toJson(github.event.pull_request.base.ref) }},
+              "PROWLER_PR_HEAD_BRANCH": ${{ toJson(github.event.pull_request.head.ref) }}
             }


### PR DESCRIPTION
### Context

The StepSecurity scan flagged two Critical controls on our `pull_request_target` workflows:

- A pwn-request exposure in `pr-conflict-checker.yml`: the untrusted PR-head checkout ran with `persist-credentials: true`, leaving a write-scoped token in the working tree controlled by an arbitrary PR author.
- A script-injection finding in `pr-merged.yml`: `base.ref` / `head.ref` were interpolated into a JSON string body instead of being safely encoded.

### Description

- `pr-conflict-checker.yml`: set `persist-credentials: false` on the untrusted PR-head checkout, removing the write-scoped token from the working tree. This is a public repository, so the existing base-ref fetch and `tj-actions/changed-files` continue to work unauthenticated.
- `pr-merged.yml`: `PROWLER_PR_BASE_BRANCH` and `PROWLER_PR_HEAD_BRANCH` now use `toJson(...)` for consistency with the other fields and to safely encode the values rather than embedding them in a raw quoted string.

### Steps to review

- Confirm the PR-head checkout in `pr-conflict-checker.yml` no longer persists credentials and that the base-ref fetch / changed-files step still resolves on a public repo.
- Confirm the two fields in `pr-merged.yml` are now wrapped with `toJson(...)` and the JSON body remains valid.

### Checklist

- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

CI-only change. No SDK/CLI, UI, or API surface is affected.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and safety of automated pull request handling by avoiding credential persistence when checking out untrusted code.
  * Updated event payload formatting for branch information to ensure cleaner, more consistent processing in merge-related automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->