### PR TITLE
fix(api): make AWS Attack Paths query aggregation Neo4j compatible

### DIFF
--- a/api/changelog.d/aws-attack-paths-neo4j-aggregation.fixed.md
+++ b/api/changelog.d/aws-attack-paths-neo4j-aggregation.fixed.md
@@ -1,0 +1,1 @@
+AWS Attack Paths privilege escalation queries no longer fail on Neo4j with `Aggregation column contains implicit grouping expressions`

--- a/api/src/backend/api/attack_paths/queries/aws.py
+++ b/api/src/backend/api/attack_paths/queries/aws.py
@@ -418,7 +418,8 @@ AWS_APPRUNNER_PRIVESC_UPDATE_SERVICE = AttackPathsQueryDefinition(
         // Find existing App Runner services with roles attached (potential targets)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'tasks.apprunner.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -523,7 +524,8 @@ AWS_BEDROCK_PRIVESC_INVOKE_CODE_INTERPRETER = AttackPathsQueryDefinition(
         // Find roles that trust the Bedrock AgentCore service (already attached to existing code interpreters)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'bedrock-agentcore.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -607,7 +609,8 @@ AWS_CLOUDFORMATION_PRIVESC_UPDATE_STACK = AttackPathsQueryDefinition(
         // Find roles that trust CloudFormation service (already attached to existing stacks)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'cloudformation.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -753,7 +756,8 @@ AWS_CLOUDFORMATION_PRIVESC_CHANGESET = AttackPathsQueryDefinition(
         // Find roles that trust CloudFormation service (already attached to existing stacks)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'cloudformation.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -844,7 +848,8 @@ AWS_CODEBUILD_PRIVESC_START_BUILD = AttackPathsQueryDefinition(
         // Find roles that trust CodeBuild service (already attached to existing projects)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'codebuild.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -880,7 +885,8 @@ AWS_CODEBUILD_PRIVESC_START_BUILD_BATCH = AttackPathsQueryDefinition(
         // Find roles that trust CodeBuild service (already attached to existing projects)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'codebuild.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -1096,7 +1102,8 @@ AWS_EC2_PRIVESC_MODIFY_INSTANCE_ATTRIBUTE = AttackPathsQueryDefinition(
         // Find EC2 instances with instance profiles (potential targets)
         MATCH path_target = (aws)--(ec2:EC2Instance)-[:STS_ASSUMEROLE_ALLOW]->(target_role:AWSRole)
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -1187,7 +1194,8 @@ AWS_EC2_PRIVESC_LAUNCH_TEMPLATE = AttackPathsQueryDefinition(
         // Find launch templates in the account (potential targets)
         MATCH path_target = (aws)--(template:LaunchTemplate)
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -1223,7 +1231,8 @@ AWS_EC2INSTANCECONNECT_PRIVESC_SEND_SSH_PUBLIC_KEY = AttackPathsQueryDefinition(
         // Find EC2 instances with attached roles (targets for credential theft via IMDS)
         MATCH path_target = (aws)--(ec2:EC2Instance)-[:STS_ASSUMEROLE_ALLOW]->(target_role:AWSRole)
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -1539,7 +1548,8 @@ AWS_ECS_PRIVESC_EXECUTE_COMMAND = AttackPathsQueryDefinition(
         // Target: roles already attached to running tasks (trust ECS tasks service)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'ecs-tasks.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -1622,7 +1632,8 @@ AWS_GLUE_PRIVESC_UPDATE_DEV_ENDPOINT = AttackPathsQueryDefinition(
         // Find roles that trust Glue service (already attached to existing dev endpoints)
         MATCH path_target = (aws)--(target_role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal {{arn: 'glue.amazonaws.com'}})
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -3337,7 +3348,8 @@ AWS_SSM_PRIVESC_START_SESSION = AttackPathsQueryDefinition(
         // Find EC2 instances with attached roles (targets for credential theft via IMDS)
         MATCH path_target = (aws)--(ec2:EC2Instance)-[:STS_ASSUMEROLE_ALLOW]->(target_role:AWSRole)
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 
@@ -3373,7 +3385,8 @@ AWS_SSM_PRIVESC_SEND_COMMAND = AttackPathsQueryDefinition(
         // Find EC2 instances with attached roles (targets for credential theft via IMDS)
         MATCH path_target = (aws)--(ec2:EC2Instance)-[:STS_ASSUMEROLE_ALLOW]->(target_role:AWSRole)
 
-        WITH principal_paths + collect(DISTINCT path_target) AS paths
+        WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+        WITH principal_paths + target_paths AS paths
         UNWIND paths AS p
         UNWIND nodes(p) AS n
 

--- a/skills/prowler-attack-paths-query/SKILL.md
+++ b/skills/prowler-attack-paths-query/SKILL.md
@@ -195,7 +195,8 @@ When all matching principals can target the same independent resource set, colle
 ```cypher
 WITH aws, collect(DISTINCT path_principal) AS principal_paths
 MATCH path_target = (aws)--(target)
-WITH principal_paths + collect(DISTINCT path_target) AS paths
+WITH principal_paths, collect(DISTINCT path_target) AS target_paths
+WITH principal_paths + target_paths AS paths
 ```
 
 Statements that constrain a target are still checked via `HAS_RESOURCE` traversals (`res`, `res2`). See IAM-015 or EC2-001 in `aws.py`.
@@ -419,6 +420,7 @@ Queries must run on both Neo4j and Amazon Neptune. Avoid these constructs:
 | `FOREACH`                               | `WITH` + `UNWIND` + `SET`                                                                                                                   |
 | Regex `=~`                              | `toLower()` + exact match, or `STARTS WITH` / `CONTAINS`                                                                                    |
 | `CALL () { UNION }`                     | Multi-label `OR` in `WHERE` (see pattern above)                                                                                             |
+| Carried value plus aggregate expression | Project the aggregate first: `WITH principal_paths, collect(...) AS target_paths`, then combine lists in the next `WITH`                    |
 | `any(x IN list ...)`                    | `size([x IN list WHERE pred]) > 0`                                                                                                          |
 | `all(x IN list ...)`                    | `size([x IN list WHERE pred]) = size(list)`                                                                                                 |
 | `none(x IN list ...)`                   | `size([x IN list WHERE pred]) = 0`                                                                                                          |


### PR DESCRIPTION
### Context

AWS predefined Attack Paths privilege escalation queries used an openCypher aggregation pattern that Neo4j rejects with implicit grouping errors. Neptune accepts the same pattern, so this change makes the active AWS query catalog portable across both supported graph backends.

### Description

- Updates 13 active AWS predefined Attack Paths queries in `aws.py` to project `collect(DISTINCT path_target)` before combining it with `principal_paths`.
- Updates the Attack Paths query-authoring skill so future generated queries use the Neo4j-compatible two-step projection pattern.
- Adds an API changelog fragment: `api/changelog.d/aws-attack-paths-neo4j-aggregation.fixed.md`.

No public docs update is needed because the public docs do not document this internal predefined-query authoring pattern.

### Steps to review

1. Confirm `aws.py` no longer contains:
   ```cypher
   WITH principal_paths + collect(DISTINCT path_target) AS paths
   ```
2. Confirm the 13 affected queries now use:
   ```cypher
    WITH principal_paths, collect(DISTINCT path_target) AS target_paths
    WITH principal_paths + target_paths AS paths
   ```
3. Review `skills/prowler-attack-paths-query/SKILL.md` and confirm it documents the openCypher compatibility rule for carried values plus aggregates.
4. Read-only checks run:
   ```bash
    rg -n "principal_paths \\+ collect\\(DISTINCT path_target\\) AS paths" api/src/backend/api/attack_paths/queries skills
    wc -l skills/prowler-attack-paths-query/SKILL.md
    rg -n "WITH principal_paths, collect\\(DISTINCT path_target\\) AS target_paths" api/src/backend/api/attack_paths/queries/aws.py
   ```

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AWS attack path queries that could fail in Neo4j with an aggregation-related error.
  * Improved compatibility for attack path lookups by changing how combined paths are assembled, preventing query failures.
* **Documentation**
  * Updated guidance for building attack-path queries so they follow a safer pattern for aggregations in openCypher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->