### PR TITLE
fix(api): resolve multi-valued SAML userType claim by highest-privilege role

### DIFF
--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -14348,6 +14348,86 @@ class TestTenantFinishACSView:
             .exists()
         )
 
+    def test_dispatch_resolves_multi_valued_usertype_to_highest_privilege(
+        self,
+        create_test_user,
+        tenants_fixture,
+        admin_role_fixture,
+        roles_fixture,
+        saml_setup,
+        settings,
+        monkeypatch,
+    ):
+        """Test that multi-valued userType claim resolves to the highest privilege role"""
+        monkeypatch.setenv("SAML_SSO_CALLBACK_URL", "http://localhost/sso-complete")
+        user = create_test_user
+        tenant = tenants_fixture[0]
+
+        admin_role = admin_role_fixture
+        viewer_role = roles_fixture[3]
+
+        social_account = SocialAccount(
+            user=user,
+            provider="saml",
+            extra_data={
+                "firstName": ["John"],
+                "lastName": ["Doe"],
+                "organization": ["testing_company"],
+                "userType": [viewer_role.name, admin_role.name],
+            },
+        )
+
+        request = RequestFactory().get(
+            reverse(
+                "saml_finish_acs", kwargs={"organization_slug": saml_setup["domain"]}
+            )
+        )
+        request.user = user
+        request.session = {}
+
+        with (
+            patch(
+                "allauth.socialaccount.providers.saml.views.get_app_or_404"
+            ) as mock_get_app_or_404,
+            patch(
+                "allauth.socialaccount.models.SocialApp.objects.get"
+            ) as mock_socialapp_get,
+            patch(
+                "allauth.socialaccount.models.SocialAccount.objects.get"
+            ) as mock_sa_get,
+            patch("api.models.SAMLDomainIndex.objects.get") as mock_saml_domain_get,
+            patch("api.models.SAMLConfiguration.objects.get") as mock_saml_config_get,
+            patch("api.models.User.objects.get") as mock_user_get,
+        ):
+            mock_get_app_or_404.return_value = MagicMock(
+                provider="saml",
+                client_id=saml_setup["domain"],
+                name="Test App",
+                settings={},
+            )
+            mock_sa_get.return_value = social_account
+            mock_socialapp_get.return_value = MagicMock(provider_id="saml")
+            mock_saml_domain_get.return_value = SimpleNamespace(tenant_id=tenant.id)
+            mock_saml_config_get.return_value = SimpleNamespace(
+                email_domain=saml_setup["domain"], tenant=tenant
+            )
+            mock_user_get.return_value = user
+
+            view = TenantFinishACSView.as_view()
+            response = view(request, organization_slug=saml_setup["domain"])
+
+        assert response.status_code == 302
+        assert (
+            UserRoleRelationship.objects.using(MainRouter.admin_db)
+            .filter(user=user, role=admin_role, tenant_id=tenant.id)
+            .exists()
+        )
+        assert not (
+            UserRoleRelationship.objects.using(MainRouter.admin_db)
+            .filter(user=user, role=viewer_role, tenant_id=tenant.id)
+            .exists()
+        )
+
 
 @pytest.mark.django_db
 class TestLighthouseConfigViewSet:

--- a/api/src/backend/api/v1/views.py
+++ b/api/src/backend/api/v1/views.py
@@ -813,16 +813,60 @@ class TenantFinishACSView(FinishACSView):
 
         # Only remap roles when the IdP provides a userType attribute.
         # Without it, the user's current roles are left untouched.
-        role_name = (
-            extra.get("userType", [""])[0].strip() if extra.get("userType") else ""
-        )
-        if role_name:
+        user_types = extra.get("userType") if extra else None
+        role_names = []
+        if user_types:
+            if isinstance(user_types, str):
+                role_names = [user_types.strip()]
+            elif isinstance(user_types, list):
+                role_names = [
+                    r.strip() for r in user_types if isinstance(r, str) and r.strip()
+                ]
+
+        if role_names:
             with transaction.atomic(using=MainRouter.admin_db):
-                role = (
-                    Role.objects.using(MainRouter.admin_db)
-                    .filter(name=role_name, tenant=tenant)
-                    .first()
-                )
+                existing_roles = {
+                    r.name: r
+                    for r in Role.objects.using(MainRouter.admin_db).filter(
+                        name__in=role_names, tenant=tenant
+                    )
+                }
+
+                def get_role_score(r):
+                    if r is None:
+                        return 0
+                    score = 0
+                    if getattr(r, "manage_account", False):
+                        score += 1000
+                    if getattr(r, "manage_users", False):
+                        score += 50
+                    if getattr(r, "manage_billing", False):
+                        score += 20
+                    if getattr(r, "manage_providers", False):
+                        score += 10
+                    if getattr(r, "manage_integrations", False):
+                        score += 10
+                    if getattr(r, "manage_scans", False):
+                        score += 10
+                    if getattr(r, "unlimited_visibility", False):
+                        score += 5
+                    return score
+
+                role_name = role_names[0]
+                role = existing_roles.get(role_name)
+                best_score = get_role_score(role)
+
+                for name in role_names[1:]:
+                    r = existing_roles.get(name)
+                    score = get_role_score(r)
+                    if score > best_score:
+                        best_score = score
+                        role_name = name
+                        role = r
+                    elif score == best_score:
+                        if role is None and r is not None:
+                            role_name = name
+                            role = r
 
                 # Only skip mapping if it would remove the last MANAGE_ACCOUNT user
                 remaining_manage_account_users = (


### PR DESCRIPTION
### Description
When an IdP user belongs to multiple groups mapped to different Prowler roles, the SAML assertion carries a multi-valued  attribute (e.g. ). Currently,  only resolves the first value (), which is non-deterministic depending on the IdP.

This PR updates the SAML role mapping logic to:
1. Retrieve all values from the  claim.
2. Query all existing roles in the tenant database.
3. Score the roles based on privilege flags (with  getting the highest priority).
4. Assign the user to the single highest-privilege role from the set.
5. Add unit test verification to .

Fixes #11733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SSO sign-in handling: when SAML provides multiple `userType` role claims, users are now assigned the most privileged matching access level available in their tenant.
* **Bug Fixes**
  * Fixed role assignment during login when multi-valued role information in SAML responses could previously result in an incorrect role being applied.
* **Tests**
  * Added coverage for SAML callbacks to verify multi-valued `userType` resolves to the highest-privilege role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->