### PR TITLE
fix(ci): extend .trivyignore CVE suppression expiries to 2026-08-15

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -15,21 +15,21 @@
 # neither vulnerable code path (Archive::Tar parsing or regex compilation of
 # attacker-controlled input) is reachable from Prowler. No Debian bookworm fix
 # is available yet.
-CVE-2026-42496 pkg:perl exp:2026-07-15
-CVE-2026-42496 pkg:perl-base exp:2026-07-15
-CVE-2026-42496 pkg:perl-modules-5.36 exp:2026-07-15
-CVE-2026-42496 pkg:libperl5.36 exp:2026-07-15
-CVE-2026-8376 pkg:perl exp:2026-07-15
-CVE-2026-8376 pkg:perl-base exp:2026-07-15
-CVE-2026-8376 pkg:perl-modules-5.36 exp:2026-07-15
-CVE-2026-8376 pkg:libperl5.36 exp:2026-07-15
+CVE-2026-42496 pkg:perl exp:2026-08-15
+CVE-2026-42496 pkg:perl-base exp:2026-08-15
+CVE-2026-42496 pkg:perl-modules-5.36 exp:2026-08-15
+CVE-2026-42496 pkg:libperl5.36 exp:2026-08-15
+CVE-2026-8376 pkg:perl exp:2026-08-15
+CVE-2026-8376 pkg:perl-base exp:2026-08-15
+CVE-2026-8376 pkg:perl-modules-5.36 exp:2026-08-15
+CVE-2026-8376 pkg:libperl5.36 exp:2026-08-15
 
 # CVE-2025-7458 — SQLite integer overflow.
 # Package: libsqlite3-0.
 # Why ignored: transitive dependency of CPython's stdlib sqlite3 module. The
 # Prowler SDK does not open user-supplied SQLite databases; SQLite usage is
 # internal and bounded. No Debian bookworm fix is available.
-CVE-2025-7458 pkg:libsqlite3-0 exp:2026-07-15
+CVE-2025-7458 pkg:libsqlite3-0 exp:2026-08-15
 
 # CVE-2026-43185 — Linux kernel ksmbd signedness bug.
 # Package: linux-libc-dev.
@@ -37,7 +37,7 @@ CVE-2025-7458 pkg:libsqlite3-0 exp:2026-07-15
 # not a running kernel. Containers execute against the host kernel, so these
 # headers are inert at runtime. The upstream fix landed in kernel 7.0-rc2 and
 # has not been backported to Debian's 6.1 LTS line.
-CVE-2026-43185 pkg:linux-libc-dev exp:2026-07-15
+CVE-2026-43185 pkg:linux-libc-dev exp:2026-08-15
 
 # CVE-2023-45853 — zlib MiniZip integer overflow / heap overflow in
 # zipOpenNewFileInZip4_64.
@@ -49,8 +49,8 @@ CVE-2026-43185 pkg:linux-libc-dev exp:2026-07-15
 # zlib 1.3.1, available in Debian trixie (13); migrating the base image would
 # clear it fully.
 # Ref: https://security-tracker.debian.org/tracker/CVE-2023-45853
-CVE-2023-45853 pkg:zlib1g exp:2026-07-15
-CVE-2023-45853 pkg:zlib1g-dev exp:2026-07-15
+CVE-2023-45853 pkg:zlib1g exp:2026-08-15
+CVE-2023-45853 pkg:zlib1g-dev exp:2026-08-15
 
 # CVE-2026-55200 — libssh2 out-of-bounds write in ssh2_transport_read() due to
 # an unchecked packet_length field in transport.c (heap corruption, possible RCE).
@@ -63,7 +63,7 @@ CVE-2023-45853 pkg:zlib1g-dev exp:2026-07-15
 # affected code is unreachable at runtime. Fixed upstream in libssh2 commit
 # 97acf3df (PR #2052); no Debian bookworm fix is available yet.
 # Ref: https://security-tracker.debian.org/tracker/CVE-2026-55200
-CVE-2026-55200 pkg:libssh2-1 exp:2026-07-15
+CVE-2026-55200 pkg:libssh2-1 exp:2026-08-15
 
 # --- API container image (api/Dockerfile) ---
 # The entries below are specific to the Prowler API image, which ships
@@ -78,13 +78,13 @@ CVE-2026-55200 pkg:libssh2-1 exp:2026-07-15
 # at runtime. The vulnerable path requires parsing attacker-controlled XML with
 # the affected interpreter, which Prowler does not do with the system Python.
 # Full mitigation also needs libexpat >= 2.8.0; no Debian bookworm fix yet.
