### PR TITLE
fix(api): retry wrapped Neptune transient errors

### DIFF
--- a/api/src/backend/api/attack_paths/sink/neptune.py
+++ b/api/src/backend/api/attack_paths/sink/neptune.py
@@ -66,7 +66,7 @@ READ_EXCEPTION_CODES = [
     "Neo.ClientError.Procedure.ProcedureNotFound",
 ]
 CLIENT_STATEMENT_EXCEPTION_PREFIX = "Neo.ClientError.Statement."
-RETRYABLE_WRITE_ERROR_PREFIXES = (
+RETRYABLE_WRITE_ERROR_FRAGMENTS = (
     "Operation failed due to conflicting concurrent operations",
     "Operation terminated (deadline exceeded)",
 )
@@ -78,7 +78,8 @@ SIGV4_TOKEN_LIFETIME_MINUTES = 4
 def _is_retryable_write_error(exc: Exception) -> bool:
     if not isinstance(exc, neo4j.exceptions.Neo4jError):
         return False
-    return bool(exc.message and exc.message.startswith(RETRYABLE_WRITE_ERROR_PREFIXES))
+    message = exc.message or ""
+    return any(fragment in message for fragment in RETRYABLE_WRITE_ERROR_FRAGMENTS)
 
 
 class NeptuneSink(SinkDatabase):

--- a/api/src/backend/api/tests/test_sink.py
+++ b/api/src/backend/api/tests/test_sink.py
@@ -332,9 +332,10 @@ class TestNeptuneRetryPolicy:
     @pytest.mark.parametrize(
         "message",
         [
-            "Operation failed due to conflicting concurrent operations "
-            + "(please retry), 0 transactions are currently rolling back.",
-            "Operation terminated (deadline exceeded)",
+            "Unexpected server exception 'Operation failed due to conflicting "
+            "concurrent operations (please retry), 0 transactions are currently "
+            "rolling back.'",
+            "Unexpected server exception 'Operation terminated (deadline exceeded)'",
         ],
     )
     def test_observed_transient_write_errors_are_retryable(self, message):
@@ -345,7 +346,9 @@ class TestNeptuneRetryPolicy:
 
     def test_unrelated_database_error_is_not_retryable(self):
         error = MagicMock(spec=neo4j.exceptions.Neo4jError)
-        error.message = "Operation terminated (out of memory)"
+        error.message = (
+            "Unexpected server exception 'Operation terminated (out of memory)'"
+        )
 
         assert _is_retryable_write_error(error) is False
 


### PR DESCRIPTION
### Context

PR #11961 added retries for transient Neptune graph mutation failures. Neptune’s Bolt driver wraps the retryable error text with `Unexpected server exception`, but the retry predicate used `startswith`.

As a result, the predicate rejected the real exception and the operation failed without retrying.

### Description

This PR:

- Matches the known retryable Neptune error fragments anywhere within a `Neo4jError` message.
- Keeps matching case-sensitive and restricted to the two documented transient errors.
- Renames `RETRYABLE_WRITE_ERROR_PREFIXES` to `RETRYABLE_WRITE_ERROR_FRAGMENTS`.
- Updates the original retry-policy tests with the complete Bolt-wrapped messages observed in Sentry.
- Verifies that a wrapped non-retryable error is still rejected.

### Steps to review

1. Confirm `_is_retryable_write_error` accepts the wrapped concurrency and deadline errors.
2. Confirm unrelated database errors and non-Neo4j exceptions remain non-retryable.
3. Run API test suite.

### Checklist

- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following this specification https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [x] Review if backport is needed.
- [x] Review if is needed to change the [README.md](https://github.com/prowler-cloud/prowler/blob/master/README.md)
- [x] Ensure a changelog fragment is added under [prowler/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/prowler/changelog.d), if applicable.

#### API

- [x] All issue/task requirements work as expected on the API
- [ ] Endpoint response output (if applicable)
- [ ] EXPLAIN ANALYZE output for new/modified queries or indexes (if applicable)
- [ ] Performance test results (if applicable)
- [ ] Any other relevant evidence of the implementation (if applicable)
- [x] Verify if API specs need to be regenerated.
- [x] Check if version updates are required (e.g., specs, uv, etc.).
- [x] Ensure a changelog fragment is added under [api/changelog.d/](https://github.com/prowler-cloud/prowler/tree/master/api/changelog.d), if applicable.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of database write failures so retryable errors are recognized even when their identifying message appears within a larger error message.
  * Updated retry behavior for certain Neo4j server and conflicting-operation errors.
  * Preserved non-retry behavior for unrelated database errors, including out-of-memory failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->