### PR TITLE
fix(api): add attack paths scan DB defaults

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
+## [1.33.1] (Prowler UNRELEASED)
+
+### 🐞 Fixed
+
+- Attack Paths: Scan rows now have database defaults for `is_migrated` and `sink_backend` so `scan-perform-scheduled` inserts survive deploy skew [(#11826)](https://github.com/prowler-cloud/prowler/pull/11826)
+
+---
+
 ## [1.33.0] (Prowler v5.32.0)
 
 ### 🚀 Added

--- a/api/src/backend/api/migrations/0097_attack_paths_scan_db_defaults.py
+++ b/api/src/backend/api/migrations/0097_attack_paths_scan_db_defaults.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0096_attack_paths_scan_is_migrated"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="attackpathsscan",
+            name="is_migrated",
+            field=models.BooleanField(db_default=False, default=False),
+        ),
+        migrations.AlterField(
+            model_name="attackpathsscan",
+            name="sink_backend",
+            field=models.CharField(
+                choices=[("neo4j", "Neo4j"), ("neptune", "Neptune")],
+                db_default="neo4j",
+                default="neo4j",
+                max_length=16,
+            ),
+        ),
+    ]

--- a/api/src/backend/api/models.py
+++ b/api/src/backend/api/models.py
@@ -814,9 +814,10 @@ class AttackPathsScan(RowLevelSecurityProtectedModel):
     # still using the previous graph shape. Query catalog selection uses this
     # flag; physical read routing uses sink_backend below.
     # TODO: drop after Neptune cutover
-    is_migrated = models.BooleanField(default=False)
+    is_migrated = models.BooleanField(default=False, db_default=False)
     sink_backend = models.CharField(
         choices=SinkBackendChoices.choices,
+        db_default=SinkBackendChoices.NEO4J,
         default=SinkBackendChoices.NEO4J,
         max_length=16,
     )

--- a/api/src/backend/tasks/tests/test_attack_paths_scan.py
+++ b/api/src/backend/tasks/tests/test_attack_paths_scan.py
@@ -2,8 +2,10 @@ from contextlib import nullcontext
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
+from uuid import uuid4
 
 import pytest
+from api.db_utils import rls_transaction
 from api.models import (
     AttackPathsScan,
     Finding,
@@ -15,6 +17,7 @@ from api.models import (
     StatusChoices,
     Task,
 )
+from django.db import connection
 from django_celery_results.models import TaskResult
 from prowler.lib.check.models import Severity
 from tasks.jobs.attack_paths import findings as findings_module
@@ -2243,6 +2246,58 @@ class TestInternetAnalysis:
 @pytest.mark.django_db
 class TestAttackPathsDbUtilsGraphDataReady:
     """Tests for db_utils functions related to graph_data_ready lifecycle."""
+
+    def test_database_defaults_allow_legacy_insert_without_cutover_columns(
+        self, tenants_fixture, providers_fixture, scans_fixture
+    ):
+        tenant = tenants_fixture[0]
+        provider = providers_fixture[0]
+        provider.provider = Provider.ProviderChoices.AWS
+        provider.save()
+        scan = scans_fixture[0]
+        scan.provider = provider
+        scan.save()
+
+        attack_paths_scan_id = uuid4()
+        now = datetime.now(tz=UTC)
+
+        with rls_transaction(str(tenant.id)), connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO attack_paths_scans (
+                    id,
+                    inserted_at,
+                    updated_at,
+                    state,
+                    progress,
+                    graph_data_ready,
+                    started_at,
+                    tenant_id,
+                    provider_id,
+                    scan_id
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                [
+                    attack_paths_scan_id,
+                    now,
+                    now,
+                    StateChoices.SCHEDULED,
+                    0,
+                    False,
+                    now,
+                    tenant.id,
+                    provider.id,
+                    scan.id,
+                ],
+            )
+
+            attack_paths_scan = AttackPathsScan.objects.get(id=attack_paths_scan_id)
+
+        assert attack_paths_scan.is_migrated is False
+        assert (
+            attack_paths_scan.sink_backend == AttackPathsScan.SinkBackendChoices.NEO4J
+        )
 
     def test_create_attack_paths_scan_first_scan_defaults_to_false(
         self, tenants_fixture, providers_fixture, scans_fixture

--- a/api/src/backend/tasks/tests/test_attack_paths_scan.py
+++ b/api/src/backend/tasks/tests/test_attack_paths_scan.py
@@ -17,7 +17,7 @@ from api.models import (
     StatusChoices,
     Task,
 )
-from django.db import connection
+from django.db import DEFAULT_DB_ALIAS
 from django_celery_results.models import TaskResult
 from prowler.lib.check.models import Severity
 from tasks.jobs.attack_paths import findings as findings_module
@@ -2261,7 +2261,7 @@ class TestAttackPathsDbUtilsGraphDataReady:
         attack_paths_scan_id = uuid4()
         now = datetime.now(tz=UTC)
 
-        with rls_transaction(str(tenant.id)), connection.cursor() as cursor:
+        with rls_transaction(str(tenant.id), using=DEFAULT_DB_ALIAS) as cursor:
             cursor.execute(
                 """
                 INSERT INTO attack_paths_scans (


### PR DESCRIPTION
### Context

`scan-perform-scheduled` can create `attack_paths_scans` rows during scan completion. During deploy skew, older workers can omit the new cutover columns after migration `0096` has already run.

### Description

Adds database defaults for `is_migrated` and `sink_backend`, and covers legacy inserts with a regression test.

### Steps to review

- Run tests.
- Execute a scheduled Prowler scan with a pre-5.32.0 `scans` worker against a database already migrated to 5.32.0, and verify scan completion can create the `attack_paths_scans` row without failing.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Attack Paths scan inserts so scheduled scans continue working during deploy skew.
  * Added database defaults for scan migration status and sink backend, preventing missing-value insert failures.

* **Tests**
  * Added coverage for direct database inserts to confirm the expected defaults are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->