### PR TITLE
fix(ui): address findings triage QA feedback

### DIFF
--- a/ui/actions/findings/findings-triage.adapter.test.ts
+++ b/ui/actions/findings/findings-triage.adapter.test.ts
@@ -400,7 +400,6 @@ describe("adaptFindingTriageDetailResponse", () => {
         canEdit: true,
         noteBody: "Current note visible only inside the modal.",
         maxNoteLength: 500,
-        privacyCopy: "This note is only visible to your team.",
       }),
     );
   });

--- a/ui/actions/findings/findings-triage.adapter.ts
+++ b/ui/actions/findings/findings-triage.adapter.ts
@@ -1,7 +1,6 @@
 import {
   FINDING_TRIAGE_BILLING_HREF,
   FINDING_TRIAGE_NOTE_MAX_LENGTH,
-  FINDING_TRIAGE_NOTE_PRIVACY_COPY,
   FINDING_TRIAGE_STATUS,
   FINDING_TRIAGE_STATUS_LABELS,
   type FindingTriageDetail,
@@ -215,6 +214,5 @@ export function adaptFindingTriageDetailResponse(
     noteId: attributes.note_id || null,
     noteBody,
     maxNoteLength: FINDING_TRIAGE_NOTE_MAX_LENGTH,
-    privacyCopy: FINDING_TRIAGE_NOTE_PRIVACY_COPY,
   };
 }

--- a/ui/app/(prowler)/_overview/graphs-tabs/findings-view/findings-view.ssr.tsx
+++ b/ui/app/(prowler)/_overview/graphs-tabs/findings-view/findings-view.ssr.tsx
@@ -6,7 +6,7 @@ import { LinkToFindings } from "@/components/overview";
 import { ColumnLatestFindings } from "@/components/overview/new-findings-table/table";
 import { CardTitle } from "@/components/shadcn";
 import { DataTable } from "@/components/ui/table";
-import { FINDINGS_FILTERED_SORT } from "@/lib";
+import { FINDINGS_FILTERED_SORT, MUTED_FILTER } from "@/lib";
 import { createDict } from "@/lib/helper";
 import { FindingProps, SearchParamsProps } from "@/types";
 
