### PR TITLE
feat(azure): add app_function_ensure_http_is_redirected_to_https check

### DIFF
--- a/prowler/changelog.d/app-function-https-only-check.added.md
+++ b/prowler/changelog.d/app-function-https-only-check.added.md
@@ -1,0 +1,1 @@
+`app_function_ensure_http_is_redirected_to_https` check for Azure provider, ensuring Function Apps enforce HTTPS-only traffic

--- a/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.metadata.json
+++ b/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.metadata.json
@@ -1,0 +1,38 @@
+{
+  "Provider": "azure",
+  "CheckID": "app_function_ensure_http_is_redirected_to_https",
+  "CheckTitle": "Function app redirects HTTP to HTTPS",
+  "CheckType": [],
+  "ServiceName": "app",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "microsoft.web/sites",
+  "ResourceGroup": "serverless",
+  "Description": "**Azure Function apps** redirect `HTTP` traffic to `HTTPS` when the `HTTPS Only` setting is enabled. This evaluation identifies Function apps that do not force secure transport by checking whether plaintext requests are automatically redirected to encrypted endpoints.",
+  "Risk": "Function apps can expose **HTTP endpoints** that accept credentials, access keys, tokens, and request payloads. Leaving **HTTP accessible** enables **man-in-the-middle** interception, credential and function key theft, and response tampering, undermining **confidentiality** and **integrity** of data in transit.",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings#enforce-https",
+    "https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts#require-https",
+    "https://learn.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-3-encrypt-sensitive-data-in-transit"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "az functionapp update --resource-group <RESOURCE_GROUP_NAME> --name <FUNCTION_APP_NAME> --set httpsOnly=true",
+      "NativeIaC": "```bicep\n// Enable HTTPS-only redirect on an existing Function App\nresource functionApp 'Microsoft.Web/sites@2022-09-01' = {\n  name: '<example_resource_name>'\n  location: resourceGroup().location\n  kind: 'functionapp'\n  properties: {\n    httpsOnly: true  // Critical: forces redirect from HTTP to HTTPS\n  }\n}\n```",
+      "Other": "1. Sign in to the Azure portal and go to Function App\n2. Select your function app\n3. Go to Settings > Configuration > General settings and set HTTPS Only to On\n4. Click Save",
+      "Terraform": "```hcl\n# Enforce HTTPS-only on a Function App\nresource \"azurerm_linux_function_app\" \"<example_resource_name>\" {\n  name                       = \"<example_resource_name>\"\n  resource_group_name        = \"<example_resource_name>\"\n  location                   = \"<example_location>\"\n  service_plan_id            = \"<example_resource_id>\"\n  storage_account_name       = \"<example_resource_name>\"\n  storage_account_access_key = \"<example_secret_value>\"\n\n  https_only = true # Critical: redirects HTTP to HTTPS\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Enforce **HTTPS-only** for all Function apps.\n- Use trusted certificates and require `TLS 1.2` or later\n- Call functions only over `https://` endpoints and update any legacy `http` clients\n- Minimize HTTP exposure via WAF/CDN or private access\nApply **defense in depth** to protect function keys and data in transit.",
+      "Url": "https://hub.prowler.com/check/app_function_ensure_http_is_redirected_to_https"
+    }
+  },
+  "Categories": [
+    "encryption"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "When it is enabled, every incoming HTTP request is redirected to the HTTPS port, adding an extra level of security for all requests made to the function app."
+}

--- a/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
+++ b/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
@@ -1,0 +1,27 @@
+from prowler.lib.check.models import Check, Check_Report_Azure
+from prowler.providers.azure.services.app.app_client import app_client
+
+
+class app_function_ensure_http_is_redirected_to_https(Check):
+    def execute(self) -> Check_Report_Azure:
+        findings = []
+
+        for (
+            subscription_id,
+            functions,
+        ) in app_client.functions.items():
+            subscription_name = app_client.subscriptions.get(
+                subscription_id, subscription_id
+            )
+            for function in functions.values():
+                report = Check_Report_Azure(metadata=self.metadata(), resource=function)
+                report.subscription = subscription_id
+                report.status = "FAIL"
+                report.status_extended = f"Function {function.name} from subscription {subscription_name} ({subscription_id}) does not have HTTP redirected to HTTPS."
+                if function.https_only:
+                    report.status = "PASS"
+                    report.status_extended = f"Function {function.name} from subscription {subscription_name} ({subscription_id}) has HTTP redirected to HTTPS."
+
+                findings.append(report)
+
+        return findings

