### PR TITLE
feat(glue): add glue_data_catalogs_connection_no_secrets_in_properties check

### DIFF
--- a/prowler/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/__init__.py
+++ b/prowler/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/__init__.py
@@ -1,0 +1,1 @@
+# empty init

--- a/prowler/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/glue_data_catalogs_connection_no_secrets_in_properties.metadata.json
+++ b/prowler/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/glue_data_catalogs_connection_no_secrets_in_properties.metadata.json
@@ -1,0 +1,43 @@
+{
+  "Provider": "aws",
+  "CheckID": "glue_data_catalogs_connection_no_secrets_in_properties",
+  "CheckTitle": "Glue Data Catalog connection has no secrets in properties",
+  "CheckType": [
+    "Software and Configuration Checks/AWS Security Best Practices",
+    "TTPs/Credential Access",
+    "Effects/Data Exposure",
+    "Sensitive Data Identifications/Security"
+  ],
+  "ServiceName": "glue",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "critical",
+  "ResourceType": "Other",
+  "ResourceGroup": "analytics",
+  "Description": "**AWS Glue Data Catalog connections** are inspected for **properties** (`ConnectionProperties`) that resemble **secrets** (keys, tokens, passwords).\n\nSuch values indicate sensitive data is stored directly in connection properties instead of being sourced securely from AWS Secrets Manager.",
+  "Risk": "Plaintext secrets in connection properties reduce confidentiality: values can be viewed in consoles, CLI output, and CloudTrail logs. Compromised credentials enable unauthorized AWS actions, data exfiltration, and lateral movement to the underlying data source.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://docs.aws.amazon.com/glue/latest/dg/populate-add-connection.html",
+    "https://docs.aws.amazon.com/glue/latest/webapi/API_Connection.html",
+    "https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "aws glue update-connection --name <connection_name> --connection-input '{\"Name\":\"<connection_name>\",\"ConnectionType\":\"JDBC\",\"ConnectionProperties\":{\"SECRET_ID\":\"<secret_name_or_arn>\"}}'",
+      "NativeIaC": "```yaml\nResources:\n  GlueConnection:\n    Type: AWS::Glue::Connection\n    Properties:\n      CatalogId: !Ref AWS::AccountId\n      ConnectionInput:\n        Name: <connection_name>\n        ConnectionType: JDBC\n        ConnectionProperties:\n          SECRET_ID: !Sub \"{{resolve:secretsmanager:${MySecret}}}\"  # Reference secret from Secrets Manager instead of plaintext\n```",
+      "Other": "1. Open the AWS Glue console and go to Data Catalog > Connections\n2. Select the connection and click Edit\n3. Identify any properties containing sensitive values like passwords\n4. Store those values securely in AWS Secrets Manager\n5. Update the connection to use the 'AWS Secrets Manager' credential type (or SECRET_ID property) referencing the secret by name or ARN instead of the plaintext password\n6. Save the connection",
+      "Terraform": "```hcl\nresource \"aws_glue_connection\" \"example\" {\n  name = \"<connection_name>\"\n\n  connection_properties = {\n    SECRET_ID = aws_secretsmanager_secret_version.example.secret_string  # Reference secret from Secrets Manager instead of plaintext\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Store secrets in **AWS Secrets Manager** and reference them by name or ARN in connection properties instead of embedding plaintext values. Enforce **least privilege** on the Glue roles and connections, rotate secrets regularly, and avoid logging or exporting connection properties.",
+      "Url": "https://hub.prowler.com/check/glue_data_catalogs_connection_no_secrets_in_properties"
+    }
+  },
+  "Categories": [
+    "secrets"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": ""
+}

