### PR TITLE
fix(ui): handle level 1 requirements for M365 CIS

### DIFF
--- a/ui/changelog.d/cis-profile-level-filter-m365.fixed.md
+++ b/ui/changelog.d/cis-profile-level-filter-m365.fixed.md
@@ -1,0 +1,1 @@
+CIS Level 1 and Level 2 compliance filters now match profiles prefixed with a license tier (e.g. "E3 Level 1"), so M365 CIS requirements are no longer hidden

--- a/ui/lib/compliance/cis.tsx
+++ b/ui/lib/compliance/cis.tsx
@@ -38,8 +38,11 @@ export const mapComplianceData = (
     const attrs = metadataArray?.[0];
     if (!attrs) continue;
 
-    // Apply profile filter
-    if (filter === "Level 1" && attrs.Profile !== "Level 1") {
+    // Apply profile filter.
+    // Most CIS benchmarks use "Level 1"/"Level 2" as the Profile, but some
+    // (e.g. M365) prefix it with the license tier: "E3 Level 1", "E5 Level 2".
+    // Match by suffix so the Level 1 filter works across all CIS variants.
+    if (filter === "Level 1" && !attrs.Profile?.endsWith("Level 1")) {
       continue; // Skip Level 2 requirements when Level 1 is selected
     }
 

--- a/ui/types/compliance.ts
+++ b/ui/types/compliance.ts
@@ -127,7 +127,7 @@ export interface ISO27001AttributesMetadata {
 export interface CISAttributesMetadata {
   Section: string;
   SubSection: string | null;
-  Profile: string; // "Level 1" or "Level 2"
+  Profile: string; // "Level 1"/"Level 2" (M365 prefixes the tier: "E3 Level 1", "E5 Level 2")
   AssessmentStatus: string; // "Manual" or "Automated"
   Description: string;
   RationaleStatement: string;


### PR DESCRIPTION
### Description

This pull request improves the handling of CIS profile filtering to better support variations in profile naming across different CIS benchmarks, such as Microsoft 365. It also updates documentation in the type definitions to clarify expected values.

<img width="1910" height="976" alt="image" src="https://github.com/user-attachments/assets/71c3ffd4-1ae5-49b9-92dd-952679b04534" />

**Filtering logic improvements:**

* Updated the profile filter in `mapComplianceData` (in `ui/lib/compliance/cis.tsx`) to match profile names by suffix, so that "Level 1" and "Level 2" filters work correctly even when the profile is prefixed with a license tier (e.g., "E3 Level 1", "E5 Level 2").

**Documentation updates:**

* Updated the comment for the `Profile` field in the `CISAttributesMetadata` interface (in `ui/types/compliance.ts`) to clarify that profile values may be prefixed by license tiers in some CIS variants.

### Steps to review

Please add a detailed description of how to review this PR.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