--- a/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
+++ b/prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https.py
@@ -3,7 +3,19 @@ from prowler.providers.azure.services.app.app_client import app_client
 
 
 class app_function_ensure_http_is_redirected_to_https(Check):
-    def execute(self) -> Check_Report_Azure:
+    """Check if Azure Function Apps redirect HTTP traffic to HTTPS.
+
+    Verifies that the 'HTTPS Only' setting is enabled for every Function App,
+    so plaintext HTTP requests are redirected to encrypted HTTPS endpoints.
+    """
+
+    def execute(self) -> list[Check_Report_Azure]:
+        """Execute the check for every Function App in every subscription.
+
+        Returns:
+            A list of reports, one per Function App: PASS when HTTPS-only
+            is enabled, FAIL when it is disabled or unset.
+        """
         findings = []
 
         for (

--- a/prowler/providers/azure/services/app/app_service.py
+++ b/prowler/providers/azure/services/app/app_service.py
@@ -178,6 +178,7 @@ class App(AzureService):
                                     ftps_state=getattr(
                                         function_config, "ftps_state", None
                                     ),
+                                    https_only=getattr(function, "https_only", False),
                                 )
                             }
                         )
@@ -301,3 +302,4 @@ class FunctionApp:
     public_access: bool
     vnet_subnet_id: str
     ftps_state: Optional[str]
+    https_only: bool = False

--- a/tests/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https_test.py
+++ b/tests/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/app_function_ensure_http_is_redirected_to_https_test.py
@@ -1,0 +1,163 @@
+from unittest import mock
+from uuid import uuid4
+
+from tests.providers.azure.azure_fixtures import (
+    AZURE_SUBSCRIPTION_DISPLAY,
+    AZURE_SUBSCRIPTION_ID,
+    AZURE_SUBSCRIPTION_NAME,
+    set_mocked_azure_provider,
+)
+
+
+class Test_app_function_ensure_http_is_redirected_to_https:
+    def test_no_subscriptions(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https.app_client",
+                new=app_client,
+            ),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+
+            app_client.functions = {}
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_subscription_empty(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https.app_client",
+                new=app_client,
+            ),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+
+            app_client.functions = {AZURE_SUBSCRIPTION_ID: {}}
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 0
+
+    def test_function_http_not_redirected_to_https(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https.app_client",
+                new=app_client,
+            ),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+            from prowler.providers.azure.services.app.app_service import FunctionApp
+
+            function_id = str(uuid4())
+
+            app_client.functions = {
+                AZURE_SUBSCRIPTION_ID: {
+                    function_id: FunctionApp(
+                        id=function_id,
+                        name="function1",
+                        location="West Europe",
+                        kind="functionapp,linux",
+                        function_keys={},
+                        environment_variables={},
+                        identity=mock.MagicMock(type="SystemAssigned"),
+                        public_access=False,
+                        vnet_subnet_id=None,
+                        ftps_state="Disabled",
+                        https_only=False,
+                    )
+                }
+            }
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "FAIL"
+            assert (
+                result[0].status_extended
+                == f"Function function1 from subscription {AZURE_SUBSCRIPTION_DISPLAY} does not have HTTP redirected to HTTPS."
+            )
+            assert result[0].resource_name == "function1"
+            assert result[0].resource_id == function_id
+            assert result[0].location == "West Europe"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID
+
+    def test_function_http_redirected_to_https(self):
+        app_client = mock.MagicMock
+        app_client.subscriptions = {AZURE_SUBSCRIPTION_ID: AZURE_SUBSCRIPTION_NAME}
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_azure_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https.app_client",
+                new=app_client,
+            ),
+        ):
+            from prowler.providers.azure.services.app.app_function_ensure_http_is_redirected_to_https.app_function_ensure_http_is_redirected_to_https import (
+                app_function_ensure_http_is_redirected_to_https,
+            )
+            from prowler.providers.azure.services.app.app_service import FunctionApp
+
+            function_id = str(uuid4())
+
+            app_client.functions = {
+                AZURE_SUBSCRIPTION_ID: {
+                    function_id: FunctionApp(
+                        id=function_id,
+                        name="function1",
+                        location="West Europe",
+                        kind="functionapp,linux",
+                        function_keys={},
+                        environment_variables={},
+                        identity=mock.MagicMock(type="SystemAssigned"),
+                        public_access=False,
+                        vnet_subnet_id=None,
+                        ftps_state="Disabled",
+                        https_only=True,
+                    )
+                }
+            }
+
+            check = app_function_ensure_http_is_redirected_to_https()
+            result = check.execute()
+            assert len(result) == 1
+            assert result[0].status == "PASS"
+            assert (
+                result[0].status_extended
+                == f"Function function1 from subscription {AZURE_SUBSCRIPTION_DISPLAY} has HTTP redirected to HTTPS."
+            )
+            assert result[0].resource_name == "function1"
+            assert result[0].resource_id == function_id
+            assert result[0].location == "West Europe"
+            assert result[0].subscription == AZURE_SUBSCRIPTION_ID

