### PR TITLE
ci: rename public ECR push-role secret to PUBLIC_ECR_PUSH_ROLE_ARN

### DIFF
--- a/.github/workflows/sdk-container-build-push.yml
+++ b/.github/workflows/sdk-container-build-push.yml
@@ -180,7 +180,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: us-east-1
-          role-to-assume: ${{ secrets.PUBLIC_ECR_IAM_ROLE_ARN }}
+          role-to-assume: ${{ secrets.PUBLIC_ECR_PUSH_ROLE_ARN }}
 
       - name: Login to Public ECR
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6
@@ -241,7 +241,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           aws-region: us-east-1
-          role-to-assume: ${{ secrets.PUBLIC_ECR_IAM_ROLE_ARN }}
+          role-to-assume: ${{ secrets.PUBLIC_ECR_PUSH_ROLE_ARN }}
 
       - name: Login to Public ECR
         uses: aws-actions/amazon-ecr-login@d539f0932e70871a027e9d5a9d8fc38589180a64 # v2.1.6


### PR DESCRIPTION
### Context

The `sdk-container-build-push.yml` workflow assumes an IAM role via OIDC to push Prowler SDK images to `public.ecr.aws/prowler-cloud/prowler`. That role is referenced through the repo secret `PUBLIC_ECR_IAM_ROLE_ARN`, a generic name left over from when it was first wired up.

As part of a platform-side IAM role cleanup that separates the image-push role from the CI/CD role, the secret is being renamed to `PUBLIC_ECR_PUSH_ROLE_ARN` to make its purpose explicit.

**⚠️ Action required before merge:** the repo secret `PUBLIC_ECR_PUSH_ROLE_ARN` must be created (value = `arn:aws:iam::998057895221:role/prowler-public-ecr-push`) before this PR merges. Otherwise, the two `Configure AWS credentials (OIDC)` steps that push to Public ECR will lose their role reference and the image-push job will fail. The old `PUBLIC_ECR_IAM_ROLE_ARN` secret can be deleted after merge.

### Description

Renames the secret reference used by the `role-to-assume` input in both `Configure AWS credentials (OIDC)` steps of `.github/workflows/sdk-container-build-push.yml`:

`${{ secrets.PUBLIC_ECR_IAM_ROLE_ARN }}` → `${{ secrets.PUBLIC_ECR_PUSH_ROLE_ARN }}`

No other lines are touched. Verified via `grep -rn "PUBLIC_ECR_IAM_ROLE_ARN"` across the repo that these were the only two references, before and after the change.

### Steps to review

1. Confirm the new secret `PUBLIC_ECR_PUSH_ROLE_ARN` exists in the repo settings (or is created before merge) with the push-role ARN as its value.
2. Diff `.github/workflows/sdk-container-build-push.yml` — only the two `role-to-assume:` lines change.
3. After merge, trigger (or wait for) the SDK container build/push workflow and confirm the OIDC role assumption and Public ECR push succeed.
4. Once confirmed working, delete the old `PUBLIC_ECR_IAM_ROLE_ARN` secret.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable. — not applicable: this is an internal CI-only workflow change (a GitHub Actions secret rename), not a user-facing SDK/CLI/API/UI/MCP change.

#### SDK/CLI
- Are there new checks included in this PR? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container publishing workflow to use a different AWS role for public package pushes, improving release pipeline permissions and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->