### PR TITLE
fix(docs): use python3 and add CI check for provider cards hook

### DIFF
--- a/.github/workflows/docs-check-provider-cards.yml
+++ b/.github/workflows/docs-check-provider-cards.yml
@@ -1,0 +1,50 @@
+name: 'Docs: Check Provider Cards Snippet'
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'v5.*'
+    paths:
+      - 'docs/user-guide/providers/**/getting-started-*.mdx'
+      - 'docs/scripts/generate_provider_cards.py'
+      - 'docs/snippets/provider-cards.mdx'
+      - 'api/src/backend/api/models.py'
+      - '.github/workflows/docs-check-provider-cards.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check-provider-cards:
+    if: github.repository == 'prowler-cloud/prowler'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify provider cards snippet is up to date
+        run: |
+          if ! python3 docs/scripts/generate_provider_cards.py; then
+            echo "::error::docs/snippets/provider-cards.mdx is out of sync with the provider getting-started pages or the API ProviderChoices enum."
+            echo "Run 'python3 docs/scripts/generate_provider_cards.py' locally and commit the regenerated snippet."
+            echo "--- diff ---"
+            git diff docs/snippets/provider-cards.mdx
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,7 +144,7 @@ repos:
 
       - id: generate-provider-cards
         name: "Docs - regenerate provider cards snippet"
-        entry: python docs/scripts/generate_provider_cards.py
+        entry: python3 docs/scripts/generate_provider_cards.py
         language: system
         files: { glob: ["docs/user-guide/providers/**/getting-started-*.mdx", "docs/scripts/generate_provider_cards.py", "docs/snippets/provider-cards.mdx", "api/src/backend/api/models.py"] }
         pass_filenames: false


### PR DESCRIPTION
### Context

  Follow-up to #11865 with two small improvements to the provider cards automation:

  1. **`python` → `python3` in the pre-commit hook.** The hook was hardcoded to `python`, which fails on setups where only
  `python3` is on PATH.
  2. **New CI workflow: `Docs: Check Provider Cards Snippet`.** Runs the generator on every PR that touches provider docs, the
  script, the snippet, or the API `ProviderChoices` enum, and fails if `docs/snippets/provider-cards.mdx` is out of sync. This
  guarantees the snippet stays consistent on `master` even if a contributor commits with `--no-verify` or without pre-commit
  installed. Pre-commit and CI are complementary here.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)

</details>


- [ ] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [ ] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes / No
    - If so, do we need to update permissions for the provider? Please review this carefully.

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [ ] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated checks to keep the provider cards documentation snippet in sync with the latest generated output on pull requests.
  * Improved the validation job’s safety and reliability with stricter permissions and isolated execution.
  * Updated the local automation command to use `python3` for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->