### PR TITLE
feat(kubernetes): add core_minimize_hostpath_volume_mounts check

### DIFF
--- a/prowler/changelog.d/k8s-hostpath-volume-check.added.md
+++ b/prowler/changelog.d/k8s-hostpath-volume-check.added.md
@@ -1,0 +1,1 @@
+`core_minimize_hostpath_volume_mounts` check for Kubernetes provider, flagging Pods that mount hostPath volumes

--- a/prowler/providers/kubernetes/services/core/core_minimize_hostpath_volume_mounts/core_minimize_hostpath_volume_mounts.metadata.json
+++ b/prowler/providers/kubernetes/services/core/core_minimize_hostpath_volume_mounts/core_minimize_hostpath_volume_mounts.metadata.json
@@ -1,0 +1,38 @@
+{
+  "Provider": "kubernetes",
+  "CheckID": "core_minimize_hostpath_volume_mounts",
+  "CheckTitle": "Pod does not mount hostPath volumes",
+  "CheckType": [],
+  "ServiceName": "core",
+  "SubServiceName": "",
+  "ResourceIdTemplate": "",
+  "Severity": "high",
+  "ResourceType": "Pod",
+  "ResourceGroup": "container",
+  "Description": "**Kubernetes Pods** defining `hostPath` volumes are identified, meaning they mount files or directories from the node's filesystem directly into the pod.",
+  "Risk": "A **hostPath volume** exposes the node filesystem to the pod. A compromised container can read node secrets (e.g., kubelet credentials, container runtime sockets) (**C**), tamper with host binaries and configuration (**I**), and escalate privileges to the node, enabling **container escape** and **lateral movement** across the cluster (**A**).",
+  "RelatedUrl": "",
+  "AdditionalURLs": [
+    "https://kubernetes.io/docs/concepts/storage/volumes/#hostpath",
+    "https://kubernetes.io/docs/concepts/security/pod-security-standards/"
+  ],
+  "Remediation": {
+    "Code": {
+      "CLI": "",
+      "NativeIaC": "",
+      "Other": "1. Open Kubernetes Dashboard\n2. For controller-managed workloads (Deployment/DaemonSet/StatefulSet):\n   - Go to Workloads > select the workload > Edit\n   - In the Pod template, remove any volumes of type hostPath and replace them with PersistentVolumeClaims, ConfigMaps, Secrets or emptyDir as appropriate\n   - Save to roll out new Pods\n3. For standalone Pods:\n   - Go to Workloads > Pods > select the Pod > Delete\n   - Click Create > upload the Pod YAML without hostPath volumes and create the Pod",
+      "Terraform": "```hcl\nresource \"kubernetes_pod\" \"<example_resource_name>\" {\n  metadata {\n    name = \"<example_resource_name>\"\n  }\n  spec {\n    container {\n      name  = \"ct\"\n      image = \"nginx\"\n      volume_mount {\n        name       = \"data\"\n        mount_path = \"/data\"\n      }\n    }\n    volume {\n      name = \"data\"\n      empty_dir {} # Critical: use emptyDir/PVC/ConfigMap instead of host_path so the Pod passes the check\n    }\n  }\n}\n```"
+    },
+    "Recommendation": {
+      "Text": "Disallow `hostPath` volumes by default. Enforce **least privilege** with admission policies (Pod Security Standards `baseline`/`restricted` or policy engines) that block them, allowing narrowly scoped, read-only exceptions only for trusted system workloads. Prefer **PersistentVolumeClaims**, **ConfigMaps**, **Secrets** or **emptyDir** for **defense in depth**.",
+      "Url": "https://hub.prowler.com/check/core_minimize_hostpath_volume_mounts"
+    }
+  },
+  "Categories": [
+    "container-security",
+    "trust-boundaries"
+  ],
+  "DependsOn": [],
+  "RelatedTo": [],
+  "Notes": "Some system workloads (e.g., CNI plugins, node agents, log collectors) legitimately require hostPath. Exceptions should be clearly defined, scoped to system namespaces and monitored."
+}

