### PR TITLE
fix(api): scope user role updates to tenant

### DIFF
--- a/api/changelog.d/user-role-tenant-scope.security.md
+++ b/api/changelog.d/user-role-tenant-scope.security.md
@@ -1,0 +1,1 @@
+User role relationship updates are limited to the active tenant to preserve role assignments in other tenants

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -9478,9 +9478,15 @@ class TestUserRoleRelationshipViewSet:
             content_type="application/vnd.api+json",
         )
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        relationships = UserRoleRelationship.objects.filter(user=create_test_user.id)
+        tenant = roles_fixture[2].tenant
+        relationships = UserRoleRelationship.objects.filter(
+            user=create_test_user.id, tenant=tenant
+        )
         assert relationships.count() == 1
         assert {rel.role.id for rel in relationships} == {roles_fixture[2].id}
+        assert (
+            UserRoleRelationship.objects.filter(user=create_test_user.id).count() == 2
+        )
 
         data = {
             "data": [
@@ -9494,12 +9500,66 @@ class TestUserRoleRelationshipViewSet:
             content_type="application/vnd.api+json",
         )
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        relationships = UserRoleRelationship.objects.filter(user=create_test_user.id)
+        relationships = UserRoleRelationship.objects.filter(
+            user=create_test_user.id, tenant=tenant
+        )
         assert relationships.count() == 2
         assert {rel.role.id for rel in relationships} == {
             roles_fixture[1].id,
             roles_fixture[2].id,
         }
+        assert (
+            UserRoleRelationship.objects.filter(user=create_test_user.id).count() == 3
+        )
+
+    def test_partial_update_relationship_preserves_foreign_tenant_roles(
+        self, authenticated_client, roles_fixture, tenants_fixture
+    ):
+        tenant_a, tenant_b, _ = tenants_fixture
+        tenant_a_role = roles_fixture[1]
+        replacement_role = roles_fixture[2]
+        foreign_role = Role.objects.create(
+            name=f"foreign-role-{uuid4()}",
+            tenant=tenant_b,
+            manage_users=False,
+            manage_account=False,
+            manage_billing=False,
+            manage_providers=False,
+            manage_integrations=False,
+            manage_scans=False,
+            unlimited_visibility=False,
+        )
+        shared_user = User.objects.create_user(
+            name="shared_user",
+            email=f"shared-user-{uuid4()}@prowler.com",
+            password="TmpPass123@",
+        )
+        Membership.objects.create(user=shared_user, tenant=tenant_a)
+        Membership.objects.create(user=shared_user, tenant=tenant_b)
+        UserRoleRelationship.objects.create(
+            user=shared_user, role=tenant_a_role, tenant=tenant_a
+        )
+        UserRoleRelationship.objects.create(
+            user=shared_user, role=foreign_role, tenant=tenant_b
+        )
+
+        data = {"data": [{"type": "roles", "id": str(replacement_role.id)}]}
+        response = authenticated_client.patch(
+            reverse("user-roles-relationship", kwargs={"pk": shared_user.id}),
+            data=data,
+            content_type="application/vnd.api+json",
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        tenant_a_relationships = UserRoleRelationship.objects.filter(
+            user=shared_user, tenant=tenant_a
+        )
+        assert tenant_a_relationships.count() == 1
+        assert {rel.role_id for rel in tenant_a_relationships} == {replacement_role.id}
+        assert UserRoleRelationship.objects.filter(
+            user=shared_user, tenant=tenant_b, role=foreign_role
+        ).exists()
+        assert UserRoleRelationship.objects.filter(user=shared_user).count() == 2
 
     def test_destroy_relationship_other_user(
         self, authenticated_client, roles_fixture, create_test_user, tenants_fixture

--- a/api/src/backend/api/v1/serializers.py
+++ b/api/src/backend/api/v1/serializers.py
@@ -444,8 +444,8 @@ class UserRoleRelationshipSerializer(RLSSerializer, BaseWriteSerializer):
 
     def create(self, validated_data):
         role_ids = [item["id"] for item in validated_data["roles"]]
-        roles = Role.objects.filter(id__in=role_ids)
         tenant_id = self.context.get("tenant_id")
+        roles = Role.objects.filter(id__in=role_ids, tenant_id=tenant_id)
 
         new_relationships = [
             UserRoleRelationship(
@@ -459,8 +459,8 @@ class UserRoleRelationshipSerializer(RLSSerializer, BaseWriteSerializer):
 
     def update(self, instance, validated_data):
         role_ids = [item["id"] for item in validated_data["roles"]]
-        roles = Role.objects.filter(id__in=role_ids)
         tenant_id = self.context.get("tenant_id")
+        roles = Role.objects.filter(id__in=role_ids, tenant_id=tenant_id)
 
         # Safeguard: A tenant must always have at least one user with MANAGE_ACCOUNT.
         # If the target roles do NOT include MANAGE_ACCOUNT, and the current user is
@@ -490,7 +490,7 @@ class UserRoleRelationshipSerializer(RLSSerializer, BaseWriteSerializer):
                     }
                 )
 
-        instance.roles.clear()
+        UserRoleRelationship.objects.filter(user=instance, tenant_id=tenant_id).delete()
         new_relationships = [
             UserRoleRelationship(user=instance, role=r, tenant_id=tenant_id)
             for r in roles


### PR DESCRIPTION
### Context

This PR hardens user role relationship updates so a PATCH only replaces role relationships for the tenant in the request context.

### Description

- Filter requested roles by the active tenant before rebuilding user role relationships
- Replace global role relationship clearing with a tenant-scoped delete through `UserRoleRelationship`
- Add regression coverage for shared users with role assignments in multiple tenants
- Add an API security changelog fragment

### Steps to review

1. Run `cd api && uv run pytest src/backend/api/tests/test_views.py::TestUserRoleRelationshipViewSet -q`
2. Run `cd api && uv run ruff check src/backend/api/v1/serializers.py src/backend/api/tests/test_views.py`
3. Run `cd api && uv run ruff format --check src/backend/api/v1/serializers.py src/backend/api/tests/test_views.py`
4. Optional local API check: `PATCH /api/v1/users/{id}/relationships/roles` returned `204 No Content` and preserved role rows for other tenants in the through table

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No
    - If so, do we need to update permissions for the provider? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [x] Endpoint response output: `PATCH /api/v1/users/{id}/relationships/roles` returned `204 No Content` in local dev verification
- [x] EXPLAIN ANALYZE output for new/modified queries or indexes: not applicable, no schema or index changes
- [x] Performance test results: not applicable, scoped delete keeps the same small relationship update path
- [x] Any other relevant evidence of the implementation: regression test covers shared users with roles in multiple tenants
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - User role updates are now limited to the active tenant, so changes in one tenant no longer affect role assignments in other tenants.
  - Partial updates preserve existing role relationships for the same user in other tenants.
  - Validation now checks tenant-specific role membership and keeps the total cross-tenant relationship count consistent.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->