### PR TITLE
chore: mark 5.32.1 changelogs as released

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler API** are documented in this file.
 
-## [1.33.1] (Prowler UNRELEASED)
+## [1.33.1] (Prowler v5.32.1)
 
 ### 🐞 Fixed
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable changes to the **Prowler API** are documented in this file.
 - Attack Paths: Provider graph cleanup now deletes Neo4j and Neptune relationships in directed batches before deleting nodes [(#11755)](https://github.com/prowler-cloud/prowler/pull/11755)
 - `scan-perform` no longer reports an error when a provider is deleted during a running scan [(#11696)](https://github.com/prowler-cloud/prowler/pull/11696)
 
+---
+
 ## [1.32.1] (Prowler v5.31.1)
 
 ### 🐞 Fixed

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the **Prowler SDK** are documented in this file.
 
-## [5.32.1] (Prowler UNRELEASED)
+## [5.32.1] (Prowler v5.32.1)
 
 ### 🐞 Fixed
 


### PR DESCRIPTION
### Description

Marks the API and SDK changelog headers for the 5.32.1 release.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the API changelog entry for version 1.33.1 to reflect the latest Prowler release label.
  * Replaced the previous “unreleased” heading with the current version identifier (5.32.1) in the Prowler changelog.
  * Adjusted minor whitespace in the changelog for cleaner formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->