### PR TITLE
fix(api): bound attack paths normalized-list child IDs

### DIFF
--- a/api/changelog.d/attack-paths-child-id-size.fixed.md
+++ b/api/changelog.d/attack-paths-child-id-size.fixed.md
@@ -1,0 +1,1 @@
+Attack Paths scans now use bounded child node identifiers for normalized list values in Neo4j and Neptune, preventing Neo4j RANGE index key size failures

--- a/api/src/backend/tasks/jobs/attack_paths/sync.py
+++ b/api/src/backend/tasks/jobs/attack_paths/sync.py
@@ -19,6 +19,7 @@ import json
 import time
 from collections import defaultdict
 from collections.abc import Iterator
+from hashlib import sha256
 from typing import Any
 
 import neo4j
@@ -392,11 +393,11 @@ def _build_child_props(
 def _build_child_id(provider_id: str, child_label: str, value_key: str) -> str:
     """Deterministic `_provider_element_id` for a list-item child node.
 
-    Dedupes within (tenant, provider): multiple parents referencing the same
-    value share one child node via the existing MERGE-on-_provider_element_id
-    index in both sinks.
+    Hashing the value keeps the ID bounded while preserving deduplication within
+    each provider and child label.
     """
-    return f"{provider_id}::{child_label}::{value_key}"
+    value_digest = sha256(value_key.encode("utf-8")).hexdigest()
+    return f"{provider_id}::{child_label}::{value_digest}"
 
 
 def _build_catalog_index(

--- a/api/src/backend/tasks/tests/test_attack_paths_scan.py
+++ b/api/src/backend/tasks/tests/test_attack_paths_scan.py
@@ -1828,6 +1828,55 @@ def _make_session_ctx(session, call_order=None, name=None):
     return ctx
 
 
+class TestBuildChildId:
+    def test_large_value_is_hashed_and_preserved_as_child_data(self):
+        value = "x" * 22_796
+        spec = sync_module.NormalizedList(
+            "SomeLabel",
+            "values",
+            "SomeLabelValuesItem",
+            "HAS_VALUES",
+        )
+        record = {
+            "element_id": "elem-1",
+            "labels": ["SomeLabel"],
+            "props": {"values": [value]},
+        }
+
+        _, parent, children, relationships = sync_module._node_to_sync_dict(
+            record,
+            "prov-1",
+            sync_module._build_catalog_index([spec]),
+        )
+
+        child = children[0]["row"]
+        child_id = child["provider_element_id"]
+        prefix = "prov-1::SomeLabelValuesItem::"
+        assert parent["provider_element_id"] == "prov-1:elem-1"
+        assert child["props"]["value"] == value
+        assert len(child_id) == len(prefix) + 64
+        assert value not in child_id
+        assert relationships[0]["row"]["end_element_id"] == child_id
+
+    @pytest.mark.parametrize(
+        ("provider_id", "child_label", "value_key"),
+        [
+            ("prov-2", "ChildLabel", "value"),
+            ("prov-1", "OtherChildLabel", "value"),
+            ("prov-1", "ChildLabel", "other-value"),
+        ],
+    )
+    def test_each_identity_component_changes_id(
+        self, provider_id, child_label, value_key
+    ):
+        child_id = sync_module._build_child_id("prov-1", "ChildLabel", "value")
+
+        assert sync_module._build_child_id("prov-1", "ChildLabel", "value") == child_id
+        assert (
+            sync_module._build_child_id(provider_id, child_label, value_key) != child_id
+        )
+
+
 class TestSyncNodes:
     def test_iter_sink_batches_rejects_zero_batch_size(self):
         with pytest.raises(


### PR DESCRIPTION
### Context

Attack Paths materializes configured list properties as child nodes. Their `_provider_element_id` previously included the complete normalized value.

Large values could exceed Neo4j's RANGE index key size limit and cause graph synchronization to fail. The generated identifier is shared by the Neo4j and Neptune sinks, so it must remain deterministic and bounded.

### Description

- Hash the existing deterministic `value_key` with SHA-256 when generating normalized-list child IDs
- Preserve the provider ID and child label as identity scopes
- Keep the complete original value in the child node properties
- Keep parent IDs, relationships, sink implementations, indexes, and Attack Paths queries unchanged
- Add regression coverage for large values, deterministic IDs, identity scopes, and relationship endpoints

No new dependencies are required.

### Steps to review

1. Review `_build_child_id()` in `tasks/jobs/attack_paths/sync.py`.
2. Confirm normalized-list values remain available in child node properties.
3. Confirm parent-child relationships use the hashed child ID.
4. Run the focused regression tests:
   ```bash
   cd api
   uv run pytest src/backend/tasks/tests/test_attack_paths_scan.py -k TestBuildChildId
   ```
5. Confirm both Neo4j and Neptune continue consuming the same transformed `provider_element_id`.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Attack Paths scans to handle very large normalized list values without exceeding database index key limits.
  * Preserved original values while using bounded identifiers for better scan reliability.

* **Tests**
  * Added coverage for large values and identifier uniqueness across different identity components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->