### PR TITLE
docs(skills): add design system discipline to prowler-ui

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Review PR requirements: template, title conventions, changelog gate | `prowler-pr` |
 | Review changelog format and conventions | `prowler-changelog` |
 | Reviewing JSON:API compliance | `jsonapi` |
+| Reviewing Prowler UI components | `prowler-ui` |
 | Reviewing compliance framework PRs | `prowler-compliance-review` |
 | Running makemigrations or pgmakemigrations | `django-migration-psql` |
 | Syncing compliance framework with upstream catalog | `prowler-compliance` |

--- a/skills/prowler-ui/SKILL.md
+++ b/skills/prowler-ui/SKILL.md
@@ -44,9 +44,9 @@ HeroUI 2.8.4 (LEGACY - do not add new components)
 
 Applies to ALL UI work. The design system is the single source of truth — reuse it exactly, extend it deliberately.
 
-- **Reuse first, never reinvent.** Before building anything, search `components/shadcn/` and existing scans/providers UI. Do NOT create a custom component, modal wrapper, or primitive when an equivalent already exists.
+- **Reuse first, never reinvent.** Before building anything, search `components/shadcn/` and existing usages in the codebase for an equivalent. Do NOT create a custom component, modal wrapper, or primitive when one already exists.
 - **Use exactly the defined variants/styles — no more, no less.** At the call site, drive appearance through the component's `variant`/`size`/`tone` props. Never add ad-hoc visual `className` (color, opacity, hover/focus/disabled, spacing-for-looks) to shared controls (`Button`, `SelectTrigger`, `SelectItem`, `Modal`, badges…), and never skip the correct semantic variant.
-- **Modals**: only `@/components/shadcn/modal`. **Selects**: `components/shadcn/select`. Inspect scans/providers usage before writing new UI.
+- **Modals**: only `@/components/shadcn/modal`. **Selects**: `components/shadcn/select`.
 - **Colors**: reuse existing semantic tokens from `ui/styles/globals.css`. No raw Tailwind color utilities (e.g. `bg-blue-950/40`), no hex. If no token fits, STOP and ask the design owner — do not invent or near-duplicate tokens.
 - **Need a genuinely new variant/token?** That is a design-system change: add it to the shared component API (with design sign-off), then consume it. It is never a call-site decision.
 

--- a/skills/prowler-ui/SKILL.md
+++ b/skills/prowler-ui/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   scope: [root, ui]
   auto_invoke:
     - "Creating/modifying Prowler UI components"
+    - "Reviewing Prowler UI components"
     - "Working on Prowler UI structure (actions/adapters/types/hooks)"
 allowed-tools: Read, Edit, Write, Glob, Grep, Bash, WebFetch, WebSearch, Task
 ---
@@ -38,6 +39,18 @@ HeroUI 2.8.4 (LEGACY - do not add new components)
 
 - **ALWAYS**: Use `shadcn/ui` + Tailwind (`components/shadcn/`)
 - **NEVER**: Add new HeroUI components (`components/ui/` is legacy only)
+
+## Design System Discipline (REQUIRED)
+
+Applies to ALL UI work. The design system is the single source of truth — reuse it exactly, extend it deliberately.
+
+- **Reuse first, never reinvent.** Before building anything, search `components/shadcn/` and existing scans/providers UI. Do NOT create a custom component, modal wrapper, or primitive when an equivalent already exists.
+- **Use exactly the defined variants/styles — no more, no less.** At the call site, drive appearance through the component's `variant`/`size`/`tone` props. Never add ad-hoc visual `className` (color, opacity, hover/focus/disabled, spacing-for-looks) to shared controls (`Button`, `SelectTrigger`, `SelectItem`, `Modal`, badges…), and never skip the correct semantic variant.
+- **Modals**: only `@/components/shadcn/modal`. **Selects**: `components/shadcn/select`. Inspect scans/providers usage before writing new UI.
+- **Colors**: reuse existing semantic tokens from `ui/styles/globals.css`. No raw Tailwind color utilities (e.g. `bg-blue-950/40`), no hex. If no token fits, STOP and ask the design owner — do not invent or near-duplicate tokens.
+- **Need a genuinely new variant/token?** That is a design-system change: add it to the shared component API (with design sign-off), then consume it. It is never a call-site decision.
+
+When reviewing UI PRs, flag: custom modals/primitives that duplicate shadcn, call-site visual `className` on shared controls, raw color utilities, and new variants/tokens introduced without going through the shared component API.
 
 ## DECISION TREES
 

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -40,6 +40,7 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Renaming or removing a data-tour-id attribute value               | `prowler-tour`      |
 | Restructuring routes or layouts covered by a tour                 | `prowler-tour`      |
 | Review changelog format and conventions                           | `prowler-changelog` |
+| Reviewing Prowler UI components                                   | `prowler-ui`        |
 | Testing hooks or utilities                                        | `vitest`            |
 | Update CHANGELOG.md in any component                              | `prowler-changelog` |
 | Using Zustand stores                                              | `zustand-5`         |


### PR DESCRIPTION
### Context

While reviewing the findings-triage PR (#11704) we noticed a standalone
`prowler-ui-component-standards` skill had been added. Its trigger collided with
`prowler-ui` on `"Creating/modifying Prowler UI components"` (which made the
`AGENTS.md` auto-invoke table fragile — the de-dup would be undone by the next
`sync.sh` run), it referenced a non-existent `ui/styles/global.css` path, and its
substance mostly belonged in the existing `prowler-ui` skill.

The skill has been removed from #11704. This PR folds the genuinely new, valuable
guidance into `prowler-ui` instead, where it fires on all UI work.

### Description

- Add a **Design System Discipline (REQUIRED)** section to `skills/prowler-ui/SKILL.md`:
  - Reuse-first: never create a custom component/modal/primitive when an equivalent exists.
  - Use exactly the design system's defined `variant`/`size`/`tone` — no ad-hoc visual
    `className` on shared controls, and no skipping the correct semantic variant.
  - Colors only from existing `ui/styles/globals.css` tokens (path corrected vs the
    removed skill); no raw Tailwind colors/hex; ask the design owner before adding tokens.
  - New variants/tokens are a design-system change (shared component API + sign-off),
    never a call-site decision.
- Wire a new `"Reviewing Prowler UI components"` auto-invoke trigger into `prowler-ui`
  and regenerate the auto-invoke tables (`AGENTS.md`, `ui/AGENTS.md`) via `skill-sync`.

No separate skill, no trigger collision, no dangling file reference.

### Steps to review

1. Read the new **Design System Discipline** section in `skills/prowler-ui/SKILL.md`.
2. Confirm the `auto_invoke` frontmatter gains `"Reviewing Prowler UI components"`.
3. Confirm `AGENTS.md` and `ui/AGENTS.md` each gain the single matching row (generated
   by `./skills/skill-sync/assets/sync.sh`).

### Checklist

- [x] Auto-invoke tables regenerated with `skill-sync` (no manual drift).
- [x] Referenced paths verified to exist (`ui/styles/globals.css`).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review guidance to include a new UI-specific instruction for handling Prowler component changes.
  * Added clearer design-system expectations for future UI work, including consistent component usage and styling practices.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->