--- a/prowler/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/glue_data_catalogs_connection_no_secrets_in_properties.py
+++ b/prowler/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/glue_data_catalogs_connection_no_secrets_in_properties.py
@@ -1,0 +1,88 @@
+import json
+
+from prowler.lib.check.models import Check, Check_Report_AWS
+from prowler.lib.utils.utils import (
+    SecretsScanError,
+    annotate_verified_secrets,
+    detect_secrets_scan_batch,
+)
+from prowler.providers.aws.services.glue.glue_client import glue_client
+
+
+class glue_data_catalogs_connection_no_secrets_in_properties(Check):
+    """Check if Glue Data Catalog connections have secrets in their properties.
+
+    Scans the ConnectionProperties of each Glue connection for hardcoded credentials,
+    tokens, passwords, and other sensitive values that should be stored in
+    Secrets Manager instead.
+    """
+
+    def execute(self):
+        findings = []
+        secrets_ignore_patterns = glue_client.audit_config.get(
+            "secrets_ignore_patterns", []
+        )
+        validate = glue_client.audit_config.get("secrets_validate", False)
+        connections = list(glue_client.connections)
+
+        # Collect every property across all connections and scan them in batched
+        # Kingfisher invocations instead of one subprocess per property. Findings
+        # are keyed by (connection index, property name).
+        def payloads():
+            for connection_index, connection in enumerate(connections):
+                if connection.properties:
+                    for prop_name, prop_value in connection.properties.items():
+                        yield (
+                            (connection_index, prop_name),
+                            json.dumps({prop_name: prop_value}),
+                        )
+
+        scan_error = None
+        try:
+            batch_results = detect_secrets_scan_batch(
+                payloads(), excluded_secrets=secrets_ignore_patterns, validate=validate
+            )
+        except SecretsScanError as error:
+            batch_results = {}
+            scan_error = error
+
+        for connection_index, connection in enumerate(connections):
+            report = Check_Report_AWS(metadata=self.metadata(), resource=connection)
+            report.status = "PASS"
+            report.status_extended = (
+                f"No secrets found in Glue connection {connection.name} properties."
+            )
+
+            if connection.properties and scan_error:
+                report.status = "MANUAL"
+                report.status_extended = (
+                    f"Could not scan Glue connection {connection.name} properties for "
+                    f"secrets: {scan_error}; manual review is required."
+                )
+                findings.append(report)
+                continue
+
+            if connection.properties:
+                secrets_found = []
+                all_secrets = []
+                for prop_name in connection.properties:
+                    detect_secrets_output = batch_results.get(
+                        (connection_index, prop_name)
+                    )
+                    if detect_secrets_output:
+                        all_secrets.extend(detect_secrets_output)
+                        secrets_found.extend(
+                            [
+                                f"{secret['type']} in property {prop_name}"
+                                for secret in detect_secrets_output
+                            ]
+                        )
+
+                if secrets_found:
+                    report.status = "FAIL"
+                    report.status_extended = f"Potential secrets found in Glue connection {connection.name} properties: {', '.join(secrets_found)}."
+                    annotate_verified_secrets(report, all_secrets)
+
+            findings.append(report)
+
+        return findings

