### PR TITLE
ci: skip codeql and e2e on changelog-only changes

### DIFF
--- a/.github/workflows/api-codeql.yml
+++ b/.github/workflows/api-codeql.yml
@@ -9,6 +9,7 @@ on:
       - 'api/**'
       - '.github/workflows/api-codeql.yml'
       - '.github/codeql/api-codeql-config.yml'
+      - '!api/CHANGELOG.md'
   pull_request:
     branches:
       - 'master'
@@ -17,6 +18,7 @@ on:
       - 'api/**'
       - '.github/workflows/api-codeql.yml'
       - '.github/codeql/api-codeql-config.yml'
+      - '!api/CHANGELOG.md'
   schedule:
     - cron: '00 12 * * *'
 

--- a/.github/workflows/ui-e2e-tests-v2.yml
+++ b/.github/workflows/ui-e2e-tests-v2.yml
@@ -14,6 +14,8 @@ on:
       - '.github/test-impact.yml'
       - 'ui/**'
       - 'api/**'  # API changes can affect UI E2E
+      - '!ui/CHANGELOG.md'
+      - '!api/CHANGELOG.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
### Context

`api-codeql` and `ui-e2e-tests-v2` use `on.paths` globs (`api/**`, `ui/**`) that also match their respective `CHANGELOG.md` files. This means a changelog-only PR triggered the full CodeQL scan and the full UI E2E suite unnecessarily.

### Description

Adds `!api/CHANGELOG.md` to the `api-codeql` path filters, and `!ui/CHANGELOG.md` plus `!api/CHANGELOG.md` to the `ui-e2e-tests-v2` path filters. This matches the pattern already used by `sdk-codeql` (`!prowler/CHANGELOG.md`) and `ui-codeql` (`!ui/CHANGELOG.md`), which already exclude their own changelogs.

### Steps to review

1. Open a PR that only touches `api/CHANGELOG.md` and confirm `api-codeql` and `ui-e2e-tests-v2` no longer trigger.
2. Open a PR that only touches `ui/CHANGELOG.md` and confirm `ui-e2e-tests-v2` no longer triggers.
3. Confirm both workflows still trigger normally on actual `api/**` or `ui/**` source changes.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [Readme.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/prowler/CHANGELOG.md), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/ui/CHANGELOG.md), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure new entries are added to [CHANGELOG.md](https://github.com/prowler-cloud/prowler/blob/master/api/CHANGELOG.md), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation rules so changelog-only updates no longer trigger certain background checks and end-to-end runs.
  * This helps avoid unnecessary workflow executions while keeping normal code changes covered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->