### PR TITLE
fix(ci): detect conflict markers in route-group paths and flag unmergeable PRs

### DIFF
--- a/.github/workflows/pr-conflict-checker.yml
+++ b/.github/workflows/pr-conflict-checker.yml
@@ -49,7 +49,8 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: '**'
-          safe_output: false # Consumed via env var (injection-safe); default escaping backslash-quotes paths like ui/app/(prowler)/, so the -f test skips them
+          safe_output: false # Raw paths (list read via env var, injection-safe); default escaping backslash-quotes chars like () and breaks the -f test
+          separator: "\n" # Newline-delimited so the reader tolerates spaces and glob chars in paths
 
       - name: Check for conflict markers
         id: conflict-check
@@ -59,19 +60,18 @@ jobs:
           CONFLICT_FILES=""
           HAS_CONFLICTS=false
 
-          # Check each changed file for conflict markers
-          for file in ${STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}; do
-            if [ -f "$file" ]; then
-              echo "Checking file: $file"
+          # Read newline-delimited paths so spaces/globs neither word-split nor glob-expand
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            [ -f "$file" ] || continue
+            echo "Checking file: $file"
 
-              # Look for conflict markers (more precise regex)
-              if grep -qE '^(<<<<<<<|=======|>>>>>>>)' "$file" 2>/dev/null; then
-                echo "Conflict markers found in: $file"
-                CONFLICT_FILES="${CONFLICT_FILES}- \`${file}\`"$'\n'
-                HAS_CONFLICTS=true
-              fi
+            if grep -qE '^(<<<<<<<|=======|>>>>>>>)' "$file" 2>/dev/null; then
+              echo "Conflict markers found in: $file"
+              CONFLICT_FILES="${CONFLICT_FILES}- \`${file}\`"$'\n'
+              HAS_CONFLICTS=true
             fi
-          done
+          done <<< "$STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES"
 
           if [ "$HAS_CONFLICTS" = true ]; then
             echo "has_conflicts=true" >> $GITHUB_OUTPUT
@@ -95,7 +95,6 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          HAS_MERGE_CONFLICT=false
           MERGEABLE=null
 
           # GitHub computes mergeability async, so .mergeable is null until ready; poll until resolved
@@ -108,31 +107,30 @@ jobs:
             sleep 3
           done
 
-          if [ "$MERGEABLE" = "false" ]; then
-            HAS_MERGE_CONFLICT=true
-            echo "PR branch cannot be merged cleanly into its base branch"
-          elif [ "$MERGEABLE" = "null" ]; then
-            # Don't block on GitHub being slow to compute mergeability
-            echo "::warning::Mergeability did not resolve after retries; treating as no conflict"
-          else
-            echo "PR branch merges cleanly into its base branch"
-          fi
+          # Keep 'unknown' distinct from 'clean' so we never assert a clean merge we could not confirm
+          case "$MERGEABLE" in
+            false) STATUS=conflict; echo "PR branch cannot be merged cleanly into its base branch" ;;
+            true)  STATUS=clean;    echo "PR branch merges cleanly into its base branch" ;;
+            *)     STATUS=unknown;  echo "::warning::Mergeability did not resolve after retries; leaving it undetermined" ;;
+          esac
 
-          echo "has_merge_conflict=${HAS_MERGE_CONFLICT}" >> "$GITHUB_OUTPUT"
+          echo "merge_status=${STATUS}" >> "$GITHUB_OUTPUT"
 
       - name: Manage conflict label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_CONFLICTS: ${{ steps.conflict-check.outputs.has_conflicts }}
-          HAS_MERGE_CONFLICT: ${{ steps.merge-check.outputs.has_merge_conflict }}
+          MERGE_STATUS: ${{ steps.merge-check.outputs.merge_status }}
         run: |
           LABEL_NAME="has-conflicts"
 
-          # Add or remove label based on either conflict signal
-          if [ "$HAS_CONFLICTS" = "true" ] || [ "$HAS_MERGE_CONFLICT" = "true" ]; then
+          if [ "$HAS_CONFLICTS" = "true" ] || [ "$MERGE_STATUS" = "conflict" ]; then
             echo "Adding conflict label to PR #${PR_NUMBER}..."
             gh pr edit "$PR_NUMBER" --add-label "$LABEL_NAME" --repo ${{ github.repository }} || true
+          elif [ "$MERGE_STATUS" = "unknown" ]; then
+            # Don't drop the label on an undetermined merge state; a later run will settle it
+            echo "Mergeability undetermined; leaving label unchanged"
           else
             echo "Removing conflict label from PR #${PR_NUMBER}..."
             gh pr edit "$PR_NUMBER" --remove-label "$LABEL_NAME" --repo ${{ github.repository }} || true
@@ -154,23 +152,25 @@ jobs:
           edit-mode: replace
           body: |
             <!-- conflict-checker-comment -->
