### PR TITLE
fix(ui): gate provider alias edit behind Cloud subscription

### DIFF
--- a/ui/changelog.d/provider-alias-subscription-gate.fixed.md
+++ b/ui/changelog.d/provider-alias-subscription-gate.fixed.md
@@ -1,0 +1,1 @@
+`Edit Provider Alias` is now disabled with a subscription badge for Prowler Cloud accounts without an active subscription, instead of failing on submit

--- a/ui/components/providers/table/data-table-row-actions.test.tsx
+++ b/ui/components/providers/table/data-table-row-actions.test.tsx
@@ -468,6 +468,92 @@ describe("DataTableRowActions", () => {
     expect(screen.queryByText("Edit Scan Schedule")).not.toBeInTheDocument();
   });
 
+  it("disables Edit Provider Alias with a subscription badge for manual-only Cloud provider rows", async () => {
+    // Given a Prowler Cloud account without a subscription (trial/onboarding):
+    // editing the alias would be rejected by the API, so the UI must not offer it.
+    vi.stubEnv("NEXT_PUBLIC_IS_CLOUD_ENV", "true");
+    const user = userEvent.setup();
+
+    render(
+      <DataTableRowActions
+        row={createRow(true)}
+        hasSelection={false}
+        isRowSelected={false}
+        testableProviderIds={[]}
+        onClearSelection={vi.fn()}
+        onOpenProviderWizard={vi.fn()}
+        onOpenOrganizationWizard={vi.fn()}
+        capability={SCAN_SCHEDULE_CAPABILITY.MANUAL_ONLY}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button"));
+
+    // Then the action is still discoverable but disabled with an upsell badge.
+    expect(screen.getByText("Requires subscription")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /edit provider alias/i }),
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("disables Edit Provider Alias for blocked Cloud provider rows", async () => {
+    // Given
+    vi.stubEnv("NEXT_PUBLIC_IS_CLOUD_ENV", "true");
+    const user = userEvent.setup();
+
+    render(
+      <DataTableRowActions
+        row={createRow(true)}
+        hasSelection={false}
+        isRowSelected={false}
+        testableProviderIds={[]}
+        onClearSelection={vi.fn()}
+        onOpenProviderWizard={vi.fn()}
+        onOpenOrganizationWizard={vi.fn()}
+        capability={SCAN_SCHEDULE_CAPABILITY.BLOCKED}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button"));
+
+    // Then
+    expect(screen.getByText("Requires subscription")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /edit provider alias/i }),
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("opens Edit Provider Alias for subscribed Cloud provider rows", async () => {
+    // Given a subscribed Cloud account (ADVANCED): the alias edit works.
+    vi.stubEnv("NEXT_PUBLIC_IS_CLOUD_ENV", "true");
+    const user = userEvent.setup();
+
+    render(
+      <DataTableRowActions
+        row={createRow(true)}
+        hasSelection={false}
+        isRowSelected={false}
+        testableProviderIds={[]}
+        onClearSelection={vi.fn()}
+        onOpenProviderWizard={vi.fn()}
+        onOpenOrganizationWizard={vi.fn()}
+        capability={SCAN_SCHEDULE_CAPABILITY.ADVANCED}
+      />,
+    );
+
+    // When
+    await user.click(screen.getByRole("button"));
+
+    // Then the item is enabled (no upsell badge) and opens the alias modal.
+    expect(screen.queryByText("Requires subscription")).not.toBeInTheDocument();
+    await user.click(screen.getByText("Edit Provider Alias"));
+    expect(
+      screen.getByRole("dialog", { name: /edit provider alias/i }),
+    ).toBeInTheDocument();
+  });
+
   it("opens scan config management with the precomputed current config id", async () => {
     // Given
     vi.stubEnv("NEXT_PUBLIC_IS_CLOUD_ENV", "true");

--- a/ui/components/providers/table/data-table-row-actions.tsx
+++ b/ui/components/providers/table/data-table-row-actions.tsx
@@ -27,6 +27,7 @@ import {
   type EditScanScheduleState,
 } from "@/components/scans/schedule/edit-scan-schedule-modal";
 import { useToast } from "@/components/shadcn";
+import { Badge } from "@/components/shadcn/badge/badge";
 import {
   ActionDropdown,
   ActionDropdownDangerZone,
@@ -35,7 +36,10 @@ import {
 import { Modal } from "@/components/shadcn/modal";
 import { runWithConcurrencyLimit } from "@/lib/concurrency";
 import { testProviderConnection } from "@/lib/provider-helpers";
-import { getScanScheduleCapability } from "@/lib/schedules";
+import {
+  canEditProviderAlias,
+  getScanScheduleCapability,
+} from "@/lib/schedules";
 import { isCloud } from "@/lib/shared/env";
 import { ORG_SETUP_PHASE, ORG_WIZARD_STEP } from "@/types/organizations";
 import { PROVIDER_WIZARD_MODE } from "@/types/provider-wizard";
@@ -291,9 +295,11 @@ export function DataTableRowActions({
   currentScanConfigId = null,
   capability,
 }: DataTableRowActionsProps) {
+  const resolvedCapability = capability ?? getScanScheduleCapability(isCloud());
   const canEditSchedule =
-    (capability ?? getScanScheduleCapability(isCloud())) ===
-    SCAN_SCHEDULE_CAPABILITY.ADVANCED;
+    resolvedCapability === SCAN_SCHEDULE_CAPABILITY.ADVANCED;
+  // Editing a provider alias requires a Prowler Cloud subscription
+  const canEditAlias = canEditProviderAlias(resolvedCapability);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isScheduleOpen, setIsScheduleOpen] = useState(false);
   const [scheduleState, setScheduleState] = useState<EditScanScheduleState>({
@@ -590,11 +596,26 @@ export function DataTableRowActions({
       )}
       <div className="relative flex items-center justify-end gap-2">
         <ActionDropdown>
-          <ActionDropdownItem
-            icon={<Pencil />}
-            label="Edit Provider Alias"
-            onSelect={() => setIsEditOpen(true)}
-          />
+          {canEditAlias ? (
+            <ActionDropdownItem
+              icon={<Pencil />}
+              label="Edit Provider Alias"
+              onSelect={() => setIsEditOpen(true)}
+            />
+          ) : (
+            <ActionDropdownItem
+              icon={<Pencil />}
+              label={
+                <span className="flex flex-col items-start gap-1">
+                  Edit Provider Alias
+                  <Badge variant="warning" size="sm">
+                    Requires subscription
+                  </Badge>
+                </span>
+              }
+              disabled
+            />
+          )}
           <ActionDropdownItem
             icon={<Timer />}
             label="View Scan Jobs"

--- a/ui/lib/schedules.test.ts
+++ b/ui/lib/schedules.test.ts
@@ -5,6 +5,7 @@ import {
   buildScheduleAttributesFromProvider,
   buildSchedulesByProviderId,
   buildScheduleUpdatePayload,
+  canEditProviderAlias,
   formatDayOfMonth,
   formatScheduleHour,
   getBrowserTimezone,
@@ -437,6 +438,28 @@ describe("scan schedule capability", () => {
     expect(getScanScheduleCapability(true)).toBe(
       SCAN_SCHEDULE_CAPABILITY.ADVANCED,
     );
+  });
+});
+
+describe("canEditProviderAlias", () => {
+  it("allows subscribed Cloud accounts (ADVANCED)", () => {
+    expect(canEditProviderAlias(SCAN_SCHEDULE_CAPABILITY.ADVANCED)).toBe(true);
+  });
+
+  it("allows OSS / self-hosted (DAILY_LEGACY, no billing)", () => {
+    expect(canEditProviderAlias(SCAN_SCHEDULE_CAPABILITY.DAILY_LEGACY)).toBe(
+      true,
+    );
+  });
+
+  it("blocks Cloud trial/onboarding without a subscription (MANUAL_ONLY)", () => {
+    expect(canEditProviderAlias(SCAN_SCHEDULE_CAPABILITY.MANUAL_ONLY)).toBe(
+      false,
+    );
+  });
+
+  it("blocks over-limit Cloud accounts (BLOCKED)", () => {
+    expect(canEditProviderAlias(SCAN_SCHEDULE_CAPABILITY.BLOCKED)).toBe(false);
   });
 });
 

--- a/ui/lib/schedules.ts
+++ b/ui/lib/schedules.ts
@@ -65,6 +65,19 @@ export function getScanScheduleCapability(
     : SCAN_SCHEDULE_CAPABILITY.DAILY_LEGACY;
 }
 
+/**
+ * Whether the current account may edit a provider alias. Alias edits require a
+ * Prowler Cloud subscription
+ */
+export function canEditProviderAlias(
+  capability: ScanScheduleCapability,
+): boolean {
+  return (
+    capability === SCAN_SCHEDULE_CAPABILITY.ADVANCED ||
+    capability === SCAN_SCHEDULE_CAPABILITY.DAILY_LEGACY
+  );
+}
+
 export function formatScheduleHour(hour: number): string {
   const normalizedHour = ((hour % 24) + 24) % 24;
   const period = normalizedHour >= 12 ? "pm" : "am";


### PR DESCRIPTION
### Context

In the Providers table, the **Edit Provider Alias** row action was shown to every account (gated only by provider type). But in Prowler Cloud, editing a provider alias requires an active subscription: an account in trial/onboarding (or over its scan limit) that opens the modal, types a new alias and submits gets rejected by the API. The UI offered an action guaranteed to fail — an inconsistency between the UI and the API.

Note the restriction is Cloud-only.

<img width="1641" height="365" alt="Captura de pantalla 2026-07-14 a las 8 59 48" src="https://github.com/user-attachments/assets/f770792d-1a58-4092-b36b-0ee50c086043" />


### Description

Gates the alias edit in the UI by reusing the billing-aware `capability` (`ScanScheduleCapability`) prop that the prowler-cloud overlay already injects into the providers row actions (today it gates *Edit Scan Schedule*). No new prop threading, no backend change, no overlay change.

- New pure helper `canEditProviderAlias(capability)` in `ui/lib/schedules.ts`:
  - **Allowed**: `ADVANCED` (subscribed Cloud) and `DAILY_LEGACY` (OSS/self-hosted, no billing)
  - **Blocked**: `MANUAL_ONLY` (Cloud trial/onboarding) and `BLOCKED` (over scan limit)
- `Edit Provider Alias` now renders **disabled with a `Requires subscription` badge** (`CloudFeatureBadge`) when the account can't edit; unchanged (enabled, opens the modal) otherwise.
- Behavior by setup:
  - OSS / self-hosted → enabled (no regression)
  - Cloud subscribed → enabled
  - Cloud trial / over-limit → disabled + `Requires subscription`

### Steps to review

- Unit tests: `cd ui && pnpm test lib/schedules.test.ts components/providers/table/data-table-row-actions.test.tsx`
  - Helper: 4 cases (one per capability value)
  - Component: item disabled + badge for `MANUAL_ONLY`/`BLOCKED`; enabled + opens modal for `ADVANCED`
- The disabled state only appears in Cloud without a subscription; the `capability` value is injected by the prowler-cloud overlay (not reproducible in OSS via env vars alone). To eyeball it locally, temporarily force `capability = MANUAL_ONLY` in `data-table-row-actions.tsx`.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the [open issues](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](https://goto.prowler.com/slack)
- [ ] I have reviewed the [open pull requests](https://github.com/prowler-cloud/prowler/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) and confirmed there is no existing PR that implements the same outcome

</details>


- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [ ] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### SDK/CLI
- Are there new checks included in this PR? No

#### UI
- [x] All issue/task requirements work as expected on the UI
- [ ] If this PR adds or updates npm dependencies, include package-health evidence (maintenance, popularity, known vulnerabilities, license, release age) and explain why existing/native alternatives are insufficient.
- [ ] Screenshots/Video of the functionality flow (if applicable) - Mobile (X < 640px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Table (640px > X < 1024px)
- [ ] Screenshots/Video of the functionality flow (if applicable) - Desktop (X > 1024px)
- [x] Ensure a changelog fragment is added under [ui/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/ui/changelog.d), if applicable.

#### API
- [ ] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [ ] Verify if API specs need to be regenerated.
- [ ] Check if version updates are required (e.g., specs, uv, etc.).
- [ ] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

#### MCP Server
- [ ] All issue/task requirements work as expected on the MCP Server
- [ ] Ensure a changelog fragment is added under [mcp_server/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/mcp_server/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription-based access controls for editing provider aliases.
  * Restricted Cloud accounts without an active subscription from editing aliases.
  * Disabled the action and displayed a “Requires subscription” badge when access is unavailable.
  * Preserved alias editing for eligible subscribed and self-hosted accounts.

* **Bug Fixes**
  * Prevented users from attempting an alias edit that would fail during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->