### PR TITLE
chore(changelog): remove backport workflow fragment

### DIFF
--- a/prowler/changelog.d/11572.added.md
+++ b/prowler/changelog.d/11572.added.md
@@ -1,1 +1,0 @@
-Changelog fragment workflow for SDK, API, UI, and MCP Server releases, including PR attribution, fragment validation, release compilation, and preserved section ordering


### PR DESCRIPTION
### Context

The changelog fragment workflow was backported to `v5.33` in #11886. That backport included an SDK `.added` fragment for the workflow itself.

On a patch release from `v5.33`, that pending `.added` fragment would make the compile workflow auto-derive the next SDK version as a minor release, for example `5.33.0` to `5.34.0`, instead of allowing a patch release such as `5.33.1` when only fix fragments are present.

### Description

Removes the SDK changelog fragment added by the workflow backport so the `v5.33` branch does not carry a pending minor-bump fragment before future patch releases.

### Steps to review

- Confirm the diff only deletes `prowler/changelog.d/11572.added.md`.
- Run `uv run pytest tests/github`.
- For a future `v5.33` patch, add real patch fragments such as `.fixed.md` and let the compile workflow derive the patch version from those fragments.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable. Not applicable, this PR removes an incorrect backport fragment.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.