### PR TITLE
fix(api): resolve critical container scan findings

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -24,6 +24,17 @@ CVE-2026-8376 pkg:perl-base exp:2026-08-15
 CVE-2026-8376 pkg:perl-modules-5.36 exp:2026-08-15
 CVE-2026-8376 pkg:libperl5.36 exp:2026-08-15
 
+# CVE-2026-13221 - Perl regex trie overflow.
+# Packages: perl, perl-base, perl-modules-5.36, libperl5.36.
+# Why ignored: upstream confirms Perl 5.36.0 is not affected; the regression
+# was introduced after this version. Debian currently marks bookworm as
+# vulnerable, which causes Trivy to report a false positive.
+# Ref: https://github.com/Perl/perl5/issues/23388
+CVE-2026-13221 pkg:perl exp:2026-08-15
+CVE-2026-13221 pkg:perl-base exp:2026-08-15
+CVE-2026-13221 pkg:perl-modules-5.36 exp:2026-08-15
+CVE-2026-13221 pkg:libperl5.36 exp:2026-08-15
+
 # CVE-2025-7458 — SQLite integer overflow.
 # Package: libsqlite3-0.
 # Why ignored: transitive dependency of CPython's stdlib sqlite3 module. The

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -113,6 +113,7 @@ RUN apt-get purge -y --auto-remove \
     make \
     libxml2-dev \
     libxmlsec1-dev \
+    libxmlsec1-openssl \
     pkg-config \
     libtool \
     libxslt1-dev \

--- a/api/changelog.d/trivy-critical-cves.security.md
+++ b/api/changelog.d/trivy-critical-cves.security.md
@@ -1,0 +1,1 @@
+`api` container image removes the unused Debian `libxml2` runtime package and scopes the `CVE-2026-13221` Trivy exception to unaffected Perl 5.36 packages


### PR DESCRIPTION
### Context

The [API container Trivy scan](https://github.com/prowler-cloud/prowler/actions/runs/29403387254/job/87312987493) reports critical findings for:

- `CVE-2026-6653` in Debian's `libxml2` package
- `CVE-2026-13221` in Debian's Perl 5.36 packages

The API uses the locked `lxml` and `xmlsec` wheels, which bundle libxml2 2.14.6 and do not dynamically link to Debian's `libxml2`. The Perl finding is a false positive because [the vulnerability does not affect Perl 5.36.0](https://github.com/Perl/perl5/issues/23388).

### Description

- Purge the unused `libxmlsec1-openssl` package from the final API image, allowing Debian's vulnerable `libxml2` package to be removed
- Add package-scoped, expiring Trivy exceptions for `CVE-2026-13221`

### Steps to review

Check API container Trivy scan again.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated container vulnerability handling for a Perl-related false positive affecting Perl 5.36 packages.
  * Removed an unused XML runtime package from the API container image, reducing its security footprint.

* **Chores**
  * Improved cleanup of build-only packages after API dependencies are installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->