### PR TITLE
fix(dms): lazy load ec2 for public access check

### DIFF
--- a/prowler/changelog.d/dms-instance-no-public-access-ec2-lazy.fixed.md
+++ b/prowler/changelog.d/dms-instance-no-public-access-ec2-lazy.fixed.md
@@ -1,0 +1,1 @@
+`dms_instance_no_public_access` no longer initializes the full EC2 service when there are no DMS replication instances

--- a/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
+++ b/prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py
@@ -1,7 +1,12 @@
 from prowler.lib.check.models import Check, Check_Report_AWS
 from prowler.providers.aws.services.dms.dms_client import dms_client
-from prowler.providers.aws.services.ec2.ec2_client import ec2_client
 from prowler.providers.aws.services.ec2.lib.security_groups import check_security_group
+
+
+def _get_ec2_client():
+    from prowler.providers.aws.services.ec2.ec2_client import ec2_client
+
+    return ec2_client
 
 
 class dms_instance_no_public_access(Check):
@@ -19,7 +24,7 @@ class dms_instance_no_public_access(Check):
                 if instance.security_groups:
                     report.status = "PASS"
                     report.status_extended = f"DMS Replication Instance {instance.id} is set as publicly accessible but filtered with security groups."
-                    for security_group in ec2_client.security_groups.values():
+                    for security_group in _get_ec2_client().security_groups.values():
                         if security_group.id in instance.security_groups:
                             for ingress_rule in security_group.ingress_rules:
                                 if check_security_group(

--- a/tests/providers/aws/services/dms/dms_instance_no_public_access/dms_no_public_access_test.py
+++ b/tests/providers/aws/services/dms/dms_instance_no_public_access/dms_no_public_access_test.py
@@ -1,3 +1,5 @@
+import ast
+from pathlib import Path
 from unittest import mock
 
 import botocore
@@ -61,6 +63,42 @@ def mock_make_api_call_private(self, operation_name, kwargs):
 
 
 class Test_dms_instance_no_public_access:
+    def test_ec2_client_is_not_imported_at_module_level(self):
+        repo_root = Path(__file__).parents[6]
+        check_source = repo_root / (
+            "prowler/providers/aws/services/dms/dms_instance_no_public_access/dms_instance_no_public_access.py"
+        )
+        check_tree = ast.parse(check_source.read_text())
+
+        top_level_imports = [
+            node
+            for node in check_tree.body
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+        ]
+
+        top_level_ec2_client_imports = [
+            node
+            for node in top_level_imports
+            if (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "prowler.providers.aws.services.ec2.ec2_client"
+            )
+            or (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "prowler.providers.aws.services.ec2"
+                and any(alias.name == "ec2_client" for alias in node.names)
+            )
+            or (
+                isinstance(node, ast.Import)
+                and any(
+                    alias.name == "prowler.providers.aws.services.ec2.ec2_client"
+                    for alias in node.names
+                )
+            )
+        ]
+
+        assert top_level_ec2_client_imports == []
+
     @mock_aws
     def test_dms_no_instances(self):
         dms_client = client("dms", region_name=AWS_REGION_US_EAST_1)
@@ -79,6 +117,10 @@ class Test_dms_instance_no_public_access:
                 "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
                 new=DMS(aws_provider),
             ),
+            mock.patch(
+                "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access._get_ec2_client",
+                side_effect=AssertionError("EC2 client should not be loaded"),
+            ) as get_ec2_client_mock,
         ):
             from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
                 dms_instance_no_public_access,
@@ -87,6 +129,7 @@ class Test_dms_instance_no_public_access:
             check = dms_instance_no_public_access()
             result = check.execute()
             assert len(result) == 0
+            get_ec2_client_mock.assert_not_called()
 
     @mock_aws
     def test_dms_private(self):
@@ -108,6 +151,10 @@ class Test_dms_instance_no_public_access:
                     "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
                     new=DMS(aws_provider),
                 ),
