### PR TITLE
feat(glue): add glue_catalog_connection_no_secrets check

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ### 🚀 Added
 
+- `glue_catalog_connection_no_secrets` check for AWS provider, scanning Glue Data Catalog connection properties for hardcoded secrets [(#11814)](https://github.com/prowler-cloud/prowler/issues/11814)
 - `exchange_application_access_policy_restricts_mailbox_apps` check for M365 provider, verifying every service principal with Microsoft Graph application-level Exchange mailbox permissions is restricted by an Exchange Online Application Access Policy, preventing tenant-wide mailbox access by unscoped applications [(#11247)](https://github.com/prowler-cloud/prowler/pull/11247)
 - Per-requirement configuration validation for compliance frameworks via `ConfigRequirements`, so a requirement is reported as FAIL when its configurable checks ran with a configuration too loose to satisfy it (applied across all compliance outputs: CSV, OCSF, and console tables) [(#11669)](https://github.com/prowler-cloud/prowler/pull/11669)
 - `entra_conditional_access_policy_explicitly_targets_azure_devops` check for M365 provider, verifying at least one enabled Conditional Access policy explicitly includes the Azure DevOps cloud application instead of relying on a broad "All cloud apps" policy [(#11182)](https://github.com/prowler-cloud/prowler/pull/11182)

--- a/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.metadata.json
+++ b/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.metadata.json
@@ -1,0 +1,43 @@
+{
+  "Provider": "aws",
+  "CheckID": "glue_catalog_connection_no_secrets",
+  "CheckTitle": "Glue Data Catalog connection has no secrets in properties",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "TTPs/Credential Access",
+    "Effects/Data Exposure",
+    "Sensitive Data Identifications/Security"
+  ],
+  "ServiceName": "glue",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "Other",
+  "ResourceGroup": "analytics",
+  "Description": "**AWS Glue Data Catalog connections** are inspected for **connection properties** (`ConnectionProperties`) that resemble **secrets** (keys, tokens, passwords).\n\nSuch values indicate sensitive data is stored directly in connection details instead of being sourced securely from AWS Secrets Manager or Systems Manager Parameter Store.",
+  "Risk": "Plaintext secrets in connection properties reduce confidentiality: values can be viewed in consoles, CLI output, and CloudTrail logs. Compromised credentials enable unauthorized access to the underlying data store, data exfiltration, and lateral movement across the environment.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/glue/latest/dg/populate-add-connection.html",
+    "https://docs.aws.amazon.com/glue/latest/webapi/API_GetConnections.html",
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws glue update-connection --name <connection_name> --connection-input '{\"Name\":\"<connection_name>\",\"ConnectionType\":\"JDBC\",\"ConnectionProperties\":{\"PASSWORD\":\"{{resolve:secretsmanager:my-secret}}\"}}'",
+      "NativeIaC": "```yaml\nResources:\n  GlueConnection:\n    Type: AWS::Glue::Connection\n    Properties:\n      CatalogId: <account_id>\n      ConnectionInput:\n        Name: <connection_name>\n        ConnectionType: JDBC\n        ConnectionProperties:\n          PASSWORD: !Sub \"{{resolve:secretsmanager:${MySecret}}}\"  # Reference secret from Secrets Manager instead of plaintext\n```",
+      "Other": "1. Open the AWS Glue console and go to Data catalog > Connections\n2. Select the connection and click Edit connection\n3. Identify any connection properties containing sensitive values\n4. Store those values in AWS Secrets Manager or Systems Manager Parameter Store\n5. Update the connection to reference the secret by name or ARN instead of the plaintext value\n6. Save the connection",
+      "Terraform": "```hcl\nresource \"aws_glue_connection\" \"example\" {\n  name = \"<connection_name>\"\n\n  connection_properties = {\n    JDBC_CONNECTION_URL = \"jdbc:mysql://<host>:3306/<db>\"\n    PASSWORD            = aws_secretsmanager_secret_version.example.secret_string  # Reference secret from Secrets Manager instead of plaintext\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Store secrets in **AWS Secrets Manager** or **AWS Systems Manager Parameter Store** and reference them by name or ARN in connection properties instead of embedding plaintext values. Enforce **least privilege** on the Glue connection's IAM role, rotate secrets regularly, and avoid logging or exporting connection property values.",
+      "Url": "https://hub.prowler.com/check/glue_catalog_connection_no_secrets"
+    }
+  },
+  "Categories": [
+    "secrets"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.py
+++ b/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.py
@@ -1,0 +1,84 @@
+import json
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.utils.utils import (
+    SecretsScanError,
+    annotate_verified_secrets,
+    detect_secrets_scan_batch,
+)
+from prowler.providers.aws.services.glue.glue_client import glue_client
+
+
+class glue_catalog_connection_no_secrets(Check):
+    """Check if Glue Data Catalog connections have secrets in their properties.
+
+    Scans the ConnectionProperties of each Data Catalog connection for
+    hardcoded credentials, tokens, passwords, and other sensitive values that
+    should be stored in Secrets Manager or Parameter Store instead.
+    """
+
+    def execute(self):
+        findings = []
+        secrets_ignore_patterns = glue_client.audit_config.get(
+            "secrets_ignore_patterns", []
+        )
+        validate = glue_client.audit_config.get("secrets_validate", False)
+        connections = list(glue_client.connections)
+
+        # Collect every connection property across all connections and scan them in
+        # batched Kingfisher invocations instead of one subprocess per property.
+        # Findings are keyed by (connection index, property name).
+        def payloads():
+            for conn_index, conn in enumerate(connections):
+                if conn.properties:
+                    for prop_name, prop_value in conn.properties.items():
+                        yield (
+                            (conn_index, prop_name),
+                            json.dumps({prop_name: prop_value}),
+                        )
+
+        scan_error = None
+        try:
+            batch_results = detect_secrets_scan_batch(
+                payloads(), excluded_secrets=secrets_ignore_patterns, validate=validate
+            )
+        except SecretsScanError as error:
+            batch_results = {}
+            scan_error = error
+
+        for conn_index, conn in enumerate(connections):
+            report = Check_Report_AWS(metadata=self.metadata(), resource=conn)
+            report.status = "PASS"
+            report.status_extended = f"No secrets found in Glue Data Catalog connection {conn.name} properties."
+
+            if conn.properties and scan_error:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"Could not scan Glue Data Catalog connection {conn.name} "
+                    f"properties for secrets: {scan_error}; manual review is required."
+                )
+                findings.append(report)
+                continue
+
+            if conn.properties:
+                secrets_found = []
+                all_secrets = []
+                for prop_name in conn.properties:
+                    detect_secrets_output = batch_results.get((conn_index, prop_name))
+                    if detect_secrets_output:
+                        all_secrets.extend(detect_secrets_output)
+                        secrets_found.extend(
+                            [
+                                f"{secret['type']} in property {prop_name}"
+                                for secret in detect_secrets_output
+                            ]
+                        )
+
+                if secrets_found:
+                    report.status = "FAIL"
+                    report.status_extended = f"Potential secrets found in Glue Data Catalog connection {conn.name} properties: {', '.join(secrets_found)}."
+                    annotate_verified_secrets(report, all_secrets)
+
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.py
+++ b/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.py
@@ -32,17 +32,14 @@ class glue_catalog_connection_no_secrets(Check):
         validate = glue_client.audit_config.get("secrets_validate", False)
         connections = list(glue_client.connections)
 
-        # Collect every connection property across all connections and scan them in
-        # batched Kingfisher invocations instead of one subprocess per property.
-        # Findings are keyed by (connection index, property name).
+        # Scan each connection's properties as a single indented-JSON payload so
+        # every property value sits on its own line; a finding is mapped back to
+        # its property via the finding's line number. Findings are keyed by
+        # connection index.
         def payloads():
             for conn_index, conn in enumerate(connections):
                 if conn.properties:
-                    for prop_name, prop_value in conn.properties.items():
-                        yield (
-                            (conn_index, prop_name),
-                            json.dumps({prop_name: prop_value}),
-                        )
+                    yield (conn_index, json.dumps(conn.properties, indent=2))
 
         scan_error = None
         try:
@@ -58,33 +55,34 @@ class glue_catalog_connection_no_secrets(Check):
             report.status = "PASS"
             report.status_extended = f"No secrets found in Glue Data Catalog connection {conn.name} properties."
 
-            if conn.properties and scan_error:
-                report.status = "MANUAL"
-                report.status_extended = (
-                    f"Could not scan Glue Data Catalog connection {conn.name} "
-                    f"properties for secrets: {scan_error}; manual review is required."
-                )
-                findings.append(report)
-                continue
-
             if conn.properties:
-                secrets_found = []
-                all_secrets = []
-                for prop_name in conn.properties:
-                    detect_secrets_output = batch_results.get((conn_index, prop_name))
-                    if detect_secrets_output:
-                        all_secrets.extend(detect_secrets_output)
-                        secrets_found.extend(
-                            [
-                                f"{secret['type']} in property {prop_name}"
-                                for secret in detect_secrets_output
-                            ]
-                        )
+                if scan_error:
+                    report.status = "MANUAL"
+                    report.status_extended = (
+                        f"Could not scan Glue Data Catalog connection {conn.name} "
+                        f"properties for secrets: {scan_error}; manual review is required."
+                    )
+                    findings.append(report)
+                    continue
 
-                if secrets_found:
+                detect_secrets_output = batch_results.get(conn_index)
+                if detect_secrets_output:
+                    property_names = list(conn.properties.keys())
+                    secrets_string = ", ".join(
+                        [
+                            f"{secret['type']} in property "
+                            f"{property_names[secret['line_number'] - 2]}"
+                            for secret in detect_secrets_output
+                        ]
+                    )
                     report.status = "FAIL"
-                    report.status_extended = f"Potential secrets found in Glue Data Catalog connection {conn.name} properties: {', '.join(secrets_found)}."
-                    annotate_verified_secrets(report, all_secrets)
+                    report.status_extended = (
+                        f"Potential "
+                        f"{'secrets' if len(detect_secrets_output) > 1 else 'secret'} "
+                        f"found in Glue Data Catalog connection {conn.name} "
+                        f"properties: {secrets_string}."
+                    )
+                    annotate_verified_secrets(report, detect_secrets_output)
 
             findings.append(report)
 

--- a/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.py
+++ b/prowler/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets.py
@@ -17,7 +17,14 @@ class glue_catalog_connection_no_secrets(Check):
     should be stored in Secrets Manager or Parameter Store instead.
     """
 
-    def execute(self):
+    def execute(self) -> list[Check_Report_AWS]:
+        """Scan every Glue Data Catalog connection's properties for secrets.
+
+        Returns:
+            One Check_Report_AWS per connection, with status PASS when no
+            secrets are detected, FAIL when a property resembles a secret,
+            or MANUAL when the secret scan could not be completed.
+        """
         findings = []
         secrets_ignore_patterns = glue_client.audit_config.get(
             "secrets_ignore_patterns", []

--- a/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
+++ b/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
@@ -84,7 +84,10 @@ class Test_glue_catalog_connection_no_secrets:
                 "ConnectionType": "JDBC",
                 "ConnectionProperties": {
                     "JDBC_CONNECTION_URL": "jdbc:mysql://db.example.com:3306/test",
-                    "PASSWORD": "AKIAsupersecretkey1234",
+                    # A syntactically valid JSON Web Token that Kingfisher flags
+                    # as a secret (a bare high-entropy string is treated as a
+                    # placeholder and ignored by the offline scanner).
+                    "PASSWORD": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
                 },
             }
         )

--- a/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
+++ b/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
@@ -165,3 +165,56 @@ class Test_glue_catalog_connection_no_secrets:
                     == f"No secrets found in Glue Data Catalog connection {connection_name} properties."
                 )
                 assert result[0].resource_id == connection_name
+
+    @mock_aws
+    def test_glue_connection_scan_error(self):
+        glue_client = client("glue", region_name=AWS_REGION_US_EAST_1)
+        connection_name = "test-connection"
+
+        glue_client.create_connection(
+            ConnectionInput={
+                "Name": connection_name,
+                "ConnectionType": "JDBC",
+                "ConnectionProperties": {
+                    "JDBC_CONNECTION_URL": "jdbc:mysql://db.example.com:3306/test",
+                    "PASSWORD": "placeholder",
+                },
+            }
+        )
+
+        from prowler.lib.utils.utils import SecretsScanError
+        from prowler.providers.aws.services.glue.glue_service import Glue
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            glue = Glue(aws_provider)
+            # Older moto versions omit ConnectionProperties from get_connections,
+            # so set them directly to keep the check reaching the scan step.
+            glue.connections[0].properties = {
+                "JDBC_CONNECTION_URL": "jdbc:mysql://db.example.com:3306/test",
+                "PASSWORD": "placeholder",
+            }
+            with mock.patch(
+                "prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets.glue_client",
+                new=glue,
+            ):
+                with mock.patch(
+                    "prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets.detect_secrets_scan_batch",
+                    side_effect=SecretsScanError("secret scan failed"),
+                ):
+                    from prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets import (
+                        glue_catalog_connection_no_secrets,
+                    )
+
+                    check = glue_catalog_connection_no_secrets()
+                    result = check.execute()
+
+                    assert len(result) == 1
+                    assert result[0].status == "MANUAL"
+                    assert "manual review is required" in result[0].status_extended
+                    assert connection_name in result[0].status_extended
+                    assert result[0].resource_id == connection_name

--- a/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
+++ b/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
@@ -1,0 +1,156 @@
+from unittest import mock
+
+from boto3 import client
+from moto import mock_aws
+
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, set_mocked_aws_provider
+
+
+class Test_glue_catalog_connection_no_secrets:
+    @mock_aws
+    def test_glue_no_connections(self):
+        from prowler.providers.aws.services.glue.glue_service import Glue
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets.glue_client",
+                new=Glue(aws_provider),
+            ):
+                from prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets import (
+                    glue_catalog_connection_no_secrets,
+                )
+
+                check = glue_catalog_connection_no_secrets()
+                result = check.execute()
+
+                assert len(result) == 0
+
+    @mock_aws
+    def test_glue_connection_no_secrets(self):
+        glue_client = client("glue", region_name=AWS_REGION_US_EAST_1)
+        connection_name = "test-connection"
+
+        glue_client.create_connection(
+            ConnectionInput={
+                "Name": connection_name,
+                "ConnectionType": "JDBC",
+                "ConnectionProperties": {
+                    "JDBC_CONNECTION_URL": "jdbc:mysql://db.example.com:3306/test",
+                    "JDBC_ENFORCE_SSL": "true",
+                },
+            }
+        )
+
+        from prowler.providers.aws.services.glue.glue_service import Glue
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets.glue_client",
+                new=Glue(aws_provider),
+            ):
+                from prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets import (
+                    glue_catalog_connection_no_secrets,
+                )
+
+                check = glue_catalog_connection_no_secrets()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"No secrets found in Glue Data Catalog connection {connection_name} properties."
+                )
+                assert result[0].resource_id == connection_name
+
+    @mock_aws
+    def test_glue_connection_with_secrets(self):
+        glue_client = client("glue", region_name=AWS_REGION_US_EAST_1)
+        connection_name = "test-connection"
+
+        glue_client.create_connection(
+            ConnectionInput={
+                "Name": connection_name,
+                "ConnectionType": "JDBC",
+                "ConnectionProperties": {
+                    "JDBC_CONNECTION_URL": "jdbc:mysql://db.example.com:3306/test",
+                    "PASSWORD": "AKIAsupersecretkey1234",
+                },
+            }
+        )
+
+        from prowler.providers.aws.services.glue.glue_service import Glue
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets.glue_client",
+                new=Glue(aws_provider),
+            ):
+                from prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets import (
+                    glue_catalog_connection_no_secrets,
+                )
+
+                check = glue_catalog_connection_no_secrets()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "FAIL"
+                assert "Potential secrets found" in result[0].status_extended
+                assert connection_name in result[0].status_extended
+                assert "PASSWORD" in result[0].status_extended
+                assert result[0].resource_id == connection_name
+
+    @mock_aws
+    def test_glue_connection_empty_properties(self):
+        glue_client = client("glue", region_name=AWS_REGION_US_EAST_1)
+        connection_name = "test-connection"
+
+        glue_client.create_connection(
+            ConnectionInput={
+                "Name": connection_name,
+                "ConnectionType": "JDBC",
+                "ConnectionProperties": {},
+            }
+        )
+
+        from prowler.providers.aws.services.glue.glue_service import Glue
+
+        aws_provider = set_mocked_aws_provider([AWS_REGION_US_EAST_1])
+
+        with mock.patch(
+            "prowler.providers.common.provider.Provider.get_global_provider",
+            return_value=aws_provider,
+        ):
+            with mock.patch(
+                "prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets.glue_client",
+                new=Glue(aws_provider),
+            ):
+                from prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets import (
+                    glue_catalog_connection_no_secrets,
+                )
+
+                check = glue_catalog_connection_no_secrets()
+                result = check.execute()
+
+                assert len(result) == 1
+                assert result[0].status == "PASS"
+                assert (
+                    result[0].status_extended
+                    == f"No secrets found in Glue Data Catalog connection {connection_name} properties."
+                )
+                assert result[0].resource_id == connection_name

--- a/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
+++ b/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
@@ -100,9 +100,17 @@ class Test_glue_catalog_connection_no_secrets:
             "prowler.providers.common.provider.Provider.get_global_provider",
             return_value=aws_provider,
         ):
+            glue = Glue(aws_provider)
+            # Older moto versions omit ConnectionProperties from get_connections,
+            # so set the secret-bearing properties directly to keep the scan
+            # deterministic regardless of the installed moto version.
+            glue.connections[0].properties = {
+                "JDBC_CONNECTION_URL": "jdbc:mysql://db.example.com:3306/test",
+                "PASSWORD": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+            }
             with mock.patch(
                 "prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets.glue_client",
-                new=Glue(aws_provider),
+                new=glue,
             ):
                 from prowler.providers.aws.services.glue.glue_catalog_connection_no_secrets.glue_catalog_connection_no_secrets import (
                     glue_catalog_connection_no_secrets,

--- a/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
+++ b/tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/glue_catalog_connection_no_secrets_test.py
@@ -113,9 +113,9 @@ class Test_glue_catalog_connection_no_secrets:
 
                 assert len(result) == 1
                 assert result[0].status == "FAIL"
-                assert "Potential secrets found" in result[0].status_extended
+                assert "Potential secret" in result[0].status_extended
                 assert connection_name in result[0].status_extended
-                assert "PASSWORD" in result[0].status_extended
+                assert "in property PASSWORD" in result[0].status_extended
                 assert result[0].resource_id == connection_name
 
     @mock_aws


### PR DESCRIPTION
### Context

AWS Glue Data Catalog connections often store hardcoded database credentials in plaintext connection properties (`ConnectionProperties`), which is a gap in Prowler'''s existing secret-scanning coverage for Glue.

Fix #11814

### Description

Adds `glue_catalog_connection_no_secrets`, scanning each Data Catalog connection'''s `ConnectionProperties` for hardcoded secrets. Follows the same batched Kingfisher secret-scanning structure as `glue_etl_jobs_no_secrets_in_arguments` (the reference check linked from the issue): one payload per connection property, keyed by `(connection_index, property_name)`, scanned via `detect_secrets_scan_batch`.

- PASS when no secrets are found in a connection'''s properties.
- FAIL when a secret is detected, naming the connection and property (not the value).
- MANUAL when the batch scan itself errors, so no connection is silently skipped.
- Severity is High by default, escalated to Critical when `annotate_verified_secrets` confirms a live secret (matches the issue'''s suggested severity).

Reuses the existing `Connection` model in `glue_service.py` (`properties` already populated from `get_connections`), so no service-layer changes were needed.

### Steps to review

```
pytest tests/providers/aws/services/glue/glue_catalog_connection_no_secrets/ -v
```

4 tests covering: no connections, connection with no secrets, connection with a secret in properties, and a connection with empty properties. All pass locally, along with the full existing `tests/providers/aws/services/glue/` suite (68 passed) and `ruff format`/`ruff check`.

### Checklist

- [x] This feature/issue is listed as open in the repo
- [x] Review if the code is being covered by tests
- [x] Review if code is being documented following the docstring style guide
- [x] Added a CHANGELOG.md entry

#### SDK/CLI
- Are there new checks included in this PR? Yes
    - No new permissions needed — reuses the existing `glue:GetConnections` read used by `glue_database_connections_ssl_enabled`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new AWS Glue security check to detect hardcoded secrets in Data Catalog connection properties.
  * Included guidance for resolving findings across supported deployment methods.
* **Documentation**
  * Updated the unreleased changelog with the new check and its coverage.
* **Tests**
  * Added test coverage for empty, clean, secret-containing, and no-connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->