### PR TITLE
feat(oraclecloud): support regionless SDK setup

### DIFF
--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ## [5.33.0] (Prowler v5.33.0)
 
+### 🔄 Changed
+
+- Oracle Cloud API key authentication now uses an internal bootstrap region when no explicit scan region filter is provided [(#11853)](https://github.com/prowler-cloud/prowler/pull/11853)
+
 ### 🐞 Fixed
 
 - Azure resource group scoped scans now keep subscription entries when scoped resource listing fails, clarify helper documentation and test organization, and align the resource group documentation example with the described values [(#11796)](https://github.com/prowler-cloud/prowler/pull/11796)

--- a/prowler/CHANGELOG.md
+++ b/prowler/CHANGELOG.md
@@ -6,10 +6,6 @@ All notable changes to the **Prowler SDK** are documented in this file.
 
 ## [5.33.0] (Prowler v5.33.0)
 
-### 🔄 Changed
-
-- Oracle Cloud API key authentication now uses an internal bootstrap region when no explicit scan region filter is provided [(#11853)](https://github.com/prowler-cloud/prowler/pull/11853)
-
 ### 🐞 Fixed
 
 - Azure resource group scoped scans now keep subscription entries when scoped resource listing fails, clarify helper documentation and test organization, and align the resource group documentation example with the described values [(#11796)](https://github.com/prowler-cloud/prowler/pull/11796)

--- a/prowler/changelog.d/oci-regionless-platform-11565.changed.md
+++ b/prowler/changelog.d/oci-regionless-platform-11565.changed.md
@@ -1,0 +1,1 @@
+Oracle Cloud API key authentication now uses an internal bootstrap region when no explicit scan region filter is provided

--- a/prowler/providers/oraclecloud/oraclecloud_provider.py
+++ b/prowler/providers/oraclecloud/oraclecloud_provider.py
@@ -68,12 +68,13 @@ class OraclecloudProvider(Provider):
     _mutelist: OCIMutelist
     audit_metadata: Audit_Metadata
     _home_region: str = "us-ashburn-1"
+    _bootstrap_region: str = "us-ashburn-1"
 
     def __init__(
         self,
         oci_config_file: str = None,
         profile: str = None,
-        region: set = set(),
+        region: set = None,
         compartment_ids: list = None,
         config_path: str = None,
         config_content: dict = None,
@@ -131,8 +132,11 @@ class OraclecloudProvider(Provider):
 
         # Check if the configuration is scanning a single region
         single_region = None
-        if region:
-            single_region = list(region)[0] if len(region) == 1 else None
+        if isinstance(region, str):
+            single_region = region
+        elif region:
+            single_region = sorted(region)[0]
+        bootstrap_region = single_region or self._bootstrap_region
 
         # Setup OCI Session
         logger.info("Setting up OCI session ...")
@@ -145,7 +149,7 @@ class OraclecloudProvider(Provider):
             key_file=key_file,
             key_content=key_content,
             tenancy=tenancy,
-            region=single_region,
+            region=bootstrap_region,
             pass_phrase=pass_phrase,
         )
 
@@ -155,7 +159,7 @@ class OraclecloudProvider(Provider):
         logger.info("Validating OCI credentials ...")
         self._identity = self.set_identity(
             session=self._session,
-            region=single_region,
+            region=bootstrap_region,
             compartment_ids=compartment_ids,
         )
         logger.info("OCI credentials validated")
@@ -165,7 +169,13 @@ class OraclecloudProvider(Provider):
         # Determine the tenancy home region from the full subscription list, independent of
         # the --region filter, so tenancy-level APIs (e.g. the Audit configuration) always
         # target the home region instead of a filtered, non-home region.
-        all_subscribed_regions = self.get_regions_to_audit()
+        try:
+            all_subscribed_regions = self.get_regions_to_audit()
+        except OCISetUpSessionError:
+            if single_region and len(self._regions) == 1:
+                all_subscribed_regions = self._regions
+            else:
+                raise
         self._home_region = next(
             (region.key for region in all_subscribed_regions if region.is_home_region),
             self._regions[0].key if self._regions else "us-ashburn-1",
@@ -284,7 +294,7 @@ class OraclecloudProvider(Provider):
             signer = None
 
             # If API key credentials are provided directly, create config from them
-            if user and fingerprint and tenancy and region:
+            if user and fingerprint and tenancy:
                 import base64
 
                 logger.info("Using API key credentials from direct parameters")
@@ -294,7 +304,7 @@ class OraclecloudProvider(Provider):
                     "user": user,
                     "fingerprint": fingerprint,
                     "tenancy": tenancy,
-                    "region": region,
+                    "region": region or OraclecloudProvider._bootstrap_region,
                 }
 
                 # Handle private key
@@ -565,6 +575,12 @@ class OraclecloudProvider(Provider):
         """
         regions = []
 
+        explicit_regions = None
+        if isinstance(region_set, str):
+            explicit_regions = {region_set}
+        elif region_set:
+            explicit_regions = set(region_set)
+
         # Audit all subscribed regions
         try:
             # Create identity client with proper authentication handling
@@ -581,11 +597,9 @@ class OraclecloudProvider(Provider):
             ).data
 
             # Check if auditing specific region or all
-            regions_check = (
-                region_set
-                if region_set
-                else [sub.region_name for sub in region_subscriptions]
-            )
+            regions_check = explicit_regions or [
+                sub.region_name for sub in region_subscriptions
+            ]
 
             for region_sub in region_subscriptions:
                 if region_sub.region_name in regions_check:
@@ -600,11 +614,21 @@ class OraclecloudProvider(Provider):
                     )
             logger.info(f"Found {len(regions)} subscribed regions")
         except Exception as error:
+            if not explicit_regions or len(explicit_regions) != 1:
+                raise OCISetUpSessionError(
+                    original_exception=error,
+                    message=(
+                        "Could not retrieve OCI subscribed regions. "
+                        "Configure an explicit region to preserve legacy single-region scans, "
+                        "or fix the credentials/permissions required to list region subscriptions."
+                    ),
+                ) from error
+
+            config_region = next(iter(explicit_regions))
             logger.warning(
-                f"Could not retrieve region subscriptions: {error}. Using configured region."
+                f"Could not retrieve region subscriptions: {error}. "
+                f"Using explicitly configured region {config_region}."
             )
-            # Fallback to configured region
-            config_region = self._session.config.get("region", "us-ashburn-1")
             regions.append(
                 OCIRegion(
                     key=config_region,
@@ -855,7 +879,7 @@ class OraclecloudProvider(Provider):
             session = None
 
             # If API key credentials are provided directly, create config from them
-            if user and fingerprint and tenancy and region:
+            if user and fingerprint and tenancy:
                 import base64
 
                 logger.info("Using API key credentials from direct parameters")
@@ -865,7 +889,7 @@ class OraclecloudProvider(Provider):
                     "user": user,
                     "fingerprint": fingerprint,
                     "tenancy": tenancy,
-                    "region": region,
+                    "region": region or OraclecloudProvider._bootstrap_region,
                 }
 
                 # Handle private key
@@ -914,7 +938,7 @@ class OraclecloudProvider(Provider):
 
             identity = OraclecloudProvider.set_identity(
                 session=session,
-                region=region,
+                region=region or OraclecloudProvider._bootstrap_region,
             )
 
             # Validate provider_id if provided

--- a/prowler/providers/oraclecloud/oraclecloud_provider.py
+++ b/prowler/providers/oraclecloud/oraclecloud_provider.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 import os
 import pathlib
 import re
@@ -74,7 +75,7 @@ class OraclecloudProvider(Provider):
         self,
         oci_config_file: str = None,
         profile: str = None,
-        region: set = None,
+        region: str | Iterable[str] = None,
         compartment_ids: list = None,
         config_path: str = None,
         config_content: dict = None,
@@ -130,13 +131,17 @@ class OraclecloudProvider(Provider):
 
         logger.info("Initializing OCI provider ...")
 
-        # Check if the configuration is scanning a single region
-        single_region = None
-        if isinstance(region, str):
-            single_region = region
-        elif region:
-            single_region = sorted(region)[0]
-        bootstrap_region = single_region or self._bootstrap_region
+        # Check if the configuration is scanning exactly one explicit region.
+        explicit_regions = self._normalize_region_input(region)
+        single_region = (
+            next(iter(explicit_regions))
+            if explicit_regions and len(explicit_regions) == 1
+            else None
+        )
+        has_direct_credentials = user and fingerprint and tenancy
+        bootstrap_region = single_region or (
+            self._bootstrap_region if has_direct_credentials else None
+        )
 
         # Setup OCI Session
         logger.info("Setting up OCI session ...")
@@ -159,7 +164,7 @@ class OraclecloudProvider(Provider):
         logger.info("Validating OCI credentials ...")
         self._identity = self.set_identity(
             session=self._session,
-            region=bootstrap_region,
+            region=single_region,
             compartment_ids=compartment_ids,
         )
         logger.info("OCI credentials validated")
@@ -252,6 +257,22 @@ class OraclecloudProvider(Provider):
         mutelist method returns the provider's mutelist.
         """
         return self._mutelist
+
+    @staticmethod
+    def _normalize_region_input(region: str | Iterable[str] = None) -> set[str] | None:
+        """Normalize OCI region input while treating strings as one region.
+
+        Args:
+            region: Region input as a string, iterable of strings, or None.
+
+        Returns:
+            A set of region names, or None when no region is provided.
+        """
+        if isinstance(region, str):
+            return {region} if region else None
+        if region:
+            return set(region)
+        return None
 
     @staticmethod
     def setup_session(
@@ -563,7 +584,7 @@ class OraclecloudProvider(Provider):
 
         return True
 
-    def get_regions_to_audit(self, region_set: set = None) -> list:
+    def get_regions_to_audit(self, region_set: str | Iterable[str] = None) -> list:
         """
         get_regions_to_audit returns the list of regions to audit.
 
@@ -575,11 +596,7 @@ class OraclecloudProvider(Provider):
         """
         regions = []
 
-        explicit_regions = None
-        if isinstance(region_set, str):
-            explicit_regions = {region_set}
-        elif region_set:
-            explicit_regions = set(region_set)
+        explicit_regions = self._normalize_region_input(region_set)
 
         # Audit all subscribed regions
         try:
@@ -615,8 +632,12 @@ class OraclecloudProvider(Provider):
             logger.info(f"Found {len(regions)} subscribed regions")
         except Exception as error:
             if not explicit_regions or len(explicit_regions) != 1:
+                logger.critical(
+                    f"OCISetUpSessionError[{error.__traceback__.tb_lineno}]: {error}"
+                )
                 raise OCISetUpSessionError(
                     original_exception=error,
+                    file=pathlib.Path(__file__).name,
                     message=(
                         "Could not retrieve OCI subscribed regions. "
                         "Configure an explicit region to preserve legacy single-region scans, "

--- a/prowler/providers/oraclecloud/oraclecloud_provider.py
+++ b/prowler/providers/oraclecloud/oraclecloud_provider.py
@@ -900,17 +900,21 @@ class OraclecloudProvider(Provider):
             session = None
 
             # If API key credentials are provided directly, create config from them
-            if user and fingerprint and tenancy:
+            has_direct_credentials = user and fingerprint and tenancy
+            identity_region = region
+            if has_direct_credentials:
                 import base64
 
                 logger.info("Using API key credentials from direct parameters")
+
+                identity_region = region or OraclecloudProvider._bootstrap_region
 
                 # Create config dict from provided credentials
                 config = {
                     "user": user,
                     "fingerprint": fingerprint,
                     "tenancy": tenancy,
-                    "region": region or OraclecloudProvider._bootstrap_region,
+                    "region": identity_region,
                 }
 
                 # Handle private key
@@ -959,7 +963,7 @@ class OraclecloudProvider(Provider):
 
             identity = OraclecloudProvider.set_identity(
                 session=session,
-                region=region or OraclecloudProvider._bootstrap_region,
+                region=identity_region,
             )
 
             # Validate provider_id if provided

--- a/tests/providers/oraclecloud/oraclecloud_provider_test.py
+++ b/tests/providers/oraclecloud/oraclecloud_provider_test.py
@@ -234,7 +234,10 @@ MIIEpQIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8n0sMcD/QHWCJ7yGSEtLN2T
             )
 
         assert connection.is_connected is True
-        assert mock_validate_config.call_args.args[0]["region"] == "us-ashburn-1"
+        assert (
+            mock_validate_config.call_args.args[0]["region"]
+            == OraclecloudProvider._bootstrap_region
+        )
 
 
 class TestOraclecloudProviderInit:
@@ -292,7 +295,9 @@ class TestOraclecloudProviderInit:
         assert provider.home_region == "us-ashburn-1"
         mock_set_global.assert_called_once_with(provider)
 
-    def test_init_with_multiple_regions_uses_deterministic_session_region(self):
+    def test_init_with_multiple_regions_does_not_use_legacy_single_region_fallback(
+        self,
+    ):
         mock_session = OCISession(
             config={"region": "us-ashburn-1"}, signer=None, profile="DEFAULT"
         )
@@ -338,8 +343,11 @@ class TestOraclecloudProviderInit:
                 mutelist_content={"Accounts": {}},
             )
 
-        assert mock_setup_session.call_args.kwargs["region"] == "us-ashburn-1"
-        assert mock_set_identity.call_args.kwargs["region"] == "us-ashburn-1"
+        assert (
+            mock_setup_session.call_args.kwargs["region"]
+            == OraclecloudProvider._bootstrap_region
+        )
+        assert mock_set_identity.call_args.kwargs["region"] is None
         assert mock_get_regions_to_audit.call_args_list[0].args == (
             {"us-phoenix-1", "us-ashburn-1"},
         )
@@ -394,7 +402,9 @@ class TestOraclecloudProviderInit:
         assert mock_setup_session.call_args.kwargs["region"] == "us-ashburn-1"
         assert mock_set_identity.call_args.kwargs["region"] == "us-ashburn-1"
 
-    def test_init_without_region_uses_bootstrap_region_without_scan_filter(self):
+    def test_init_without_region_uses_direct_credentials_bootstrap_without_scan_filter(
+        self,
+    ):
         mock_session = OCISession(
             config={"region": "us-ashburn-1"}, signer=None, profile="DEFAULT"
         )
@@ -440,8 +450,113 @@ class TestOraclecloudProviderInit:
                 mutelist_content={"Accounts": {}},
             )
 
-        assert mock_setup_session.call_args.kwargs["region"] == "us-ashburn-1"
-        assert mock_set_identity.call_args.kwargs["region"] == "us-ashburn-1"
+        assert (
+            mock_setup_session.call_args.kwargs["region"]
+            == OraclecloudProvider._bootstrap_region
+        )
+        assert mock_set_identity.call_args.kwargs["region"] is None
+        assert mock_get_regions_to_audit.call_args_list[0].args == (None,)
+        assert provider.regions == all_subscribed_regions
+
+    def test_init_with_config_file_auth_without_region_uses_session_config_region_for_identity(
+        self,
+    ):
+        mock_session = OCISession(
+            config={
+                "tenancy": "ocid1.tenancy.oc1..aaaaaaaexample",
+                "user": "ocid1.user.oc1..aaaaaaaexample",
+                "region": "eu-frankfurt-1",
+            },
+            signer=None,
+            profile="DEFAULT",
+        )
+        all_subscribed_regions = [
+            OCIRegion(key="eu-frankfurt-1", name="eu-frankfurt-1", is_home_region=True),
+            OCIRegion(key="us-ashburn-1", name="us-ashburn-1", is_home_region=False),
+        ]
+
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ) as mock_setup_session,
+            patch("oci.identity.IdentityClient") as mock_identity_client,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_regions_to_audit",
+                return_value=all_subscribed_regions,
+            ) as mock_get_regions_to_audit,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_compartments_to_audit",
+                return_value=["ocid1.compartment.oc1..aaaaaaaexample"],
+            ),
+            patch("prowler.providers.common.provider.Provider.set_global_provider"),
+        ):
+            mock_tenancy = MagicMock()
+            mock_tenancy.name = "test-tenancy"
+            mock_identity_client.return_value.get_tenancy.return_value.data = (
+                mock_tenancy
+            )
+
+            provider = OraclecloudProvider(
+                config_content={"dummy": True},
+                mutelist_content={"Accounts": {}},
+            )
+
+        assert mock_setup_session.call_args.kwargs["region"] is None
+        assert provider.identity.region == "eu-frankfurt-1"
+        assert provider.identity.audited_regions == {"eu-frankfurt-1"}
+        assert mock_get_regions_to_audit.call_args_list[0].args == (None,)
+        assert provider.regions == all_subscribed_regions
+
+    def test_init_with_instance_principal_without_region_uses_session_config_region_for_identity(
+        self,
+    ):
+        mock_signer = MagicMock()
+        mock_session = OCISession(
+            config={
+                "tenancy": "ocid1.tenancy.oc1..aaaaaaaexample",
+                "region": "uk-london-1",
+            },
+            signer=mock_signer,
+            profile=None,
+        )
+        all_subscribed_regions = [
+            OCIRegion(key="uk-london-1", name="uk-london-1", is_home_region=True),
+            OCIRegion(key="us-ashburn-1", name="us-ashburn-1", is_home_region=False),
+        ]
+
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ) as mock_setup_session,
+            patch("oci.identity.IdentityClient") as mock_identity_client,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_regions_to_audit",
+                return_value=all_subscribed_regions,
+            ) as mock_get_regions_to_audit,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_compartments_to_audit",
+                return_value=["ocid1.compartment.oc1..aaaaaaaexample"],
+            ),
+            patch("prowler.providers.common.provider.Provider.set_global_provider"),
+        ):
+            mock_tenancy = MagicMock()
+            mock_tenancy.name = "test-tenancy"
+            mock_identity_client.return_value.get_tenancy.return_value.data = (
+                mock_tenancy
+            )
+
+            provider = OraclecloudProvider(
+                use_instance_principal=True,
+                config_content={"dummy": True},
+                mutelist_content={"Accounts": {}},
+            )
+
+        assert mock_setup_session.call_args.kwargs["region"] is None
+        assert provider.identity.region == "uk-london-1"
+        assert provider.identity.user_id == "instance-principal"
+        assert provider.identity.audited_regions == {"uk-london-1"}
         assert mock_get_regions_to_audit.call_args_list[0].args == (None,)
         assert provider.regions == all_subscribed_regions
 

