### PR TITLE
feat(azure): add app_function_ensure_http_is_redirected_to_https check

### DIFF
--- a/prowler/changelog.d/app-function-https-redirect.added.md
+++ b/prowler/changelog.d/app-function-https-redirect.added.md
@@ -1,0 +1,1 @@
+`app_function_ensure_http_is_redirected_to_https` check for Azure provider, flagging Function Apps that do not enforce HTTPS-only traffic so that HTTP requests are not redirected to HTTPS

--- a/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.metadata.json
+++ b/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.metadata.json
@@ -1,0 +1,37 @@
+{
+  "Provider": "azure",
+  "CheckID": "app_function_ensure_http_is_redirected_to_https",
+  "CheckTitle": "Function App redirects HTTP to HTTPS",
+  "CheckType": [],
+  "ServiceName": "app",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "microsoft.web/sites",
+  "ResourceGroup": "serverless",
+  "Description": "**Azure Function Apps** redirect `HTTP` traffic to `HTTPS` when the `HTTPS Only` setting is enabled. This evaluation identifies Function Apps that do not force secure transport by checking whether plaintext requests are automatically redirected to encrypted endpoints.",
+  "Risk": "Leaving **HTTP accessible** on a Function App enables **man-in-the-middle** interception, credential and cookie theft, and response tampering. This undermines **confidentiality** and **integrity**, and can lead to session hijacking or downgrade attacks that bypass TLS.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings#enforce-https",
+    "https://learn.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-3-encrypt-sensitive-data-in-transit"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "az functionapp update --resource-group <RESOURCE_GROUP_NAME> --name <FUNCTION_APP_NAME> --set httpsOnly=true",
+      "NativeIaC": "```bicep\n// Enable HTTPS-only redirect on an existing Function App\nresource functionApp 'Microsoft.Web/sites@2022-09-01' = {\n  name: '<example_resource_name>'\n  location: resourceGroup().location\n  kind: 'functionapp'\n  properties: {\n    httpsOnly: true  // Critical: forces redirect from HTTP to HTTPS\n  }\n}\n```",
+      "Other": "1. Sign in to the Azure portal and go to Function App\n2. Select your Function App\n3. Go to TLS/SSL settings and set HTTPS Only to On\n4. Click Save",
+      "Terraform": "```hcl\n# Enforce HTTPS-only on a Linux Function App\nresource \"azurerm_linux_function_app\" \"<example_resource_name>\" {\n  name                = \"<example_resource_name>\"\n  resource_group_name = \"<example_resource_name>\"\n  location            = \"<example_location>\"\n  service_plan_id     = \"<example_resource_id>\"\n\n  https_only = true # Critical: redirects HTTP to HTTPS\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Enforce **HTTPS-only** for all Function Apps.\n- Use trusted certificates and require `TLS 1.2` or later\n- Enable **HSTS** to prevent downgrade/mixed-content\n- Redirect legacy `http` links to `https`\n- Minimize HTTP exposure via WAF/CDN or private access\nApply **defense in depth** to protect data in transit.",
+      "Url": "https://hub.prowler.com/check/app_function_ensure_http_is_redirected_to_https"
+    }
+  },
+  "Categories": [
+    "encryption"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "When enabled, every incoming HTTP request to the Function App is redirected to the HTTPS port, adding an extra level of security to requests made to the app."
+}

--- a/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
+++ b/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
@@ -3,7 +3,7 @@ from prowler.providers.azure.services.app.app_client import app_client
 
 
 class app_function_ensure_http_is_redirected_to_https(Check):
-    def execute(self) -> Check_Report_Azure:
+    def execute(self) -> list[Check_Report_Azure]:
         findings = []
 
         for (

--- a/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
+++ b/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
@@ -1,0 +1,28 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.app.app_client import app_client
+
+
+class app_function_ensure_http_is_redirected_to_https(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+
+        for (
+            subscription_id,
+            functions,
+        ) in app_client.functions.items():
+            subscription_name = app_client.subscriptions.get(
+                subscription_id, subscription_id
+            )
+            for function in functions.values():
+                report = Check_Report_Azure(metadata=self.metadata(), resource=function)
+                report.subscription = subscription_id
+                report.status = "PASS"
+                report.status_extended = f"HTTP is redirected to HTTPS for Function App '{function.name}' in subscription '{subscription_name} ({subscription_id})'."
+
+                if not function.https_only:
+                    report.status = "FAIL"
+                    report.status_extended = f"HTTP is not redirected to HTTPS for Function App '{function.name}' in subscription '{subscription_name} ({subscription_id})'."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/app/app_service.py
+++ b/prowler/providers/azure/services/app/app_service.py
@@ -178,6 +178,9 @@ class App(AzureService):
                                     ftps_state=getattr(
                                         function_config, "ftps_state", None
                                     ),
+                                    https_only=getattr(
+                                        function, "https_only", False
+                                    ),
                                 )
                             }
                         )
@@ -301,3 +304,4 @@ class FunctionApp:
     public_access: bool
     vnet_subnet_id: str
     ftps_state: Optional[str]
+    https_only: bool = False

--- a/prowler/providers/azure/services/app/app_service.py
+++ b/prowler/providers/azure/services/app/app_service.py
@@ -178,9 +178,7 @@ class App(AzureService):
                                     ftps_state=getattr(
                                         function_config, "ftps_state", None
                                     ),
-                                    https_only=getattr(
-                                        function, "https_only", False
-                                    ),
+                                    https_only=getattr(function, "https_only", False),
                                 )
                             }
                         )