--- a/prowler/providers/kubernetes/services/core/core_minimize_hostpath_volume_mounts/core_minimize_hostpath_volume_mounts.py
+++ b/prowler/providers/kubernetes/services/core/core_minimize_hostpath_volume_mounts/core_minimize_hostpath_volume_mounts.py
@@ -1,0 +1,38 @@
+from prowler.lib.check.models import Check, Check_Report_Kubernetes
+from prowler.providers.kubernetes.services.core.core_client import core_client
+
+
+class core_minimize_hostpath_volume_mounts(Check):
+    """Check if Pods mount hostPath volumes.
+
+    hostPath volumes expose the node filesystem inside the pod, enabling
+    container escape, tampering with host files and privilege escalation
+    to the node, so their use should be minimized.
+    """
+
+    def execute(self) -> list[Check_Report_Kubernetes]:
+        """Execute the check for every Pod collected by the core client.
+
+        Returns:
+            A list of reports, one per Pod: PASS when the Pod defines no
+            hostPath volumes, FAIL when any volume is of type hostPath.
+        """
+        findings = []
+        for pod in core_client.pods.values():
+            report = Check_Report_Kubernetes(metadata=self.metadata(), resource=pod)
+            host_path_volumes = [
+                volume["name"]
+                for volume in pod.volumes or []
+                if volume.get("host_path")
+            ]
+            if host_path_volumes:
+                report.status = "FAIL"
+                report.status_extended = f"Pod {pod.name} mounts hostPath volumes: {', '.join(host_path_volumes)}."
+            else:
+                report.status = "PASS"
+                report.status_extended = (
+                    f"Pod {pod.name} does not mount hostPath volumes."
+                )
+            findings.append(report)
+
+        return findings

--- a/prowler/providers/kubernetes/services/core/core_service.py
+++ b/prowler/providers/kubernetes/services/core/core_service.py
@@ -54,6 +54,11 @@ class Core(KubernetesService):
                         containers=containers,
                         init_containers=init_containers,
                         ephemeral_containers=ephemeral_containers,
+                        volumes=(
+                            [volume.to_dict() for volume in pod.spec.volumes]
+                            if pod.spec.volumes
+                            else []
+                        ),
                     )
         except Exception as error:
             logger.error(
@@ -188,6 +193,7 @@ class Pod(BaseModel):
     containers: Optional[dict]
     init_containers: Optional[dict] = None
     ephemeral_containers: Optional[dict] = None
+    volumes: Optional[List[dict]] = None
 
 
 class ConfigMap(BaseModel):

--- a/tests/providers/kubernetes/services/core/conftest.py
+++ b/tests/providers/kubernetes/services/core/conftest.py
@@ -31,6 +31,7 @@ def make_pod(
     containers=None,
     init_containers=None,
     ephemeral_containers=None,
+    volumes=None,
     name="test-pod",
     uid="test-pod-uid",
 ):
@@ -52,6 +53,7 @@ def make_pod(
         containers=containers or {},
         init_containers=init_containers or {},
         ephemeral_containers=ephemeral_containers or {},
+        volumes=volumes or [],
     )
 
 

--- a/tests/providers/kubernetes/services/core/core_minimize_hostpath_volume_mounts/core_minimize_hostpath_volume_mounts_test.py
+++ b/tests/providers/kubernetes/services/core/core_minimize_hostpath_volume_mounts/core_minimize_hostpath_volume_mounts_test.py
@@ -1,0 +1,92 @@
+from tests.providers.kubernetes.services.core.conftest import (
+    make_core_client,
+    make_pod,
+    run_check,
+)
+
+MODULE = "prowler.providers.kubernetes.services.core.core_minimize_hostpath_volume_mounts.core_minimize_hostpath_volume_mounts"
+CLASS = "core_minimize_hostpath_volume_mounts"
+
+
+class TestCoreMinimizeHostpathVolumeMounts:
+    def test_no_pods(self):
+        result = run_check(MODULE, CLASS, make_core_client({}))
+
+        assert len(result) == 0
+
+    def test_pod_without_volumes_pass(self):
+        pod = make_pod(volumes=[])
+
+        result = run_check(MODULE, CLASS, make_core_client({pod.uid: pod}))
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended == "Pod test-pod does not mount hostPath volumes."
+        )
+
+    def test_pod_with_non_hostpath_volumes_pass(self):
+        pod = make_pod(
+            volumes=[
+                {"name": "config", "config_map": {"name": "app-config"}},
+                {"name": "scratch", "empty_dir": {}},
+            ]
+        )
+
+        result = run_check(MODULE, CLASS, make_core_client({pod.uid: pod}))
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"
+        assert (
+            result[0].status_extended == "Pod test-pod does not mount hostPath volumes."
+        )
+
+    def test_pod_with_hostpath_volume_fail(self):
+        pod = make_pod(
+            volumes=[
+                {"name": "host-logs", "host_path": {"path": "/var/log"}},
+            ]
+        )
+
+        result = run_check(MODULE, CLASS, make_core_client({pod.uid: pod}))
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == "Pod test-pod mounts hostPath volumes: host-logs."
+        )
+
+    def test_pod_with_mixed_volumes_fail(self):
+        pod = make_pod(
+            volumes=[
+                {"name": "scratch", "empty_dir": {}},
+                {
+                    "name": "docker-socket",
+                    "host_path": {"path": "/var/run/docker.sock"},
+                },
+                {"name": "host-etc", "host_path": {"path": "/etc"}},
+            ]
+        )
+
+        result = run_check(MODULE, CLASS, make_core_client({pod.uid: pod}))
+
+        assert len(result) == 1
+        assert result[0].status == "FAIL"
+        assert (
+            result[0].status_extended
+            == "Pod test-pod mounts hostPath volumes: docker-socket, host-etc."
+        )
+
+    def test_pod_with_none_hostpath_key_pass(self):
+        # V1Volume.to_dict() emits host_path: None for non-hostPath volumes
+        pod = make_pod(
+            volumes=[
+                {"name": "scratch", "empty_dir": {}, "host_path": None},
+            ]
+        )
+
+        result = run_check(MODULE, CLASS, make_core_client({pod.uid: pod}))
+
+        assert len(result) == 1
+        assert result[0].status == "PASS"


