### PR TITLE
fix(api): combine permissions across assigned roles

### DIFF
--- a/api/changelog.d/multi-role-permission-gates.fixed.md
+++ b/api/changelog.d/multi-role-permission-gates.fixed.md
@@ -1,0 +1,1 @@
+RBAC permission gates now combine permissions from every role assigned to a user in the active tenant

--- a/api/src/backend/api/rbac/permissions.py
+++ b/api/src/backend/api/rbac/permissions.py
@@ -34,7 +34,7 @@ class HasPermissions(BasePermission):
         if not tenant_id:
             return False
 
-        user_roles = (
+        user_roles = list(
             User.objects.using(MainRouter.admin_db)
             .get(id=request.user.id)
             .roles.using(MainRouter.admin_db)
@@ -43,11 +43,10 @@ class HasPermissions(BasePermission):
         if not user_roles:
             return False
 
-        for perm in required_permissions:
-            if not getattr(user_roles[0], perm.value, False):
-                return False
-
-        return True
+        return all(
+            any(getattr(role, permission.value, False) for role in user_roles)
+            for permission in required_permissions
+        )
 
 
 def get_role(user: User, tenant_id: str) -> Role:

--- a/api/src/backend/api/tests/test_rbac.py
+++ b/api/src/backend/api/tests/test_rbac.py
@@ -11,6 +11,7 @@ from api.models import (
     User,
     UserRoleRelationship,
 )
+from api.rbac.permissions import HasPermissions, Permissions
 from api.v1.serializers import TokenSerializer
 from conftest import TEST_PASSWORD, TODAY
 from django.urls import reverse
@@ -814,6 +815,48 @@ class TestRolePermissions:
             content_type="application/vnd.api+json",
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+class TestHasPermissions:
+    def test_permissions_are_combined_across_roles(
+        self, create_test_user_rbac_no_roles
+    ):
+        user = create_test_user_rbac_no_roles
+        tenant = Membership.objects.get(user=user).tenant
+        manage_users_role = Role.objects.create(
+            name="manage_users_only",
+            tenant=tenant,
+            manage_users=True,
+        )
+        UserRoleRelationship.objects.create(
+            user=user,
+            role=manage_users_role,
+            tenant=tenant,
+        )
+        request = Mock(user=user, tenant_id=tenant.id)
+        view = Mock(
+            required_permissions=[
+                Permissions.MANAGE_USERS,
+                Permissions.MANAGE_ACCOUNT,
+            ]
+        )
+        permission = HasPermissions()
+
+        assert not permission.has_permission(request, view)
+
+        manage_account_role = Role.objects.create(
+            name="manage_account_only",
+            tenant=tenant,
+            manage_account=True,
+        )
+        UserRoleRelationship.objects.create(
+            user=user,
+            role=manage_account_role,
+            tenant=tenant,
+        )
+
+        assert permission.has_permission(request, view)
 
 
 @pytest.mark.django_db

--- a/api/src/backend/api/tests/test_views.py
+++ b/api/src/backend/api/tests/test_views.py
@@ -9435,20 +9435,22 @@ class TestUserRoleRelationshipViewSet:
         assert added_role_ids.issubset(relationship_role_ids)
 
     def test_create_relationship_already_exists(
-        self, authenticated_client, roles_fixture, create_test_user
+        self, authenticated_client, roles_fixture, create_test_user_rbac_no_roles
     ):
-        # Only add Role One (which has manage_account=True) to ensure
-        # the second request has permission to add roles
         data = {
             "data": [
-                {"type": "roles", "id": str(roles_fixture[0].id)},
+                {"type": "roles", "id": str(role.id)} for role in roles_fixture[:2]
             ]
         }
-        authenticated_client.post(
-            reverse("user-roles-relationship", kwargs={"pk": create_test_user.id}),
+        setup_response = authenticated_client.post(
+            reverse(
+                "user-roles-relationship",
+                kwargs={"pk": create_test_user_rbac_no_roles.id},
+            ),
             data=data,
             content_type="application/vnd.api+json",
         )
+        assert setup_response.status_code == status.HTTP_204_NO_CONTENT
 
         data = {
             "data": [
@@ -9456,7 +9458,10 @@ class TestUserRoleRelationshipViewSet:
             ]
         }
         response = authenticated_client.post(
-            reverse("user-roles-relationship", kwargs={"pk": create_test_user.id}),
+            reverse(
+                "user-roles-relationship",
+                kwargs={"pk": create_test_user_rbac_no_roles.id},
+            ),
             data=data,
             content_type="application/vnd.api+json",
         )


### PR DESCRIPTION
### Context

RBAC permission checks previously used only the first role assigned to a user. Since role ordering is not guaranteed, users with multiple roles could receive `403 Forbidden` even when another assigned role provided the required permission.

The duplicate role relationship test also modified the authenticated user’s roles, making its result depend on role ordering.

### Description

- Combine permissions from every role assigned to the user in the active tenant.
- Keep the rule that every required permission must be provided by at least one assigned role.
- Add deterministic coverage for permissions split across two roles.
- Use a separate same-tenant user in the duplicate relationship test.
- Preserve the existing `400 Bad Request` response for duplicate relationships.

### Steps to review

1. Confirm `HasPermissions` loads the active tenant’s roles once.
2. Confirm each required permission can come from any assigned role.
3. Confirm the duplicate relationship test does not modify the authenticated user.
4. Confirm tests run without fails.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission checks now combine permissions from all roles assigned to a user within the active tenant.
  * Users can satisfy multi-permission requirements when permissions are distributed across multiple roles.

* **Tests**
  * Added coverage for combined permissions across roles.
  * Updated relationship creation tests to reflect multi-role permission behavior.

* **Documentation**
  * Updated the changelog to describe the corrected role permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->