--- a/tests/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https_test.py
+++ b/tests/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https_test.py
@@ -1,0 +1,150 @@
+from unittest import mock
+from uuid import uuid4
+
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_DISPLAY,
+    AZURE_SUBSCRIPTION_ID,
+    AZURE_SUBSCRIPTION_NAME,
+    set_mocked_azure_provider,
+)
+
+CHECK_PATH = "prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https"
+
+
+class Test_app_function_ensure_http_is_redirected_to_https:
+    def test_no_subscriptions(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.app_client", new=app_client),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+
+            app_client.functions = {}
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_subscription_empty(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.app_client", new=app_client),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+
+            app_client.functions = {AZURE_SUBSCRIPTION_ID: {}}
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_function_https_only_enabled(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.app_client", new=app_client),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+            from prowler.providers.azure.services.app.app_service import FunctionApp
+
+            function_id = str(uuid4())
+            app_client.functions = {
+                AZURE_SUBSCRIPTION_ID: {
+                    function_id: FunctionApp(
+                        id=function_id,
+                        name="function1",
+                        location="West Europe",
+                        kind="functionapp,linux",
+                        function_keys={},
+                        environment_variables={},
+                        identity=mock.MagicMock(type="SystemAssigned"),
+                        public_access=False,
+                        vnet_subnet_id=None,
+                        ftps_state="Disabled",
+                        https_only=True,
+                    )
+                }
+            }
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"HTTP is redirected to HTTPS for Function App 'function1' in subscription '{AZURE_SUBSCRIPTION_DISPLAY}'."
+            )
+            assert result[0].resource_name == "function1"
+            assert result[0].resource_id == function_id
+            assert result[0].location == "West Europe"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+
+    def test_function_https_only_disabled(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(f"{CHECK_PATH}.app_client", new=app_client),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+            from prowler.providers.azure.services.app.app_service import FunctionApp
+
+            function_id = str(uuid4())
+            app_client.functions = {
+                AZURE_SUBSCRIPTION_ID: {
+                    function_id: FunctionApp(
+                        id=function_id,
+                        name="function1",
+                        location="West Europe",
+                        kind="functionapp,linux",
+                        function_keys={},
+                        environment_variables={},
+                        identity=mock.MagicMock(type="SystemAssigned"),
+                        public_access=False,
+                        vnet_subnet_id=None,
+                        ftps_state="Disabled",
+                        https_only=False,
+                    )
+                }
+            }
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"HTTP is not redirected to HTTPS for Function App 'function1' in subscription '{AZURE_SUBSCRIPTION_DISPLAY}'."
+            )
+            assert result[0].resource_name == "function1"
+            assert result[0].resource_id == function_id
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID

--- a/tests/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https_test.py
+++ b/tests/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https_test.py
@@ -147,4 +147,5 @@ class Test_app_function_ensure_http_is_redirected_to_https:
             )
             assert result[0].resource_name == "function1"
             assert result[0].resource_id == function_id
+            assert result[0].location == "West Europe"
             assert result[0].subscription == AZURE_SUBSCRIPTION_ID


### PR DESCRIPTION
### Context

Azure Function Apps can serve traffic over plaintext HTTP. When the `HTTPS Only` (`https_only` / `httpsOnly`) setting is disabled, requests are not redirected to HTTPS, which can expose credentials, tokens, cookies, and request data in transit. The existing check `app_ensure_http_is_redirected_to_https` only evaluates Web Apps (`app_client.apps`) and does not cover Function Apps.

Fix #11923

### Description

Adds a new Azure check `app_function_ensure_http_is_redirected_to_https` that evaluates every Function App in each scanned subscription:

- **PASS** when the Function App has HTTPS-only enabled (`https_only` is `True`).
- **FAIL** when HTTPS-only is disabled or unset.

Changes:
- Added the `https_only` field to the `FunctionApp` model and populate it in `_get_functions()` (`prowler/providers/azure/services/app/app_service.py`), mirroring how `_get_apps()` collects it for Web Apps.
- New check, metadata, and unit tests under `prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/`.
- Changelog fragment under `prowler/changelog.d/`.

The check logic mirrors the existing Web App check `app_ensure_http_is_redirected_to_https`, keeping the Web App and Function App checks separate as suggested in the issue. Severity: **high**; category: **encryption**. No new provider permissions are required — it reads the same `Microsoft.Web/sites` data already collected for Function Apps.

### Steps to review

1. Confirm the new check mirrors `app_ensure_http_is_redirected_to_https` but iterates `app_client.functions` and reads `function.https_only`.
2. Confirm `https_only` is added to the `FunctionApp` dataclass (keyword field, defaults to `False`) and populated in `_get_functions()`.
3. Run the tests:

```bash
pytest tests/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/ -v
```

Four cases cover: no subscriptions, empty subscription, HTTPS-only enabled (PASS), and HTTPS-only disabled (FAIL). The full `app` service suite passes (110 tests).

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`.

#### SDK/CLI
- New checks included: **Yes** (`app_function_ensure_http_is_redirected_to_https`). No new provider permissions required — the Function App data (`Microsoft.Web/sites`) is already collected by the existing App Service integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Azure security check for Function Apps to verify HTTPS-only enforcement (HTTP is redirected to HTTPS).
  * Function App records now include an HTTPS-only indicator to improve security reporting.

* **Bug Fixes**
  * Function Apps that allow non-HTTPS traffic are now correctly reported as failed.
  * Improved handling and reporting for scenarios with no subscriptions or no Function Apps.

* **Tests**
  * Added unit tests covering empty environments plus both HTTPS-only (pass) and non-HTTPS-only (fail) Function App cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->