### PR TITLE
fix(ui): allow rename and delete for dynamic providers

### DIFF
--- a/ui/changelog.d/dynamic-provider-alias-delete.changed.md
+++ b/ui/changelog.d/dynamic-provider-alias-delete.changed.md
@@ -1,0 +1,1 @@
+Dynamic providers can now be renamed and deleted from the Providers table

--- a/ui/components/providers/table/data-table-row-actions.test.tsx
+++ b/ui/components/providers/table/data-table-row-actions.test.tsx
@@ -303,7 +303,7 @@ describe("DataTableRowActions", () => {
     expect(screen.queryByText("Update Credentials")).not.toBeInTheDocument();
   });
 
-  it("blocks provider-account actions (alias/credentials/delete) for a dynamic provider but keeps operational actions", async () => {
+  it("allows rename/delete and operational actions for a dynamic provider but hides credential management", async () => {
     // Given a dynamic provider outside the configurable set, with the advanced
     // schedule capability enabled (so Edit Scan Schedule can show).
     const user = userEvent.setup();
@@ -323,15 +323,16 @@ describe("DataTableRowActions", () => {
     // When
     await user.click(screen.getByRole("button"));
 
-    // Then — provider-account CRUD is suppressed (can't add/edit/delete it)
-    expect(screen.queryByText("Edit Provider Alias")).not.toBeInTheDocument();
-    expect(screen.queryByText("Add Credentials")).not.toBeInTheDocument();
-    expect(screen.queryByText("Update Credentials")).not.toBeInTheDocument();
-    expect(screen.queryByText("Delete Provider")).not.toBeInTheDocument();
-    // ...but operational actions the provider exists for stay available
+    // Then — rename and delete are backend-generic, so they stay available
+    expect(screen.getByText("Edit Provider Alias")).toBeInTheDocument();
+    expect(screen.getByText("Delete Provider")).toBeInTheDocument();
+    // ...operational actions stay available too
     expect(screen.getByText("Test Connection")).toBeInTheDocument();
     expect(screen.getByText("View Scan Jobs")).toBeInTheDocument();
     expect(screen.getByText("Edit Scan Schedule")).toBeInTheDocument();
+    // ...but credential management is hidden (no bespoke wizard for dynamic types)
+    expect(screen.queryByText("Add Credentials")).not.toBeInTheDocument();
+    expect(screen.queryByText("Update Credentials")).not.toBeInTheDocument();
   });
 
   it("navigates to the provider-filtered scan jobs from View Scan Jobs", async () => {

--- a/ui/components/providers/table/data-table-row-actions.tsx
+++ b/ui/components/providers/table/data-table-row-actions.tsx
@@ -310,9 +310,7 @@ export function DataTableRowActions({
   const provider = isOrganizationRow ? null : rowData;
   const providerId = provider?.id ?? "";
   const providerType = provider?.attributes.provider ?? "";
-  // Credentials are gated to the hardcoded provider set: only those types have a
-  // bespoke credential wizard. Alias-edit and delete are backend-generic, so they
-  // stay available for every provider, including dynamic ones.
+  // Only predefined providers can manage credentials from the UI
   const canManageCredentials = isConfigurableProvider(providerType);
   const providerUid = provider?.attributes.uid ?? "";
   const providerAlias = provider?.attributes.alias ?? null;

--- a/ui/components/providers/table/data-table-row-actions.tsx
+++ b/ui/components/providers/table/data-table-row-actions.tsx
@@ -310,8 +310,10 @@ export function DataTableRowActions({
   const provider = isOrganizationRow ? null : rowData;
   const providerId = provider?.id ?? "";
   const providerType = provider?.attributes.provider ?? "";
-  // Only predefined providers can be managed from the UI
-  const canManageProvider = isConfigurableProvider(providerType);
+  // Credentials are gated to the hardcoded provider set: only those types have a
+  // bespoke credential wizard. Alias-edit and delete are backend-generic, so they
+  // stay available for every provider, including dynamic ones.
+  const canManageCredentials = isConfigurableProvider(providerType);
   const providerUid = provider?.attributes.uid ?? "";
   const providerAlias = provider?.attributes.alias ?? null;
   const providerSecretId = provider?.relationships.secret.data?.id ?? null;
@@ -590,13 +592,11 @@ export function DataTableRowActions({
       )}
       <div className="relative flex items-center justify-end gap-2">
         <ActionDropdown>
-          {canManageProvider && (
-            <ActionDropdownItem
-              icon={<Pencil />}
-              label="Edit Provider Alias"
-              onSelect={() => setIsEditOpen(true)}
-            />
-          )}
+          <ActionDropdownItem
+            icon={<Pencil />}
+            label="Edit Provider Alias"
+            onSelect={() => setIsEditOpen(true)}
+          />
           <ActionDropdownItem
             icon={<Timer />}
             label="View Scan Jobs"
@@ -634,7 +634,7 @@ export function DataTableRowActions({
                 disabled
               />
             )}
-          {canManageProvider && (
+          {canManageCredentials && (
             <ActionDropdownItem
               icon={<KeyRound />}
               label={hasSecret ? "Update Credentials" : "Add Credentials"}
@@ -661,16 +661,14 @@ export function DataTableRowActions({
             }}
             disabled={!hasSecret || loading}
           />
-          {canManageProvider && (
-            <ActionDropdownDangerZone>
-              <ActionDropdownItem
-                icon={<Trash2 />}
-                label="Delete Provider"
-                destructive
-                onSelect={() => setIsDeleteOpen(true)}
-              />
-            </ActionDropdownDangerZone>
-          )}
+          <ActionDropdownDangerZone>
+            <ActionDropdownItem
+              icon={<Trash2 />}
+              label="Delete Provider"
+              destructive
+              onSelect={() => setIsDeleteOpen(true)}
+            />
+          </ActionDropdownDangerZone>
         </ActionDropdown>
       </div>
     </>


### PR DESCRIPTION
### Context

PR #11869 (`feat(ui): support dynamic providers`) introduced a **read-only boundary**: for dynamic / non-configurable providers (plug-in types outside the hardcoded set) the Providers table hid **Edit Provider Alias**, **Add/Update Credentials**, and **Delete Provider**, all behind a single gate (`canManageProvider = isConfigurableProvider(providerType)`).

Bundling alias + delete with credentials was over-restrictive:

- The API supports alias `PATCH` and provider `DELETE` for **any** provider — `ProviderViewSet.partial_update`/`destroy` and `ProviderUpdateSerializer` (which whitelists only `alias`) carry no provider-type or `is_dynamic` guard.
- `EditNameForm` / `DeleteForm` and the `updateProvider` / `deleteProvider` server actions are already provider-type-agnostic.
- Only **credential management** genuinely can't work for dynamic types: the credential wizard is hardcoded to the configurable set (`PROWLER-1792` deferred) and `build-credentials.ts` throws for non-configurable types.

This PR narrows the boundary so dynamic providers can be renamed and deleted, while keeping *Add/Update Credentials* and *Edit Scan Configuration* disabled for them. Epic: `PROWLER-1793`.

### Description

- **`data-table-row-actions.tsx`** — split the shared gate:
  - Renamed `canManageProvider` → `canManageCredentials` (still `isConfigurableProvider(providerType)`); it now gates only the credential wizard action.
  - Ungated **Edit Provider Alias** and **Delete Provider** so they render for every provider row (they are backend-generic).
  - Scan Configuration gating is unchanged (still `!isDynamicProvider`).
- Underlying forms (`EditNameForm`, `DeleteForm`) and server actions (`updateProvider`, `deleteProvider`) needed no change — already type-agnostic.
- Updated the dynamic-provider unit test to assert *Edit Provider Alias* + *Delete Provider* are present and credential actions are absent.

### Steps to review

1. In the Providers table, open the row-actions menu for a **dynamic** provider (`is_dynamic: true`, e.g. `template`): **Edit Provider Alias** and **Delete Provider** now appear alongside operational actions (Test Connection / View Scan Jobs / Edit Scan Schedule).
2. **Add/Update Credentials** and **Edit Scan Configuration** stay hidden for that dynamic provider.
3. Known providers (`aws`, `azure`, …) are unchanged — full action set including credentials.
4. Exercise both re-enabled actions against a backend with a dynamic provider:
   - **Rename** → `PATCH` succeeds and the new alias persists.
   - **Delete** → confirm the backend behavior. The delete restriction previously lived only in the UI; whether a deleted dynamic provider stays deleted or is re-created by asset-presence sync should be verified against the dev backend. If it re-syncs back, this is flagged for a follow-up (confirmation copy / product decision).
5. Unit tests: `cd ui && pnpm test data-table-row-actions` — green.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under `ui/changelog.d/`, if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [ ] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - Mobile (X < 640px)
- [ ] Screenshots/Video - Tablet (640px > X < 1024px)
- [ ] Screenshots/Video - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under `ui/changelog.d/`

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic providers can now be renamed and deleted directly from the Providers table.
  * Dynamic providers retain access to connection testing, scan jobs, and schedule editing.

* **Bug Fixes**
  * Credential management actions remain hidden when unavailable for dynamic providers, while alias and deletion actions are correctly shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->