### PR TITLE
ci(workflows): push SDK image to Public ECR via OIDC

### DIFF
--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -138,6 +138,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Harden Runner
@@ -147,6 +148,8 @@ jobs:
           allowed-endpoints: >
             api.ecr-public.us-east-1.amazonaws.com:443
             public.ecr.aws:443
+            sts.amazonaws.com:443
+            sts.us-east-1.amazonaws.com:443
             registry-1.docker.io:443
             production.cloudflare.docker.com:443
             production.cloudfront.docker.com:443
@@ -173,14 +176,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to Public ECR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.PUBLIC_ECR_AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.PUBLIC_ECR_AWS_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: ${{ env.AWS_REGION }}
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.PUBLIC_ECR_IAM_ROLE_ARN }}
+
+      - name: Login to Public ECR
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+        with:
+          registry-type: public
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -206,6 +211,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Harden Runner
@@ -221,6 +227,8 @@ jobs:
             github.com:443
             release-assets.githubusercontent.com:443
             api.ecr-public.us-east-1.amazonaws.com:443
+            sts.amazonaws.com:443
+            sts.us-east-1.amazonaws.com:443
 
 
       - name: Login to DockerHub
@@ -229,14 +237,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to Public ECR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.PUBLIC_ECR_AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.PUBLIC_ECR_AWS_SECRET_ACCESS_KEY }}
-        env:
-          AWS_REGION: ${{ env.AWS_REGION }}
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.PUBLIC_ECR_IAM_ROLE_ARN }}
+
+      - name: Login to Public ECR
+        uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
+        with:
+          registry-type: public
 
       - name: Create and push manifests for push event
         if: github.event_name == 'push'


### PR DESCRIPTION
### Context

The `sdk-container-build-push` workflow authenticates to `public.ecr.aws` with a static IAM access key (`PUBLIC_ECR_AWS_ACCESS_KEY_ID` / `PUBLIC_ECR_AWS_SECRET_ACCESS_KEY`) that is roughly 4 years old. This migrates that authentication to short-lived GitHub OIDC, eliminating a long-lived secret.

### Description

In both the `container-build-push` and `create-manifest` jobs:

- Replace the static-key `docker/login-action` against `public.ecr.aws` with `aws-actions/configure-aws-credentials` (OIDC, `role-to-assume: ${{ secrets.PUBLIC_ECR_IAM_ROLE_ARN }}`, region `us-east-1`) followed by `aws-actions/amazon-ecr-login` with `registry-type: public`.
- Add `id-token: write` to the job permissions.
- Add `sts.amazonaws.com` and `sts.us-east-1.amazonaws.com` to the Harden-Runner allowed-endpoints.
- Remove the `PUBLIC_ECR_AWS_ACCESS_KEY_ID` / `PUBLIC_ECR_AWS_SECRET_ACCESS_KEY` references.

DockerHub login is unchanged.

Depends on the `PUBLIC_ECR_IAM_ROLE_ARN` repository secret and the backing IAM role (`prowler-public-ecr-github-actions`, account `998057895221`, trust scoped to this repo's master + tag refs), both already in place.

### Steps to review

- Confirm both jobs configure OIDC credentials before `amazon-ecr-login --registry-type public`.
- Confirm `id-token: write` is present on both jobs and the STS endpoints are allowlisted in Harden-Runner.
- Confirm no static `PUBLIC_ECR_AWS_*` secrets remain and DockerHub login is untouched.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container publishing workflow to use more secure, role-based authentication for Amazon ECR.
  * Improved access handling for build and manifest jobs to support the new login flow.
  * Expanded allowed network access for the build environment to complete authentication successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->