### PR TITLE
chore(multi-tenant): delete last tenant from profile page

### DIFF
--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the **Prowler UI** are documented in this file.
 
+## [1.33.0] (Prowler v5.33.0)
+
+### 🚀 Added
+
+- Owners can delete their last organization from the profile page [(#XXXXX)](https://github.com/prowler-cloud/prowler/pull/XXXXX)
+
+### 🔄 Changed
+
+- Organization row actions in the profile page are aligned in fixed columns and the Active indicator now sits next to the organization name [(#XXXXX)](https://github.com/prowler-cloud/prowler/pull/XXXXX)
+
+---
+
 ## [1.32.1] (Prowler v5.32.1)
 
 ### 🐞 Fixed

--- a/ui/CHANGELOG.md
+++ b/ui/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to the **Prowler UI** are documented in this file.
 
 ### 🚀 Added
 
-- Owners can delete their last organization from the profile page [(#XXXXX)](https://github.com/prowler-cloud/prowler/pull/XXXXX)
+- Owners can delete their last organization from the profile page [(#11864)](https://github.com/prowler-cloud/prowler/pull/11864)
 
 ### 🔄 Changed
 
-- Organization row actions in the profile page are aligned in fixed columns and the Active indicator now sits next to the organization name [(#XXXXX)](https://github.com/prowler-cloud/prowler/pull/XXXXX)
+- Organization row actions in the profile page are aligned in fixed columns and the Active indicator now sits next to the organization name [(#11864)](https://github.com/prowler-cloud/prowler/pull/11864)
 
 ---
 

--- a/ui/actions/users/tenants.ts
+++ b/ui/actions/users/tenants.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
+import { signOut } from "@/auth.config";
 import { apiBaseUrl, getAuthHeaders } from "@/lib/helper";
 import { handleApiError, handleApiResponse } from "@/lib/server-actions-helper";
 
@@ -285,6 +286,47 @@ export async function deleteTenant(
   } catch (error) {
     return handleApiError(error);
   }
+}
+
+export async function deleteTenantThenSignOut(
+  _prevState: DeleteTenantState | null,
+  formData: FormData,
+): Promise<DeleteTenantState> {
+  const formDataObject = Object.fromEntries(formData);
+  const validatedData = deleteTenantSchema.safeParse(formDataObject);
+
+  if (!validatedData.success) {
+    return { error: "Invalid tenant ID" };
+  }
+
+  const { tenantId } = validatedData.data;
+  const headers = await getAuthHeaders({ contentType: false });
+
+  try {
+    const url = new URL(`${apiBaseUrl}/tenants/${tenantId}`);
+    const response = await fetch(url.toString(), {
+      method: "DELETE",
+      headers,
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      const errorDetail =
+        errorData?.errors?.[0]?.detail ||
+        `Failed to delete tenant: ${response.statusText}`;
+      throw new Error(errorDetail);
+    }
+  } catch (error) {
+    return handleApiError(error);
+  }
+
+  // Deleting the last tenant also removes the user account server-side, so
+  // there is no profile left to revalidate; close the session instead.
+  // signOut redirects by throwing, so it must stay outside the try/catch.
+  await signOut({ redirectTo: "/sign-in" });
+
+  // Unreachable: signOut always redirects. Present to satisfy the return type.
+  return { success: true };
 }
 
 interface SwitchThenDeleteSuccess {

--- a/ui/components/users/forms/delete-tenant-form.test.tsx
+++ b/ui/components/users/forms/delete-tenant-form.test.tsx
@@ -2,8 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
-import { logOut } from "@/actions/auth";
-import { deleteTenant } from "@/actions/users/tenants";
+import { deleteTenantThenSignOut } from "@/actions/users/tenants";
 
 import { DeleteTenantForm } from "./delete-tenant-form";
 
@@ -18,12 +17,9 @@ vi.mock("@/auth.config", () => ({
 
 vi.mock("@/actions/users/tenants", () => ({
   deleteTenant: vi.fn(),
+  deleteTenantThenSignOut: vi.fn(),
   switchTenant: vi.fn(),
   switchThenDeleteTenant: vi.fn(),
-}));
-
-vi.mock("@/actions/auth", () => ({
-  logOut: vi.fn(),
 }));
 
 const mockToast = vi.fn();
@@ -111,9 +107,14 @@ describe("DeleteTenantForm", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("last-tenant submit enables with name only, then deletes and signs out", async () => {
+  it("last-tenant submit enables with name only and calls the delete-and-sign-out action", async () => {
     const user = userEvent.setup();
-    vi.mocked(deleteTenant).mockResolvedValue({ success: true });
+    // The action redirects server-side on success, so the promise never
+    // resolves with a value in the real flow; a NEXT_REDIRECT rejection is
+    // the closest observable behavior.
+    vi.mocked(deleteTenantThenSignOut).mockRejectedValue({
+      digest: "NEXT_REDIRECT;replace;/sign-in;303;",
+    });
 
     render(
       <DeleteTenantForm
@@ -136,14 +137,19 @@ describe("DeleteTenantForm", () => {
     await user.click(submitBtn);
 
     await waitFor(() => {
-      expect(deleteTenant).toHaveBeenCalled();
-      expect(logOut).toHaveBeenCalled();
+      expect(deleteTenantThenSignOut).toHaveBeenCalled();
     });
+    // A redirect is not a failure: no error toast
+    expect(mockToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" }),
+    );
   });
 
-  it("last-tenant submit does not sign out when delete fails", async () => {
+  it("last-tenant submit shows error and re-enables when delete fails", async () => {
     const user = userEvent.setup();
-    vi.mocked(deleteTenant).mockResolvedValue({ error: "Delete failed" });
+    vi.mocked(deleteTenantThenSignOut).mockResolvedValue({
+      error: "Delete failed",
+    });
 
     render(
       <DeleteTenantForm
@@ -161,11 +167,43 @@ describe("DeleteTenantForm", () => {
     await user.click(screen.getByRole("button", { name: /delete/i }));
 
     await waitFor(() => {
-      expect(deleteTenant).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          description: "Delete failed",
+        }),
+      );
+    });
+    // Submitting state is reset so the user is not stuck on a disabled button
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
+  });
+
+  it("last-tenant submit recovers when the action call itself fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteTenantThenSignOut).mockRejectedValue(
+      new Error("network error"),
+    );
+
+    render(
+      <DeleteTenantForm
+        {...baseProps}
+        isActiveTenant={true}
+        isLastTenant={true}
+        availableTenants={[]}
+      />,
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("My Organization"),
+      "My Organization",
+    );
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({ variant: "destructive" }),
       );
     });
-    expect(logOut).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled();
   });
 });

--- a/ui/components/users/forms/delete-tenant-form.test.tsx
+++ b/ui/components/users/forms/delete-tenant-form.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { logOut } from "@/actions/auth";
+import { deleteTenant } from "@/actions/users/tenants";
 
 import { DeleteTenantForm } from "./delete-tenant-form";
 
@@ -19,6 +22,10 @@ vi.mock("@/actions/users/tenants", () => ({
   switchThenDeleteTenant: vi.fn(),
 }));
 
+vi.mock("@/actions/auth", () => ({
+  logOut: vi.fn(),
+}));
+
 const mockToast = vi.fn();
 vi.mock("@/components/ui", () => ({
   useToast: () => ({ toast: mockToast }),
@@ -28,6 +35,7 @@ const baseProps = {
   tenantId: "tenant-1",
   tenantName: "My Organization",
   isActiveTenant: false,
+  isLastTenant: false,
   availableTenants: [{ id: "tenant-2", name: "Other Org" }],
   setIsOpen: vi.fn(),
 };
@@ -86,5 +94,78 @@ describe("DeleteTenantForm", () => {
     render(<DeleteTenantForm {...baseProps} />);
     await user.click(screen.getByRole("button", { name: /cancel/i }));
     expect(baseProps.setIsOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("shows last-tenant warning and no target select when isLastTenant", () => {
+    render(
+      <DeleteTenantForm
+        {...baseProps}
+        isActiveTenant={true}
+        isLastTenant={true}
+        availableTenants={[]}
+      />,
+    );
+    expect(screen.getByText(/close your session/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/switch to after deletion/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("last-tenant submit enables with name only, then deletes and signs out", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteTenant).mockResolvedValue({ success: true });
+
+    render(
+      <DeleteTenantForm
+        {...baseProps}
+        isActiveTenant={true}
+        isLastTenant={true}
+        availableTenants={[]}
+      />,
+    );
+
+    const submitBtn = screen.getByRole("button", { name: /delete/i });
+    expect(submitBtn).toBeDisabled();
+
+    await user.type(
+      screen.getByPlaceholderText("My Organization"),
+      "My Organization",
+    );
+    expect(submitBtn).toBeEnabled();
+
+    await user.click(submitBtn);
+
+    await waitFor(() => {
+      expect(deleteTenant).toHaveBeenCalled();
+      expect(logOut).toHaveBeenCalled();
+    });
+  });
+
+  it("last-tenant submit does not sign out when delete fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteTenant).mockResolvedValue({ error: "Delete failed" });
+
+    render(
+      <DeleteTenantForm
+        {...baseProps}
+        isActiveTenant={true}
+        isLastTenant={true}
+        availableTenants={[]}
+      />,
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("My Organization"),
+      "My Organization",
+    );
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(deleteTenant).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "destructive" }),
+      );
+    });
+    expect(logOut).not.toHaveBeenCalled();
   });
 });

--- a/ui/components/users/forms/delete-tenant-form.tsx
+++ b/ui/components/users/forms/delete-tenant-form.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from "react";
 
+import { logOut } from "@/actions/auth";
 import { deleteTenant, switchThenDeleteTenant } from "@/actions/users/tenants";
 import { Input } from "@/components/shadcn/input/input";
 import {
@@ -28,6 +29,7 @@ interface DeleteTenantFormProps {
   tenantId: string;
   tenantName: string;
   isActiveTenant: boolean;
+  isLastTenant: boolean;
   availableTenants: TenantOption[];
   setIsOpen: Dispatch<SetStateAction<boolean>>;
 }
@@ -36,6 +38,7 @@ export const DeleteTenantForm = ({
   tenantId,
   tenantName,
   isActiveTenant,
+  isLastTenant,
   availableTenants,
   setIsOpen,
 }: DeleteTenantFormProps) => {
@@ -48,7 +51,10 @@ export const DeleteTenantForm = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const nameMatches = confirmName === tenantName;
-  const canSubmit = isActiveTenant
+  // Deleting the last tenant needs no switch target — there is nothing to
+  // switch to; the session is closed after deletion instead.
+  const needsSwitchTarget = isActiveTenant && !isLastTenant;
+  const canSubmit = needsSwitchTarget
     ? nameMatches && targetTenantId !== ""
     : nameMatches;
 
@@ -70,6 +76,32 @@ export const DeleteTenantForm = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deleteState]);
+
+  // Handle last-tenant delete: the tenant is deleted with the current token
+  // (still valid at request time) and the session is closed right after,
+  // since the API also removes users whose only tenant was the deleted one.
+  const handleLastTenantDelete = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    const formData = new FormData(e.currentTarget);
+    const result = await deleteTenant(null, formData);
+
+    if ("success" in result) {
+      toast({
+        title: "Organization deleted",
+        description: "Your account has been removed. Closing the session.",
+      });
+      await logOut();
+    } else {
+      toast({
+        variant: "destructive",
+        title: "Oops! Something went wrong",
+        description: result.error,
+      });
+      setIsSubmitting(false);
+    }
+  };
 
   // Handle active-tenant delete: call server action directly to avoid
   // React's RSC reconciliation unmounting this component before we can
@@ -115,12 +147,18 @@ export const DeleteTenantForm = ({
 
   return (
     <form
-      action={isActiveTenant ? undefined : deleteFormAction}
-      onSubmit={isActiveTenant ? handleActiveTenantDelete : undefined}
+      action={isActiveTenant || isLastTenant ? undefined : deleteFormAction}
+      onSubmit={
+        isLastTenant
+          ? handleLastTenantDelete
+          : isActiveTenant
+            ? handleActiveTenantDelete
+            : undefined
+      }
       className="flex flex-col gap-4"
     >
       <input type="hidden" name="tenantId" value={tenantId} />
-      {isActiveTenant && targetTenantId && (
+      {needsSwitchTarget && targetTenantId && (
         <input type="hidden" name="targetTenantId" value={targetTenantId} />
       )}
 
@@ -137,7 +175,14 @@ export const DeleteTenantForm = ({
         autoComplete="off"
       />
 
-      {isActiveTenant && (
+      {isLastTenant && (
+        <div className="text-text-error-primary text-sm">
+          This is your only organization. Deleting it will also remove your user
+          account and close your session.
+        </div>
+      )}
+
+      {needsSwitchTarget && (
         <div className="flex flex-col gap-2">
           <div className="text-sm">
             This is your active organization. Select which organization to

--- a/ui/components/users/forms/delete-tenant-form.tsx
+++ b/ui/components/users/forms/delete-tenant-form.tsx
@@ -10,8 +10,11 @@ import {
   useState,
 } from "react";
 
-import { logOut } from "@/actions/auth";
-import { deleteTenant, switchThenDeleteTenant } from "@/actions/users/tenants";
+import {
+  deleteTenant,
+  deleteTenantThenSignOut,
+  switchThenDeleteTenant,
+} from "@/actions/users/tenants";
 import { Input } from "@/components/shadcn/input/input";
 import {
   Select,
@@ -77,27 +80,39 @@ export const DeleteTenantForm = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [deleteState]);
 
-  // Handle last-tenant delete: the tenant is deleted with the current token
-  // (still valid at request time) and the session is closed right after,
-  // since the API also removes users whose only tenant was the deleted one.
+  // Handle last-tenant delete: a single server action deletes the tenant and
+  // closes the session, since the API also removes users whose only tenant
+  // was the deleted one. On success it redirects to /sign-in server-side.
   const handleLastTenantDelete = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsSubmitting(true);
 
     const formData = new FormData(e.currentTarget);
-    const result = await deleteTenant(null, formData);
 
-    if ("success" in result) {
-      toast({
-        title: "Organization deleted",
-        description: "Your account has been removed. Closing the session.",
-      });
-      await logOut();
-    } else {
+    try {
+      const result = await deleteTenantThenSignOut(null, formData);
+      if (result && "error" in result) {
+        toast({
+          variant: "destructive",
+          title: "Oops! Something went wrong",
+          description: result.error,
+        });
+        setIsSubmitting(false);
+      }
+    } catch (error) {
+      // The action redirects by throwing NEXT_REDIRECT — never a failure.
+      if (
+        error &&
+        typeof error === "object" &&
+        "digest" in error &&
+        String(error.digest).startsWith("NEXT_REDIRECT")
+      ) {
+        return;
+      }
       toast({
         variant: "destructive",
         title: "Oops! Something went wrong",
-        description: result.error,
+        description: "The organization could not be deleted. Please try again.",
       });
       setIsSubmitting(false);
     }

--- a/ui/components/users/profile/membership-item.test.tsx
+++ b/ui/components/users/profile/membership-item.test.tsx
@@ -15,6 +15,11 @@ vi.mock("@/actions/users/tenants", () => ({
   switchTenant: vi.fn(),
   updateTenantName: vi.fn(),
   deleteTenant: vi.fn(),
+  switchThenDeleteTenant: vi.fn(),
+}));
+
+vi.mock("@/actions/auth", () => ({
+  logOut: vi.fn(),
 }));
 
 vi.mock("@/components/ui", () => ({
@@ -133,7 +138,7 @@ describe("MembershipItem", () => {
     expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
   });
 
-  it("hides Delete button when membershipCount === 1", () => {
+  it("shows Delete button when isOrgOwner and membershipCount === 1", () => {
     render(
       <MembershipItem
         membership={baseMembership}
@@ -145,9 +150,7 @@ describe("MembershipItem", () => {
         membershipCount={1}
       />,
     );
-    expect(
-      screen.queryByRole("button", { name: /delete/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
   });
 
   it("hides Delete button when not isOrgOwner", () => {

--- a/ui/components/users/profile/membership-item.test.tsx
+++ b/ui/components/users/profile/membership-item.test.tsx
@@ -15,11 +15,8 @@ vi.mock("@/actions/users/tenants", () => ({
   switchTenant: vi.fn(),
   updateTenantName: vi.fn(),
   deleteTenant: vi.fn(),
+  deleteTenantThenSignOut: vi.fn(),
   switchThenDeleteTenant: vi.fn(),
-}));
-
-vi.mock("@/actions/auth", () => ({
-  logOut: vi.fn(),
 }));
 
 vi.mock("@/components/ui", () => ({

--- a/ui/components/users/profile/membership-item.tsx
+++ b/ui/components/users/profile/membership-item.tsx
@@ -2,7 +2,14 @@
 
 import { useState } from "react";
 
-import { Badge, Button, Card } from "@/components/shadcn";
+import {
+  Badge,
+  Button,
+  Card,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/shadcn";
 import { InfoField } from "@/components/shadcn/info-field/info-field";
 import { Modal } from "@/components/shadcn/modal";
 import { DateWithTime } from "@/components/ui/entities";
@@ -33,7 +40,7 @@ export const MembershipItem = ({
   const [isDeletingOpen, setIsDeletingOpen] = useState(false);
 
   const isActiveTenant = tenantId === sessionTenantId;
-  const canDelete = isOrgOwner && membershipCount > 1;
+  const isLastTenant = membershipCount === 1;
 
   return (
     <>
@@ -56,74 +63,102 @@ export const MembershipItem = ({
         open={isDeletingOpen}
         onOpenChange={setIsDeletingOpen}
         title="Delete organization"
-        description="This will permanently delete the organization and all its data. Users with no other organizations will lose access. This action cannot be undone."
+        description={
+          isLastTenant
+            ? "This will permanently delete the organization and all its data. Since it is your only organization, your user account will also be removed and your session will be closed. This action cannot be undone."
+            : "This will permanently delete the organization and all its data. Users with no other organizations will lose access. This action cannot be undone."
+        }
       >
         <DeleteTenantForm
           tenantId={tenantId}
           tenantName={tenantName}
           isActiveTenant={isActiveTenant}
+          isLastTenant={isLastTenant}
           availableTenants={availableTenants}
           setIsOpen={setIsDeletingOpen}
         />
       </Modal>
       <Card variant="inner" className="p-2">
         <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-          <Badge variant="secondary">{membership.attributes.role}</Badge>
+          <span className="flex w-16 shrink-0">
+            <Badge variant="secondary">{membership.attributes.role}</Badge>
+          </span>
 
-          <div className="flex flex-row flex-wrap gap-1 gap-x-4">
-            <InfoField label="Name" inline variant="transparent">
-              <span className="font-semibold whitespace-nowrap">
-                {tenantName}
-              </span>
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <InfoField
+              label="Name"
+              inline
+              variant="transparent"
+              className="min-w-0 [&>div]:min-w-0"
+            >
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="block truncate font-semibold">
+                    {tenantName}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{tenantName}</TooltipContent>
+              </Tooltip>
             </InfoField>
-            <InfoField label="Joined on" inline variant="transparent">
-              <DateWithTime
-                inline
-                showTime={false}
-                dateTime={membership.attributes.date_joined}
-              />
-            </InfoField>
-          </div>
-
-          <div className="ml-auto flex items-center gap-2">
-            {isOrgOwner && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsEditOpen(true)}
-              >
-                Edit
-              </Button>
-            )}
-            {canDelete && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="text-destructive hover:text-destructive"
-                onClick={() => setIsDeletingOpen(true)}
-              >
-                Delete
-              </Button>
-            )}
-            {isActiveTenant ? (
-              <Badge
-                variant="outline"
-                className="border-emerald-600 text-emerald-600"
-              >
+            {isActiveTenant && (
+              <Badge variant="success" className="shrink-0">
                 Active
               </Badge>
-            ) : (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={() => setIsSwitchingOpen(true)}
-              >
-                Switch
-              </Button>
             )}
+          </div>
+
+          <InfoField
+            label="Joined on"
+            inline
+            variant="transparent"
+            className="shrink-0"
+          >
+            <DateWithTime
+              inline
+              showTime={false}
+              dateTime={membership.attributes.date_joined}
+            />
+          </InfoField>
+
+          {/* Fixed-width slots keep Edit/Delete/Switch aligned across rows */}
+          <div className="flex shrink-0 items-center gap-2 self-end sm:self-auto">
+            <span className="flex w-18 justify-center">
+              {isOrgOwner && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsEditOpen(true)}
+                >
+                  Edit
+                </Button>
+              )}
+            </span>
+            <span className="flex w-18 justify-center">
+              {isOrgOwner && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="text-text-error-primary"
+                  onClick={() => setIsDeletingOpen(true)}
+                >
+                  Delete
+                </Button>
+              )}
+            </span>
+            <span className="flex w-18 justify-center">
+              {!isActiveTenant && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsSwitchingOpen(true)}
+                >
+                  Switch
+                </Button>
+              )}
+            </span>
           </div>
         </div>
       </Card>

--- a/ui/components/users/profile/membership-item.tsx
+++ b/ui/components/users/profile/membership-item.tsx
@@ -65,7 +65,7 @@ export const MembershipItem = ({
         title="Delete organization"
         description={
           isLastTenant
-            ? "This will permanently delete the organization and all its data. Since it is your only organization, your user account will also be removed and your session will be closed. This action cannot be undone."
+            ? "This will permanently delete the organization and all its data. This action cannot be undone."
             : "This will permanently delete the organization and all its data. Users with no other organizations will lose access. This action cannot be undone."
         }
       >

--- a/ui/components/users/profile/memberships-card-client.tsx
+++ b/ui/components/users/profile/memberships-card-client.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/shadcn";
 import { Modal } from "@/components/shadcn/modal";
+import { CustomLink } from "@/components/ui/custom/custom-link";
 import { CreateTenantForm } from "@/components/users/forms/create-tenant-form";
 import { MembershipDetailData, TenantDetailData } from "@/types/users";
 
@@ -51,7 +52,10 @@ export const MembershipsCardClient = ({
           <div className="flex flex-col gap-1">
             <CardTitle>Organizations</CardTitle>
             <p className="text-xs text-gray-500">
-              Organizations this user is associated with
+              Organizations this user is associated with.{" "}
+              <CustomLink href="https://docs.prowler.com/user-guide/tutorials/prowler-app-multi-tenant">
+                Learn more
+              </CustomLink>
             </p>
           </div>
           <CardAction>


### PR DESCRIPTION
### Context

After moving "Cancel Subscription" to the Billing page there was no way to delete the last tenant for an owner.

### Description

- Allow to delete the last tenant for an owner
- Align table columns

### Steps to review

1. Go to profile page
<img width="715" height="314" alt="Screenshot 2026-07-07 at 00 15 42" src="https://github.com/user-attachments/assets/3c6285fb-9445-4737-bdce-b14f407920c2" />


https://github.com/user-attachments/assets/1c71da02-d923-4dfd-a72f-0996c5993845


### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Owners can delete their last organization from the profile page with a dedicated last-organization flow and warning.

* **Bug Fixes**
  * Updated last-organization deletion behavior (no target-organization selector) and improved submit gating/feedback, including proper handling of redirect outcomes.
  * Reformatted the Organizations list so action buttons and the “Active” indicator are consistently aligned.

* **Documentation**
  * Added a “Learn more” link in the Organizations section for additional guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->