### PR TITLE
fix(compliance): skip MANUAL findings in section tally to avoid KeyError

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
+## Unreleased
+
+### 🐛 Fixed
+
+- `KeyError: 'MANUAL'` crash while rendering the compliance summary table (e.g. CIS Microsoft 365) when a framework has manual, checks-less requirements with a Level 1/Level 2 profile; `MANUAL` findings are now skipped in the PASS/FAIL section tally instead of raising [(#11822)](https://github.com/prowler-cloud/prowler/issues/11822)
+
 ## [5.32.0] (Prowler v5.32.0)
 
 ### 🚀 Added

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ## [5.32.1] (Prowler UNRELEASED)
 
-### 🐛 Fixed
+### 🐞 Fixed
 
 - `KeyError: 'MANUAL'` crash while rendering the compliance summary table (e.g. CIS Microsoft 365) when a framework has manual, checks-less requirements with a Level 1/Level 2 profile; `MANUAL` findings are now skipped in the PASS/FAIL section tally instead of raising [(#11822)](https://github.com/prowler-cloud/prowler/issues/11822)
 

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
-## Unreleased
+## [5.32.1] (Prowler UNRELEASED)
 
 ### 🐛 Fixed
 
 - `KeyError: 'MANUAL'` crash while rendering the compliance summary table (e.g. CIS Microsoft 365) when a framework has manual, checks-less requirements with a Level 1/Level 2 profile; `MANUAL` findings are now skipped in the PASS/FAIL section tally instead of raising [(#11822)](https://github.com/prowler-cloud/prowler/issues/11822)
+
+---
 
 ## [5.32.0] (Prowler v5.32.0)
 

--- a/prowler/lib/check/compliance_config_eval.py
+++ b/prowler/lib/check/compliance_config_eval.py
@@ -395,6 +395,12 @@ def accumulate_group_status(
 ) -> None:
     """Count a finding once per group, upgrading a counted PASS to FAIL on conflict (mutates ``counts``/``seen``)."""
     previous = seen.get(index)
+    if status == "MANUAL":
+        # MANUAL findings come from manual, checks-less requirements and are
+        # informational only: they have no PASS/FAIL/Muted column in the section
+        # tally, so counting them would raise KeyError on counts[status] += 1.
+        # Skip them (an unexpected status still raises loudly below).
+        return
     if previous is None:
         seen[index] = status
         counts[status] += 1

--- a/tests/lib/check/compliance_config_eval_test.py
+++ b/tests/lib/check/compliance_config_eval_test.py
@@ -351,6 +351,37 @@ class Test_accumulate_group_status:
         with pytest.raises(KeyError):
             accumulate_group_status(0, "Muted", counts, {})
 
+    def test_manual_status_is_ignored_not_counted(self):
+        # A MANUAL finding (from a manual, checks-less requirement) has no
+        # PASS/FAIL/Muted column: it must be skipped, not raise KeyError, and
+        # not appear in the tally. Regression test for the M365 CIS compliance
+        # crash "KeyError: 'MANUAL'" (issue #11822).
+        counts = {"FAIL": 0, "PASS": 0}
+        seen = {}
+        accumulate_group_status(0, "MANUAL", counts, seen)
+        assert counts == {"FAIL": 0, "PASS": 0}
+        assert seen == {}
+
+    def test_manual_mixed_with_pass_and_fail(self):
+        # MANUAL findings interleaved with real PASS/FAIL ones only skip
+        # themselves; the PASS/FAIL tally is unaffected.
+        counts = {"FAIL": 0, "PASS": 0}
+        seen = {}
+        accumulate_group_status(0, "MANUAL", counts, seen)
+        accumulate_group_status(1, "PASS", counts, seen)
+        accumulate_group_status(2, "FAIL", counts, seen)
+        accumulate_group_status(3, "MANUAL", counts, seen)
+        assert counts == {"FAIL": 1, "PASS": 1}
+
+    def test_manual_ignored_on_counts_with_muted_key(self):
+        # MANUAL is skipped regardless of the counts shape (e.g. the universal
+        # table's PASS/FAIL/Muted buckets), never creating a "MANUAL" key.
+        counts = {"FAIL": 0, "PASS": 0, "Muted": 0}
+        seen = {}
+        accumulate_group_status(0, "MANUAL", counts, seen)
+        assert counts == {"FAIL": 0, "PASS": 0, "Muted": 0}
+        assert "MANUAL" not in counts
+
 
 class Test_apply_config_status:
     def test_none_config_status_keeps_finding(self):


### PR DESCRIPTION
### Context

Fixes #11822.

A Prowler Microsoft 365 scan with `--output-formats json-ocsf csv` crashes during the compliance-reporting phase:

```
[File: compliance.py:295]  [Module: compliance]  CRITICAL: KeyError:187 -- 'MANUAL'
```

Prowler exits with code 1 and **no OCSF/CSV output is written**. It reproduces on any framework that has manual, checks-less requirements carrying a `Level 1`/`Level 2` profile — CIS Microsoft 365 4.0 alone has **52** such requirements.

### Root cause

The per-section summary buckets are initialized with only `PASS`/`FAIL` (and sometimes `Muted`) keys. For example `get_cis_table` (`prowler/lib/outputs/compliance/cis/cis.py`) does:

```python
sections[section] = {
    "Status": ...,
    "Level 1": {"FAIL": 0, "PASS": 0},   # no "MANUAL" key
    "Level 2": {"FAIL": 0, "PASS": 0},
    "Muted": 0,
}
```

A manual requirement (empty `Checks`) produces a finding with `status == "MANUAL"` (see `cis_m365.py`, which sets `Status="MANUAL"`). That status flows through `get_effective_status` unchanged and reaches the shared `accumulate_group_status`:

```python
def accumulate_group_status(index, status, counts, seen):
    previous = seen.get(index)
    if previous is None:
        seen[index] = status
        counts[status] += 1      # <- KeyError: 'MANUAL'
```

Since `counts` has no `"MANUAL"` key, `counts[status] += 1` raises `KeyError: 'MANUAL'`, which the top-level compliance handler turns into a `CRITICAL` + `sys.exit(1)`.

This shared helper is used by CIS, MITRE ATT&CK, C5, CCC, ASD Essential Eight, ThreatScore and the universal tables, so the bug is a class, not an M365-only quirk.

### Fix

`MANUAL` findings come from manual checks and are **informational** — they are not part of the PASS/FAIL/Muted tally. `accumulate_group_status` now skips them instead of trying to count them:

```python
    previous = seen.get(index)
    if status == "MANUAL":
        # MANUAL findings come from manual, checks-less requirements and are
        # informational only: they have no PASS/FAIL/Muted column in the section
        # tally, so counting them would raise KeyError on counts[status] += 1.
        # Skip them (an unexpected status still raises loudly below).
        return
```

This mirrors the sibling `accumulate_overview_status`, which already ignores statuses it does not track. The change is deliberately scoped to the known `MANUAL` status: a genuinely unexpected status still raises loudly (the existing `test_muted_on_fail_pass_only_counts_raises` safety-net test is untouched and still passes).

### Before / after

Reproducing the exact failing call (the CIS `Level 1` bucket receiving a `MANUAL` finding):

| | `accumulate_group_status(0, "MANUAL", {"FAIL": 0, "PASS": 0}, {})` |
|---|---|
| **Before** | `KeyError: 'MANUAL'` (compliance output aborts, exit 1) |
| **After** | no-op — `{"FAIL": 0, "PASS": 0}` (MANUAL not counted) |

PASS/FAIL counting, the PASS→FAIL upgrade path, and `Muted` counting (where the bucket has a `Muted` key) are all unchanged.

### Steps to review / tests

Added three regression tests to `Test_accumulate_group_status` in `tests/lib/check/compliance_config_eval_test.py`:

- `test_manual_status_is_ignored_not_counted` — MANUAL against a `PASS`/`FAIL`-only bucket is skipped, no `KeyError`.
- `test_manual_mixed_with_pass_and_fail` — interleaved real PASS/FAIL findings are still tallied correctly.
- `test_manual_ignored_on_counts_with_muted_key` — MANUAL is skipped for `PASS`/`FAIL`/`Muted` buckets too, never creating a `"MANUAL"` key.

Proof the tests guard the bug (stash the source fix, keep the tests):

```
# without the fix
3 failed  ->  KeyError: 'MANUAL' at compliance_config_eval.py:400
# with the fix
9 passed  (whole Test_accumulate_group_status class)
```

The remaining 3 failures in this test module on my machine (`Test_get_scan_audit_config` / `Test_get_scan_provider_type`) are **pre-existing and unrelated** — they patch `prowler.providers.common.provider`, which needs the full provider package installed; they fail identically on a clean checkout without this change.

`ruff check` and `ruff format --check` pass on both changed Python files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compliance-table rendering crash for frameworks with manual, checks-less requirements.
  * Manual findings are now ignored during PASS/FAIL tallying to prevent tally errors and keep summaries accurate.

* **Tests**
  * Added unit tests to verify manual findings are skipped, don’t create unexpected tally buckets, and don’t impact PASS/FAIL counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->