### PR DESCRIPTION
### Context

hostPath volumes expose the node filesystem inside a pod, enabling container escape, tampering with host files, and privilege escalation to the node (CIS Kubernetes Benchmark 5.2 / Pod Security Standards). Prowler already covers hostNetwork/hostPID/hostIPC exposure but had no check for hostPath volume mounts.

Fix #11804

### Description

Adds a new Kubernetes check `core_minimize_hostpath_volume_mounts` that evaluates every Pod's volumes:

- Collects pod spec volumes in the core service `Pod` model (`volumes` field, populated from the already-fetched `list_namespaced_pod` response - no new API calls or permissions)
- FAIL when any volume is of type hostPath (offending volume names are listed in the finding), PASS when the Pod defines no hostPath volumes
- Follows the existing `core_minimize_hostNetwork_containers` / `core_minimize_hostPID_containers` "minimize host exposure" pattern
- Adds a changelog fragment under `prowler/changelog.d/`

### Steps to review

1. Review the model change in `prowler/providers/kubernetes/services/core/core_service.py` (`volumes` field + population in `_get_pods()`)
2. Review the check logic and metadata in `prowler/providers/kubernetes/services/core/core_minimize_hostpath_volume_mounts/`
3. Run the tests: `pytest tests/providers/kubernetes/services/core -q` (55 passed locally; new tests cover no pods, no volumes, non-hostPath volumes, single/multiple hostPath volumes, and the `host_path: None` key emitted by `V1Volume.to_dict()`)

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [x] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [x] Assignment requested in #11804

</details>

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md) (not needed)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? Yes
    - No new permissions needed: volumes come from the pod list response the core service already collects.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes security check to identify Pods using `hostPath` volumes.
  * Included guidance and severity details for the new check in the app’s check catalog.

* **Bug Fixes**
  * Pod volume information is now collected during Kubernetes inventory gathering, enabling accurate check results.

* **Tests**
  * Added coverage for Pods with no volumes, safe volumes, mixed volumes, and `hostPath` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->