+                mock.patch(
+                    "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access._get_ec2_client",
+                    side_effect=AssertionError("EC2 client should not be loaded"),
+                ) as get_ec2_client_mock,
             ):
                 from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
                     dms_instance_no_public_access,
@@ -125,6 +172,7 @@ class Test_dms_instance_no_public_access:
                 assert result[0].resource_id == DMS_INSTANCE_NAME
                 assert result[0].resource_arn == DMS_INSTANCE_ARN
                 assert result[0].resource_tags == []
+                get_ec2_client_mock.assert_not_called()
 
     @mock_aws
     def test_dms_public(self):
@@ -146,6 +194,10 @@ class Test_dms_instance_no_public_access:
                     "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.dms_client",
                     new=DMS(aws_provider),
                 ),
+                mock.patch(
+                    "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access._get_ec2_client",
+                    side_effect=AssertionError("EC2 client should not be loaded"),
+                ) as get_ec2_client_mock,
             ):
                 from prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access import (
                     dms_instance_no_public_access,
@@ -163,6 +215,7 @@ class Test_dms_instance_no_public_access:
                 assert result[0].resource_id == DMS_INSTANCE_NAME
                 assert result[0].resource_arn == DMS_INSTANCE_ARN
                 assert result[0].resource_tags == []
+                get_ec2_client_mock.assert_not_called()
 
     @mock_aws
     def test_dms_public_with_public_sg(self):
@@ -218,8 +271,8 @@ class Test_dms_instance_no_public_access:
                     new=dms_client,
                 ),
                 mock.patch(
-                    "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.ec2_client",
-                    new=EC2(aws_provider),
+                    "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access._get_ec2_client",
+                    return_value=EC2(aws_provider),
                 ),
             ):
                 # Test Check
@@ -298,8 +351,8 @@ class Test_dms_instance_no_public_access:
                     new=dms_client,
                 ),
                 mock.patch(
-                    "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access.ec2_client",
-                    new=EC2(aws_provider),
+                    "prowler.providers.aws.services.dms.dms_instance_no_public_access.dms_instance_no_public_access._get_ec2_client",
+                    return_value=EC2(aws_provider),
                 ),
             ):
                 # Test Check


### PR DESCRIPTION
### Context

Fix #11894

DMS scans were slow in empty environments because `dms_instance_no_public_access` imported the EC2 service client at module load time, which bootstrapped the full EC2 inventory even when no DMS replication instances existed.

### Description

- Lazy-load the EC2 client only when a public DMS replication instance has security groups to inspect
- Add regression coverage to prevent reintroducing a top-level EC2 client import
- Add a SDK changelog fragment for the fix

### Steps to review

- Review `dms_instance_no_public_access` and confirm EC2 is only loaded in the public-with-security-groups path
- Review the DMS check tests, especially the top-level import regression test
- Run:
  - `uv run pytest -q tests/providers/aws/services/dms/dms_instance_no_public_access/dms_no_public_access_test.py`
  - `uv run pytest -q tests/providers/aws/services/dms/dms_service_test.py`

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the open issues or roadmap.prowler.com
- [x] Is it assigned to me, if not, request it via the open issues or Prowler Community Slack

</details>

- [x] Review if the code is being covered by tests
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed
- [ ] Review if is needed to change the README.md
- [x] Ensure a changelog fragment is added under prowler/changelog.d/, if applicable

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under ui/changelog.d/, if applicable

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated
- [ ] Check if version updates are required (e.g., specs, uv, etc.)
- [ ] Ensure a changelog fragment is added under api/changelog.d/, if applicable

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under mcp_server/changelog.d/, if applicable

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of DMS replication instance checks so the app no longer loads EC2-related services when there are no DMS instances.
  * Preserved existing pass/fail results for public-access checks, including security group filtering cases.
* **Tests**
  * Added coverage to verify the EC2 service is only loaded when needed and not during unrelated DMS checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->