--- a/tests/providers/oraclecloud/oraclecloud_provider_test.py
+++ b/tests/providers/oraclecloud/oraclecloud_provider_test.py
@@ -5,6 +5,7 @@ import pytest
 from prowler.providers.oraclecloud.exceptions.exceptions import (
     OCIAuthenticationError,
     OCIInvalidConfigError,
+    OCISetUpSessionError,
 )
 from prowler.providers.oraclecloud.models import OCIIdentityInfo, OCIRegion, OCISession
 from prowler.providers.oraclecloud.oraclecloud_provider import OraclecloudProvider
@@ -200,6 +201,41 @@ MIIEpQIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8n0sMcD/QHWCJ7yGSEtLN2T
 
             assert connection.is_connected is True
 
+    def test_test_connection_direct_credentials_without_region_uses_bootstrap_region(
+        self,
+    ):
+        """Direct API key auth should not fall back to config-file auth without a region."""
+        import base64
+
+        valid_key = (
+            "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"
+        )
+        encoded_key = base64.b64encode(valid_key.encode("utf-8")).decode("utf-8")
+
+        with (
+            patch("oci.config.validate_config") as mock_validate_config,
+            patch("oci.identity.IdentityClient") as mock_identity_client,
+        ):
+            mock_tenancy = MagicMock()
+            mock_tenancy.name = "test-tenancy"
+            mock_response = MagicMock()
+            mock_response.data = mock_tenancy
+            mock_client_instance = MagicMock()
+            mock_client_instance.get_tenancy.return_value = mock_response
+            mock_identity_client.return_value = mock_client_instance
+
+            connection = OraclecloudProvider.test_connection(
+                key_content=encoded_key,
+                user="ocid1.user.oc1..aaaaaaaexample",
+                fingerprint="aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+                tenancy="ocid1.tenancy.oc1..aaaaaaaexample",
+                provider_id="ocid1.tenancy.oc1..aaaaaaaexample",
+                raise_on_exception=False,
+            )
+
+        assert connection.is_connected is True
+        assert mock_validate_config.call_args.args[0]["region"] == "us-ashburn-1"
+
 
 class TestOraclecloudProviderInit:
     """Tests for OraclecloudProvider initialization"""
