### PR TITLE
fix(api): prevent concurrent scan summary deadlocks

### DIFF
--- a/api/changelog.d/scan-summary-deadlocks.fixed.md
+++ b/api/changelog.d/scan-summary-deadlocks.fixed.md
@@ -1,0 +1,1 @@
+`scan-summary` aggregation now upserts summaries in deterministic conflict-key order, preventing PostgreSQL deadlocks during concurrent reaggregation

--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -1490,7 +1490,7 @@ def aggregate_findings(tenant_id: str, scan_id: str):
             if agg["resources__service"] is not None
             and agg["resources__region"] is not None
         ]
-        # Sort by the conflict key so concurrent upserts acquire locks consistently.
+        # Needed sort so concurrent upserts acquire locks consistently
         scan_aggregations.sort(
             key=lambda summary: (
                 summary.tenant_id,

--- a/api/src/backend/tasks/jobs/scan.py
+++ b/api/src/backend/tasks/jobs/scan.py
@@ -1464,7 +1464,7 @@ def aggregate_findings(tenant_id: str, scan_id: str):
         )
 
     with rls_transaction(tenant_id):
-        scan_aggregations = {
+        scan_aggregations = [
             ScanSummary(
                 tenant_id=tenant_id,
                 scan_id=scan_id,
@@ -1489,9 +1489,18 @@ def aggregate_findings(tenant_id: str, scan_id: str):
             for agg in aggregation
             if agg["resources__service"] is not None
             and agg["resources__region"] is not None
-        }
-        # Upsert so re-runs (post-mute reaggregation) don't trip
-        # `unique_scan_summary`; race-safe under concurrent writers.
+        ]
+        # Sort by the conflict key so concurrent upserts acquire locks consistently.
+        scan_aggregations.sort(
+            key=lambda summary: (
+                summary.tenant_id,
+                summary.scan_id,
+                summary.check_id,
+                summary.service,
+                summary.severity,
+                summary.region,
+            )
+        )
         ScanSummary.objects.bulk_create(
             scan_aggregations,
             batch_size=3000,

--- a/api/src/backend/tasks/tests/test_scan.py
+++ b/api/src/backend/tasks/tests/test_scan.py
@@ -3655,6 +3655,95 @@ class TestAggregateFindings:
     @patch("tasks.jobs.scan.Finding.objects.filter")
     @patch("tasks.jobs.scan.ScanSummary.objects.bulk_create")
     @patch("tasks.jobs.scan.rls_transaction")
+    def test_aggregate_findings_orders_upserts_by_conflict_key(
+        self, mock_rls_transaction, mock_bulk_create, mock_findings_filter
+    ):
+        """Scan summaries must use a stable lock order for concurrent upserts."""
+        tenant_id = str(uuid.uuid4())
+        scan_id = str(uuid.uuid4())
+        counts = {
+            "fail": 1,
+            "_pass": 0,
+            "muted_count": 0,
+            "total": 1,
+            "new": 1,
+            "changed": 0,
+            "unchanged": 0,
+            "fail_new": 1,
+            "fail_changed": 0,
+            "pass_new": 0,
+            "pass_changed": 0,
+            "muted_new": 0,
+            "muted_changed": 0,
+        }
+
+        mock_queryset = MagicMock()
+        mock_queryset.values.return_value = mock_queryset
+        mock_queryset.annotate.return_value = [
+            {
+                "check_id": "check-b",
+                "resources__service": "s3",
+                "severity": "high",
+                "resources__region": "us-east-1",
+                **counts,
+            },
+            {
+                "check_id": "check-a",
+                "resources__service": "sqs",
+                "severity": "high",
+                "resources__region": "us-east-1",
+                **counts,
+            },
+            {
+                "check_id": "check-a",
+                "resources__service": "s3",
+                "severity": "medium",
+                "resources__region": "us-east-1",
+                **counts,
+            },
+            {
+                "check_id": "check-a",
+                "resources__service": "s3",
+                "severity": "high",
+                "resources__region": "us-west-2",
+                **counts,
+            },
+            {
+                "check_id": "check-a",
+                "resources__service": "s3",
+                "severity": "high",
+                "resources__region": "us-east-1",
+                **counts,
+            },
+        ]
+
+        ctx = MagicMock()
+        ctx.__enter__.return_value = None
+        ctx.__exit__.return_value = False
+        mock_rls_transaction.return_value = ctx
+        mock_findings_filter.return_value = mock_queryset
+
+        aggregate_findings(tenant_id, scan_id)
+
+        summaries = mock_bulk_create.call_args.args[0]
+        assert isinstance(summaries, list)
+        conflict_keys = [
+            (
+                str(summary.tenant_id),
+                str(summary.scan_id),
+                summary.check_id,
+                summary.service,
+                summary.severity,
+                summary.region,
+            )
+            for summary in summaries
+        ]
+        assert len(conflict_keys) == 5
+        assert conflict_keys == sorted(conflict_keys)
+
+    @patch("tasks.jobs.scan.Finding.objects.filter")
+    @patch("tasks.jobs.scan.ScanSummary.objects.bulk_create")
+    @patch("tasks.jobs.scan.rls_transaction")
     def test_aggregate_findings_skips_rows_with_null_service_or_region(
         self, mock_rls_transaction, mock_bulk_create, mock_findings_filter
     ):


### PR DESCRIPTION
### Context

Concurrent `scan-summary` reaggregation can upsert the same summary rows in different orders. PostgreSQL may then acquire unique-index locks inconsistently and deadlock.

### Description

- Build scan-summary aggregations as a list.
- Sort summaries by the full conflict key before the existing bulk upsert.
- Add a regression test for the ordering invariant.

The bulk upsert configuration and public interfaces remain unchanged. This change has no new dependencies.

### Steps to review

1. Confirm the sort key matches the `unique_scan_summary` conflict key: `(tenant_id, scan_id, check_id, service, severity, region)`.
2. Run the focused ordering and existing reaggregation tests:

   ```console
   cd api
   uv run pytest -x --tb=short \
     src/backend/tasks/tests/test_scan.py::TestAggregateFindings::test_aggregate_findings_orders_upserts_by_conflict_key \
     src/backend/tasks/tests/test_scan.py::TestAggregateFindings::test_aggregate_findings_is_idempotent_on_rerun \
     src/backend/tasks/tests/test_scan.py::TestAggregateFindings::test_aggregate_findings_reflects_mute_between_runs
   ```
3. Confirm the batch size, conflict fields, and update fields remain unchanged.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API
- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scan summary aggregation to prevent database deadlocks during concurrent processing.
  * Ensured summaries are saved in a consistent order for more reliable reaggregation.

* **Tests**
  * Added coverage verifying deterministic ordering during scan summary updates.

* **Documentation**
  * Documented the deadlock prevention improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->