--- a/tests/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/glue_data_catalogs_connection_no_secrets_in_properties_test.py
+++ b/tests/providers/aws/services/glue/glue_data_catalogs_connection_no_secrets_in_properties/glue_data_catalogs_connection_no_secrets_in_properties_test.py
@@ -1,0 +1,175 @@
+from unittest.mock import MagicMock, patch
+
+from prowler.providers.aws.services.glue.glue_service import Connection
+from tests.providers.aws.utils import AWS_REGION_US_EAST_1, AWS_ACCOUNT_NUMBER
+
+
+class Test_glue_data_catalogs_connection_no_secrets_in_properties:
+    def test_glue_no_connections(self):
+        glue_client = MagicMock
+        glue_client.connections = []
+        glue_client.audit_config = {
+            "secrets_ignore_patterns": [],
+            "secrets_validate": False,
+        }
+
+        with (
+            patch(
+                "prowler.providers.aws.services.glue.glue_service.Glue",
+                new=glue_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.glue.glue_client.glue_client",
+                new=glue_client,
+            ),
+        ):
+            from prowler.providers.aws.services.glue.glue_data_catalogs_connection_no_secrets_in_properties.glue_data_catalogs_connection_no_secrets_in_properties import (
+                glue_data_catalogs_connection_no_secrets_in_properties,
+            )
+
+            check = glue_data_catalogs_connection_no_secrets_in_properties()
+            result = check.execute()
+
+            assert len(result) == 0
+
+    def test_glue_connection_no_secrets(self):
+        glue_client = MagicMock
+        glue_client.audit_config = {
+            "secrets_ignore_patterns": [],
+            "secrets_validate": False,
+        }
+        connection_name = "test-connection"
+        connection_arn = f"arn:aws:glue:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:connection/{connection_name}"
+
+        glue_client.connections = [
+            Connection(
+                name=connection_name,
+                type="JDBC",
+                properties={
+                    "JDBC_CONNECTION_URL": "jdbc:mysql://example.com:3306/mydb"
+                },
+                region=AWS_REGION_US_EAST_1,
+                arn=connection_arn,
+                tags=[{"test": "test"}],
+            )
+        ]
+
+        with (
+            patch(
+                "prowler.providers.aws.services.glue.glue_service.Glue",
+                new=glue_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.glue.glue_client.glue_client",
+                new=glue_client,
+            ),
+        ):
+            from prowler.providers.aws.services.glue.glue_data_catalogs_connection_no_secrets_in_properties.glue_data_catalogs_connection_no_secrets_in_properties import (
+                glue_data_catalogs_connection_no_secrets_in_properties,
+            )
+
+            check = glue_data_catalogs_connection_no_secrets_in_properties()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"No secrets found in Glue connection {connection_name} properties."
+            )
+            assert result[0].resource_id == connection_name
+            assert result[0].resource_arn == connection_arn
+
+    def test_glue_connection_with_secrets(self):
+        glue_client = MagicMock
+        glue_client.audit_config = {
+            "secrets_ignore_patterns": [],
+            "secrets_validate": False,
+        }
+        connection_name = "test-connection"
+        connection_arn = f"arn:aws:glue:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:connection/{connection_name}"
+
+        glue_client.connections = [
+            Connection(
+                name=connection_name,
+                type="JDBC",
+                properties={
+                    "PASSWORD": "AKIAsupersecretkey1234",
+                    "JDBC_CONNECTION_URL": "jdbc:mysql://example.com:3306/mydb",
+                },
+                region=AWS_REGION_US_EAST_1,
+                arn=connection_arn,
+                tags=[{"test": "test"}],
+            )
+        ]
+
+        with (
+            patch(
+                "prowler.providers.aws.services.glue.glue_service.Glue",
+                new=glue_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.glue.glue_client.glue_client",
+                new=glue_client,
+            ),
+        ):
+            from prowler.providers.aws.services.glue.glue_data_catalogs_connection_no_secrets_in_properties.glue_data_catalogs_connection_no_secrets_in_properties import (
+                glue_data_catalogs_connection_no_secrets_in_properties,
+            )
+
+            check = glue_data_catalogs_connection_no_secrets_in_properties()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert "Potential secrets found" in result[0].status_extended
+            assert connection_name in result[0].status_extended
+            assert "PASSWORD" in result[0].status_extended
+            assert result[0].resource_id == connection_name
+            assert result[0].resource_arn == connection_arn
+
+    def test_glue_connection_empty_properties(self):
+        glue_client = MagicMock
+        glue_client.audit_config = {
+            "secrets_ignore_patterns": [],
+            "secrets_validate": False,
+        }
+        connection_name = "test-connection"
+        connection_arn = f"arn:aws:glue:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:connection/{connection_name}"
+
+        glue_client.connections = [
+            Connection(
+                name=connection_name,
+                type="JDBC",
+                properties={},
+                region=AWS_REGION_US_EAST_1,
+                arn=connection_arn,
+                tags=[{"test": "test"}],
+            )
+        ]
+
+        with (
+            patch(
+                "prowler.providers.aws.services.glue.glue_service.Glue",
+                new=glue_client,
+            ),
+            patch(
+                "prowler.providers.aws.services.glue.glue_client.glue_client",
+                new=glue_client,
+            ),
+        ):
+            from prowler.providers.aws.services.glue.glue_data_catalogs_connection_no_secrets_in_properties.glue_data_catalogs_connection_no_secrets_in_properties import (
+                glue_data_catalogs_connection_no_secrets_in_properties,
+            )
+
+            check = glue_data_catalogs_connection_no_secrets_in_properties()
+            result = check.execute()
+
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"No secrets found in Glue connection {connection_name} properties."
+            )
+            assert result[0].resource_id == connection_name
+            assert result[0].resource_arn == connection_arn


### PR DESCRIPTION
Closes #11814

Adds a new Glue check that scans Data Catalog connection properties
(ConnectionProperties) for hardcoded secrets, following the same
detect_secrets_scan_batch pattern used by glue_etl_jobs_no_secrets_in_arguments.

- No changes to glue_service.py — reuses the existing Connection.properties
  field already collected by the service.
- Tests follow the established MagicMock + Connection-model pattern used by
  glue_database_connections_ssl_enabled, avoiding a moto limitation where
  ConnectionProperties is dropped by create_connection/get_connections on
  the pinned moto==5.1.11.
- All new and existing Glue tests pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new AWS Glue security check that scans connection properties for exposed secrets and reports pass/fail results per connection.
  * Included guidance and severity details to help users understand and remediate findings.

* **Bug Fixes**
  * Improved handling for scan issues by marking affected connections for manual review when secret detection cannot complete.

* **Tests**
  * Added coverage for empty connections, clean properties, detected secrets, and empty property sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->