@@ -255,6 +291,159 @@ class TestOraclecloudProviderInit:
         assert provider.compartments == mock_compartments
         assert provider.home_region == "us-ashburn-1"
         mock_set_global.assert_called_once_with(provider)
+
+    def test_init_with_multiple_regions_uses_deterministic_session_region(self):
+        mock_session = OCISession(
+            config={"region": "us-ashburn-1"}, signer=None, profile="DEFAULT"
+        )
+        mock_identity = OCIIdentityInfo(
+            tenancy_id="ocid1.tenancy.oc1..aaaaaaaexample",
+            tenancy_name="test-tenancy",
+            user_id="ocid1.user.oc1..aaaaaaaexample",
+            region="us-ashburn-1",
+            profile="DEFAULT",
+            audited_regions=set(),
+            audited_compartments=[],
+        )
+        audited_regions = [
+            OCIRegion(key="us-ashburn-1", name="us-ashburn-1", is_home_region=True),
+            OCIRegion(key="us-phoenix-1", name="us-phoenix-1", is_home_region=False),
+        ]
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ) as mock_setup_session,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.set_identity",
+                return_value=mock_identity,
+            ) as mock_set_identity,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_regions_to_audit",
+                return_value=audited_regions,
+            ) as mock_get_regions_to_audit,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_compartments_to_audit",
+                return_value=["ocid1.compartment.oc1..aaaaaaaexample"],
+            ),
+            patch("prowler.providers.common.provider.Provider.set_global_provider"),
+        ):
+            provider = OraclecloudProvider(
+                region={"us-phoenix-1", "us-ashburn-1"},
+                user="ocid1.user.oc1..aaaaaaaexample",
+                fingerprint="aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+                key_content="fake-base64-key-content",
+                tenancy="ocid1.tenancy.oc1..aaaaaaaexample",
+                config_content={"dummy": True},
+                mutelist_content={"Accounts": {}},
+            )
+
+        assert mock_setup_session.call_args.kwargs["region"] == "us-ashburn-1"
+        assert mock_set_identity.call_args.kwargs["region"] == "us-ashburn-1"
+        assert mock_get_regions_to_audit.call_args_list[0].args == (
+            {"us-phoenix-1", "us-ashburn-1"},
+        )
+        assert provider.regions == audited_regions
+
+    def test_init_with_legacy_region_string_uses_full_region_for_identity(self):
+        mock_session = OCISession(
+            config={"region": "us-ashburn-1"}, signer=None, profile="DEFAULT"
+        )
+        mock_identity = OCIIdentityInfo(
+            tenancy_id="ocid1.tenancy.oc1..aaaaaaaexample",
+            tenancy_name="test-tenancy",
+            user_id="ocid1.user.oc1..aaaaaaaexample",
+            region="us-ashburn-1",
+            profile="DEFAULT",
+            audited_regions=set(),
+            audited_compartments=[],
+        )
+        audited_regions = [
+            OCIRegion(key="us-ashburn-1", name="us-ashburn-1", is_home_region=True),
+        ]
+
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ) as mock_setup_session,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.set_identity",
+                return_value=mock_identity,
+            ) as mock_set_identity,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_regions_to_audit",
+                return_value=audited_regions,
+            ),
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_compartments_to_audit",
+                return_value=["ocid1.compartment.oc1..aaaaaaaexample"],
+            ),
+            patch("prowler.providers.common.provider.Provider.set_global_provider"),
+        ):
+            OraclecloudProvider(
+                region="us-ashburn-1",
+                user="ocid1.user.oc1..aaaaaaaexample",
+                fingerprint="aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+                key_content="fake-base64-key-content",
+                tenancy="ocid1.tenancy.oc1..aaaaaaaexample",
+                config_content={"dummy": True},
+                mutelist_content={"Accounts": {}},
+            )
+
+        assert mock_setup_session.call_args.kwargs["region"] == "us-ashburn-1"
+        assert mock_set_identity.call_args.kwargs["region"] == "us-ashburn-1"
+
+    def test_init_without_region_uses_bootstrap_region_without_scan_filter(self):
+        mock_session = OCISession(
+            config={"region": "us-ashburn-1"}, signer=None, profile="DEFAULT"
+        )
+        mock_identity = OCIIdentityInfo(
+            tenancy_id="ocid1.tenancy.oc1..aaaaaaaexample",
+            tenancy_name="test-tenancy",
+            user_id="ocid1.user.oc1..aaaaaaaexample",
+            region="us-ashburn-1",
+            profile="DEFAULT",
+            audited_regions=set(),
+            audited_compartments=[],
+        )
+        all_subscribed_regions = [
+            OCIRegion(key="us-ashburn-1", name="us-ashburn-1", is_home_region=True),
+            OCIRegion(key="us-phoenix-1", name="us-phoenix-1", is_home_region=False),
+        ]
+
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ) as mock_setup_session,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.set_identity",
+                return_value=mock_identity,
+            ) as mock_set_identity,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_regions_to_audit",
+                return_value=all_subscribed_regions,
+            ) as mock_get_regions_to_audit,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_compartments_to_audit",
+                return_value=["ocid1.compartment.oc1..aaaaaaaexample"],
+            ),
+            patch("prowler.providers.common.provider.Provider.set_global_provider"),
+        ):
+            provider = OraclecloudProvider(
+                user="ocid1.user.oc1..aaaaaaaexample",
+                fingerprint="aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99",
+                key_content="fake-base64-key-content",
+                tenancy="ocid1.tenancy.oc1..aaaaaaaexample",
+                config_content={"dummy": True},
+                mutelist_content={"Accounts": {}},
+            )
+
+        assert mock_setup_session.call_args.kwargs["region"] == "us-ashburn-1"
+        assert mock_set_identity.call_args.kwargs["region"] == "us-ashburn-1"
+        assert mock_get_regions_to_audit.call_args_list[0].args == (None,)
+        assert provider.regions == all_subscribed_regions
 
     def test_home_region_uses_full_subscription_list_not_region_filter(self):
         """Home region must come from the full subscription list, not the --region filter.
@@ -313,3 +502,105 @@ class TestOraclecloudProviderInit:
 
         assert provider.regions == audited_regions
         assert provider.home_region == "us-ashburn-1"
+
+    def test_init_with_legacy_single_region_preserves_fallback_for_home_region(self):
+        mock_session = OCISession(
+            config={"region": "us-phoenix-1"}, signer=None, profile="DEFAULT"
+        )
+        mock_identity = OCIIdentityInfo(
+            tenancy_id="ocid1.tenancy.oc1..aaaaaaaexample",
+            tenancy_name="test-tenancy",
+            user_id="ocid1.user.oc1..aaaaaaaexample",
+            region="us-phoenix-1",
+            profile="DEFAULT",
+            audited_regions=set(),
+            audited_compartments=[],
+        )
+
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ),
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.set_identity",
+                return_value=mock_identity,
+            ),
+            patch("oci.identity.IdentityClient") as mock_identity_client,
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.get_compartments_to_audit",
+                return_value=["ocid1.compartment.oc1..aaaaaaaexample"],
+            ),
+            patch("prowler.providers.common.provider.Provider.set_global_provider"),
+        ):
+            mock_identity_client.return_value.list_region_subscriptions.side_effect = (
+                Exception("discovery failed")
+            )
+
+            provider = OraclecloudProvider(
+                region="us-phoenix-1",
+                config_content={"dummy": True},
+                mutelist_content={"Accounts": {}},
+            )
+
+        assert [region.key for region in provider.regions] == ["us-phoenix-1"]
+        assert provider.home_region == "us-phoenix-1"
+
+
+class TestGetRegionsToAudit:
+    def _provider_with_identity(self):
+        provider = OraclecloudProvider.__new__(OraclecloudProvider)
+        provider._session = OCISession(
+            config={"region": "us-ashburn-1"}, signer=None, profile="DEFAULT"
+        )
+        provider._identity = OCIIdentityInfo(
+            tenancy_id="ocid1.tenancy.oc1..aaaaaaaexample",
+            tenancy_name="test-tenancy",
+            user_id="ocid1.user.oc1..aaaaaaaexample",
+            region="us-ashburn-1",
+            profile="DEFAULT",
+            audited_regions=set(),
+            audited_compartments=[],
+        )
+        return provider
+
+    def test_regionless_scan_raises_when_region_subscription_discovery_fails(self):
+        provider = self._provider_with_identity()
+
+        with patch("oci.identity.IdentityClient") as mock_identity_client:
+            mock_identity_client.return_value.list_region_subscriptions.side_effect = (
+                Exception("discovery failed")
+            )
+
+            with pytest.raises(OCISetUpSessionError) as exc_info:
+                provider.get_regions_to_audit()
+
+        assert "Could not retrieve OCI subscribed regions" in str(exc_info.value)
+
+    def test_single_explicit_region_falls_back_when_region_subscription_discovery_fails(
+        self,
+    ):
+        provider = self._provider_with_identity()
+
+        with patch("oci.identity.IdentityClient") as mock_identity_client:
+            mock_identity_client.return_value.list_region_subscriptions.side_effect = (
+                Exception("discovery failed")
+            )
+
+            regions = provider.get_regions_to_audit("us-phoenix-1")
+
+        assert len(regions) == 1
+        assert regions[0].key == "us-phoenix-1"
+
+    def test_multiple_explicit_regions_raise_when_region_subscription_discovery_fails(
+        self,
+    ):
+        provider = self._provider_with_identity()
+
+        with patch("oci.identity.IdentityClient") as mock_identity_client:
+            mock_identity_client.return_value.list_region_subscriptions.side_effect = (
+                Exception("discovery failed")
+            )
+
+            with pytest.raises(OCISetUpSessionError):
+                provider.get_regions_to_audit({"us-ashburn-1", "us-phoenix-1"})

--- a/tests/providers/oraclecloud/oraclecloud_provider_test.py
+++ b/tests/providers/oraclecloud/oraclecloud_provider_test.py
@@ -240,6 +240,91 @@ MIIEpQIBAAKCAQEA0Z3VS5JJcds3xfn/ygWyF8n0sMcD/QHWCJ7yGSEtLN2T
         )
 
 
+class TestTestConnectionRegionHandling:
+    """Tests for region handling in test_connection()."""
+
+    def test_config_file_auth_without_region_preserves_session_region_for_identity(
+        self,
+    ):
+        mock_session = OCISession(
+            config={
+                "tenancy": "ocid1.tenancy.oc1..aaaaaaaexample",
+                "user": "ocid1.user.oc1..aaaaaaaexample",
+                "region": "eu-frankfurt-1",
+            },
+            signer=None,
+            profile="DEFAULT",
+        )
+        mock_identity = OCIIdentityInfo(
+            tenancy_id="ocid1.tenancy.oc1..aaaaaaaexample",
+            tenancy_name="test-tenancy",
+            user_id="ocid1.user.oc1..aaaaaaaexample",
+            region="eu-frankfurt-1",
+            profile="DEFAULT",
+            audited_regions={"eu-frankfurt-1"},
+            audited_compartments=[],
+        )
+
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ),
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.set_identity",
+                return_value=mock_identity,
+            ) as mock_set_identity,
+        ):
+            connection = OraclecloudProvider.test_connection(
+                oci_config_file="/tmp/config",
+                profile="DEFAULT",
+                raise_on_exception=False,
+            )
+
+        assert connection.is_connected is True
+        mock_set_identity.assert_called_once_with(session=mock_session, region=None)
+
+    def test_instance_principal_auth_without_region_preserves_session_region_for_identity(
+        self,
+    ):
+        mock_signer = MagicMock()
+        mock_session = OCISession(
+            config={
+                "tenancy": "ocid1.tenancy.oc1..aaaaaaaexample",
+                "region": "uk-london-1",
+            },
+            signer=mock_signer,
+            profile=None,
+        )
+        mock_identity = OCIIdentityInfo(
+            tenancy_id="ocid1.tenancy.oc1..aaaaaaaexample",
+            tenancy_name="test-tenancy",
+            user_id="instance-principal",
+            region="uk-london-1",
+            profile=None,
+            audited_regions={"uk-london-1"},
+            audited_compartments=[],
+        )
+
+        with (
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.setup_session",
+                return_value=mock_session,
+            ),
+            patch(
+                "prowler.providers.oraclecloud.oraclecloud_provider.OraclecloudProvider.set_identity",
+                return_value=mock_identity,
+            ) as mock_set_identity,
+        ):
+            connection = OraclecloudProvider.test_connection(
+                use_instance_principal=True,
+                raise_on_exception=False,
+            )
+
+        assert connection.is_connected is True
+        mock_set_identity.assert_called_once_with(session=mock_session, region=None)
+
+
 class TestOraclecloudProviderInit:
     """Tests for OraclecloudProvider initialization"""
 


### PR DESCRIPTION
### Context

Oracle Cloud credentials in Prowler can be valid without using a user-selected scan region. The SDK needs a safe internal region only to bootstrap the OCI client and discover subscribed regions.

### Description

This PR updates the Oracle Cloud provider initialization so API-key authentication can fall back to the internal default region when no explicit scan region filter is provided. It also adds SDK tests for regionless credentials and documents the SDK change in the changelog.

Changed files:

| File | Change |
|------|--------|
| `prowler/CHANGELOG.md` | Adds the SDK changelog entry. |
| `prowler/providers/oraclecloud/oraclecloud_provider.py` | Adds the regionless fallback behavior. |
| `tests/providers/oraclecloud/oraclecloud_provider_test.py` | Adds SDK coverage for regionless OCI setup. |

### Steps to review

1. Review the SDK diff against the platform slice.
2. Confirm the SDK changes match the SDK portion of #11565.
3. Confirm the API slice builds on this PR.

Validation previously run for this slice:

```text
uv run pytest tests/providers/oraclecloud/oraclecloud_provider_test.py
```

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

## Chain Context

| Field | Value |
|-------|-------|
| Chain | OCI regionless provider setup split from #11565 |
| Tracker PR | #11565 |
| Position | 2 of 4 |
| Base | `ci/oci-regionless-platform-11565` |
| Depends on | #11739 |
| Follow-up | #11741 |
| Review budget | 357 / 400 |
| Starts at | Platform CI guard slice |
| Ends with | SDK regionless OCI provider setup |

### Chain Overview

```text
master
 └── #11739 Platform CI guard
      └── 📍 #11740 SDK regionless OCI setup
           └── #11741 API regionless OCI credentials
                └── #11742 UI regionless OCI credentials
```

### Scope
- Includes: SDK provider fallback, SDK tests, and SDK changelog from #11565.
- Excludes: API and UI credential handling.

### Autonomy
- [ ] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Oracle Cloud scans now use a deterministic bootstrap region for API-key authentication when no scan region is provided.
  * Region selection now supports explicit region inputs (single or multiple) with improved legacy single-region behavior.
  * If region subscription discovery fails, scans fall back only for supported single-explicit-region cases and otherwise fail with a clear error.
* **Tests**
  * Added coverage for bootstrap-region selection, explicit-region behavior, and subscription-discovery failure handling.
* **Documentation**
  * Updated the Oracle Cloud changelog to reflect the new region behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->