### PR TITLE
fix(github): skip archived repos in repository_has_codeowners_file check

### DIFF
--- a/prowler/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file.py
+++ b/prowler/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file.py
@@ -22,6 +22,8 @@ class repository_has_codeowners_file(Check):
         """
         findings = []
         for repo in repository_client.repositories.values():
+            if repo.archived:
+                continue
             if repo.codeowners_exists is not None:
                 report = CheckReportGithub(metadata=self.metadata(), resource=repo)
                 if repo.codeowners_exists:

--- a/tests/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file_test.py
+++ b/tests/providers/github/services/repository/repository_has_codeowners_file/repository_has_codeowners_file_test.py
@@ -28,6 +28,58 @@ class Test_repository_has_codeowners_file:
             result = check.execute()
             assert len(result) == 0
 
+    def test_archived_repository_is_skipped(self):
+        repository_client = mock.MagicMock
+        repo_name = "archived-repo"
+        repository_client.repositories = {
+            1: Repo(
+                id=1,
+                name=repo_name,
+                owner="account-name",
+                full_name="account-name/archived-repo",
+                default_branch=Branch(
+                    name="main",
+                    protected=False,
+                    default_branch=True,
+                    require_pull_request=False,
+                    approval_count=0,
+                    required_linear_history=False,
+                    allow_force_pushes=True,
+                    branch_deletion=True,
+                    status_checks=False,
+                    enforce_admins=False,
+                    require_code_owner_reviews=False,
+                    require_signed_commits=False,
+                    conversation_resolution=False,
+                ),
+                private=False,
+                securitymd=True,
+                codeowners_exists=False,
+                secret_scanning_enabled=False,
+                archived=True,
+                pushed_at=datetime.now(timezone.utc),
+                delete_branch_on_merge=False,
+            ),
+        }
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_github_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.github.services.repository.repository_has_codeowners_file.repository_has_codeowners_file.repository_client",
+                new=repository_client,
+            ),
+        ):
+            from prowler.providers.github.services.repository.repository_has_codeowners_file.repository_has_codeowners_file import (
+                repository_has_codeowners_file,
+            )
+
+            check = repository_has_codeowners_file()
+            result = check.execute()
+            assert len(result) == 0
+
     def test_one_repository_no_codeowners(self):
         repository_client = mock.MagicMock
         repo_name = "repo1"


### PR DESCRIPTION
## Description

Fixes #11734

Archived repositories are **read-only** — they cannot be updated without first being unarchived. Flagging them for a missing CODEOWNERS file generates a finding that is not actionable, which adds noise to security reports.

## Changes

**`repository_has_codeowners_file.py`** — skip archived repositories before evaluating the CODEOWNERS check:

```python
if repo.archived:
    continue
```

**`repository_has_codeowners_file_test.py`** — adds `test_archived_repository_is_skipped` to verify that an archived repo with `codeowners_exists=False` produces zero findings.

## Testing

New test case added following the same pattern as the existing test suite. Verifies that `check.execute()` returns an empty list when the only repository is archived.

## Related

This approach is consistent with how other prowler checks treat non-actionable states — the finding is simply not emitted rather than being marked PASS, since the archived state has no bearing on the check's intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archived repositories are now skipped when checking for a `CODEOWNERS` file, so they no longer produce pass/fail findings.
* **Tests**
  * Added coverage to verify archived repositories return no results from this check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->