### PR TITLE
refactor(ui): rename reserved billing flag to CLOUD_BILLING_ENABLED

### DIFF
--- a/ui/lib/env.test.ts
+++ b/ui/lib/env.test.ts
@@ -62,6 +62,7 @@ describe("lib/env gated integration validation", () => {
     "POSTHOG_KEY",
     "UI_POSTHOG_HOST",
     "POSTHOG_HOST",
+    "CLOUD_BILLING_ENABLED",
   ] as const;
 
   beforeEach(() => {
@@ -140,5 +141,31 @@ describe("lib/env gated integration validation", () => {
     vi.stubEnv("POSTHOG_KEY", "phc_key");
 
     await expect(import("@/lib/env")).rejects.toThrow("POSTHOG_HOST");
+  });
+
+  it("throws when CLOUD_BILLING_ENABLED is metronome but PostHog is not enabled", async () => {
+    // metronome billing routes per tenant via the BILLING_SYSTEM_METRONOME
+    // PostHog flag, so PostHog must be enabled.
+    vi.stubEnv("CLOUD_BILLING_ENABLED", "metronome");
+
+    await expect(import("@/lib/env")).rejects.toThrow(
+      "PostHog is required for per-tenant billing routing",
+    );
+  });
+
+  it("resolves when CLOUD_BILLING_ENABLED is metronome and PostHog is enabled", async () => {
+    vi.stubEnv("CLOUD_BILLING_ENABLED", "metronome");
+    vi.stubEnv("UI_POSTHOG_ENABLE", "true");
+    vi.stubEnv("UI_POSTHOG_KEY", "phc_key");
+    vi.stubEnv("UI_POSTHOG_HOST", "https://eu.i.posthog.com");
+
+    await expect(import("@/lib/env")).resolves.toBeDefined();
+  });
+
+  it("resolves when CLOUD_BILLING_ENABLED is legacy without PostHog", async () => {
+    // legacy billing forces V1 and never touches PostHog.
+    vi.stubEnv("CLOUD_BILLING_ENABLED", "legacy");
+
+    await expect(import("@/lib/env")).resolves.toBeDefined();
   });
 });

--- a/ui/lib/env.ts
+++ b/ui/lib/env.ts
@@ -2,7 +2,7 @@ import {
   assertGatedIntegrations,
   warnGatedIntegrationsMisconfig,
 } from "@/lib/integrations";
-import { readEnv } from "@/lib/runtime-env";
+import { readBoolEnv, readEnv } from "@/lib/runtime-env";
 
 // Boot-time required-env assertion so a misconfigured container fails fast
 // with a clear message. A key with a deprecated legacy name is satisfied by
@@ -23,6 +23,19 @@ for (const { key, legacy } of REQUIRED) {
 }
 
 assertGatedIntegrations();
+
+// `metronome` billing evaluates the BILLING_SYSTEM_METRONOME PostHog flag per
+// tenant, so PostHog must be enabled or every tenant would be misrouted to the
+// wrong billing system. Fail fast instead of degrading silently.
+if (
+  readEnv("CLOUD_BILLING_ENABLED") === "metronome" &&
+  !readBoolEnv("UI_POSTHOG_ENABLE")
+) {
+  throw new Error(
+    'CLOUD_BILLING_ENABLED is "metronome" but UI_POSTHOG_ENABLE is not "true"; PostHog is required for per-tenant billing routing.',
+  );
+}
+
 warnGatedIntegrationsMisconfig();
 
 export {};

--- a/ui/lib/get-runtime-config.client.test.ts
+++ b/ui/lib/get-runtime-config.client.test.ts
@@ -98,7 +98,7 @@ describe("getRuntimeConfigClient", () => {
       [
         "apiBaseUrl",
         "apiDocsUrl",
-        "billingCloudEnable",
+        "cloudBillingEnabled",
         "googleTagManagerId",
         "posthogHost",
         "posthogKey",
@@ -108,9 +108,9 @@ describe("getRuntimeConfigClient", () => {
       ].sort(),
     );
     expect(config.apiBaseUrl).toBe("https://api.example.com/api/v1");
-    // billingCloudEnable is a boolean flag, so it defaults to false (not null)
+    // cloudBillingEnabled is a boolean flag, so it defaults to false (not null)
     // when absent from the island.
-    expect(config.billingCloudEnable).toBe(false);
+    expect(config.cloudBillingEnabled).toBe(false);
     expect(
       (config as unknown as Record<string, unknown>).notAllowlisted,
     ).toBeUndefined();

--- a/ui/lib/get-runtime-config.client.ts
+++ b/ui/lib/get-runtime-config.client.ts
@@ -20,7 +20,7 @@ const pickConfig = (
   posthogKey: parsed.posthogKey ?? null,
   posthogHost: parsed.posthogHost ?? null,
   reoDevClientId: parsed.reoDevClientId ?? null,
-  billingCloudEnable: parsed.billingCloudEnable ?? false,
+  cloudBillingEnabled: parsed.cloudBillingEnabled ?? false,
 });
 
 // Reads the <head> island once (memoized); all-null during SSR or if it's

--- a/ui/lib/runtime-config.shared.ts
+++ b/ui/lib/runtime-config.shared.ts
@@ -9,7 +9,7 @@ export interface RuntimePublicConfig {
   posthogKey: string | null; // reserved
   posthogHost: string | null; // reserved
   reoDevClientId: string | null; // reserved
-  billingCloudEnable: boolean;
+  cloudBillingEnabled: boolean;
 }
 
 export const RUNTIME_CONFIG_SCRIPT_ID = "__PROWLER_RUNTIME_CONFIG__";
@@ -24,5 +24,5 @@ export const EMPTY_RUNTIME_PUBLIC_CONFIG: RuntimePublicConfig = {
   posthogKey: null,
   posthogHost: null,
   reoDevClientId: null,
-  billingCloudEnable: false,
+  cloudBillingEnabled: false,
 };

--- a/ui/lib/runtime-config.ts
+++ b/ui/lib/runtime-config.ts
@@ -4,7 +4,7 @@ import { connection } from "next/server";
 
 import { readGatedEnv } from "@/lib/integrations";
 import type { RuntimePublicConfig } from "@/lib/runtime-config.shared";
-import { readBoolEnv, readEnv } from "@/lib/runtime-env";
+import { readEnv } from "@/lib/runtime-env";
 
 // `connection()` forces a per-request runtime read (never build-snapshotted);
 // only this allowlist reaches the client. Each migrated key falls back to its
@@ -44,6 +44,10 @@ export async function getRuntimePublicConfig(): Promise<RuntimePublicConfig> {
       "POSTHOG_HOST",
     ),
     reoDevClientId: readEnv("REO_DEV_CLIENT_ID"),
-    billingCloudEnable: readBoolEnv("BILLING_CLOUD_ENABLE"),
+    // Install-level selector "legacy" | "metronome" | "false"; the client only
+    // needs on/off, so expose a derived boolean (the raw selector is read
+    // server-side for V1/V2 routing). Default (unset) is off.
+    cloudBillingEnabled:
+      (readEnv("CLOUD_BILLING_ENABLED") ?? "false") !== "false",
   };
 }

--- a/ui/tests/runtime-config/runtime-config-page.ts
+++ b/ui/tests/runtime-config/runtime-config-page.ts
@@ -19,7 +19,7 @@ export const RUNTIME_CONFIG_KEYS = [
   "posthogKey",
   "posthogHost",
   "reoDevClientId",
-  "billingCloudEnable",
+  "cloudBillingEnabled",
 ] as const satisfies ReadonlyArray<keyof RuntimePublicConfig>;
 
 /**

--- a/ui/types/env.d.ts
+++ b/ui/types/env.d.ts
@@ -28,7 +28,7 @@ declare global {
       NEXT_PUBLIC_SENTRY_ENVIRONMENT?: string;
       UI_SENTRY_ENVIRONMENT?: string;
 
-      BILLING_CLOUD_ENABLE?: "true" | "false";
+      CLOUD_BILLING_ENABLED?: "legacy" | "metronome" | "false";
 
       // Build-time public config
       NEXT_PUBLIC_IS_CLOUD_ENV?: "true" | "false";


### PR DESCRIPTION
### Context

The runtime-config island (#11500) reserved a billing enable flag as `BILLING_CLOUD_ENABLE` (boolean, no consumer yet). The Prowler Cloud product will consume it as a 3-value install-level selector, not a boolean. This aligns the reserved placeholder to its final name and type **before any consumer exists**, so it is a no-op rename with zero user impact.

### Description

- Rename the env var `BILLING_CLOUD_ENABLE` → `CLOUD_BILLING_ENABLED` and the island key `billingCloudEnable` → `cloudBillingEnabled`.
- Type `CLOUD_BILLING_ENABLED` as the billing selector `"legacy" | "metronome" | "false"` (was `"true" | "false"`).
- The client island still receives a **derived boolean** (`value !== "false"`); the raw selector is read server-side only (for V1/V2 routing on the consumer side).
- Add a boot-time fail-fast: when `CLOUD_BILLING_ENABLED` is `metronome` but `UI_POSTHOG_ENABLE` is not `"true"`, throw — `metronome` billing routes per tenant via the `BILLING_SYSTEM_METRONOME` PostHog flag, so PostHog must be enabled.

No runtime consumer exists yet, so there is no behavior change for any current deployment.

### Steps to review

- `cd ui && pnpm run typecheck`
- `cd ui && pnpm vitest run lib/env.test.ts lib/integrations.test.ts lib/get-runtime-config.client.test.ts lib/runtime-env.test.ts` (52 tests, incl. 3 new boot-check cases)
- Confirm no old references remain: `rg "BILLING_CLOUD_ENABLE\b|billingCloudEnable"` → empty

### Checklist

- [x] Review if the code is being covered by tests.
- [x] No new checks; no provider permission changes.
- [ ] Screenshots not applicable (no UI surface; reserved config key, no consumer).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.