### PR TITLE
fix(ui): show scan in Findings filter from View Findings action

### DIFF
--- a/ui/changelog.d/findings-scan-filter-selection.fixed.md
+++ b/ui/changelog.d/findings-scan-filter-selection.fixed.md
@@ -1,0 +1,1 @@
+`Scan ID` filter on the Findings page now shows the active scan when opening findings from a scan's `View Findings` action

--- a/ui/components/scans/table/scan-jobs-row-actions.test.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.test.tsx
@@ -333,7 +333,7 @@ describe("ScanJobsRowActions", () => {
 
     // Then
     expect(pushMock).toHaveBeenCalledWith(
-      "/findings?filter[scan]=scan-1&filter[inserted_at]=2026-01-01&filter[status__in]=FAIL",
+      "/findings?filter[scan__in]=scan-1&filter[inserted_at]=2026-01-01&filter[status__in]=FAIL",
     );
   });
 

--- a/ui/components/scans/table/scan-jobs-row-actions.tsx
+++ b/ui/components/scans/table/scan-jobs-row-actions.tsx
@@ -93,7 +93,7 @@ export function ScanJobsRowActions({
   const openFindings = () => {
     if (!isCompleted || !scanDate) return;
     router.push(
-      `/findings?filter[scan]=${scan.id}&filter[inserted_at]=${scanDate}&filter[status__in]=FAIL`,
+      `/findings?filter[scan__in]=${scan.id}&filter[inserted_at]=${scanDate}&filter[status__in]=FAIL`,
     );
   };
 


### PR DESCRIPTION
### Context

Opening a scan's **View Findings** action navigates to `/findings` with the scan pre-filtered, and the applied-filter chip correctly reads `Scan: <provider>`. But when the filter panel is expanded, the **Scan ID** dropdown shows nothing selected, while Date and Status do reflect their values.

Root cause is a URL key mismatch, not a value one: the row action emitted `filter[scan]` (exact), whereas the Scan ID dropdown reads its selected state under `FILTER_FIELD.SCAN = scan__in`. The batch filter state is derived from the URL verbatim, so `getFilterValue("scan__in")` never sees `filter[scan]` and the dropdown renders empty.


https://github.com/user-attachments/assets/3d310295-1f95-47c4-a783-bd32de1e620e


https://github.com/user-attachments/assets/95d3e2ff-f77e-484c-919f-e1e63af910c9



### Description

- Emit `filter[scan__in]` instead of `filter[scan]` from the Scans **View Findings** row action, aligning it with the dropdown key that the rest of the app already uses (e.g. the Overview "Severity over time" drill-down).
- No consumer handled `filter[scan]` exclusively, so nothing regresses; chip label/value, date/status, the findings list and historical-endpoint routing all already accept `scan__in`. As a bonus, the switch also removes a latent duplicate-key case (interacting with the dropdown after arriving used to leave both `filter[scan]` and `filter[scan__in]` in the URL) and makes chip removal consistent with the dropdown.
- Update the row-action unit test and add a changelog fragment.

### Steps to review

1. Go to **Scans**, open a completed scan's actions menu, click **View Findings**.
2. The findings list is filtered and the `Scan: <provider>` chip appears (as before).
3. Expand **Less/More Filters**: the **Scan ID** dropdown now shows the scan selected (alongside Date and Status). The URL contains `filter[scan__in]`.
4. Remove the `Scan` chip → it clears from both the dropdown and the URL. Re-select in the dropdown → the URL keeps a single scan key.

### Checklist

<details>

<summary><b>Community Checklist</b></summary>

- [ ] This feature/issue is listed in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or roadmap.prowler.com
- [ ] Is it assigned to me, if not, request it via the issue/feature in [here](https://github.com/prowler-cloud/prowler/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen) or [Prowler Community Slack](goto.prowler.com/slack)

</details>

- Are there new checks included in this PR? No
- [x] Review if the code is being covered by tests.
- [x] Review if code is being documented following https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
- [ ] Review if backport is needed.
- [x] Review if is needed to change the Readme.md
- [x] Ensure a changelog fragment is added under <component>/changelog.d/, if applicable.

#### UI (if applicable)
- [x] All issue/task requirements work as expected on the UI
- [ ] Screenshots/Video - before & after (to be added)
- [x] Ensure a changelog fragment is added under ui/changelog.d/

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Findings page’s Scan ID filter to correctly reflect the scan selected through **View Findings**.
  * Updated scan-to-findings navigation so completed scans open results with the appropriate scan filter applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->