-            ${{ (steps.conflict-check.outputs.has_conflicts == 'true' || steps.merge-check.outputs.has_merge_conflict == 'true') && '⚠️ **Conflicts Detected**' || '✅ **No Conflicts**' }}
+            ${{ (steps.conflict-check.outputs.has_conflicts == 'true' || steps.merge-check.outputs.merge_status == 'conflict') && '⚠️ **Conflicts Detected**' || (steps.merge-check.outputs.merge_status == 'unknown' && 'ℹ️ **Conflict Check Incomplete**' || '✅ **No Conflicts**') }}
             ${{ steps.conflict-check.outputs.has_conflicts == 'true' && format('
             **Conflict markers** are present in the following files:
 
             {0}
             Resolve them by removing every `<<<<<<<`, `=======`, and `>>>>>>>` marker, then commit and push.', steps.conflict-check.outputs.conflict_files) || '' }}
-            ${{ steps.merge-check.outputs.has_merge_conflict == 'true' && '
+            ${{ steps.merge-check.outputs.merge_status == 'conflict' && '
             **Merge conflict with the base branch.** This PR cannot be merged cleanly. Update your branch with the latest base (rebase or merge) and resolve the conflicts.' || '' }}
-            ${{ (steps.conflict-check.outputs.has_conflicts != 'true' && steps.merge-check.outputs.has_merge_conflict != 'true') && '
+            ${{ steps.merge-check.outputs.merge_status == 'unknown' && '
+            GitHub had not finished computing mergeability, so base-branch conflict status could not be verified on this run.' || '' }}
+            ${{ (steps.conflict-check.outputs.has_conflicts != 'true' && steps.merge-check.outputs.merge_status == 'clean') && '
             No conflict markers, and the branch merges cleanly into its base.' || '' }}
 
       - name: Fail workflow if conflicts detected
-        if: steps.conflict-check.outputs.has_conflicts == 'true' || steps.merge-check.outputs.has_merge_conflict == 'true'
+        if: steps.conflict-check.outputs.has_conflicts == 'true' || steps.merge-check.outputs.merge_status == 'conflict'
         env:
           HAS_CONFLICTS: ${{ steps.conflict-check.outputs.has_conflicts }}
-          HAS_MERGE_CONFLICT: ${{ steps.merge-check.outputs.has_merge_conflict }}
+          MERGE_STATUS: ${{ steps.merge-check.outputs.merge_status }}
         run: |
           [ "$HAS_CONFLICTS" = "true" ] && echo "::error::Conflict markers detected in changed files"
-          [ "$HAS_MERGE_CONFLICT" = "true" ] && echo "::error::PR branch has merge conflicts with the base branch"
+          [ "$MERGE_STATUS" = "conflict" ] && echo "::error::PR branch has merge conflicts with the base branch"
           exit 1

--- a/.github/workflows/pr-conflict-checker.yml
+++ b/.github/workflows/pr-conflict-checker.yml
@@ -49,6 +49,7 @@ jobs:
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: '**'
+          safe_output: false # Consumed via env var (injection-safe); default escaping backslash-quotes paths like ui/app/(prowler)/, so the -f test skips them
 
       - name: Check for conflict markers
         id: conflict-check
@@ -87,16 +88,49 @@ jobs:
         env:
           STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
+      - name: Check base-branch mergeability
+        id: merge-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          HAS_MERGE_CONFLICT=false
+          MERGEABLE=null
+
+          # GitHub computes mergeability async, so .mergeable is null until ready; poll until resolved
+          for attempt in 1 2 3 4 5; do
+            MERGEABLE=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.mergeable')
+            if [ "$MERGEABLE" != "null" ]; then
+              break
+            fi
+            echo "Attempt ${attempt}: mergeability not computed yet, retrying..."
+            sleep 3
+          done
+
+          if [ "$MERGEABLE" = "false" ]; then
+            HAS_MERGE_CONFLICT=true
+            echo "PR branch cannot be merged cleanly into its base branch"
+          elif [ "$MERGEABLE" = "null" ]; then
+            # Don't block on GitHub being slow to compute mergeability
+            echo "::warning::Mergeability did not resolve after retries; treating as no conflict"
+          else
+            echo "PR branch merges cleanly into its base branch"
+          fi
+
+          echo "has_merge_conflict=${HAS_MERGE_CONFLICT}" >> "$GITHUB_OUTPUT"
+
       - name: Manage conflict label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_CONFLICTS: ${{ steps.conflict-check.outputs.has_conflicts }}
+          HAS_MERGE_CONFLICT: ${{ steps.merge-check.outputs.has_merge_conflict }}
         run: |
           LABEL_NAME="has-conflicts"
 
-          # Add or remove label based on conflict status
-          if [ "$HAS_CONFLICTS" = "true" ]; then
+          # Add or remove label based on either conflict signal
+          if [ "$HAS_CONFLICTS" = "true" ] || [ "$HAS_MERGE_CONFLICT" = "true" ]; then
             echo "Adding conflict label to PR #${PR_NUMBER}..."
             gh pr edit "$PR_NUMBER" --add-label "$LABEL_NAME" --repo ${{ github.repository }} || true
           else
@@ -120,20 +154,23 @@ jobs:
           edit-mode: replace
           body: |
             <!-- conflict-checker-comment -->
-            ${{ steps.conflict-check.outputs.has_conflicts == 'true' && '⚠️ **Conflict Markers Detected**' || '✅ **Conflict Markers Resolved**' }}
-
-            ${{ steps.conflict-check.outputs.has_conflicts == 'true' && format('This pull request contains unresolved conflict markers in the following files:
+            ${{ (steps.conflict-check.outputs.has_conflicts == 'true' || steps.merge-check.outputs.has_merge_conflict == 'true') && '⚠️ **Conflicts Detected**' || '✅ **No Conflicts**' }}
+            ${{ steps.conflict-check.outputs.has_conflicts == 'true' && format('
+            **Conflict markers** are present in the following files:
 
             {0}
-
-            Please resolve these conflicts by:
-            1. Locating the conflict markers: `<<<<<<<`, `=======`, and `>>>>>>>`
-            2. Manually editing the files to resolve the conflicts
-            3. Removing all conflict markers
-            4. Committing and pushing the changes', steps.conflict-check.outputs.conflict_files) || 'All conflict markers have been successfully resolved in this pull request.' }}
+            Resolve them by removing every `<<<<<<<`, `=======`, and `>>>>>>>` marker, then commit and push.', steps.conflict-check.outputs.conflict_files) || '' }}
+            ${{ steps.merge-check.outputs.has_merge_conflict == 'true' && '
+            **Merge conflict with the base branch.** This PR cannot be merged cleanly. Update your branch with the latest base (rebase or merge) and resolve the conflicts.' || '' }}
+            ${{ (steps.conflict-check.outputs.has_conflicts != 'true' && steps.merge-check.outputs.has_merge_conflict != 'true') && '
+            No conflict markers, and the branch merges cleanly into its base.' || '' }}
 
       - name: Fail workflow if conflicts detected
-        if: steps.conflict-check.outputs.has_conflicts == 'true'
+        if: steps.conflict-check.outputs.has_conflicts == 'true' || steps.merge-check.outputs.has_merge_conflict == 'true'
+        env:
+          HAS_CONFLICTS: ${{ steps.conflict-check.outputs.has_conflicts }}
+          HAS_MERGE_CONFLICT: ${{ steps.merge-check.outputs.has_merge_conflict }}
         run: |
-          echo "::error::Workflow failed due to conflict markers detected in the PR"
+          [ "$HAS_CONFLICTS" = "true" ] && echo "::error::Conflict markers detected in changed files"
+          [ "$HAS_MERGE_CONFLICT" = "true" ] && echo "::error::PR branch has merge conflicts with the base branch"
           exit 1


### PR DESCRIPTION
### Context

The `pr-conflict-checker` workflow silently missed committed conflict markers in files whose paths contain shell-special characters, most notably Next.js parenthesized route-group folders such as `ui/app/(prowler)/`. It also only inspected changed files for markers, so a PR that was structurally unmergeable against its base branch (no committed markers, but a real merge conflict) passed unnoticed.

### Description

Two changes to `.github/workflows/pr-conflict-checker.yml`:

- **Bug fixed:** `tj-actions/changed-files` defaults to `safe_output: true`, which backslash-escapes shell-special characters in file paths. Files under parenthesized route-group folders (e.g. `ui/app/(prowler)/...`) therefore arrived as `ui/app/\(prowler\)/...`. The `[ -f "$file" ]` existence test failed on the escaped name and silently skipped those files, so committed conflict markers went undetected. Setting `safe_output: false` fixes it. The file list is consumed via an environment variable rather than interpolated into the shell, so disabling escaping stays injection-safe.

- **Added:** a base-branch mergeability check that polls the GitHub API `mergeable` field (which GitHub computes asynchronously). PRs that cannot be merged cleanly into their base branch are now labeled, commented on, and fail the workflow, in addition to the existing committed-marker detection. Both conflict signals feed the same label, comment, and failure logic.

### Steps to review

1. Confirm `safe_output: false` on the `tj-actions/changed-files` step, and that `all_changed_files` is still consumed via the `STEPS_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES` env var (no direct interpolation into the run script).
2. Review the new `Check base-branch mergeability` step: it polls `repos/{repo}/pulls/{number}` for `.mergeable`, retries while the value is `null`, warns (does not block) if it never resolves, and sets `has_merge_conflict`.
3. Confirm the label, comment, and fail steps now trigger on either `has_conflicts` or `has_merge_conflict`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request conflict detection by combining checks for visible conflict markers with GitHub mergeability status.
  * Updated conflict labeling and PR comment messaging to show accurate details for marker-based conflicts, mergeability-based conflicts, and undetermined cases.
  * Broadened workflow failure conditions so checks fail reliably when conflicts are present or GitHub reports a base-branch merge conflict.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->