### PR TITLE
chore(ci): disable Dependabot version updates in favor of Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,17 +30,18 @@ updates:
   #     - "pip"
   #     - "component/api"
 
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 25
-    target-branch: master
-    labels:
-      - "dependencies"
-      - "github_actions"
-    cooldown:
-      default-days: 7
+  # Dependabot version updates disabled - migrated to Renovate - 2026/07/02
+  # - package-ecosystem: "github-actions"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "monthly"
+  #   open-pull-requests-limit: 25
+  #   target-branch: master
+  #   labels:
+  #     - "dependencies"
+  #     - "github_actions"
+  #   cooldown:
+  #     default-days: 7
 
   # Dependabot Updates are temporary disabled - 2025/03/19
   # - package-ecosystem: "npm"
@@ -54,17 +55,18 @@ updates:
   #     - "npm"
   #     - "component/ui"
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 25
-    target-branch: master
-    labels:
-      - "dependencies"
-      - "docker"
-    cooldown:
-      default-days: 7
+  # Dependabot version updates disabled - migrated to Renovate - 2026/07/02
+  # - package-ecosystem: "docker"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "monthly"
+  #   open-pull-requests-limit: 25
+  #   target-branch: master
+  #   labels:
+  #     - "dependencies"
+  #     - "docker"
+  #   cooldown:
+  #     default-days: 7
 
   # - package-ecosystem: "pre-commit"
   #   directory: "/"


### PR DESCRIPTION
### Context

Renovate (`.github/renovate.json`) now owns all dependency updates in this repository. The two remaining active Dependabot **version updates** — `github-actions` and `docker` — are therefore redundant, since both ecosystems are already handled by Renovate.

### Description

Comments out the two active Dependabot version-update entries in `.github/dependabot.yml`:

- `github-actions` (`/`)
- `docker` (`/`)

Both are commented out (not deleted) to match the existing "temporary disabled" style already used throughout the file, with a note indicating the migration to Renovate. After this change, `updates:` has no active entries, which is intentional: Renovate covers github-actions and docker version updates.

Note: Dependabot **security updates** and **Dependabot alerts** are unaffected and remain enabled — this PR only disables Dependabot's *version update* PRs.

### Steps to review

1. Confirm only `.github/dependabot.yml` is touched.
2. Confirm both previously-active blocks (`github-actions`, `docker`) are now commented out, matching the existing disabled-entry style.
3. Confirm Renovate config (`.github/renovate.json`) covers github-actions and docker.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to use a different update service.
  * Disabled scheduled update checks for GitHub Actions and Docker in the old configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->