-CVE-2026-7210 pkg:python3.11 exp:2026-07-15
-CVE-2026-7210 pkg:python3.11-dev exp:2026-07-15
-CVE-2026-7210 pkg:python3.11-minimal exp:2026-07-15
-CVE-2026-7210 pkg:libpython3.11 exp:2026-07-15
-CVE-2026-7210 pkg:libpython3.11-dev exp:2026-07-15
-CVE-2026-7210 pkg:libpython3.11-minimal exp:2026-07-15
-CVE-2026-7210 pkg:libpython3.11-stdlib exp:2026-07-15
+CVE-2026-7210 pkg:python3.11 exp:2026-08-15
+CVE-2026-7210 pkg:python3.11-dev exp:2026-08-15
+CVE-2026-7210 pkg:python3.11-minimal exp:2026-08-15
+CVE-2026-7210 pkg:libpython3.11 exp:2026-08-15
+CVE-2026-7210 pkg:libpython3.11-dev exp:2026-08-15
+CVE-2026-7210 pkg:libpython3.11-minimal exp:2026-08-15
+CVE-2026-7210 pkg:libpython3.11-stdlib exp:2026-08-15
 
 # CVE-2026-33278 — Unbound DNSSEC validator use-after-free (DoS, possible RCE).
 # CVE-2026-42960 — Unbound DNS cache poisoning via promiscuous additional records.
@@ -94,5 +94,5 @@ CVE-2026-7210 pkg:libpython3.11-stdlib exp:2026-07-15
 # vulnerabilities require operating a live Unbound recursive DNSSEC validator
 # that processes attacker-influenced DNS responses. Prowler never starts an
 # Unbound resolver, so neither code path is reachable. No Debian bookworm fix yet.
-CVE-2026-33278 pkg:libunbound8 exp:2026-07-15
-CVE-2026-42960 pkg:libunbound8 exp:2026-07-15
+CVE-2026-33278 pkg:libunbound8 exp:2026-08-15
+CVE-2026-42960 pkg:libunbound8 exp:2026-08-15


### PR DESCRIPTION
### Context

All nine CVE suppressions in `.trivyignore` carried `exp:2026-07-15` and expired today (re-review is forced on expiry by design). This PR is that scheduled re-review.

Each entry was re-checked against the **Debian Security Tracker** — the authoritative source, since every suppressed CVE is against a package from the Debian **bookworm** base image used by the SDK and API container images. The finding: **none of the nine CVEs has a bookworm fix yet**, so every entry's original justification (unreachable code path / inert build-time artifact / real-not-affected) still holds. The correct action is to bump the expiries and force the next re-review, not to remove any suppression.

### Description

Bumps all `exp:2026-07-15` → `exp:2026-08-15` (22 lines). No rationale comments changed. Per-package scoping and justifications are untouched.

Re-review results (Debian bookworm status as of 2026-07-14):

| CVE | Package(s) | Bookworm status | Fix landed in |
|-----|-----------|-----------------|---------------|
| CVE-2026-42496 | perl* | vulnerable — *postponed*, "minor, wait for upstream regressions" | unstable only |
| CVE-2026-8376 | perl* | vulnerable — no-dsa, point-release | 5.40.1-8 (unstable) |
| CVE-2025-7458 | libsqlite3-0 | vulnerable — no-dsa, minor | — |
| CVE-2026-43185 | linux-libc-dev | vulnerable (6.1.176-1) | — |
| CVE-2023-45853 | zlib1g / zlib1g-dev | **ignored** — real-not-affected (minizip not built) | trixie (13) |
| CVE-2026-55200 | libssh2-1 | vulnerable (1.10.0-3) | trixie 1.11.1-1+deb13u1 |
| CVE-2026-7210 | python3.11* / libpython3.11* | vulnerable — no-dsa, minor | — |
| CVE-2026-33278 | libunbound8 | vulnerable | trixie 1.22.0-2+deb13u3 |
| CVE-2026-42960 | libunbound8 | vulnerable | trixie 1.22.0-2+deb13u3 |

Note: zlib, libssh2, and unbound are already fixed in **trixie (Debian 13)** — reinforcing the existing note that migrating the base image bookworm → trixie would clear those suppressions entirely. That is a separate base-image change and out of scope here.

### Steps to review

1. Confirm the diff only changes expiry dates (`exp:2026-07-15` → `exp:2026-08-15`) and nothing else — `git diff master...HEAD`.
2. Spot-check any CVE against its Debian tracker page (e.g. https://security-tracker.debian.org/tracker/CVE-2026-55200) to confirm bookworm is still unfixed.
3. Verify the SDK/API container Trivy scans (`.github/workflows/*-container-checks.yml`) still pass with the extended expiries.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the review period for several security vulnerability suppressions through August 15, 2026.
  * No changes were made to the affected package scopes or suppression criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->