### PR TITLE
fix(ui): reference renamed UI_POSTHOG_ENABLED flag in metronome billing guard

### DIFF
--- a/ui/changelog.d/metronome-posthog-flag.fixed.md
+++ b/ui/changelog.d/metronome-posthog-flag.fixed.md
@@ -1,0 +1,1 @@
+Fixed metronome billing failing to start when PostHog was enabled, caused by a stale reference to the renamed UI_POSTHOG_ENABLED flag

--- a/ui/lib/env.test.ts
+++ b/ui/lib/env.test.ts
@@ -155,7 +155,7 @@ describe("lib/env gated integration validation", () => {
 
   it("resolves when CLOUD_BILLING_ENABLED is metronome and PostHog is enabled", async () => {
     vi.stubEnv("CLOUD_BILLING_ENABLED", "metronome");
-    vi.stubEnv("UI_POSTHOG_ENABLE", "true");
+    vi.stubEnv("UI_POSTHOG_ENABLED", "true");
     vi.stubEnv("UI_POSTHOG_KEY", "phc_key");
     vi.stubEnv("UI_POSTHOG_HOST", "https://eu.i.posthog.com");
 

--- a/ui/lib/env.ts
+++ b/ui/lib/env.ts
@@ -29,10 +29,10 @@ assertGatedIntegrations();
 // wrong billing system. Fail fast instead of degrading silently.
 if (
   readEnv("CLOUD_BILLING_ENABLED") === "metronome" &&
-  !readBoolEnv("UI_POSTHOG_ENABLE")
+  !readBoolEnv("UI_POSTHOG_ENABLED")
 ) {
   throw new Error(
-    'CLOUD_BILLING_ENABLED is "metronome" but UI_POSTHOG_ENABLE is not "true"; PostHog is required for per-tenant billing routing.',
+    'CLOUD_BILLING_ENABLED is "metronome" but UI_POSTHOG_ENABLED is not "true"; PostHog is required for per-tenant billing routing.',
   );
 }
 


### PR DESCRIPTION
### Context

#11917 renamed the `UI_POSTHOG_ENABLE` environment flag to `UI_POSTHOG_ENABLED` throughout the UI, but the metronome-billing startup guard in `ui/lib/env.ts` (added in #11920) was left reading the old, retired name.

### Description

`ui/lib/env.ts` throws at startup when `CLOUD_BILLING_ENABLED=metronome` and PostHog is not enabled, since PostHog is required for per-tenant billing routing. The guard checked `readBoolEnv("UI_POSTHOG_ENABLE")` instead of the current `UI_POSTHOG_ENABLED`, so the guard always evaluated as "PostHog not enabled" and threw even when PostHog was correctly configured via the new flag name. The error message string had the same stale reference.

The accompanying test in `ui/lib/env.test.ts` stubbed the same wrong name (`vi.stubEnv("UI_POSTHOG_ENABLE", "true")`), so the test passed for the wrong reason and CI never caught the mismatch.

This PR renames all three remaining references from `UI_POSTHOG_ENABLE` to `UI_POSTHOG_ENABLED`:
- `ui/lib/env.ts`: the `readBoolEnv(...)` call and the thrown error message text.
- `ui/lib/env.test.ts`: the `vi.stubEnv(...)` call in the "resolves when CLOUD_BILLING_ENABLED is metronome and PostHog is enabled" test.

No behavior change beyond fixing the flag name; no new dependencies.

### Steps to review

1. Confirm `UI_POSTHOG_ENABLED` is the correct, current flag name (see #11917 and #11920).
2. Set `CLOUD_BILLING_ENABLED=metronome` and `UI_POSTHOG_ENABLED=true` (plus `UI_POSTHOG_KEY`/`UI_POSTHOG_HOST`) locally and confirm the app starts without the guard throwing.
3. Run `ui/lib/env.test.ts` and confirm the metronome/PostHog-enabled test still passes now that it stubs the correct flag name.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)

</details>


- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
N/A — no API changes in this PR.

#### MCP Server
N/A — no MCP Server changes in this PR.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed metronome billing startup when PostHog is enabled.
  - Corrected environment-variable validation and error messaging for PostHog configuration.
  - Added coverage to ensure billing recognizes the enabled PostHog setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->