@@ -23,6 +23,7 @@ export async function FindingsViewSSR({ searchParams }: FindingsViewSSRProps) {
   const defaultFilters = {
     "filter[status]": "FAIL",
     "filter[delta]": "new",
+    "filter[muted]": MUTED_FILTER.EXCLUDE,
   };
 
   const filters = pickFilterParams(searchParams);

--- a/ui/components/findings/table/column-finding-resources.test.tsx
+++ b/ui/components/findings/table/column-finding-resources.test.tsx
@@ -401,6 +401,38 @@ describe("column-finding-resources", () => {
     expect(screen.getByText(EDITING_UNAVAILABLE_COPY)).toBeInTheDocument();
   });
 
+  it("should keep the compact Triage label on resource cells for headerless nested rows", () => {
+    // Given
+    const columns = getColumnFindingResources({
+      rowSelection: {},
+      selectableRowCount: 1,
+    });
+    const triageColumn = columns.find(
+      (col) => (col as { id?: string }).id === "triage",
+    );
+    if (!triageColumn?.cell) {
+      throw new Error("triage column not found");
+    }
+    const CellComponent = triageColumn.cell as (props: {
+      row: { original: FindingResourceRow };
+    }) => ReactNode;
+
+    // When
+    render(
+      <div>
+        {CellComponent({
+          row: {
+            original: makeResource({ triage: makeTriageSummary() }),
+          },
+        })}
+      </div>,
+    );
+
+    // Then — expanded finding-group rows render without a header row, so the
+    // cell itself must carry the label, like Service/Region/Last seen do.
+    expect(screen.getByText("Triage")).toBeInTheDocument();
+  });
+
   it("should disable non-paying Cloud triage control with only-in-Cloud tooltip copy", () => {
     // Given
     const columns = getColumnFindingResources({

--- a/ui/components/findings/table/column-finding-resources.test.tsx
+++ b/ui/components/findings/table/column-finding-resources.test.tsx
@@ -7,6 +7,13 @@ import type {
 } from "react";
 import { describe, expect, it, vi } from "vitest";
 
+// CustomLink pulls the "@/lib" barrel (and next-auth with it) into the unit env.
+vi.mock("@/components/ui/custom/custom-link", () => ({
+  CustomLink: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
 vi.mock("@/components/shadcn", () => ({
   Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
     <button {...props}>{children}</button>

--- a/ui/components/findings/table/column-finding-resources.tsx
+++ b/ui/components/findings/table/column-finding-resources.tsx
@@ -354,17 +354,20 @@ export function getColumnFindingResources({
       },
       enableSorting: false,
     },
-    // Triage
+    // Triage — keep the compact label: these cells also render inside
+    // expanded finding-group rows, which have no header row of their own.
     {
       id: "triage",
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Triage" />
       ),
       cell: ({ row }) => (
-        <FindingTriageStatusCell
-          triage={row.original.triage}
-          onTriageUpdateAction={onTriageUpdateAction}
-        />
+        <InfoField label="Triage" variant="compact">
+          <FindingTriageStatusCell
+            triage={row.original.triage}
+            onTriageUpdateAction={onTriageUpdateAction}
+          />
+        </InfoField>
       ),
       enableSorting: false,
     },

--- a/ui/components/findings/table/column-standalone-findings.test.tsx
+++ b/ui/components/findings/table/column-standalone-findings.test.tsx
@@ -5,6 +5,13 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: vi.fn() }),
 }));
 
+// CustomLink pulls the "@/lib" barrel (and next-auth with it) into the unit env.
+vi.mock("@/components/ui/custom/custom-link", () => ({
+  CustomLink: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
 vi.mock("@/components/findings/mute-findings-modal", () => ({
   MuteFindingsModal: () => null,
 }));

--- a/ui/components/findings/table/column-standalone-findings.tsx
+++ b/ui/components/findings/table/column-standalone-findings.tsx
@@ -67,7 +67,7 @@ function FindingTitleCell({
       finding={finding}
       defaultOpen={defaultOpen}
       trigger={
-        <div className="max-w-[500px]">
+        <div className="max-w-[500px] min-w-[160px]">
           <p className="text-text-neutral-primary hover:text-button-tertiary cursor-pointer text-left text-sm break-words whitespace-normal hover:underline">
             {finding.attributes.check_metadata.checktitle}
           </p>

--- a/ui/components/findings/table/finding-note-modal.test.tsx
+++ b/ui/components/findings/table/finding-note-modal.test.tsx
@@ -251,6 +251,44 @@ describe("FindingNoteModal", () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
+  it("should lock the status picker for resolved findings while keeping the note editable", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onTriageUpdateAction = vi.fn();
+    renderNoteModal({
+      triage: makeTriageDetail({
+        status: FINDING_TRIAGE_STATUS.RESOLVED,
+        label: "Resolved",
+      }),
+      onTriageUpdateAction,
+    });
+
+    // Then — automation owns the transition out of Resolved.
+    expect(
+      screen.getByRole("combobox", { name: "Triage status" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Triage status is managed automatically once the finding is resolved.",
+      ),
+    ).toBeVisible();
+    expect(screen.getByLabelText("Note text")).toBeEnabled();
+
+    // When — the note itself can still be updated.
+    const textarea = screen.getByLabelText("Note text");
+    await user.clear(textarea);
+    await user.type(textarea, "Documenting the resolution.");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    // Then
+    expect(onTriageUpdateAction).toHaveBeenCalledWith(
+      expect.objectContaining({ note: "Documenting the resolution." }),
+    );
+    expect(onTriageUpdateAction).toHaveBeenCalledWith(
+      expect.not.objectContaining({ status: expect.anything() }),
+    );
+  });
+
   it("should render counter and cancel/update actions without privacy copy", async () => {
     // Given
     const user = userEvent.setup();

--- a/ui/components/findings/table/finding-note-modal.test.tsx
+++ b/ui/components/findings/table/finding-note-modal.test.tsx
@@ -9,6 +9,13 @@ vi.mock("@/components/icons/providers-badge/provider-type-icon", () => ({
   ),
 }));
 
+// CustomLink pulls the "@/lib" barrel (and next-auth with it) into the unit env.
+vi.mock("@/components/ui/custom/custom-link", () => ({
+  CustomLink: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
 vi.mock("@/components/shadcn/modal", () => ({
   Modal: ({
     children,
@@ -44,7 +51,6 @@ beforeAll(() => {
 
 import {
   FINDING_TRIAGE_DISABLED_REASON,
-  FINDING_TRIAGE_NOTE_PRIVACY_COPY,
   FINDING_TRIAGE_STATUS,
   type FindingTriageDetail,
   type UpdateFindingTriageInput,
@@ -72,7 +78,6 @@ function makeTriageDetail(
     noteId: "note-1",
     noteBody: "Existing investigation note",
     maxNoteLength: 500,
-    privacyCopy: FINDING_TRIAGE_NOTE_PRIVACY_COPY,
     ...overrides,
   };
 }
@@ -246,7 +251,7 @@ describe("FindingNoteModal", () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
-  it("should render counter, privacy copy, and cancel/update actions", async () => {
+  it("should render counter and cancel/update actions without privacy copy", async () => {
     // Given
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
@@ -258,7 +263,9 @@ describe("FindingNoteModal", () => {
 
     // Then
     expect(screen.getByText("3/500")).toBeInTheDocument();
-    expect(screen.getByText(FINDING_TRIAGE_NOTE_PRIVACY_COPY)).toBeVisible();
+    expect(
+      screen.queryByText("This note is only visible to your team."),
+    ).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(
@@ -305,7 +312,11 @@ describe("FindingNoteModal", () => {
     await user.click(screen.getByRole("option", { name: "Risk Accepted" }));
 
     // Then
-    expect(screen.getByText(/will be muted/i)).toBeVisible();
+    expect(
+      screen.getByText(
+        "Changing triage to Risk Accepted will mute the finding",
+      ),
+    ).toBeVisible();
     await waitFor(() =>
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument(),
     );

--- a/ui/components/findings/table/finding-note-modal.tsx
+++ b/ui/components/findings/table/finding-note-modal.tsx
@@ -11,11 +11,13 @@ import { DOCS_URLS } from "@/lib/external-urls";
 import {
   FINDING_TRIAGE_DISABLED_REASON,
   FINDING_TRIAGE_ORIGIN,
+  FINDING_TRIAGE_RESOLVED_LOCKED_COPY,
   FINDING_TRIAGE_STATUS,
   type FindingTriageDetail,
   type FindingTriageStatus,
   getFindingTriageMuteInfoCopy,
   isMutelistShortcutStatus,
+  isTriageStatusLocked,
 } from "@/types/findings-triage";
 import type { ProviderType } from "@/types/providers";
 
@@ -69,6 +71,7 @@ export function FindingNoteModal({
     isMutelistShortcutStatus(selectedStatus);
   const shouldShowRemediatingInfo =
     selectedStatus === FINDING_TRIAGE_STATUS.REMEDIATING;
+  const isStatusLocked = isTriageStatusLocked(triage.status);
   // Opened from a dropdown item: move focus into the dialog on mount so Radix's
   // aria-hidden is not applied to the still-focused dropdown that opened it.
   const handleOpenAutoFocus = (event: Event) => {
@@ -155,6 +158,14 @@ export function FindingNoteModal({
             onValueChange={setSelectedStatus}
           />
         </div>
+
+        {isStatusLocked && (
+          <Alert variant="info">
+            <AlertDescription>
+              {FINDING_TRIAGE_RESOLVED_LOCKED_COPY}
+            </AlertDescription>
+          </Alert>
+        )}
 
         {shouldShowMutelistInfo && (
           <Alert variant="warning">

--- a/ui/components/findings/table/finding-note-modal.tsx
+++ b/ui/components/findings/table/finding-note-modal.tsx
@@ -5,6 +5,11 @@ import { type FormEvent, useRef, useState } from "react";
 import { ProviderTypeIcon } from "@/components/icons/providers-badge/provider-type-icon";
 import { Alert, AlertDescription, Button, Textarea } from "@/components/shadcn";
 import { Modal } from "@/components/shadcn/modal";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn/tooltip";
 import { CloudFeatureBadgeLink } from "@/components/shared/cloud-feature-badge";
 import { CustomLink } from "@/components/ui/custom/custom-link";
 import { DOCS_URLS } from "@/lib/external-urls";
@@ -122,7 +127,10 @@ export function FindingNoteModal({
       title="Add Triage Note"
       size="lg"
     >
-      <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+      {/* min-w-0: the form is a grid item of DialogContent; without it, long
+          unbreakable content (e.g. resource UIDs) widens the grid track past
+          the modal instead of truncating. */}
+      <form className="flex min-w-0 flex-col gap-5" onSubmit={handleSubmit}>
         <div className="flex items-center gap-4">
           <div className="bg-bg-neutral-tertiary flex size-9 shrink-0 items-center justify-center rounded-lg">
             {findingContext.providerType ? (
@@ -133,12 +141,17 @@ export function FindingNoteModal({
               </span>
             )}
           </div>
-          <div>
-            <p className="text-text-neutral-primary text-sm font-semibold">
-              {findingContext.title}
-            </p>
+          <div className="min-w-0">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <p className="text-text-neutral-primary truncate text-sm font-semibold">
+                  {findingContext.title}
+                </p>
+              </TooltipTrigger>
+              <TooltipContent>{findingContext.title}</TooltipContent>
+            </Tooltip>
             {(findingContext.resource || findingContext.provider) && (
-              <p className="text-text-neutral-secondary mt-1 text-xs">
+              <p className="text-text-neutral-secondary mt-1 truncate text-xs">
                 {[findingContext.resource, findingContext.provider]
                   .filter(Boolean)
                   .join(" · ")}

--- a/ui/components/findings/table/finding-note-modal.tsx
+++ b/ui/components/findings/table/finding-note-modal.tsx
@@ -151,12 +151,14 @@ export function FindingNoteModal({
           <span className="text-text-neutral-primary text-sm font-semibold">
             Status:
           </span>
-          <FindingTriageStatusControl
-            origin={FINDING_TRIAGE_ORIGIN.MODAL}
-            triage={triage}
-            value={selectedStatus}
-            onValueChange={setSelectedStatus}
-          />
+          <div className="w-1/2 min-w-44">
+            <FindingTriageStatusControl
+              origin={FINDING_TRIAGE_ORIGIN.MODAL}
+              triage={triage}
+              value={selectedStatus}
+              onValueChange={setSelectedStatus}
+            />
+          </div>
         </div>
 
         {isStatusLocked && (

--- a/ui/components/findings/table/finding-note-modal.tsx
+++ b/ui/components/findings/table/finding-note-modal.tsx
@@ -147,11 +147,11 @@ export function FindingNoteModal({
           </div>
         </div>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center justify-end gap-3">
           <span className="text-text-neutral-primary text-sm font-semibold">
             Status:
           </span>
-          <div className="ml-auto w-1/2 min-w-44">
+          <div className="w-1/2 min-w-44">
             <FindingTriageStatusControl
               origin={FINDING_TRIAGE_ORIGIN.MODAL}
               triage={triage}

--- a/ui/components/findings/table/finding-note-modal.tsx
+++ b/ui/components/findings/table/finding-note-modal.tsx
@@ -6,12 +6,15 @@ import { ProviderTypeIcon } from "@/components/icons/providers-badge/provider-ty
 import { Alert, AlertDescription, Button, Textarea } from "@/components/shadcn";
 import { Modal } from "@/components/shadcn/modal";
 import { CloudFeatureBadgeLink } from "@/components/shared/cloud-feature-badge";
+import { CustomLink } from "@/components/ui/custom/custom-link";
+import { DOCS_URLS } from "@/lib/external-urls";
 import {
   FINDING_TRIAGE_DISABLED_REASON,
   FINDING_TRIAGE_ORIGIN,
   FINDING_TRIAGE_STATUS,
   type FindingTriageDetail,
   type FindingTriageStatus,
+  getFindingTriageMuteInfoCopy,
   isMutelistShortcutStatus,
 } from "@/types/findings-triage";
 import type { ProviderType } from "@/types/providers";
@@ -37,10 +40,8 @@ interface FindingNoteModalProps {
   onTriageUpdateAction?: FindingTriageUpdateHandler;
 }
 
-const MUTELIST_INFO_COPY =
-  "This finding will be muted through the existing Mutelist flow.";
 const REMEDIATING_INFO_COPY =
-  "Once this finding is fixed and passes in the next scan, it will be automatically changed to Resolved.";
+  "Once this finding is remediated, if in the following scan its status changes to Pass, it will be automatically changed to Resolved";
 
 export function FindingNoteModal({
   open,
@@ -157,13 +158,20 @@ export function FindingNoteModal({
 
         {shouldShowMutelistInfo && (
           <Alert variant="warning">
-            <AlertDescription>{MUTELIST_INFO_COPY}</AlertDescription>
+            <AlertDescription>
+              {getFindingTriageMuteInfoCopy(selectedStatus)}
+            </AlertDescription>
           </Alert>
         )}
 
         {shouldShowRemediatingInfo && (
           <Alert variant="info">
-            <AlertDescription>{REMEDIATING_INFO_COPY}</AlertDescription>
+            <AlertDescription>
+              {REMEDIATING_INFO_COPY}.{" "}
+              <CustomLink href={DOCS_URLS.FINDINGS_TRIAGE} size="sm">
+                Learn more
+              </CustomLink>
+            </AlertDescription>
           </Alert>
         )}
 
@@ -184,10 +192,7 @@ export function FindingNoteModal({
             textareaSize="lg"
             onChange={(event) => setNote(event.target.value)}
           />
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-text-neutral-tertiary text-xs">
-              {triage.privacyCopy}
-            </p>
+          <div className="flex items-center justify-end">
             <p className="text-text-neutral-tertiary shrink-0 text-xs">
               {note.length}/{triage.maxNoteLength}
             </p>

--- a/ui/components/findings/table/finding-note-modal.tsx
+++ b/ui/components/findings/table/finding-note-modal.tsx
@@ -151,7 +151,7 @@ export function FindingNoteModal({
           <span className="text-text-neutral-primary text-sm font-semibold">
             Status:
           </span>
-          <div className="w-1/2 min-w-44">
+          <div className="ml-auto w-1/2 min-w-44">
             <FindingTriageStatusControl
               origin={FINDING_TRIAGE_ORIGIN.MODAL}
               triage={triage}

--- a/ui/components/findings/table/finding-triage-cells.test.tsx
+++ b/ui/components/findings/table/finding-triage-cells.test.tsx
@@ -8,14 +8,17 @@ vi.mock("@/components/shadcn/modal", () => ({
     children,
     open,
     title,
+    description,
   }: {
     children: ReactNode;
     open: boolean;
     title?: string;
+    description?: string;
   }) =>
     open ? (
       <div role="dialog" aria-label={title}>
         <h2>{title}</h2>
+        {description && <p>{description}</p>}
         {children}
       </div>
     ) : null,
@@ -25,6 +28,13 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),
+}));
+
+// CustomLink pulls the "@/lib" barrel (and next-auth with it) into the unit env.
+vi.mock("@/components/ui/custom/custom-link", () => ({
+  CustomLink: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
 }));
 
 vi.mock("@/components/shadcn/dropdown", () => ({
@@ -659,6 +669,11 @@ describe("finding triage cells", () => {
 
     // Then: the user is warned before the server action handles muting.
     expect(screen.getByRole("dialog", { name: "Mute finding?" })).toBeVisible();
+    expect(
+      screen.getByText(
+        "Changing triage to False Positive will mute the finding",
+      ),
+    ).toBeVisible();
     expect(onTriageUpdateAction).not.toHaveBeenCalled();
 
     // When

--- a/ui/components/findings/table/finding-triage-cells.test.tsx
+++ b/ui/components/findings/table/finding-triage-cells.test.tsx
@@ -244,6 +244,57 @@ describe("finding triage cells", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("should lock the table status picker for resolved findings", async () => {
+    // Given
+    const user = userEvent.setup();
+    const onTriageUpdateAction = vi.fn();
+    render(
+      <FindingTriageStatusCell
+        triage={makeTriageSummary({
+          status: FINDING_TRIAGE_STATUS.RESOLVED,
+          label: "Resolved",
+        })}
+        onTriageUpdateAction={onTriageUpdateAction}
+      />,
+    );
+
+    const statusControl = screen.getByRole("combobox", {
+      name: "Triage status",
+    });
+
+    // When
+    await user.click(statusControl);
+
+    // Then — automation owns the transition out of Resolved.
+    expect(statusControl).toBeDisabled();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "Triage status is managed automatically once the finding is resolved.",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(onTriageUpdateAction).not.toHaveBeenCalled();
+  });
+
+  it("should keep the note action available for resolved findings", () => {
+    // Given
+    render(
+      <FindingNoteActionItem
+        triage={makeTriageSummary({
+          status: FINDING_TRIAGE_STATUS.RESOLVED,
+          label: "Resolved",
+          hasVisibleNote: false,
+        })}
+        onTriageUpdateAction={vi.fn()}
+      />,
+    );
+
+    // Then — the lock only applies to status transitions, not notes.
+    expect(
+      screen.getByRole("button", { name: "Add Triage Note" }),
+    ).toBeEnabled();
+  });
+
   it("should not open an editable empty-note modal for an existing note without a loader", async () => {
     // Given
     const user = userEvent.setup();

--- a/ui/components/findings/table/finding-triage-cells.test.tsx
+++ b/ui/components/findings/table/finding-triage-cells.test.tsx
@@ -162,11 +162,6 @@ describe("finding triage cells", () => {
     await user.click(statusControl);
 
     // Then
-    expect(screen.getByText("Triage").parentElement).toHaveClass(
-      "text-text-neutral-secondary",
-      "text-[10px]",
-      "whitespace-nowrap",
-    );
     expect(statusControl.parentElement).toHaveClass("w-32");
     expect(statusControl).toHaveAttribute("data-size", "xs");
     expect(within(statusControl).getByText("Under Review")).toHaveClass(

--- a/ui/components/findings/table/finding-triage-cells.test.tsx
+++ b/ui/components/findings/table/finding-triage-cells.test.tsx
@@ -66,6 +66,7 @@ import {
 
 import {
   FindingNoteActionItem,
+  FindingTriageStatusBadge,
   FindingTriageStatusCell,
 } from "./finding-triage-cells";
 
@@ -190,6 +191,22 @@ describe("finding triage cells", () => {
         "False Positive",
       ),
     ).toHaveClass("text-text-neutral-secondary");
+  });
+
+  it("renders a read-only triage status badge with the status color", () => {
+    // Given / When
+    render(
+      <FindingTriageStatusBadge
+        triage={makeTriageSummary({
+          status: FINDING_TRIAGE_STATUS.REMEDIATING,
+          label: "Remediating",
+        })}
+      />,
+    );
+
+    // Then
+    expect(screen.getByText("Triage:")).toBeInTheDocument();
+    expect(screen.getByText("Remediating")).toHaveClass("text-bg-data-info");
   });
 
   it("should disable table status mutation when no update handler is wired", async () => {

--- a/ui/components/findings/table/finding-triage-cells.tsx
+++ b/ui/components/findings/table/finding-triage-cells.tsx
@@ -14,11 +14,13 @@ import {
   FINDING_TRIAGE_DISABLED_REASON,
   FINDING_TRIAGE_NOTE_MAX_LENGTH,
   FINDING_TRIAGE_ORIGIN,
+  FINDING_TRIAGE_RESOLVED_LOCKED_COPY,
   FINDING_TRIAGE_STATUS_LABELS,
   type FindingTriageDetail,
   type FindingTriageLoadedNote,
   type FindingTriageStatus,
   type FindingTriageSummary,
+  isTriageStatusLocked,
   type UpdateFindingTriageInput,
 } from "@/types/findings-triage";
 
@@ -38,12 +40,19 @@ export const EDITING_UNAVAILABLE_COPY = "Editing is currently unavailable.";
 const getDisabledCopy = ({
   triage,
   hasUpdateHandler,
+  lockResolved = false,
 }: {
   triage: FindingTriageSummary;
   hasUpdateHandler: boolean;
+  lockResolved?: boolean;
 }): string | undefined => {
   if (triage.disabledReason === FINDING_TRIAGE_DISABLED_REASON.CLOUD_ONLY) {
     return CLOUD_ONLY_TOOLTIP_COPY;
+  }
+
+  // Status-picker only: notes stay available on resolved findings.
+  if (lockResolved && isTriageStatusLocked(triage.status)) {
+    return FINDING_TRIAGE_RESOLVED_LOCKED_COPY;
   }
 
   if (triage.canEdit && !hasUpdateHandler) {
@@ -151,6 +160,7 @@ export function FindingTriageStatusCell({
   const disabledCopy = getDisabledCopy({
     triage,
     hasUpdateHandler: Boolean(onTriageUpdateAction),
+    lockResolved: true,
   });
   if (!disabledCopy) {
     return control;

--- a/ui/components/findings/table/finding-triage-cells.tsx
+++ b/ui/components/findings/table/finding-triage-cells.tsx
@@ -13,7 +13,6 @@ import { cn } from "@/lib/utils";
 import {
   FINDING_TRIAGE_DISABLED_REASON,
   FINDING_TRIAGE_NOTE_MAX_LENGTH,
-  FINDING_TRIAGE_NOTE_PRIVACY_COPY,
   FINDING_TRIAGE_ORIGIN,
   FINDING_TRIAGE_STATUS_LABELS,
   type FindingTriageDetail,
@@ -62,7 +61,6 @@ const getTriageDetailFromSummary = (
   noteId: loadedNote?.noteId ?? null,
   noteBody: loadedNote?.noteBody ?? "",
   maxNoteLength: FINDING_TRIAGE_NOTE_MAX_LENGTH,
-  privacyCopy: FINDING_TRIAGE_NOTE_PRIVACY_COPY,
 });
 
 export function FindingTriageStatusCell({

--- a/ui/components/findings/table/finding-triage-cells.tsx
+++ b/ui/components/findings/table/finding-triage-cells.tsx
@@ -159,8 +159,7 @@ export function FindingTriageStatusCell({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        {/* Block-level so the tooltip wrapper doesn't add inline baseline spacing
-            that would push the compact "Triage" label below the sibling columns. */}
+        {/* Block-level wrapper keeps the picker aligned with the sibling columns. */}
         <span className="flex">{control}</span>
       </TooltipTrigger>
       <TooltipContent>{disabledCopy}</TooltipContent>

--- a/ui/components/findings/table/finding-triage-cells.tsx
+++ b/ui/components/findings/table/finding-triage-cells.tsx
@@ -9,6 +9,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/shadcn/tooltip";
+import { cn } from "@/lib/utils";
 import {
   FINDING_TRIAGE_DISABLED_REASON,
   FINDING_TRIAGE_NOTE_MAX_LENGTH,
@@ -29,6 +30,7 @@ import {
 import {
   FindingTriageStatusControl,
   type FindingTriageUpdateHandler,
+  TRIAGE_STATUS_TEXT_CLASS,
 } from "./finding-triage-status-control";
 
 export const CLOUD_ONLY_TOOLTIP_COPY = "Available in Prowler Cloud";
@@ -164,6 +166,28 @@ export function FindingTriageStatusCell({
       </TooltipTrigger>
       <TooltipContent>{disabledCopy}</TooltipContent>
     </Tooltip>
+  );
+}
+
+// Read-only triage status indicator, e.g. for the side drawer header where the
+// editable picker would be out of place among the status/severity badges.
+export function FindingTriageStatusBadge({
+  triage,
+}: {
+  triage: FindingTriageSummary;
+}) {
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-text-neutral-tertiary text-xs">Triage:</span>
+      <span
+        className={cn(
+          "text-xs font-medium",
+          TRIAGE_STATUS_TEXT_CLASS[triage.status],
+        )}
+      >
+        {triage.label}
+      </span>
+    </div>
   );
 }
 

--- a/ui/components/findings/table/finding-triage-status-control.tsx
+++ b/ui/components/findings/table/finding-triage-status-control.tsx
@@ -3,7 +3,6 @@
 import { type ComponentProps, useState } from "react";
 
 import { Button } from "@/components/shadcn";
-import { InfoField } from "@/components/shadcn/info-field/info-field";
 import { Modal } from "@/components/shadcn/modal";
 import {
   Select,
@@ -174,16 +173,14 @@ export function FindingTriageStatusControl(
 
   return (
     <>
-      <InfoField label="Triage" variant="compact">
-        <div className="w-32">
-          <TriageStatusPicker
-            disabled={!canMutateFromTable}
-            size="xs"
-            value={triage.status}
-            onValueChange={handleTableValueChange}
-          />
-        </div>
-      </InfoField>
+      <div className="w-32">
+        <TriageStatusPicker
+          disabled={!canMutateFromTable}
+          size="xs"
+          value={triage.status}
+          onValueChange={handleTableValueChange}
+        />
+      </div>
       {tableUpdateError && (
         <span className="sr-only" role="alert">
           {tableUpdateError}

--- a/ui/components/findings/table/finding-triage-status-control.tsx
+++ b/ui/components/findings/table/finding-triage-status-control.tsx
@@ -21,6 +21,7 @@ import {
   getFindingTriageMuteInfoCopy,
   isManualStatus,
   isMutelistShortcutStatus,
+  isTriageStatusLocked,
   type UpdateFindingTriageInput,
 } from "@/types/findings-triage";
 
@@ -117,7 +118,7 @@ export function FindingTriageStatusControl(
   if (props.origin === FINDING_TRIAGE_ORIGIN.MODAL) {
     return (
       <TriageStatusPicker
-        disabled={!triage.canEdit}
+        disabled={!triage.canEdit || isTriageStatusLocked(triage.status)}
         value={props.value}
         onValueChange={props.onValueChange}
       />
@@ -125,7 +126,10 @@ export function FindingTriageStatusControl(
   }
 
   const canMutateFromTable =
-    triage.canEdit && Boolean(props.onTriageUpdateAction) && !isTableUpdating;
+    triage.canEdit &&
+    Boolean(props.onTriageUpdateAction) &&
+    !isTableUpdating &&
+    !isTriageStatusLocked(triage.status);
 
   const applyTableStatus = async (status: FindingTriageManualStatus) => {
     if (!props.onTriageUpdateAction || status === triage.status) {

--- a/ui/components/findings/table/finding-triage-status-control.tsx
+++ b/ui/components/findings/table/finding-triage-status-control.tsx
@@ -18,6 +18,7 @@ import {
   type FindingTriageManualStatus,
   type FindingTriageStatus,
   type FindingTriageSummary,
+  getFindingTriageMuteInfoCopy,
   isManualStatus,
   isMutelistShortcutStatus,
   type UpdateFindingTriageInput,
@@ -42,8 +43,6 @@ export const TRIAGE_STATUS_TEXT_CLASS = {
 } as const satisfies Record<FindingTriageStatus, string>;
 
 const MUTELIST_CONFIRMATION_TITLE = "Mute finding?";
-const MUTELIST_CONFIRMATION_COPY =
-  "Changing to this triage status will mute the finding.";
 
 function TriageStatusPicker({
   disabled,
@@ -194,7 +193,11 @@ export function FindingTriageStatusControl(
           }
         }}
         title={MUTELIST_CONFIRMATION_TITLE}
-        description={MUTELIST_CONFIRMATION_COPY}
+        description={
+          pendingShortcutStatus
+            ? getFindingTriageMuteInfoCopy(pendingShortcutStatus)
+            : undefined
+        }
         size="sm"
       >
         <div className="flex justify-end gap-2 pt-2">

--- a/ui/components/findings/table/finding-triage-status-control.tsx
+++ b/ui/components/findings/table/finding-triage-status-control.tsx
@@ -31,7 +31,7 @@ type TriageStatusPickerSize = NonNullable<
   ComponentProps<typeof SelectTrigger>["size"]
 >;
 
-const TRIAGE_STATUS_TEXT_CLASS = {
+export const TRIAGE_STATUS_TEXT_CLASS = {
   open: "text-text-error-primary",
   under_review: "text-text-warning-primary",
   remediating: "text-bg-data-info",

--- a/ui/components/findings/table/finding-triage-submit.test.ts
+++ b/ui/components/findings/table/finding-triage-submit.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   FINDING_TRIAGE_NOTE_MAX_LENGTH,
-  FINDING_TRIAGE_NOTE_PRIVACY_COPY,
   FINDING_TRIAGE_STATUS,
   type FindingTriageDetail,
 } from "@/types/findings-triage";
@@ -26,7 +25,6 @@ function makeTriageDetail(
     noteId: "note-1",
     noteBody: "Existing investigation note",
     maxNoteLength: FINDING_TRIAGE_NOTE_MAX_LENGTH,
-    privacyCopy: FINDING_TRIAGE_NOTE_PRIVACY_COPY,
     ...overrides,
   };
 }

--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.test.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.test.tsx
@@ -461,6 +461,12 @@ vi.mock("../finding-triage-cells", () => ({
     ) : (
       <span>-</span>
     ),
+  FindingTriageStatusBadge: ({ triage }: { triage: { label: string } }) => (
+    <div>
+      <span>Triage:</span>
+      <span>{triage.label}</span>
+    </div>
+  ),
 }));
 
 vi.mock("./resource-detail-skeleton", () => ({

--- a/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
+++ b/ui/components/findings/table/resource-detail-drawer/resource-detail-drawer-content.tsx
@@ -84,6 +84,7 @@ import { Muted } from "../../muted";
 import { DeltaIndicator } from "../delta-indicator";
 import {
   FindingNoteActionItem,
+  FindingTriageStatusBadge,
   FindingTriageStatusCell,
 } from "../finding-triage-cells";
 import { DeltaValues, NotificationIndicator } from "../notification-indicator";
@@ -560,6 +561,7 @@ export function ResourceDetailDrawerContent({
           {findingIsMuted !== undefined && (
             <Muted isMuted={findingIsMuted} mutedReason={findingMutedReason} />
           )}
+          {findingTriage && <FindingTriageStatusBadge triage={findingTriage} />}
         </div>
 
         {showCheckMetaContent ? (

--- a/ui/components/overview/new-findings-table/table/column-latest-findings.tsx
+++ b/ui/components/overview/new-findings-table/table/column-latest-findings.tsx
@@ -2,10 +2,18 @@
 
 import { ColumnDef } from "@tanstack/react-table";
 
+import {
+  loadLatestFindingTriageNote,
+  updateFindingTriage,
+} from "@/actions/findings";
 import { getStandaloneFindingColumns } from "@/components/findings/table/column-standalone-findings";
 import { FindingProps } from "@/types";
 
 export const ColumnLatestFindings: ColumnDef<FindingProps>[] =
   getStandaloneFindingColumns({
     includeUpdatedAt: true,
+    onTriageUpdateAction: async (input) => {
+      await updateFindingTriage(input);
+    },
+    onTriageNoteLoadAction: loadLatestFindingTriageNote,
   });

--- a/ui/components/shadcn/dialog.tsx
+++ b/ui/components/shadcn/dialog.tsx
@@ -85,7 +85,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      className={cn("flex flex-col gap-2 text-left", className)}
       {...props}
     />
   );

--- a/ui/lib/external-urls.ts
+++ b/ui/lib/external-urls.ts
@@ -6,6 +6,8 @@ export const DOCS_URLS = {
     "https://docs.prowler.com/user-guide/tutorials/prowler-app#step-8:-analyze-the-findings",
   FINDINGS_INGESTION:
     "https://docs.prowler.com/user-guide/tutorials/prowler-app-import-findings",
+  FINDINGS_TRIAGE:
+    "https://docs.prowler.com/user-guide/tutorials/prowler-app-findings-triage",
   AWS_ORGANIZATIONS:
     "https://docs.prowler.com/user-guide/tutorials/prowler-cloud-aws-organizations",
   ALERTS: "https://docs.prowler.com/user-guide/tutorials/prowler-app-alerts",

--- a/ui/types/findings-triage.ts
+++ b/ui/types/findings-triage.ts
@@ -57,6 +57,14 @@ export const isMutelistShortcutStatus = (status: unknown): boolean => {
 export const getFindingTriageMuteInfoCopy = (status: FindingTriageStatus) =>
   `Changing triage to ${FINDING_TRIAGE_STATUS_LABELS[status]} will mute the finding`;
 
+// Only RESOLVED locks manual edits: automation owns the transition out of it
+// (REOPENED on a failing rescan), while REOPENED invites human re-triage.
+export const isTriageStatusLocked = (status: FindingTriageStatus): boolean =>
+  status === FINDING_TRIAGE_STATUS.RESOLVED;
+
+export const FINDING_TRIAGE_RESOLVED_LOCKED_COPY =
+  "Triage status is managed automatically once the finding is resolved." as const;
+
 export const FINDING_TRIAGE_DISABLED_REASON = {
   CLOUD_ONLY: "cloud_only",
   FORBIDDEN: "forbidden",

--- a/ui/types/findings-triage.ts
+++ b/ui/types/findings-triage.ts
@@ -54,6 +54,9 @@ export const isMutelistShortcutStatus = (status: unknown): boolean => {
   );
 };
 
+export const getFindingTriageMuteInfoCopy = (status: FindingTriageStatus) =>
+  `Changing triage to ${FINDING_TRIAGE_STATUS_LABELS[status]} will mute the finding`;
+
 export const FINDING_TRIAGE_DISABLED_REASON = {
   CLOUD_ONLY: "cloud_only",
   FORBIDDEN: "forbidden",
@@ -69,8 +72,6 @@ export const FINDING_TRIAGE_ORIGIN = {
 } as const;
 
 export const FINDING_TRIAGE_NOTE_MAX_LENGTH = 500 as const;
-export const FINDING_TRIAGE_NOTE_PRIVACY_COPY =
-  "This note is only visible to your team." as const;
 export const FINDING_TRIAGE_BILLING_HREF =
   "https://prowler.com/pricing" as const;
 
@@ -92,7 +93,6 @@ export interface FindingTriageDetail extends FindingTriageSummary {
   noteId: string | null;
   noteBody: string;
   maxNoteLength: typeof FINDING_TRIAGE_NOTE_MAX_LENGTH;
-  privacyCopy: typeof FINDING_TRIAGE_NOTE_PRIVACY_COPY;
 }
 
 export interface UpdateFindingTriageInput {


### PR DESCRIPTION
### Context

QA follow-ups on the Findings Triage UI (#11704) after testing in dev. UI-only; backend/API remains out of scope.

### Description

**Latest New Failed Findings (Overview table)**

- Exclude muted findings explicitly with `filter[muted]=false`, matching the other Overview widgets. The view previously relied on the API default, which changed.
- Remove the redundant per-row `Triage` label above the status selector where the table already has a `Triage` column header. Headerless nested rows (findings expanded inside a finding group) keep their compact per-cell label, like Service/Region/Last seen.
- Enable triage editing: wire `updateFindingTriage` and `loadLatestFindingTriageNote` into the Overview columns so the status selector and `Add Triage Note` action work (previously no handler was wired, so they rendered disabled).
- Enforce a 160px minimum width on the `Finding` column (content-based `min-w`, since this table uses auto layout where TanStack `minSize` has no effect).

**Side drawers**

- Show a read-only triage status badge (`Triage: <status>`) in the drawer header next to the Status/Severity/Delta/Muted indicators. Covers both the resource detail drawer and the finding detail drawer (shared content component).

**Triage copy & behavior**

- Mutelist warnings now name the target status: `Changing triage to Risk Accepted will mute the finding` / `Changing triage to False Positive will mute the finding`, both in the table confirmation modal and the note modal (single shared helper).
- Remediating info copy updated to: `Once this finding is remediated, if in the following scan its status changes to Pass, it will be automatically changed to Resolved`, with a `Learn more` documentation link.
- Removed `This note is only visible to your team.` from the note modal (field removed from the DTO contract end to end).
- Lock manual triage edits for `Resolved` findings (UI only): automation owns the transition out of Resolved (`Reopened` on a failing rescan). Table and modal pickers are disabled with an explanatory tooltip/alert; notes remain available. `Reopened` stays manually editable.

> **Note for reviewers:** the `Learn more` link points to `https://docs.prowler.com/user-guide/tutorials/prowler-app-findings-triage`, which does not exist yet — please confirm the final docs URL or land the docs page alongside this change.

### Steps to review

1. Overview → Latest New Failed Findings: muted findings are not listed, no per-row `Triage` label, triage status is editable and `Add Triage Note` works, and the Finding column never shrinks below 160px.
2. Open a finding/resource side drawer: the header shows `Triage: <status>` next to the existing badges.
3. From any findings table, change triage to Risk Accepted or False Positive: the confirmation modal names the status. Same message inside the note modal when selecting those statuses.
4. In the note modal, select Remediating: check the new copy and the `Learn more` link. Confirm the privacy note is gone.
5. On a finding with triage status Resolved: the status picker is disabled (tooltip in table, info alert in modal) while adding/opening notes still works.
6. Run:

```bash
cd ui
pnpm test:unit findings-triage finding-note-modal finding-triage-cells column-standalone-findings column-finding-resources column-finding-groups resource-detail-drawer-content findings-view
pnpm run healthcheck
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md). Not applicable.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable. Not applicable; follow-up of #11704, which ships without a changelog entry (`no-changelog`).

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [x] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient. No npm dependencies added.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable. Not applicable; `no-changelog` label is applied.

#### API
- [x] All issue/task requirements work as expected on the API. API/backend out of scope.
- [x] Endpoint response output (if applicable). Not applicable.
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable). Not applicable.
- [x] Performance test results (if applicable). Not applicable.
- [x] Any other relevant evidence of the implementation (if applicable). Not applicable.
- [x] Verify if API specs need to be regenerated. Not applicable.
- [x] Check if version updates are required (e.g., specs, uv, etc.). Not applicable.
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable. Not applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compact “Triage” badges across the findings table and resource detail drawers.
  * Added “Learn more” links in findings triage alerts.
* **Bug Fixes**
  * Muted findings are now excluded by default from the findings overview.
  * Resolved triage status is now locked to prevent status changes while note editing remains available.
  * Removed outdated triage privacy-copy text from the triage note modal and updated related triage/mute guidance.
* **UI Improvements**
  * Refined tooltip and mute-confirmation messaging for locked/resolved and mute-change scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