--- a/tests/providers/azure/services/app/app_service_test.py
+++ b/tests/providers/azure/services/app/app_service_test.py
@@ -227,6 +227,7 @@ class Test_App_Service:
                 public_access=True,
                 vnet_subnet_id="",
                 ftps_state="FtpsOnly",
+                https_only=True,
             )
 
             app_service = MagicMock()
@@ -240,6 +241,9 @@ class Test_App_Service:
                 ].ftps_state
                 == "FtpsOnly"
             )
+            assert app_service.functions["mock-subscription"][
+                "/subscriptions/resource_id"
+            ].https_only
             assert (
                 app_service.functions["mock-subscription"][
                     "/subscriptions/resource_id"


### PR DESCRIPTION
### Context

Azure Function Apps can expose HTTP endpoints. If HTTPS-only is disabled, plaintext traffic may allow credential, function key, token, or request data exposure in transit. The existing check `app_ensure_http_is_redirected_to_https` only evaluates Web Apps (`app_client.apps`), so Function Apps were not covered.

Fix #11923

### Description

Adds a new Azure check `app_function_ensure_http_is_redirected_to_https` that evaluates every Function App in every scanned subscription:

- Adds `https_only` to the `FunctionApp` model, populated from the site `httpsOnly` property in `_get_functions()` (no new API calls or permissions: the property comes from the already-collected `web_apps.list` response)
- PASS when the Function App has HTTPS-only enabled, FAIL when disabled or unset
- Logic mirrors `app_ensure_http_is_redirected_to_https`, iterating `app_client.functions` as suggested in the issue
- Adds a changelog fragment under `prowler/changelog.d/`

### Steps to review

1. Review the model change in `prowler/providers/azure/services/app/app_service.py` (`https_only` field + population in `_get_functions()`)
2. Review the check logic and metadata in `prowler/providers/azure/services/app/app_function_ensure_http_is_redirected_to_https/`
3. Run the tests: `pytest tests/providers/azure/services/app -q` (110 passed locally; new tests cover no-subscriptions, empty subscription, FAIL and PASS cases)

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Assignment requested in #11923

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) (not needed)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes
    - No new permissions needed: `https_only` is read from the `Microsoft.Web/sites` list response already collected by the service.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Azure check for Function Apps to verify HTTPS-only enforcement (HTTP-to-HTTPS redirection).
  * The check flags Function Apps where HTTPS-only is not enabled and passes when it is.

* **Documentation**
  * Added a new changelog entry for the HTTPS-only enforcement check.

* **Tests / Coverage**
  * Added automated test coverage for passing and failing scenarios of the new Function Apps HTTPS-only check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->