### PR TITLE
fix(sdk): preserve regional IMDSv2 account findings

### DIFF
--- a/prowler/changelog.d/ec2-imdsv2-regional-resource-identity.fixed.md
+++ b/prowler/changelog.d/ec2-imdsv2-regional-resource-identity.fixed.md
@@ -1,0 +1,1 @@
+`ec2_instance_account_imdsv2_enabled` findings now use regional resource ARNs, preventing findings from different AWS Regions from collapsing into one resource

--- a/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled.py
+++ b/prowler/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled.py
@@ -14,7 +14,11 @@ class ec2_instance_account_imdsv2_enabled(Check):
                     metadata=self.metadata(),
                     resource=instance_metadata_default,
                 )
-                report.resource_arn = ec2_client.account_arn_template
+                report.resource_arn = (
+                    f"arn:{ec2_client.audited_partition}:ec2:"
+                    f"{instance_metadata_default.region}:"
+                    f"{ec2_client.audited_account}:account"
+                )
                 report.resource_id = ec2_client.audited_account
                 if instance_metadata_default.http_tokens == "required":
                     report.status = "PASS"

--- a/tests/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled_test.py
+++ b/tests/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled_test.py
@@ -1,15 +1,64 @@
+from types import SimpleNamespace
 from unittest import mock
 
 from moto import mock_aws
 
 from tests.providers.aws.utils import (
     AWS_ACCOUNT_NUMBER,
+    AWS_COMMERCIAL_PARTITION,
+    AWS_REGION_EU_WEST_1,
     AWS_REGION_US_EAST_1,
     set_mocked_aws_provider,
 )
 
 
 class Test_ec2_instance_account_imdsv2_enabled:
+    @mock_aws
+    def test_ec2_imdsv2_uses_region_in_resource_arn(self):
+        from prowler.providers.aws.services.ec2.ec2_service import (
+            InstanceMetadataDefaults,
+        )
+
+        ec2_client = SimpleNamespace(
+            instance_metadata_defaults=[
+                InstanceMetadataDefaults(
+                    http_tokens=None,
+                    instances=True,
+                    region=AWS_REGION_US_EAST_1,
+                ),
+                InstanceMetadataDefaults(
+                    http_tokens=None,
+                    instances=True,
+                    region=AWS_REGION_EU_WEST_1,
+                ),
+            ],
+            audited_account=AWS_ACCOUNT_NUMBER,
+            audited_partition=AWS_COMMERCIAL_PARTITION,
+            provider=SimpleNamespace(scan_unused_services=False),
+        )
+
+        with (
+            mock.patch(
+                "prowler.providers.common.provider.Provider.get_global_provider",
+                return_value=set_mocked_aws_provider(),
+            ),
+            mock.patch(
+                "prowler.providers.aws.services.ec2.ec2_instance_account_imdsv2_enabled.ec2_instance_account_imdsv2_enabled.ec2_client",
+                new=ec2_client,
+            ),
+        ):
+            from prowler.providers.aws.services.ec2.ec2_instance_account_imdsv2_enabled.ec2_instance_account_imdsv2_enabled import (
+                ec2_instance_account_imdsv2_enabled,
+            )
+
+            result = ec2_instance_account_imdsv2_enabled().execute()
+
+            assert len(result) == 2
+            assert {report.resource_arn for report in result} == {
+                f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:account",
+                f"arn:aws:ec2:{AWS_REGION_EU_WEST_1}:{AWS_ACCOUNT_NUMBER}:account",
+            }
+
     @mock_aws
     def test_ec2_imdsv2_required(self):
         from prowler.providers.aws.services.ec2.ec2_service import (
@@ -23,10 +72,8 @@ class Test_ec2_instance_account_imdsv2_enabled:
             )
         ]
         ec2_client.audited_account = AWS_ACCOUNT_NUMBER
+        ec2_client.audited_partition = AWS_COMMERCIAL_PARTITION
         ec2_client.region = AWS_REGION_US_EAST_1
-        ec2_client.account_arn_template = (
-            f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:account"
-        )
 
         with (
             mock.patch(
@@ -71,11 +118,8 @@ class Test_ec2_instance_account_imdsv2_enabled:
             )
         ]
         ec2_client.audited_account = AWS_ACCOUNT_NUMBER
+        ec2_client.audited_partition = AWS_COMMERCIAL_PARTITION
         ec2_client.region = AWS_REGION_US_EAST_1
-
-        ec2_client.account_arn_template = (
-            f"arn:aws:ec2:{AWS_REGION_US_EAST_1}:{AWS_ACCOUNT_NUMBER}:account"
-        )
 
         with (
             mock.patch(


### PR DESCRIPTION
### Context

The EC2 IMDSv2 account-level check emits one finding per AWS Region. All findings previously reused the EC2 client's default-region account ARN, so findings from different Regions mapped to the same API resource. The Attack Surface overview counted each finding while the Finding Groups drill-down collapsed them into one resource.

### Description

- Build the account resource ARN from the Region evaluated by `ec2_instance_account_imdsv2_enabled`
- Preserve distinct resource identities for regional IMDS defaults
- Add a multi-Region regression test
- Add the SDK changelog fragment

### Steps to review

1. Run `uv run pytest tests/providers/aws/services/ec2/ec2_instance_account_imdsv2_enabled/ec2_instance_account_imdsv2_enabled_test.py -q`.
2. Verify findings for `us-east-1` and `eu-west-1` use different account resource ARNs.
3. Confirm Finding Groups reports both regional resources while the Attack Surface overview reports two failed findings.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [ ] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under `prowler/changelog.d/`, if applicable.

#### SDK/CLI

- Are there new checks included in this PR? No
- Are new permissions required for the provider? No

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - EC2 Instance Metadata Service findings now use region-specific resource identifiers.
  - Findings from the same account in different AWS Regions are no longer combined or overwritten, improving the accuracy and completeness of security reports.
  - Resource identifiers now correctly reflect the audited AWS partition and Region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->